### PR TITLE
feat: Add environment variable for cityGmlPath in worker README

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -35,12 +35,42 @@ C:\> vcpkg install libxml2:x64-windows
 C:\> vcpkg integrate install
 ```
 
-## Usage
-
-### Set up the environment variables
-```console
-export FLOW_VARS_cityGmlPath="file:///root/53395658_bldg_6697_op.gml"
+## Input Variables
+### Declaring an Input Variable
+``` yaml
+id: a7fc8f35-b84f-496b-a2cb-65be3bfec285
+name: "lod_splitter_with_dm"
+entryGraphId: 3e3450c8-2344-4728-afa9-5fdb81eec33a
+with:
+  cityGmlPath:
+  cityCode:
+  codelistsPath:
+  schemasPath:
+  schemaJson: !include ../config/schema.txt
+  targetPackages:
+    - bldg
+  addNsprefixToFeatureTypes: true
+  extractDmGeometryAsXmlFragment: false
 ```
+
+### Variables on the Command Line
+* To specify individual variables on the command line, use the -var option when running the
+
+``` console
+$ cargo run -- run --var="cityGmlPath=file:///root/53395658_bldg_6697_op.gml"
+$ cargo run -- run --var='cityGmlPath_list=["file:///root/53395658_bldg_6697_op.gml","file:///root/53395658_bldg_6698_op.gml"]' --var="addNsprefixToFeatureTypes=false"
+$ cargo run -- run --var='cityGmlPath_map={"path01":"file:///root/53395658_bldg_6697_op.gml","path02":"file:///root/53395658_bldg_6698_op.gml"}'
+```
+
+### Environment Variables
+* As a fallback for the other ways of defining variables, Flow searches the environment of its own process for environment variables named FLOW_VAR_ followed by the name of a declared variable.
+
+```console
+export FLOW_VAR_cityGmlPath="file:///root/53395658_bldg_6697_op.gml"
+export FLOW_VAR_targetPackages='["bldg", "fld"]'
+```
+
+## Usage
 
 ### Run workflow
 ```console

--- a/worker/crates/cli/src/run.rs
+++ b/worker/crates/cli/src/run.rs
@@ -59,8 +59,8 @@ fn action_log_cli_arg() -> Arg {
 }
 
 fn vars_arg() -> Arg {
-    Arg::new("values")
-        .long("value")
+    Arg::new("var")
+        .long("var")
         .help("Workflow variables")
         .required(false)
         .action(ArgAction::Append)
@@ -73,7 +73,7 @@ pub struct RunCliCommand {
     job_id: Option<String>,
     dataframe_state_uri: Option<String>,
     action_log_uri: Option<String>,
-    values: HashMap<String, String>,
+    vars: HashMap<String, String>,
 }
 
 impl RunCliCommand {
@@ -84,10 +84,9 @@ impl RunCliCommand {
         let job_id = matches.remove_one::<String>("job_id");
         let dataframe_state_uri = matches.remove_one::<String>("dataframe_state");
         let action_log_uri = matches.remove_one::<String>("action_log");
-        let values = matches.remove_many::<String>("values");
-        let values = if let Some(values) = values {
-            values
-                .into_iter()
+        let vars = matches.remove_many::<String>("var");
+        let vars = if let Some(vars) = vars {
+            vars.into_iter()
                 .flat_map(|v| {
                     let parts: Vec<&str> = v.splitn(2, '=').collect();
                     if parts.len() == 2 {
@@ -105,7 +104,7 @@ impl RunCliCommand {
             job_id,
             dataframe_state_uri,
             action_log_uri,
-            values,
+            vars,
         })
     }
 
@@ -125,7 +124,7 @@ impl RunCliCommand {
             String::from_utf8(bytes.to_vec()).map_err(crate::Error::init)?
         };
         let mut workflow = Workflow::try_from_str(&json);
-        workflow.merge_with(self.values.clone());
+        workflow.merge_with(self.vars.clone());
         let job_id = match &self.job_id {
             Some(job_id) => uuid::Uuid::from_str(job_id.as_str()).map_err(crate::Error::init)?,
             None => uuid::Uuid::new_v4(),

--- a/worker/crates/common/src/serde.rs
+++ b/worker/crates/common/src/serde.rs
@@ -2,7 +2,7 @@ use serde;
 use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
 
-enum SerdeFormat {
+pub enum SerdeFormat {
     Json,
     Yaml,
     Unknown,
@@ -24,7 +24,7 @@ where
     }
 }
 
-fn determine_format(input: &str) -> SerdeFormat {
+pub fn determine_format(input: &str) -> SerdeFormat {
     if serde_json::from_str::<JsonValue>(input).is_ok() {
         SerdeFormat::Json
     } else if serde_yaml::from_str::<YamlValue>(input).is_ok() {

--- a/worker/examples/Cargo.toml
+++ b/worker/examples/Cargo.toml
@@ -43,3 +43,7 @@ path = "plateau/xml_validator.rs"
 [[example]]
 name = "domain_of_definition_validator"
 path = "plateau/domain_of_definition_validator.rs"
+
+[[example]]
+name = "lod_splitter_with_dm"
+path = "plateau/lod_splitter_with_dm.rs"

--- a/worker/examples/plateau/attribute_reader.rs
+++ b/worker/examples/plateau/attribute_reader.rs
@@ -1,5 +1,5 @@
 mod helper;
 
 fn main() {
-    helper::execute("lod_splitter_with_dm.yml");
+    helper::execute("attribute_reader.yml");
 }

--- a/worker/examples/plateau/lod_splitter_with_dm.rs
+++ b/worker/examples/plateau/lod_splitter_with_dm.rs
@@ -1,0 +1,5 @@
+mod helper;
+
+fn main() {
+    helper::execute("lod_splitter_with_dm.yml");
+}


### PR DESCRIPTION
# Overview
The commit adds instructions for setting up the environment variable
`FLOW_VAR_cityGmlPath` in the worker README file. This variable is used
to specify the path to the cityGml file.


## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
