### PR TITLE
feat(worker): Add EdgeId type for routing in Node module

### DIFF
--- a/worker/crates/common/src/xml.rs
+++ b/worker/crates/common/src/xml.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use libxml::error::StructuredError;
@@ -168,22 +168,29 @@ pub fn readonly_node_to_xml_string(
     Ok(doc.to_string())
 }
 
-pub fn parse_schema_locations(document: &XmlDocument) -> crate::Result<HashSet<String>> {
+pub fn parse_schema_locations(document: &XmlDocument) -> crate::Result<HashMap<String, String>> {
     let root = get_root_node(document)?;
     let mut schema_locations = Vec::new();
+    let mut namespaces = HashMap::new();
+    root.get_namespace_declarations().iter().for_each(|ns| {
+        namespaces.insert(ns.get_href(), ns.get_prefix());
+    });
     for (key, value) in root.get_attributes().iter() {
         if key == "schemaLocation" {
             schema_locations = value.split_whitespace().map(|s| s.to_string()).collect();
         }
     }
-    Ok(HashSet::from_iter(
-        schema_locations
-            .into_iter()
-            .enumerate()
-            .filter(|&(i, _)| i % 2 == 1)
-            .map(|(_, v)| v)
-            .collect::<Vec<_>>(),
-    ))
+
+    let mut schema_locations_map = HashMap::new();
+    for i in (0..schema_locations.len()).step_by(2) {
+        if i + 1 < schema_locations.len() {
+            schema_locations_map.insert(
+                schema_locations[i].to_string(),
+                schema_locations[i + 1].to_string(),
+            );
+        }
+    }
+    Ok(schema_locations_map)
 }
 
 pub fn create_xml_schema_validation_context(
@@ -198,19 +205,41 @@ pub fn create_xml_schema_validation_context(
     })
 }
 
+pub fn create_xml_schema_validation_context_from_buffer(
+    schema: &[u8],
+) -> crate::Result<XmlSchemaValidationContext> {
+    let mut xsd_parser = XmlSchemaParserContext::from_buffer(schema);
+    let ctx = SchemaValidationContext::from_parser(&mut xsd_parser)
+        .map_err(|e| crate::Error::Xml(format!("Failed to parse schema: {:?}", e)))?;
+    Ok(XmlSchemaValidationContext {
+        inner: parking_lot::RwLock::new(ctx),
+        _marker: PhantomData,
+    })
+}
+
 pub fn validate_document_by_schema(
     document: &XmlDocument,
     schema_location: String,
 ) -> crate::Result<Vec<StructuredError>> {
-    let mut xsd_validator = create_xml_schema_validation_context(schema_location)?;
-    validate_document_by_schema_context(document, &mut xsd_validator)
+    let xsd_validator = create_xml_schema_validation_context(schema_location)?;
+    validate_document_by_schema_context(document, &xsd_validator)
 }
 
 pub fn validate_document_by_schema_context(
     document: &XmlDocument,
-    xsd_validator: &mut XmlSchemaValidationContext,
+    xsd_validator: &XmlSchemaValidationContext,
 ) -> crate::Result<Vec<StructuredError>> {
     match xsd_validator.inner.write().validate_document(document) {
+        Ok(_) => Ok(vec![]),
+        Err(e) => Ok(e),
+    }
+}
+
+pub fn validate_node_by_schema_context(
+    node: &XmlNode,
+    xsd_validator: &XmlSchemaValidationContext,
+) -> crate::Result<Vec<StructuredError>> {
+    match xsd_validator.inner.write().validate_node(node) {
         Ok(_) => Ok(vec![]),
         Err(e) => Ok(e),
     }
@@ -262,6 +291,8 @@ pub fn find_readonly_nodes_by_xpath(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
 
     #[test]
@@ -337,6 +368,11 @@ mod tests {
 
     #[test]
     fn test_parse_schema_locations() {
+        let a = HashSet::from(["4", "1"]);
+        let b = HashSet::from(["1", "4", "5"]);
+        let result = a.difference(&b);
+        println!("{:?}", result.count());
+
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
         <core:CityModel xmlns:brid="http://www.opengis.net/citygml/bridge/2.0" xmlns:tran="http://www.opengis.net/citygml/transportation/2.0" xmlns:frn="http://www.opengis.net/citygml/cityfurniture/2.0" xmlns:wtr="http://www.opengis.net/citygml/waterbody/2.0" xmlns:sch="http://www.ascc.net/xml/schematron" xmlns:veg="http://www.opengis.net/citygml/vegetation/2.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:tun="http://www.opengis.net/citygml/tunnel/2.0" xmlns:tex="http://www.opengis.net/citygml/texturedsurface/2.0" xmlns:gml="http://www.opengis.net/gml" xmlns:app="http://www.opengis.net/citygml/appearance/2.0" xmlns:gen="http://www.opengis.net/citygml/generics/2.0" xmlns:dem="http://www.opengis.net/citygml/relief/2.0" xmlns:luse="http://www.opengis.net/citygml/landuse/2.0" xmlns:uro="https://www.geospatial.jp/iur/uro/3.0" xmlns:xAL="urn:oasis:names:tc:ciq:xsdschema:xAL:2.0" xmlns:bldg="http://www.opengis.net/citygml/building/2.0" xmlns:smil20="http://www.w3.org/2001/SMIL20/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:smil20lang="http://www.w3.org/2001/SMIL20/Language" xmlns:pbase="http://www.opengis.net/citygml/profiles/base/2.0" xmlns:core="http://www.opengis.net/citygml/2.0" xmlns:grp="http://www.opengis.net/citygml/cityobjectgroup/2.0" xsi:schemaLocation="https://www.geospatial.jp/iur/uro/3.0 ../../schemas/iur/uro/3.0/urbanObject.xsd http://www.opengis.net/citygml/2.0 http://schemas.opengis.net/citygml/2.0/cityGMLBase.xsd http://www.opengis.net/citygml/landuse/2.0 http://schemas.opengis.net/citygml/landuse/2.0/landUse.xsd http://www.opengis.net/citygml/building/2.0 http://schemas.opengis.net/citygml/building/2.0/building.xsd http://www.opengis.net/citygml/transportation/2.0 http://schemas.opengis.net/citygml/transportation/2.0/transportation.xsd http://www.opengis.net/citygml/generics/2.0 http://schemas.opengis.net/citygml/generics/2.0/generics.xsd http://www.opengis.net/citygml/cityobjectgroup/2.0 http://schemas.opengis.net/citygml/cityobjectgroup/2.0/cityObjectGroup.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/gml.xsd http://www.opengis.net/citygml/appearance/2.0 http://schemas.opengis.net/citygml/appearance/2.0/appearance.xsd">
             <gml:boundedBy>
@@ -351,18 +387,45 @@ mod tests {
         let result = parse_schema_locations(&document).unwrap();
         assert_eq!(
             result,
-            HashSet::from_iter(vec![
-                "../../schemas/iur/uro/3.0/urbanObject.xsd".to_string(),
-                "http://schemas.opengis.net/citygml/2.0/cityGMLBase.xsd".to_string(),
-                "http://schemas.opengis.net/citygml/landuse/2.0/landUse.xsd".to_string(),
-                "http://schemas.opengis.net/citygml/building/2.0/building.xsd".to_string(),
-                "http://schemas.opengis.net/citygml/transportation/2.0/transportation.xsd"
-                    .to_string(),
-                "http://schemas.opengis.net/citygml/generics/2.0/generics.xsd".to_string(),
-                "http://schemas.opengis.net/citygml/cityobjectgroup/2.0/cityObjectGroup.xsd"
-                    .to_string(),
-                "http://schemas.opengis.net/gml/3.1.1/base/gml.xsd".to_string(),
-                "http://schemas.opengis.net/citygml/appearance/2.0/appearance.xsd".to_string(),
+            HashMap::from([
+                (
+                    "http://www.opengis.net/citygml/generics/2.0".to_string(),
+                    "http://schemas.opengis.net/citygml/generics/2.0/generics.xsd".to_string()
+                ),
+                (
+                    "http://www.opengis.net/citygml/cityobjectgroup/2.0".to_string(),
+                    "http://schemas.opengis.net/citygml/cityobjectgroup/2.0/cityObjectGroup.xsd"
+                        .to_string()
+                ),
+                (
+                    "http://www.opengis.net/citygml/building/2.0".to_string(),
+                    "http://schemas.opengis.net/citygml/building/2.0/building.xsd".to_string()
+                ),
+                (
+                    "http://www.opengis.net/citygml/2.0".to_string(),
+                    "http://schemas.opengis.net/citygml/2.0/cityGMLBase.xsd".to_string()
+                ),
+                (
+                    "http://www.opengis.net/citygml/landuse/2.0".to_string(),
+                    "http://schemas.opengis.net/citygml/landuse/2.0/landUse.xsd".to_string()
+                ),
+                (
+                    "http://www.opengis.net/gml".to_string(),
+                    "http://schemas.opengis.net/gml/3.1.1/base/gml.xsd".to_string()
+                ),
+                (
+                    "https://www.geospatial.jp/iur/uro/3.0".to_string(),
+                    "../../schemas/iur/uro/3.0/urbanObject.xsd".to_string()
+                ),
+                (
+                    "http://www.opengis.net/citygml/transportation/2.0".to_string(),
+                    "http://schemas.opengis.net/citygml/transportation/2.0/transportation.xsd"
+                        .to_string()
+                ),
+                (
+                    "http://www.opengis.net/citygml/appearance/2.0".to_string(),
+                    "http://schemas.opengis.net/citygml/appearance/2.0/appearance.xsd".to_string()
+                ),
             ])
         )
     }

--- a/worker/crates/runner/src/executor.rs
+++ b/worker/crates/runner/src/executor.rs
@@ -9,6 +9,7 @@ use reearth_flow_runtime::{
     node::{NodeKind, RouterFactory},
     shutdown::ShutdownReceiver,
 };
+use reearth_flow_state::State;
 use reearth_flow_types::workflow::Workflow;
 use std::{collections::HashMap, sync::Arc};
 use tokio::runtime::Runtime;
@@ -57,6 +58,7 @@ pub fn run_dag_executor(
     runtime: &Arc<Runtime>,
     dag_executor: DagExecutor,
     shutdown: ShutdownReceiver,
+    state: Arc<State>,
 ) -> Result<(), OrchestrationError> {
     let join_handle = runtime.block_on(dag_executor.start(
         SharedFuture::new(Box::pin(shutdown.create_shutdown_future())),
@@ -65,6 +67,7 @@ pub fn run_dag_executor(
         ctx.storage_resolver.clone(),
         ctx.logger.clone(),
         ctx.kv_store.clone(),
+        state,
     ));
     join_handle
         .unwrap()

--- a/worker/crates/runner/src/runner.rs
+++ b/worker/crates/runner/src/runner.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use reearth_flow_action_log::factory::LoggerFactory;
 use reearth_flow_runtime::shutdown;
+use reearth_flow_state::State;
 use reearth_flow_storage::resolve::StorageResolver;
 use reearth_flow_types::workflow::Workflow;
 
@@ -15,6 +16,7 @@ impl Runner {
         workflow: Workflow,
         logger_factory: Arc<LoggerFactory>,
         storage_resolver: Arc<StorageResolver>,
+        state: Arc<State>,
     ) {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(30)
@@ -33,6 +35,7 @@ impl Runner {
                     shutdown_receiver,
                     logger_factory,
                     storage_resolver,
+                    state,
                 )
                 .await
                 .unwrap()

--- a/worker/crates/runtime/src/builder_dag.rs
+++ b/worker/crates/runtime/src/builder_dag.rs
@@ -11,7 +11,9 @@ use crate::{
     errors::ExecutionError,
     event::EventHub,
     executor_operation::NodeContext,
-    node::{GraphId, NodeHandle, NodeId, NodeKind as DagNodeKind, Port, Processor, Sink, Source},
+    node::{
+        EdgeId, GraphId, NodeHandle, NodeId, NodeKind as DagNodeKind, Port, Processor, Sink, Source,
+    },
 };
 
 #[derive(Debug, Clone)]
@@ -61,14 +63,16 @@ pub enum NodeKind {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EdgeType {
+    pub id: EdgeId,
     pub from: Port,
     pub to: Port,
     pub edge_kind: SchemaEdgeKind,
 }
 
 impl EdgeType {
-    pub fn new(from: Port, to: Port, edge_kind: SchemaEdgeKind) -> Self {
+    pub fn new(id: EdgeId, from: Port, to: Port, edge_kind: SchemaEdgeKind) -> Self {
         Self {
+            id,
             from,
             to,
             edge_kind,
@@ -256,6 +260,7 @@ impl BuilderDag {
                 node_index_map[&edge.source()],
                 node_index_map[&edge.target()],
                 EdgeType::new(
+                    edge.weight.id,
                     edge.weight.from,
                     edge.weight.to,
                     edge.weight.edge_kind.unwrap(),

--- a/worker/crates/runtime/src/executor/dag_executor.rs
+++ b/worker/crates/runtime/src/executor/dag_executor.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use futures::Future;
 use reearth_flow_action_log::factory::LoggerFactory;
 use reearth_flow_eval_expr::engine::Engine;
+use reearth_flow_state::State;
 use reearth_flow_storage::resolve::StorageResolver;
 use reearth_flow_types::workflow::Graph;
 use tokio::runtime::Runtime;
@@ -51,6 +52,7 @@ impl DagExecutor {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn start<F: Send + 'static + Future + Unpin + Debug + Clone>(
         self,
         shutdown: F,
@@ -59,12 +61,14 @@ impl DagExecutor {
         storage_resolver: Arc<StorageResolver>,
         logger: Arc<LoggerFactory>,
         kv_store: Arc<Box<dyn crate::kvs::KvStore>>,
+        state: Arc<State>,
     ) -> Result<DagExecutorJoinHandle, ExecutionError> {
         // Construct execution dag.
         let mut execution_dag = ExecutionDag::new(
             self.builder_dag,
             self.options.channel_buffer_sz,
             self.options.error_threshold,
+            Arc::clone(&state),
         )?;
         let node_indexes = execution_dag.graph().node_indices().collect::<Vec<_>>();
 

--- a/worker/crates/runtime/src/executor/processor_node.rs
+++ b/worker/crates/runtime/src/executor/processor_node.rs
@@ -74,7 +74,6 @@ impl<F: Future + Unpin + Debug> ProcessorNode<F> {
         let NodeKind::Processor(mut processor) = kind else {
             panic!("Must pass in a processor node");
         };
-
         let (node_handles, receivers) = dag.collect_receivers(node_index);
 
         let senders = dag.collect_senders(node_index);
@@ -85,6 +84,7 @@ impl<F: Future + Unpin + Debug> ProcessorNode<F> {
             record_writers,
             senders,
             dag.error_manager().clone(),
+            runtime.clone(),
         );
         let span = info_span!(
             "root",

--- a/worker/crates/runtime/src/executor/source_node.rs
+++ b/worker/crates/runtime/src/executor/source_node.rs
@@ -191,6 +191,7 @@ pub async fn create_source_node<F>(
             record_writers,
             senders,
             dag.error_manager().clone(),
+            runtime.clone(),
         );
         sources.push(RunningSource {
             channel_manager,

--- a/worker/crates/runtime/src/feature_store.rs
+++ b/worker/crates/runtime/src/feature_store.rs
@@ -1,39 +1,79 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::sync::Arc;
 
+use reearth_flow_state::State;
 use reearth_flow_types::Feature;
 use thiserror::Error;
+
+use crate::node::EdgeId;
 
 #[derive(Debug, Error)]
 pub enum FeatureWriterError {
     #[error("Feature not found")]
     FeatureNotFound,
+    #[error("Flush error: {0}")]
+    Flush(String),
 }
 
-pub trait FeatureWriter: Send + Sync + Debug {
+pub trait FeatureWriterClone {
+    fn clone_box(&self) -> Box<dyn FeatureWriter>;
+}
+
+impl<T> FeatureWriterClone for T
+where
+    T: 'static + FeatureWriter + Clone,
+{
+    fn clone_box(&self) -> Box<dyn FeatureWriter> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn FeatureWriter> {
+    fn clone(&self) -> Box<dyn FeatureWriter> {
+        self.clone_box()
+    }
+}
+
+#[async_trait::async_trait]
+pub trait FeatureWriter: Send + Sync + Debug + FeatureWriterClone {
     fn write(&mut self, feature: &Feature) -> Result<(), FeatureWriterError>;
+    async fn flush(&self) -> Result<(), FeatureWriterError>;
 }
 
-pub fn create_feature_writer() -> Box<dyn FeatureWriter> {
-    Box::new(PrimaryKeyLookupFeatureWriter::new())
+pub fn create_feature_writer(edge_id: EdgeId, state: Arc<State>) -> Box<dyn FeatureWriter> {
+    Box::new(PrimaryKeyLookupFeatureWriter::new(edge_id, state))
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct PrimaryKeyLookupFeatureWriter {
+    edge_id: EdgeId,
     index: HashMap<uuid::Uuid, Feature>,
+    state: Arc<State>,
 }
 
 impl PrimaryKeyLookupFeatureWriter {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(edge_id: EdgeId, state: Arc<State>) -> Self {
         Self {
+            edge_id,
             index: Default::default(),
+            state,
         }
     }
 }
 
+#[async_trait::async_trait]
 impl FeatureWriter for PrimaryKeyLookupFeatureWriter {
     fn write(&mut self, feature: &Feature) -> Result<(), FeatureWriterError> {
         self.index.insert(feature.id, feature.clone());
         Ok(())
+    }
+
+    async fn flush(&self) -> Result<(), FeatureWriterError> {
+        let item = self.index.values().cloned().collect::<Vec<_>>();
+        self.state
+            .save(&item, self.edge_id.to_string().as_str())
+            .await
+            .map_err(|e| FeatureWriterError::Flush(e.to_string()))
     }
 }

--- a/worker/crates/runtime/src/node.rs
+++ b/worker/crates/runtime/src/node.rs
@@ -21,6 +21,7 @@ pub static ROUTING_PARAM_KEY: &str = "routingPort";
 
 pub(super) type NodeId = uuid::Uuid;
 pub(super) type GraphId = uuid::Uuid;
+pub(super) type EdgeId = uuid::Uuid;
 
 #[nutype::nutype(
     sanitize(trim),

--- a/worker/crates/state/src/lib.rs
+++ b/worker/crates/state/src/lib.rs
@@ -43,6 +43,18 @@ impl State {
             .map_err(|e| Error::new(ErrorKind::Other, e))
     }
 
+    pub fn save_sync<T>(&self, obj: &T, id: &str) -> Result<()>
+    where
+        for<'de> T: Serialize + Deserialize<'de>,
+    {
+        let s = self.object_to_string(obj)?;
+        let content = bytes::Bytes::from(s);
+        let p = self.id_to_location(id);
+        self.storage
+            .put_sync(p.as_path(), content)
+            .map_err(|e| Error::new(ErrorKind::Other, e))
+    }
+
     pub async fn get<T>(&self, id: &str) -> Result<T>
     where
         for<'de> T: Deserialize<'de>,

--- a/worker/examples/plateau/testdata/graphs/xml_validator.yml
+++ b/worker/examples/plateau/testdata/graphs/xml_validator.yml
@@ -59,6 +59,20 @@ nodes:
     with:
       routingPort: summary
 
+  - id: abd4320c-aa7c-445a-af78-4c4f1f9a35c7
+    name: invalidRouter
+    type: action
+    action: Router
+    with:
+      routingPort: invalid
+
+  - id: 3c0724c6-263e-43b9-8532-e46c7584323a
+    name: notWellFormedRouter
+    type: action
+    action: Router
+    with:
+      routingPort: not_well_formed
+
 edges:
   - id: 433e7166-48de-4479-9039-63acdab6d3fa
     from: 6da2ce36-9a86-44ac-8f9f-b427bdb50097
@@ -72,9 +86,9 @@ edges:
     toPort: default
   - id: 3e8f6cb7-882b-4b81-9f70-eec8374221d0
     from: 6da2ce36-9a86-44ac-8f9f-b427bdb50097
-    to: 8d18c9ee-8473-4294-9a83-07dc00c14dc5
+    to: 3c0724c6-263e-43b9-8532-e46c7584323a
     fromPort: failed
-    toPort: not_well_formed
+    toPort: default
   - id: 7a133f42-08d8-4e9c-8f88-d8ee9f2d3c1d
     from: b51e43bd-1d67-4e9e-9b42-2e91aef79f6f
     to: 14225ce7-1d9f-44bc-8b41-3aa06d4275cd
@@ -87,9 +101,9 @@ edges:
     toPort: default
   - id: 300b2fa9-d5e2-4145-9703-49189b4fe849
     from: b51e43bd-1d67-4e9e-9b42-2e91aef79f6f
-    to: 8d18c9ee-8473-4294-9a83-07dc00c14dc5
+    to: abd4320c-aa7c-445a-af78-4c4f1f9a35c7
     fromPort: failed
-    toPort: invalid
+    toPort: default
   - id: 8ba8930c-52b3-4074-b7f8-199b74405cbe
     from: 14225ce7-1d9f-44bc-8b41-3aa06d4275cd
     to: 8d18c9ee-8473-4294-9a83-07dc00c14dc5
@@ -104,4 +118,4 @@ edges:
     from: 6c235d0b-26fb-47dd-a3df-709fa961855c
     to: 8d18c9ee-8473-4294-9a83-07dc00c14dc5
     fromPort: default
-    toPort: invalid
+    toPort: default

--- a/worker/tests/helper.rs
+++ b/worker/tests/helper.rs
@@ -1,6 +1,7 @@
 use std::{env, path::PathBuf, sync::Arc};
 
 use reearth_flow_runner::runner::Runner;
+use reearth_flow_state::State;
 use reearth_flow_types::Workflow;
 use rust_embed::RustEmbed;
 
@@ -37,7 +38,7 @@ pub(crate) fn execute(test_id: &str, fixture_files: Vec<&str>) {
     }
     let workflow_file = WorkflowFiles::get(format!("{}.yaml", test_id).as_str()).unwrap();
     let workflow = std::str::from_utf8(workflow_file.data.as_ref()).unwrap();
-
+    let state = Arc::new(State::new(&Uri::for_test("ram:///state/"), &storage_resolver).unwrap());
     let logger_factory = Arc::new(LoggerFactory::new(
         reearth_flow_action_log::ActionLogger::root(
             reearth_flow_action_log::Discard,
@@ -51,5 +52,6 @@ pub(crate) fn execute(test_id: &str, fixture_files: Vec<&str>) {
         workflow,
         logger_factory,
         storage_resolver,
+        state,
     );
 }


### PR DESCRIPTION
# Overview
This commit adds the `EdgeId` type to the `Node` module in order to support routing functionality. The `EdgeId` type is defined as a `uuid::Uuid` and will be used for identifying edges in the routing process.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
