### PR TITLE
chore: update dependabot.yml to change package directory to /worker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: cargo
-    directory: /
+    directory: /worker
     schedule:
       interval: "daily"
       time: "08:00"


### PR DESCRIPTION
# Overview
- update dependabot.yml to change package directory to /worker

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
