### PR TITLE
feat(worker): add LineOnLineOverlayer module to geometry crate

### DIFF
--- a/worker/crates/action-processor/src/geometry.rs
+++ b/worker/crates/action-processor/src/geometry.rs
@@ -6,6 +6,7 @@ pub mod extruder;
 pub mod filter;
 pub mod hole_counter;
 pub mod hole_extractor;
+pub mod line_on_line_overlayer;
 pub mod mapping;
 pub mod orientation_extractor;
 pub mod planarity_filter;

--- a/worker/crates/action-processor/src/geometry/coercer.rs
+++ b/worker/crates/action-processor/src/geometry/coercer.rs
@@ -99,7 +99,7 @@ impl Processor for GeometryCoercer {
     ) -> Result<(), BoxedError> {
         let feature = &ctx.feature;
         let Some(geometry) = &feature.geometry else {
-            fw.send(ctx.new_with_feature_and_port(feature.clone(), DEFAULT_PORT.clone()));
+            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), DEFAULT_PORT.clone()));
             return Ok(());
         };
         match &geometry.value {

--- a/worker/crates/action-processor/src/geometry/errors.rs
+++ b/worker/crates/action-processor/src/geometry/errors.rs
@@ -47,6 +47,10 @@ pub(super) enum GeometryProcessorError {
     GeometryCoercerFactory(String),
     #[error("GeometryCoercer error: {0}")]
     GeometryCoercer(String),
+    #[error("LineOnLineOverlayer Factory error: {0}")]
+    LineOnLineOverlayerFactory(String),
+    #[error("LineOnLineOverlayer error: {0}")]
+    LineOnLineOverlayer(String),
 }
 
 pub(super) type Result<T, E = GeometryProcessorError> = std::result::Result<T, E>;

--- a/worker/crates/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/worker/crates/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -180,9 +180,9 @@ impl LineOnLineOverlayer {
     ) {
         let mut overlap = 0;
         let mut points = Vec::<Point2D<f64>>::new();
-        for (i, &current) in lines.iter().enumerate() {
-            for &next in &lines[i + 1..] {
-                match line_intersection(current, next) {
+        for (i, current) in lines.iter().enumerate() {
+            for next in &lines[i + 1..] {
+                match line_intersection(*current, *next) {
                     Some(line_intersection::LineIntersection::SinglePoint {
                         intersection, ..
                     }) => {
@@ -255,9 +255,9 @@ impl LineOnLineOverlayer {
     ) {
         let mut overlap = 0;
         let mut points = Vec::<Point3D<f64>>::new();
-        for (i, &current) in lines.iter().enumerate() {
-            for &next in &lines[i + 1..] {
-                match line_intersection(current, next) {
+        for (i, current) in lines.iter().enumerate() {
+            for next in &lines[i + 1..] {
+                match line_intersection(*current, *next) {
                     Some(line_intersection::LineIntersection::SinglePoint {
                         intersection, ..
                     }) => {

--- a/worker/crates/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/worker/crates/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -1,0 +1,297 @@
+use std::collections::HashMap;
+
+use once_cell::sync::Lazy;
+use reearth_flow_geometry::algorithm::line_intersection::{self, line_intersection};
+use reearth_flow_geometry::types::geometry::Geometry2D;
+use reearth_flow_geometry::types::geometry::Geometry3D;
+use reearth_flow_geometry::types::line::{Line2D, Line3D};
+use reearth_flow_geometry::types::multi_point::{MultiPoint2D, MultiPoint3D};
+use reearth_flow_geometry::types::point::{Point2D, Point3D};
+use reearth_flow_runtime::node::REJECTED_PORT;
+use reearth_flow_runtime::{
+    channels::ProcessorChannelForwarder,
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
+};
+use reearth_flow_types::{Attribute, AttributeValue, Feature, Geometry, GeometryValue};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Number, Value};
+
+use super::errors::GeometryProcessorError;
+
+pub static POINT_PORT: Lazy<Port> = Lazy::new(|| Port::new("point"));
+pub static LINE_PORT: Lazy<Port> = Lazy::new(|| Port::new("line"));
+pub static COLLINEAR_PORT: Lazy<Port> = Lazy::new(|| Port::new("collinear"));
+
+#[derive(Debug, Clone, Default)]
+pub struct LineOnLineOverlayerFactory;
+
+impl ProcessorFactory for LineOnLineOverlayerFactory {
+    fn name(&self) -> &str {
+        "LineOnLineOverlayer"
+    }
+
+    fn description(&self) -> &str {
+        "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines."
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        Some(schemars::schema_for!(LineOnLineOverlayerParam))
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["Geometry"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![POINT_PORT.clone(), LINE_PORT.clone(), REJECTED_PORT.clone()]
+    }
+
+    fn build(
+        &self,
+        _ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        let params: LineOnLineOverlayerParam = if let Some(with) = with {
+            let value: Value = serde_json::to_value(with).map_err(|e| {
+                GeometryProcessorError::LineOnLineOverlayerFactory(format!(
+                    "Failed to serialize with: {}",
+                    e
+                ))
+            })?;
+            serde_json::from_value(value).map_err(|e| {
+                GeometryProcessorError::LineOnLineOverlayerFactory(format!(
+                    "Failed to deserialize with: {}",
+                    e
+                ))
+            })?
+        } else {
+            return Err(GeometryProcessorError::LineOnLineOverlayerFactory(
+                "Missing required parameter `with`".to_string(),
+            )
+            .into());
+        };
+        Ok(Box::new(LineOnLineOverlayer {
+            output_attribute: params.output_attribute,
+        }))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LineOnLineOverlayerParam {
+    output_attribute: Attribute,
+}
+
+#[derive(Debug, Clone)]
+pub struct LineOnLineOverlayer {
+    output_attribute: Attribute,
+}
+
+impl Processor for LineOnLineOverlayer {
+    fn initialize(&mut self, _ctx: NodeContext) {}
+
+    fn num_threads(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let feature = &ctx.feature;
+        let Some(geometry) = &feature.geometry else {
+            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
+            return Ok(());
+        };
+        match &geometry.value {
+            GeometryValue::Null => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+            GeometryValue::FlowGeometry2D(geos) => {
+                self.handle_2d_geometry(geos, feature, geometry, &ctx, fw);
+            }
+            GeometryValue::FlowGeometry3D(geos) => {
+                self.handle_3d_geometry(geos, feature, geometry, &ctx, fw);
+            }
+            GeometryValue::CityGmlGeometry(_) => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(
+        &self,
+        _ctx: NodeContext,
+        _fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "LineOnLineOverlayer"
+    }
+}
+
+impl LineOnLineOverlayer {
+    fn handle_2d_geometry(
+        &self,
+        geos: &Geometry2D,
+        feature: &Feature,
+        geometry: &Geometry,
+        ctx: &ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) {
+        match geos {
+            Geometry2D::MultiLineString(line_strings) => {
+                let mut lines = Vec::new();
+                for line_string in line_strings.iter() {
+                    lines.extend(line_string.lines());
+                }
+                self.handle_2d_lines(feature, geometry, lines, ctx, fw);
+            }
+            Geometry2D::LineString(line_string) => {
+                let lines = line_string.lines();
+                self.handle_2d_lines(feature, geometry, lines.into_iter().collect(), ctx, fw);
+            }
+            _ => unimplemented!(),
+        }
+        fw.send(ctx.new_with_feature_and_port(feature.clone(), DEFAULT_PORT.clone()));
+    }
+
+    fn handle_2d_lines(
+        &self,
+        feature: &Feature,
+        geometry: &Geometry,
+        lines: Vec<Line2D<f64>>,
+        ctx: &ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) {
+        let mut overlap = 0;
+        let mut points = Vec::<Point2D<f64>>::new();
+        for (i, &current) in lines.iter().enumerate() {
+            for &next in &lines[i + 1..] {
+                match line_intersection(current, next) {
+                    Some(line_intersection::LineIntersection::SinglePoint {
+                        intersection, ..
+                    }) => {
+                        overlap += 1;
+                        points.push(intersection.into());
+                    }
+                    Some(line_intersection::LineIntersection::Collinear { .. }) => {
+                        fw.send(
+                            ctx.new_with_feature_and_port(feature.clone(), COLLINEAR_PORT.clone()),
+                        );
+                        return;
+                    }
+                    None => {}
+                }
+            }
+        }
+        if points.is_empty() {
+            let mut feature = feature.clone();
+            feature.attributes.insert(
+                self.output_attribute.clone(),
+                AttributeValue::Number(Number::from(overlap)),
+            );
+            fw.send(ctx.new_with_feature_and_port(feature, LINE_PORT.clone()));
+            return;
+        }
+        let mut geometry = geometry.clone();
+        let mut feature = feature.clone();
+        geometry.value =
+            GeometryValue::FlowGeometry2D(Geometry2D::MultiPoint(MultiPoint2D::new(points)));
+        feature.geometry = Some(geometry);
+        feature.attributes.insert(
+            self.output_attribute.clone(),
+            AttributeValue::Number(Number::from(overlap)),
+        );
+        fw.send(ctx.new_with_feature_and_port(feature, POINT_PORT.clone()));
+    }
+
+    fn handle_3d_geometry(
+        &self,
+        geos: &Geometry3D,
+        feature: &Feature,
+        geometry: &Geometry,
+        ctx: &ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) {
+        match geos {
+            Geometry3D::MultiLineString(line_strings) => {
+                let mut lines = Vec::new();
+                for line_string in line_strings.iter() {
+                    lines.extend(line_string.lines());
+                }
+                self.handle_3d_lines(feature, geometry, lines, ctx, fw);
+            }
+            Geometry3D::LineString(line_string) => {
+                let lines = line_string.lines();
+                self.handle_3d_lines(feature, geometry, lines.into_iter().collect(), ctx, fw);
+            }
+            _ => unimplemented!(),
+        }
+        fw.send(ctx.new_with_feature_and_port(feature.clone(), DEFAULT_PORT.clone()));
+    }
+
+    fn handle_3d_lines(
+        &self,
+        feature: &Feature,
+        geometry: &Geometry,
+        lines: Vec<Line3D<f64>>,
+        ctx: &ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) {
+        let mut overlap = 0;
+        let mut points = Vec::<Point3D<f64>>::new();
+        for (i, &current) in lines.iter().enumerate() {
+            for &next in &lines[i + 1..] {
+                match line_intersection(current, next) {
+                    Some(line_intersection::LineIntersection::SinglePoint {
+                        intersection, ..
+                    }) => {
+                        overlap += 1;
+                        points.push(intersection.into());
+                    }
+                    Some(line_intersection::LineIntersection::Collinear { .. }) => {
+                        fw.send(
+                            ctx.new_with_feature_and_port(feature.clone(), COLLINEAR_PORT.clone()),
+                        );
+                        return;
+                    }
+                    None => {}
+                }
+            }
+        }
+        if points.is_empty() {
+            let mut feature = feature.clone();
+            feature.attributes.insert(
+                self.output_attribute.clone(),
+                AttributeValue::Number(Number::from(overlap)),
+            );
+            fw.send(ctx.new_with_feature_and_port(feature, LINE_PORT.clone()));
+            return;
+        }
+        let mut geometry = geometry.clone();
+        let mut feature = feature.clone();
+        geometry.value =
+            GeometryValue::FlowGeometry3D(Geometry3D::MultiPoint(MultiPoint3D::new(points)));
+        feature.geometry = Some(geometry);
+        feature.attributes.insert(
+            self.output_attribute.clone(),
+            AttributeValue::Number(Number::from(overlap)),
+        );
+        fw.send(ctx.new_with_feature_and_port(feature, POINT_PORT.clone()));
+    }
+}

--- a/worker/crates/action-processor/src/geometry/mapping.rs
+++ b/worker/crates/action-processor/src/geometry/mapping.rs
@@ -7,6 +7,7 @@ use super::{
     coercer::GeometryCoercerFactory, coordinate_system_setter::CoordinateSystemSetterFactory,
     extractor::GeometryExtractorFactory, extruder::ExtruderFactory, filter::GeometryFilterFactory,
     hole_counter::HoleCounterFactory, hole_extractor::HoleExtractorFactory,
+    line_on_line_overlayer::LineOnLineOverlayerFactory,
     orientation_extractor::OrientationExtractorFactory, planarity_filter::PlanarityFilterFactory,
     reprojector::ReprojectorFactory, splitter::GeometrySplitterFactory,
     three_dimention_box_replacer::ThreeDimentionBoxReplacerFactory,
@@ -30,6 +31,7 @@ pub static ACTION_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
         Box::<HoleCounterFactory>::default(),
         Box::<HoleExtractorFactory>::default(),
         Box::<PlanarityFilterFactory>::default(),
+        Box::<LineOnLineOverlayerFactory>::default(),
     ];
     factories
         .into_iter()


### PR DESCRIPTION
# Overview
- add LineOnLineOverlayer module to geometry crate

## What I've done
- create LineOnLineOverlayer module 

## What I haven't done
- N/A

## How I tested
- Unit Test

## Screenshot
- N/A

## Which point I want you to review particularly
- N/A

## Memo
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `LineOnLineOverlayer` processor to handle intersections of 2D and 3D lines, generating point features with attributes based on the intersections.

- **Bug Fixes**
  - Fixed syntax error in `GeometryCoercer` implementation to correctly reference the `feature` variable when sending data.

- **Improvements**
  - Added new error handling specific to `LineOnLineOverlayer` functionality for better error management.
  - Included new test cases for various line intersection scenarios to improve robustness.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->