### PR TITLE
ci: migrate GCR to GAR

### DIFF
--- a/.github/actions/build_deploy_api/action.yml
+++ b/.github/actions/build_deploy_api/action.yml
@@ -132,7 +132,7 @@ jobs:
         if: ${{ github.event.inputs.name == 'nightly' }}
         env:
           IMAGE: reearth/reearth-flow-api:nightly
-          IMAGE_GCP: us.gcr.io/reearth-oss/reearth-flow-api:nightly
+          IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-api:nightly
           GCP_REGION: us-central1
           CLOUD_RUN_SERVICE: reearth-flow-api
         steps:
@@ -142,7 +142,7 @@ jobs:
           - name: Set up Cloud SDK
             uses: google-github-actions/setup-gcloud@v0
           - name: Configure docker
-            run: gcloud auth configure-docker --quiet
+            run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
           - name: docker push
             run: |
               docker pull $IMAGE

--- a/.github/actions/build_deploy_ui/action.yml
+++ b/.github/actions/build_deploy_ui/action.yml
@@ -167,7 +167,7 @@ jobs:
         if: ${{ github.event.inputs.name == 'nightly' }}
         env:
           IMAGE: reearth/reearth-flow-ui:nightly
-          IMAGE_GCP: us.gcr.io/reearth-oss/reearth-flow-ui:nightly
+          IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-ui:nightly
           GCP_REGION: us-central1
           CLOUD_RUN_SERVICE: reearth-flow-ui
         steps:
@@ -177,7 +177,7 @@ jobs:
           - name: Set up Cloud SDK
             uses: google-github-actions/setup-gcloud@v0
           - name: Configure docker
-            run: gcloud auth configure-docker --quiet
+            run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
           - name: docker push
             run: |
               docker pull $IMAGE


### PR DESCRIPTION
# Overview

Because the GCR (Google Container Registry) will be decommissioned.

* [Transition from Container Registry, Google Cloud](https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr) 

> Container Registry is deprecated and scheduled for shutdown. After May 15, 2024, Artifact Registry will host images for the gcr.io domain in Google Cloud projects without previous Container Registry usage

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo

Re:Earth Visualizer version: https://github.com/reearth/reearth-visualizer/pull/1018
