### PR TITLE
feat(worker): add HoleExtractor module to geometry

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -999,6 +999,24 @@
       ]
     },
     {
+      "name": "HoleExtractor",
+      "type": "processor",
+      "description": "Extracts holes in a geometry and adds it as an attribute.",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "outershell",
+        "hole",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "OrientationExtractor",
       "type": "processor",
       "description": "Extracts the orientation of a geometry from a feature and adds it as an attribute.",

--- a/worker/crates/action-processor/src/geometry.rs
+++ b/worker/crates/action-processor/src/geometry.rs
@@ -4,6 +4,7 @@ pub mod extractor;
 pub mod extruder;
 pub mod filter;
 pub mod hole_counter;
+pub mod hole_extractor;
 pub mod mapping;
 pub mod orientation_extractor;
 pub mod planarity_filter;

--- a/worker/crates/action-processor/src/geometry/hole_extractor.rs
+++ b/worker/crates/action-processor/src/geometry/hole_extractor.rs
@@ -1,0 +1,193 @@
+use std::{collections::HashMap, vec};
+
+use once_cell::sync::Lazy;
+use reearth_flow_geometry::types::{
+    geometry::{Geometry2D, Geometry3D},
+    polygon::{Polygon2D, Polygon3D},
+};
+use reearth_flow_runtime::{
+    channels::ProcessorChannelForwarder,
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT, REJECTED_PORT},
+};
+use reearth_flow_types::{Feature, GeometryValue};
+use serde_json::Value;
+
+pub static OUTERSHELL_PORT: Lazy<Port> = Lazy::new(|| Port::new("outershell"));
+pub static HOLE_PORT: Lazy<Port> = Lazy::new(|| Port::new("hole"));
+
+#[derive(Debug, Clone, Default)]
+pub struct HoleExtractorFactory;
+
+impl ProcessorFactory for HoleExtractorFactory {
+    fn name(&self) -> &str {
+        "HoleExtractor"
+    }
+
+    fn description(&self) -> &str {
+        "Extracts holes in a geometry and adds it as an attribute."
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        None
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["Geometry"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![
+            OUTERSHELL_PORT.clone(),
+            HOLE_PORT.clone(),
+            REJECTED_PORT.clone(),
+        ]
+    }
+    fn build(
+        &self,
+        _ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        _with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        Ok(Box::new(HoleExtractor))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HoleExtractor;
+
+impl Processor for HoleExtractor {
+    fn initialize(&mut self, _ctx: NodeContext) {}
+
+    fn num_threads(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let feature = &ctx.feature;
+        let Some(geometry) = &feature.geometry else {
+            fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            return Ok(());
+        };
+        match &geometry.value {
+            GeometryValue::Null => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()))
+            }
+            GeometryValue::FlowGeometry2D(geometry) => match geometry {
+                Geometry2D::Polygon(polygon) => {
+                    handle_polygon2d(polygon, feature, &ctx, fw);
+                }
+                Geometry2D::MultiPolygon(mpolygon) => {
+                    for polygon in mpolygon.iter() {
+                        handle_polygon2d(polygon, feature, &ctx, fw);
+                    }
+                }
+                _ => {
+                    fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+                }
+            },
+            GeometryValue::FlowGeometry3D(geometry) => match geometry {
+                Geometry3D::Polygon(polygon) => {
+                    handle_polygon3d(polygon, feature, &ctx, fw);
+                }
+                Geometry3D::MultiPolygon(mpolygon) => {
+                    for polygon in mpolygon.iter() {
+                        handle_polygon3d(polygon, feature, &ctx, fw);
+                    }
+                }
+                _ => {
+                    fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+                }
+            },
+            GeometryValue::CityGmlGeometry(geometry) => {
+                for geo_feature in geometry.features.iter() {
+                    for polygon in &geo_feature.polygons {
+                        handle_polygon3d(polygon, feature, &ctx, fw);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(
+        &self,
+        _ctx: NodeContext,
+        _fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "HoleExtractor"
+    }
+}
+
+fn handle_polygon2d(
+    polygon: &Polygon2D<f64>,
+    feature: &Feature,
+    ctx: &ExecutorContext,
+    fw: &mut dyn ProcessorChannelForwarder,
+) {
+    let exterior = polygon.exterior();
+    let exterior_polygon = Polygon2D::new(exterior.clone(), vec![]);
+    if let Some(ref geometry) = &feature.geometry {
+        let mut exterior_feature = feature.clone();
+        let mut exterior_geometry = geometry.clone();
+        exterior_geometry.value =
+            GeometryValue::FlowGeometry2D(Geometry2D::Polygon(exterior_polygon));
+        exterior_feature.geometry = Some(exterior_geometry);
+        fw.send(ctx.new_with_feature_and_port(exterior_feature, OUTERSHELL_PORT.clone()));
+    }
+    for interior in polygon.interiors().iter() {
+        let interior_polygon = Polygon2D::new(interior.clone(), vec![]);
+        if let Some(ref geometry) = &feature.geometry {
+            let mut interior_feature = feature.clone();
+            let mut interior_geometry = geometry.clone();
+            interior_geometry.value =
+                GeometryValue::FlowGeometry2D(Geometry2D::Polygon(interior_polygon));
+            interior_feature.geometry = Some(interior_geometry);
+            fw.send(ctx.new_with_feature_and_port(interior_feature, OUTERSHELL_PORT.clone()));
+        }
+    }
+}
+
+fn handle_polygon3d(
+    polygon: &Polygon3D<f64>,
+    feature: &Feature,
+    ctx: &ExecutorContext,
+    fw: &mut dyn ProcessorChannelForwarder,
+) {
+    let exterior = polygon.exterior();
+    let exterior_polygon = Polygon3D::new(exterior.clone(), vec![]);
+    if let Some(ref geometry) = &feature.geometry {
+        let mut exterior_feature = feature.clone();
+        let mut exterior_geometry = geometry.clone();
+        exterior_geometry.value =
+            GeometryValue::FlowGeometry3D(Geometry3D::Polygon(exterior_polygon));
+        exterior_feature.geometry = Some(exterior_geometry);
+        fw.send(ctx.new_with_feature_and_port(exterior_feature, OUTERSHELL_PORT.clone()));
+    }
+    for interior in polygon.interiors().iter() {
+        let interior_polygon = Polygon3D::new(interior.clone(), vec![]);
+        if let Some(ref geometry) = &feature.geometry {
+            let mut interior_feature = feature.clone();
+            let mut interior_geometry = geometry.clone();
+            interior_geometry.value =
+                GeometryValue::FlowGeometry3D(Geometry3D::Polygon(interior_polygon));
+            interior_feature.geometry = Some(interior_geometry);
+            fw.send(ctx.new_with_feature_and_port(interior_feature, OUTERSHELL_PORT.clone()));
+        }
+    }
+}

--- a/worker/crates/action-processor/src/geometry/mapping.rs
+++ b/worker/crates/action-processor/src/geometry/mapping.rs
@@ -6,8 +6,9 @@ use reearth_flow_runtime::node::{NodeKind, ProcessorFactory};
 use super::{
     coordinate_system_setter::CoordinateSystemSetterFactory, extractor::GeometryExtractorFactory,
     extruder::ExtruderFactory, filter::GeometryFilterFactory, hole_counter::HoleCounterFactory,
-    orientation_extractor::OrientationExtractorFactory, planarity_filter::PlanarityFilterFactory,
-    reprojector::ReprojectorFactory, splitter::GeometrySplitterFactory,
+    hole_extractor::HoleExtractorFactory, orientation_extractor::OrientationExtractorFactory,
+    planarity_filter::PlanarityFilterFactory, reprojector::ReprojectorFactory,
+    splitter::GeometrySplitterFactory,
     three_dimention_box_replacer::ThreeDimentionBoxReplacerFactory,
     two_dimention_forcer::TwoDimentionForcerFactory, validator::GeometryValidatorFactory,
 };
@@ -27,6 +28,7 @@ pub static ACTION_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
         Box::<GeometryValidatorFactory>::default(),
         Box::<HoleCounterFactory>::default(),
         Box::<PlanarityFilterFactory>::default(),
+        Box::<HoleExtractorFactory>::default(),
     ];
     factories
         .into_iter()


### PR DESCRIPTION
# Overview
This commit adds the HoleExtractor module to the geometry crate in the worker. The HoleExtractor module is responsible for extracting holes in a geometry and adding them as attributes. It introduces the HoleExtractor struct, which has input and output ports for the outer shell, holes, and rejected geometry. This module enhances the functionality of the geometry crate by providing a way to extract holes in a geometry.

## What I've done
- create HoleExtractor module 

## What I haven't done
- N/A

## How I tested
- unit test

## Screenshot
- N/A

## Which point I want you to review particularly
- N/A

## Memo
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the `HoleExtractor` processor to handle geometry processing by extracting holes from geometries and adding them as attributes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->