### PR TITLE
feat(worker): Add bounded_by field to CityGML parsing

### DIFF
--- a/worker/Cargo.lock
+++ b/worker/Cargo.lock
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
 dependencies = [
  "anstream",
  "anstyle",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "colorchoice"
@@ -1674,7 +1674,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#7bee2a57ab28f71d1e7fd9b449caac70e788e405"
+source = "git+https://github.com/reearth/plateau-gis-converter#79edcca7d4ed6c9fcff9d849d51d5e43f3e7b446"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "nusamai-citygml"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#7bee2a57ab28f71d1e7fd9b449caac70e788e405"
+source = "git+https://github.com/reearth/plateau-gis-converter#79edcca7d4ed6c9fcff9d849d51d5e43f3e7b446"
 dependencies = [
  "ahash 0.8.11",
  "chrono",
@@ -1891,7 +1891,7 @@ dependencies = [
 [[package]]
 name = "nusamai-geometry"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#7bee2a57ab28f71d1e7fd9b449caac70e788e405"
+source = "git+https://github.com/reearth/plateau-gis-converter#79edcca7d4ed6c9fcff9d849d51d5e43f3e7b446"
 dependencies = [
  "num-traits",
  "serde",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "nusamai-plateau"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#7bee2a57ab28f71d1e7fd9b449caac70e788e405"
+source = "git+https://github.com/reearth/plateau-gis-converter#79edcca7d4ed6c9fcff9d849d51d5e43f3e7b446"
 dependencies = [
  "chrono",
  "hashbrown 0.14.5",
@@ -1910,6 +1910,7 @@ dependencies = [
  "nusamai-geometry",
  "quick-xml",
  "serde",
+ "serde_json",
  "stretto",
  "url",
 ]
@@ -1917,7 +1918,7 @@ dependencies = [
 [[package]]
 name = "nusamai-projection"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#7bee2a57ab28f71d1e7fd9b449caac70e788e405"
+source = "git+https://github.com/reearth/plateau-gis-converter#79edcca7d4ed6c9fcff9d849d51d5e43f3e7b446"
 dependencies = [
  "japan-geoid",
  "thiserror",
@@ -3726,9 +3727,9 @@ checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 
 [[package]]
 name = "strum_macros"
-version = "0.26.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7993a8e3a9e88a00351486baae9522c91b123a088f76469e5bd5cc17198ea87"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/worker/crates/action-processor/src/feature/reader/citygml.rs
+++ b/worker/crates/action-processor/src/feature/reader/citygml.rs
@@ -83,7 +83,7 @@ fn parse_tree_reader<R: BufRead>(
                 let id = cityobj.id();
                 let name = cityobj.name();
                 let description = cityobj.description();
-
+                let bounded = cityobj.bounded_by();
                 if let Some(root) = cityobj.into_object() {
                     let entity = Entity {
                         id,
@@ -92,7 +92,8 @@ fn parse_tree_reader<R: BufRead>(
                         root,
                         base_url: base_url.clone(),
                         geometry_store: RwLock::new(geometry_store).into(),
-                        appearance_store: Default::default(), // TODO: from local appearances
+                        appearance_store: Default::default(),
+                        bounded,
                     };
                     entities.push(entity);
                 }

--- a/worker/crates/action-source/src/file/reader/citygml.rs
+++ b/worker/crates/action-source/src/file/reader/citygml.rs
@@ -75,6 +75,7 @@ async fn parse_tree_reader<'a, 'b, R: BufRead>(
                 let id = cityobj.id();
                 let name = cityobj.name();
                 let description = cityobj.description();
+                let bounded = cityobj.bounded_by();
 
                 if let Some(root) = cityobj.into_object() {
                     let entity = Entity {
@@ -85,6 +86,7 @@ async fn parse_tree_reader<'a, 'b, R: BufRead>(
                         base_url: base_url.clone(),
                         geometry_store: RwLock::new(geometry_store).into(),
                         appearance_store: Default::default(), // TODO: from local appearances
+                        bounded,
                     };
                     entities.push(entity);
                 }


### PR DESCRIPTION
# Overview
- This commit adds the `bounded_by` field to the CityGML parsing logic in both the `action-source` and `action-processor` crates. The `bounded_by` field is now included in the `Entity` struct, allowing for better handling of CityGML objects with bounding information.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
