### PR TITLE
feat(worker): Add schema-action and schema-workflow commands to CLI

### DIFF
--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Workflow",
+  "type": "object",
+  "required": [
+    "entryGraphId",
+    "graphs",
+    "id",
+    "name"
+  ],
+  "properties": {
+    "entryGraphId": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "graphs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Graph"
+      }
+    },
+    "id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "name": {
+      "type": "string"
+    },
+    "with": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
+    }
+  },
+  "definitions": {
+    "Edge": {
+      "type": "object",
+      "required": [
+        "from",
+        "fromPort",
+        "id",
+        "to",
+        "toPort"
+      ],
+      "properties": {
+        "from": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "fromPort": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "to": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "toPort": {
+          "type": "string"
+        }
+      }
+    },
+    "Graph": {
+      "type": "object",
+      "required": [
+        "edges",
+        "id",
+        "name",
+        "nodes"
+      ],
+      "properties": {
+        "edges": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Edge"
+          }
+        },
+        "id": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "name": {
+          "type": "string"
+        },
+        "nodes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Node"
+          }
+        }
+      }
+    },
+    "Node": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "action",
+            "id",
+            "name",
+            "type"
+          ],
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "action"
+              ]
+            },
+            "with": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "id",
+            "name",
+            "subGraphId",
+            "type"
+          ],
+          "properties": {
+            "id": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "name": {
+              "type": "string"
+            },
+            "subGraphId": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "subGraph"
+              ]
+            },
+            "with": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/worker/Cargo.lock
+++ b/worker/Cargo.lock
@@ -3361,6 +3361,7 @@ dependencies = [
  "schemars_derive",
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -97,7 +97,7 @@ rhai = {version = "1.18.0", features = ["internals", "sync", "serde"]}
 robust = "1.1.0"
 rstest = "0.21.0"
 rust_xlsxwriter = "0.64.2"
-schemars = "0.8.21"
+schemars = {version = "0.8.21", features = ["uuid1"]}
 serde = {version = "1.0.203", features = ["derive"]}
 serde_derive = "1.0.203"
 serde_json = {version = "1.0.117", features = ["arbitrary_precision"]}

--- a/worker/Makefile.toml
+++ b/worker/Makefile.toml
@@ -56,5 +56,12 @@ git ls-files |grep -E '.rs$' |(! xargs grep 'todo!')
 script = ['''
 #!/usr/bin/env bash -eux
 rm -rf ../schema/actions.json
-cargo run -- schema > ../schema/actions.json
+cargo run -- schema-action > ../schema/actions.json
+''']
+
+[tasks.doc-workflow]
+script = ['''
+#!/usr/bin/env bash -eux
+rm -rf ../schema/workflow.json
+cargo run -- schema-workflow > ../schema/workflow.json
 ''']

--- a/worker/crates/cli/src/cli.rs
+++ b/worker/crates/cli/src/cli.rs
@@ -5,13 +5,15 @@ use tracing::Level;
 
 use crate::dot::{build_dot_command, DotCliCommand};
 use crate::run::{build_run_command, RunCliCommand};
-use crate::schema::{build_schema_command, SchemaCliCommand};
+use crate::schema_action::{build_schema_action_command, SchemaActionCliCommand};
+use crate::schema_workflow::{build_schema_workflow_command, SchemaWorkflowCliCommand};
 
 pub fn build_cli() -> Command {
     Command::new("Re:Earth Flow")
         .subcommand(build_run_command().display_order(1))
         .subcommand(build_dot_command().display_order(2))
-        .subcommand(build_schema_command().display_order(3))
+        .subcommand(build_schema_action_command().display_order(3))
+        .subcommand(build_schema_workflow_command().display_order(4))
         .arg_required_else_help(true)
         .disable_help_subcommand(true)
         .subcommand_required(true)
@@ -21,7 +23,8 @@ pub fn build_cli() -> Command {
 pub enum CliCommand {
     Run(RunCliCommand),
     Dot(DotCliCommand),
-    Schema(SchemaCliCommand),
+    SchemaAction(SchemaActionCliCommand),
+    SchemaWorkflow(SchemaWorkflowCliCommand),
 }
 
 impl CliCommand {
@@ -32,7 +35,8 @@ impl CliCommand {
         env_level.unwrap_or(match self {
             CliCommand::Run(_) => Level::INFO,
             CliCommand::Dot(_) => Level::WARN,
-            CliCommand::Schema(_) => Level::WARN,
+            CliCommand::SchemaAction(_) => Level::WARN,
+            CliCommand::SchemaWorkflow(_) => Level::WARN,
         })
     }
 
@@ -43,7 +47,8 @@ impl CliCommand {
         match subcommand.as_str() {
             "run" => RunCliCommand::parse_cli_args(submatches).map(CliCommand::Run),
             "dot" => DotCliCommand::parse_cli_args(submatches).map(CliCommand::Dot),
-            "schema" => Ok(CliCommand::Schema(SchemaCliCommand)),
+            "schema-action" => Ok(CliCommand::SchemaAction(SchemaActionCliCommand)),
+            "schema-workflow" => Ok(CliCommand::SchemaWorkflow(SchemaWorkflowCliCommand)),
             _ => Err(crate::Error::unknown_command(subcommand)),
         }
     }
@@ -52,7 +57,8 @@ impl CliCommand {
         match self {
             CliCommand::Run(subcommand) => subcommand.execute(),
             CliCommand::Dot(subcommand) => subcommand.execute(),
-            CliCommand::Schema(subcommand) => subcommand.execute(),
+            CliCommand::SchemaAction(subcommand) => subcommand.execute(),
+            CliCommand::SchemaWorkflow(subcommand) => subcommand.execute(),
         }
     }
 }

--- a/worker/crates/cli/src/lib.rs
+++ b/worker/crates/cli/src/lib.rs
@@ -2,7 +2,8 @@ pub mod cli;
 pub mod dot;
 pub mod logger;
 pub mod run;
-pub mod schema;
+pub mod schema_action;
+pub mod schema_workflow;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/worker/crates/cli/src/schema_action.rs
+++ b/worker/crates/cli/src/schema_action.rs
@@ -47,16 +47,16 @@ impl ActionSchema {
     }
 }
 
-pub fn build_schema_command() -> Command {
-    Command::new("schema")
-        .about("Show schema.")
-        .long_about("Show schema.")
+pub fn build_schema_action_command() -> Command {
+    Command::new("schema-action")
+        .about("Show action schema.")
+        .long_about("Show action schema.")
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct SchemaCliCommand;
+pub struct SchemaActionCliCommand;
 
-impl SchemaCliCommand {
+impl SchemaActionCliCommand {
     pub fn execute(&self) -> crate::Result<()> {
         let mut actions = ACTION_MAPPINGS
             .clone()

--- a/worker/crates/cli/src/schema_workflow.rs
+++ b/worker/crates/cli/src/schema_workflow.rs
@@ -1,0 +1,20 @@
+use clap::Command;
+use reearth_flow_types::Workflow;
+use schemars::schema_for;
+
+pub fn build_schema_workflow_command() -> Command {
+    Command::new("schema-workflow")
+        .about("Show workflow schema.")
+        .long_about("Show workflow schema.")
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct SchemaWorkflowCliCommand;
+
+impl SchemaWorkflowCliCommand {
+    pub fn execute(&self) -> crate::Result<()> {
+        let schema = schema_for!(Workflow);
+        println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+        Ok(())
+    }
+}

--- a/worker/crates/geometry/src/validation.rs
+++ b/worker/crates/geometry/src/validation.rs
@@ -266,6 +266,8 @@ impl Display for ValidationProblemReport {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ValidationType {
     DuplicatePoints,
+    CorruptGeometry,
+    SelfIntersection,
 }
 
 pub trait Validator<
@@ -281,16 +283,14 @@ impl<
         Z: GeoNum + approx::AbsDiffEq<Epsilon = f64>,
     > Validator<T, Z> for Coordinate<T, Z>
 {
-    fn validate(&self, valid_type: ValidationType) -> Option<ValidationProblemReport> {
+    fn validate(&self, _valid_type: ValidationType) -> Option<ValidationProblemReport> {
         if utils::check_coord_is_not_finite(self) {
             return Some(ValidationProblemReport(vec![ValidationProblemAtPosition(
                 ValidationProblem::NotFinite,
                 ValidationProblemPosition::Point,
             )]));
         }
-        match valid_type {
-            ValidationType::DuplicatePoints => None,
-        }
+        None
     }
 }
 
@@ -300,9 +300,7 @@ impl<
     > Validator<T, Z> for Point<T, Z>
 {
     fn validate(&self, valid_type: ValidationType) -> Option<ValidationProblemReport> {
-        match valid_type {
-            ValidationType::DuplicatePoints => self.0.validate(valid_type),
-        }
+        self.0.validate(valid_type)
     }
 }
 
@@ -335,6 +333,7 @@ impl<
                     }
                 }
             }
+            _ => unimplemented!(),
         }
         if reason.is_empty() {
             None
@@ -379,6 +378,7 @@ where
                     ));
                 }
             }
+            _ => unimplemented!(),
         }
         if reason.is_empty() {
             None
@@ -415,6 +415,7 @@ impl<
                     }
                 }
             }
+            _ => unimplemented!(),
         }
         if reason.is_empty() {
             None
@@ -447,6 +448,7 @@ impl<
                     }
                 }
             }
+            _ => unimplemented!(),
         }
         if reason.is_empty() {
             None
@@ -479,6 +481,7 @@ impl<
                     }
                 }
             }
+            _ => unimplemented!(),
         }
         if reason.is_empty() {
             None
@@ -512,6 +515,7 @@ impl<
                     }
                 }
             }
+            _ => unimplemented!(),
         }
         if reason.is_empty() {
             None
@@ -548,6 +552,7 @@ impl<
                     }
                 }
             }
+            _ => unimplemented!(),
         }
         if reason.is_empty() {
             None
@@ -577,6 +582,7 @@ impl<
                     }
                 }
             }
+            _ => unimplemented!(),
         }
         if reason.is_empty() {
             None
@@ -608,6 +614,7 @@ impl<
                     }
                 }
             }
+            _ => unimplemented!(),
         }
         if reason.is_empty() {
             None

--- a/worker/crates/types/src/workflow.rs
+++ b/worker/crates/types/src/workflow.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, env};
 
 use reearth_flow_common::serde::SerdeFormat;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use uuid::Uuid;
@@ -15,7 +16,7 @@ pub type Parameter = Map<String, Value>;
 
 static ENVIRONMENT_PREFIX: &str = "FLOW_VAR_";
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Workflow {
     pub id: Id,
@@ -98,14 +99,14 @@ impl Workflow {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 pub struct NodeEntity {
     pub id: Id,
     pub name: String,
     pub with: Option<NodeProperty>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(tag = "type")]
 pub enum Node {
     #[serde(rename = "action")]
@@ -165,7 +166,7 @@ impl Node {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Edge {
     pub id: Id,
@@ -175,7 +176,7 @@ pub struct Edge {
     pub to_port: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub struct Graph {
     pub id: Id,
     pub name: String,


### PR DESCRIPTION
# Overview
This commit adds the `schema-action` and `schema-workflow` commands to
the CLI in the `worker` crate. These commands allow users to view the
action and workflow schemas respectively. The `schema-action` command
shows the schema for actions, while the `schema-workflow` command shows
the schema for workflows.

The changes include:
- Adding `schema_action.rs` and `schema_workflow.rs` modules to the
  `cli` crate
- Renaming the `schema.rs` module to `schema_action.rs`
- Implementing the `SchemaActionCliCommand` struct and the
  `build_schema_action_command` function
- Implementing the `SchemaWorkflowCliCommand` struct and the
  `build_schema_workflow_command` function
- Updating the `Makefile.toml` file to include the new commands in the
  `doc` workflow task

These changes improve the usability of the CLI by providing easy access
to the schemas for actions and workflows.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
