### PR TITLE
ci: use workflow_call instead of workflow_dispatch

### DIFF
--- a/.github/actions/build_deploy_api/action.yml
+++ b/.github/actions/build_deploy_api/action.yml
@@ -1,4 +1,4 @@
-Copyname: build-api
+name: build-api
 on:
   workflow_call:
     inputs:

--- a/.github/actions/build_deploy_api/action.yml
+++ b/.github/actions/build_deploy_api/action.yml
@@ -1,26 +1,28 @@
-name: build-api
-description: Builds the Backend API and Its Docker Image
-inputs:
-  sha_short:
-    description: 'sha_short'
-    required: true
-  new_tag:
-    description: 'new_tag'
-    required: true
-  new_tag_short:
-    description: 'new_tag_short'
-    required: true
-  name:
-    description: 'name'
-    required: true
-  sha:
-    description: "sha"
-    required: true
+Copyname: build-api
+on:
+  workflow_call:
+    inputs:
+      sha_short:
+        required: true
+        type: string
+      new_tag:
+        required: true
+        type: string
+      new_tag_short:
+        required: true
+        type: string
+      name:
+        required: true
+        type: string
+      sha:
+        required: true
+        type: string
+
 jobs:
   build-api:
     name: Build and release api
     runs-on: ubuntu-latest
-    if: github.event.inputs.name || github.event.inputs.new_tag
+    if: inputs.name != 'blank' || inputs.new_tag != 'blank'
     env:
       ARTIFACTS: api/dist/reearth_*.*
     steps:
@@ -37,41 +39,41 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist ${{ github.event.inputs.new_tag == 'blank' && '--snapshot' || '' }}
+          args: release --rm-dist ${{ inputs.new_tag == 'blank' && '--snapshot' || '' }}
           workdir: api
         env:
-          GORELEASER_CURRENT_TAG: ${{ github.event.inputs.new_tag == 'blank' && '0.0.0' || github.event.inputs.new_tag }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.new_tag == 'blank' && '0.0.0' || inputs.new_tag }}
       - name: Rename artifacts
-        if: ${{ github.event.inputs.name != 'blank' }}
-        run: for f in $ARTIFACTS; do mv $f $(echo $f | sed -E 's/_0\.0\.0-SNAPSHOT-[^_]*/_${{ github.event.inputs.name }}/'); done
+        if: ${{ inputs.name != 'blank' }}
+        run: for f in $ARTIFACTS; do mv $f $(echo $f | sed -E 's/_0\.0\.0-SNAPSHOT-[^_]*/_${{ inputs.name }}/'); done
       - name: List artifacts
         run: ls -l api/dist
       - name: Release nightly/rc
-        if: ${{ github.event.inputs.name != 'blank' }}
+        if: ${{ inputs.name != 'blank' }}
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
           artifacts: ${{ env.ARTIFACTS }}
-          commit: ${{ github.event.inputs.sha }}
-          name: ${{ github.event.inputs.name }}
-          tag: ${{ github.event.inputs.name }}
-          body: ${{ github.event.inputs.sha_short }}
+          commit: ${{ inputs.sha }}
+          name: ${{ inputs.name }}
+          tag: ${{ inputs.name }}
+          body: ${{ inputs.sha_short }}
           prerelease: true
       - name: Create GitHub release
-        if: ${{ github.event.inputs.new_tag != 'blank' }}
+        if: ${{ inputs.new_tag != 'blank' }}
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
           artifacts: ${{ env.ARTIFACTS }}
-          commit: ${{ github.event.inputs.sha }}
-          name: ${{ github.event.inputs.new_tag }}
-          tag: ${{ github.event.inputs.new_tag}}
+          commit: ${{ inputs.sha }}
+          name: ${{ inputs.new_tag }}
+          tag: ${{ inputs.new_tag}}
           bodyFile: CHANGELOG_latest.md
 
   build-docker-image:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.name != 'blank' || github.event.inputs.new_tag != 'blank' }}
+    if: ${{ inputs.name != 'blank' || inputs.new_tag != 'blank' }}
     env:
       IMAGE_NAME: reearth/reearth-flow-api
     defaults:
@@ -97,9 +99,9 @@ jobs:
       - name: Get options
         id: options
         env:
-          TAG: ${{ github.event.inputs.new_tag_short && github.event.inputs.new_tag_short != 'blank' && github.event.inputs.new_tag_short || '' }}
-          NAME: ${{ github.event.inputs.name }}
-          SHA: ${{ github.event.inputs.sha_short }}
+          TAG: ${{ inputs.new_tag_short && inputs.new_tag_short != 'blank' && inputs.new_tag_short || '' }}
+          NAME: ${{ inputs.name }}
+          SHA: ${{ inputs.sha_short }}
         run: |
           if [[ -n $TAG ]]; then
             PLATFORMS=linux/amd64,linux/arm64
@@ -129,7 +131,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Deploy to nightly
-        if: ${{ github.event.inputs.name == 'nightly' }}
+        if: ${{ inputs.name == 'nightly' }}
         env:
           IMAGE: reearth/reearth-flow-api:nightly
           IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-api:nightly

--- a/.github/actions/build_deploy_ui/action.yml
+++ b/.github/actions/build_deploy_ui/action.yml
@@ -1,21 +1,22 @@
 name: build-ui
-description: Builds the UI Editor and Its Docker Image
-inputs:
-  sha_short:
-    description: 'sha_short'
-    required: true
-  new_tag:
-    description: 'new_tag'
-    required: true
-  new_tag_short:
-    description: 'new_tag_short'
-    required: true
-  name:
-    description: 'name'
-    required: true
-  sha:
-    description: "sha"
-    required: true
+on:
+  workflow_call:
+    inputs:
+      sha_short:
+        required: true
+        type: string
+      new_tag:
+        required: true
+        type: string
+      new_tag_short:
+        required: true
+        type: string
+      name:
+        required: true
+        type: string
+      sha:
+        required: true
+        type: string
 
 jobs:
   build-ui:
@@ -24,7 +25,7 @@ jobs:
     defaults:
       run:
         working-directory: ui
-    if: github.event.inputs.name
+    if: inputs.name != 'blank'
     env:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
@@ -59,9 +60,9 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [build-ui]
-    if: ${{ github.event.inputs.name != 'blank' || github.event.inputs.new_tag != 'blank' }}
+    if: ${{ inputs.name != 'blank' || inputs.new_tag != 'blank' }}
     env:
-      ARTIFACT: flow-ui_${{ github.event.inputs.name && github.event.inputs.name != 'blank' && github.event.inputs.name || github.event.inputs.new_tag }}.tar.gz
+      ARTIFACT: flow-ui_${{ inputs.name && inputs.name != 'blank' && inputs.name || inputs.new_tag }}.tar.gz
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -74,34 +75,34 @@ jobs:
           allowUpdates: true
           artifacts: ${{ env.ARTIFACT }}
           artifactContentType: application/gzip
-          commit: ${{ github.event.inputs.sha }}
-          name: ${{ github.event.inputs.name && github.event.inputs.name != 'blank' && github.event.inputs.name || github.event.inputs.new_tag }}
-          tag: ${{ github.event.inputs.name && github.event.inputs.name != 'blank' && github.event.inputs.name || github.event.inputs.new_tag }}
-          body: ${{ github.event.inputs.sha }}
-          prerelease: ${{ github.event.inputs.name && github.event.inputs.name != 'blank' }}
+          commit: ${{ inputs.sha }}
+          name: ${{ inputs.name && inputs.name != 'blank' && inputs.name || inputs.new_tag }}
+          tag: ${{ inputs.name && inputs.name != 'blank' && inputs.name || inputs.new_tag }}
+          body: ${{ inputs.sha }}
+          prerelease: ${{ inputs.name && inputs.name != 'blank' }}
       - name: Download latest changelog
-        if: ${{ github.event.inputs.new_tag != 'blank' }}
+        if: ${{ inputs.new_tag != 'blank' }}
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: release.yml
-          name: changelog-${{ github.event.inputs.new_tag }}
+          name: changelog-${{ inputs.new_tag }}
       - name: Update GitHub release
-        if: ${{ github.event.inputs.new_tag != 'blank' }}
+        if: ${{ inputs.new_tag != 'blank' }}
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
           artifacts: ${{ env.ARTIFACT }}
           artifactContentType: application/gzip
-          commit: ${{ github.event.inputs.sha }}
-          name: ${{ github.event.inputs.new_tag }}
-          tag: ${{ github.event.inputs.new_tag }}
+          commit: ${{ inputs.sha }}
+          name: ${{ inputs.new_tag }}
+          tag: ${{ inputs.new_tag }}
           bodyFile: CHANGELOG_latest.md
 
   build-docker-image:
     name: Build and push Docker image
     runs-on: ubuntu-latest
     needs: [release]
-    if: ${{ github.event.inputs.name != 'blank' || github.event.inputs.new_tag != 'blank' }}
+    if: ${{ inputs.name != 'blank' || inputs.new_tag != 'blank' }}
     env:
       IMAGE_NAME: reearth/reearth-flow-ui
     defaults:
@@ -122,9 +123,9 @@ jobs:
       - name: Get options
         id: options
         env:
-          TAG: ${{ github.event.inputs.new_tag_short && github.event.inputs.new_tag_short != 'blank' && github.event.inputs.new_tag_short || '' }}
-          NAME: ${{ github.event.inputs.name }}
-          SHA: ${{ github.event.inputs.sha_short }}
+          TAG: ${{ inputs.new_tag_short && inputs.new_tag_short != 'blank' && inputs.new_tag_short || '' }}
+          NAME: ${{ inputs.name }}
+          SHA: ${{ inputs.sha_short }}
         run: |
           if [[ -n $TAG ]]; then
             PLATFORMS=linux/amd64,linux/arm64
@@ -147,8 +148,8 @@ jobs:
         uses: dsaltares/fetch-gh-release-asset@master
         with:
           repo: reearth/reearth-flow
-          version: tags/${{ github.event.inputs.name && github.event.inputs.name != 'blank' && github.event.inputs.name || github.event.inputs.new_tag }}
-          file: flow-ui_${{ github.event.inputs.name && github.event.inputs.name != 'blank' && github.event.inputs.name || github.event.inputs.new_tag }}.tar.gz
+          version: tags/${{ inputs.name && inputs.name != 'blank' && inputs.name || inputs.new_tag }}
+          file: flow-ui_${{ inputs.name && inputs.name != 'blank' && inputs.name || inputs.new_tag }}.tar.gz
           token: ${{ secrets.GITHUB_TOKEN }}
           target: server/flow-ui.tar.gz
       - name: Extract reearth-flow/ui
@@ -164,7 +165,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Deploy to nightly
-        if: ${{ github.event.inputs.name == 'nightly' }}
+        if: ${{ inputs.name == 'nightly' }}
         env:
           IMAGE: reearth/reearth-flow-ui:nightly
           IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-ui:nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       ui: ${{ steps.ui.outputs.any_changed }}
       api: ${{ steps.api.outputs.any_changed }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: changed files for ui
@@ -64,7 +64,7 @@ jobs:
       name: ${{ steps.info.outputs.name || 'blank' }}
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Fetch tags
         run: git fetch --prune --unshallow --tags
       - name: Get info


### PR DESCRIPTION
# Why
This PR attempts to fix an issue observed during deployment nightly version of `api` and `ui`.

# How
The problem was that the build workflows were designed to be run as standalone workflows triggered by `workflow_dispatch` events, not as reusable workflows called from another workflow.

To fix this and make these workflows work as reusable workflows, you'll need to make some modifications:
* For both workflows, change the trigger from workflow_dispatch to workflow_call and define the inputs.
* Replace all instances of github.event.inputs with just inputs.
* Modify the if conditions to use the passed inputs instead of relying on github context.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Standardized input handling and conditionals in build and deploy workflows for both API and UI components. This improves consistency and reliability of the deployment process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->