### PR TITLE
feat: add HTTP protocol support to URI enum and resolve_operator function

### DIFF
--- a/crates/common/src/uri.rs
+++ b/crates/common/src/uri.rs
@@ -17,6 +17,7 @@ pub enum Protocol {
     File = 1,
     Ram = 2,
     Google = 3,
+    Http = 4,
 }
 
 impl Protocol {
@@ -25,11 +26,12 @@ impl Protocol {
             Protocol::File => "file",
             Protocol::Ram => "ram",
             Protocol::Google => "gs",
+            Protocol::Http => "https",
         }
     }
 
     pub fn is_file(&self) -> bool {
-        matches!(&self, Protocol::File)
+        matches!(&self, Protocol::File | Protocol::Ram | Protocol::Http)
     }
 
     pub fn is_file_storage(&self) -> bool {
@@ -55,6 +57,7 @@ impl FromStr for Protocol {
             "file" => Ok(Protocol::File),
             "ram" => Ok(Protocol::Ram),
             "gs" => Ok(Protocol::Google),
+            "https" => Ok(Protocol::Http),
             _ => bail!("unknown URI protocol `{protocol}`"),
         }
     }

--- a/crates/storage/src/operator.rs
+++ b/crates/storage/src/operator.rs
@@ -9,6 +9,7 @@ use opendal::services;
 use opendal::Builder;
 use opendal::Operator;
 use reearth_flow_common::uri::{Protocol, Uri};
+use tracing::info;
 
 /// init_operator will init an opendal operator based on storage config.
 pub(crate) fn resolve_operator(uri: &Uri) -> Result<Operator> {
@@ -16,6 +17,7 @@ pub(crate) fn resolve_operator(uri: &Uri) -> Result<Operator> {
         Protocol::File => build_operator(init_fs_operator(uri)),
         Protocol::Ram => build_operator(init_memory_operator()),
         Protocol::Google => build_operator(init_gcs_operator(uri)),
+        Protocol::Http => build_operator(init_http_operator(uri)),
     }
 }
 
@@ -60,4 +62,12 @@ fn init_gcs_operator(uri: &Uri) -> impl Builder {
 /// init_memory_operator will init a opendal memory operator.
 fn init_memory_operator() -> impl Builder {
     services::Memory::default()
+}
+
+fn init_http_operator(uri: &Uri) -> impl Builder {
+    let mut builder = services::Http::default();
+    info!("init_http_operator: {}", uri.root());
+    builder.endpoint(&format!("https://{}", uri.root()));
+    builder.root("/");
+    builder
 }


### PR DESCRIPTION
# Overview
- add HTTP protocol support to URI enum and resolve_operator function

## What I've done
- HTTP protocol support to URI enum 
- modify resolve_operator function

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
