### PR TITLE
feat(worker): support reading workflow from stdin

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -942,6 +942,36 @@
       ]
     },
     {
+      "name": "Reprojector",
+      "type": "processor",
+      "description": "Reprojects the geometry of a feature to a specified coordinate system",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "properties": {
+          "epsgCode": {
+            "format": "uint16",
+            "minimum": 0.0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "epsgCode"
+        ],
+        "title": "ReprojectorParam",
+        "type": "object"
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "Router",
       "type": "processor",
       "description": "Action for last port forwarding for sub-workflows.",


### PR DESCRIPTION
# Overview
This commit adds support for reading the workflow JSON from stdin in the `run` command of the CLI. If the workflow path is set to "-", the JSON will be read from stdin. This allows users to pipe the workflow JSON directly into the command, providing more flexibility in how the workflow is provided.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
