### PR TITLE
feat(worker): add bufferable module

### DIFF
--- a/worker/crates/geometry/src/algorithm.rs
+++ b/worker/crates/geometry/src/algorithm.rs
@@ -8,6 +8,7 @@ pub mod area2d;
 pub mod area3d;
 pub mod bool_ops;
 pub mod bounding_rect;
+pub mod bufferable;
 pub mod contains;
 pub mod convex_hull;
 pub mod coordinate_position;

--- a/worker/crates/geometry/src/algorithm/bufferable.rs
+++ b/worker/crates/geometry/src/algorithm/bufferable.rs
@@ -1,0 +1,77 @@
+use crate::types::{
+    coordinate::{Coordinate, Coordinate2D},
+    line_string::LineString2D,
+    multi_polygon::MultiPolygon2D,
+    polygon::Polygon2D,
+};
+
+use super::convex_hull::ConvexHull;
+
+pub trait Bufferable {
+    fn to_polygon(&self, distance: f64, segments: usize) -> Polygon2D<f64>;
+}
+
+impl Bufferable for Coordinate2D<f64> {
+    fn to_polygon(&self, distance: f64, segments: usize) -> Polygon2D<f64> {
+        let mut coords = Vec::with_capacity(segments + 1);
+        for i in 0..=segments {
+            let angle = 2.0 * std::f64::consts::PI * i as f64 / segments as f64;
+            let x = self.x + distance * angle.cos();
+            let y = self.y + distance * angle.sin();
+            coords.push(Coordinate { x, y, z: self.z });
+        }
+        Polygon2D::new(coords.into(), vec![])
+    }
+}
+
+impl Bufferable for LineString2D<f64> {
+    fn to_polygon(&self, distance: f64, segments: usize) -> Polygon2D<f64> {
+        let mut coords = Vec::new();
+        for coord in self.coords() {
+            let polygon = coord.to_polygon(distance, segments);
+            coords.extend(polygon.exterior().coords().copied());
+        }
+        let polygon = Polygon2D::new(coords.into(), vec![]);
+        MultiPolygon2D::new(vec![polygon]).convex_hull()
+    }
+}
+
+impl Bufferable for Polygon2D<f64> {
+    fn to_polygon(&self, distance: f64, segments: usize) -> Polygon2D<f64> {
+        let mut coords = Vec::new();
+        for coord in self.exterior().coords() {
+            let coord_polygon = coord.to_polygon(distance, segments);
+            coords.extend(coord_polygon.exterior().coords().copied());
+        }
+        let polygon = Polygon2D::new(coords.into(), vec![]);
+        MultiPolygon2D::new(vec![polygon]).convex_hull()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::coord;
+
+    use super::*;
+
+    #[test]
+    fn test_coordinate_to_polygon() {
+        let coord = coord! { x: 1.0, y: 1.0 };
+        let polygon = coord.to_polygon(1.0, 4);
+
+        // Expected polygon with 4 segments (square around the point)
+        let expected_polygon = Polygon2D::new(
+            vec![(2.0, 1.0), (1.0, 2.0), (0.0, 1.0), (1.0, 0.0), (2.0, 1.0)].into(),
+            Vec::new(),
+        );
+        println!("{:?}", polygon);
+        println!("{:?}", expected_polygon);
+    }
+
+    #[test]
+    fn test_linestring_to_polygon() {
+        let line = LineString2D::new(vec![coord! { x: 0.0, y: 0.0}, coord! { x: 1.0, y: 1.0}]);
+        let polygon = line.to_polygon(0.5, 4);
+        println!("{:?}", polygon);
+    }
+}

--- a/worker/crates/geometry/src/algorithm/convex_hull.rs
+++ b/worker/crates/geometry/src/algorithm/convex_hull.rs
@@ -1,3 +1,20 @@
+use super::{coords_iter::CoordsIter, GeoNum};
+
+pub mod qhull;
+pub use qhull::quick_hull;
+
+pub mod graham;
+pub use graham::graham_hull;
+
+use crate::{
+    algorithm::{
+        kernels::{Orientation, RobustKernel},
+        utils::lex_cmp,
+        winding_order::Winding,
+    },
+    types::{coordinate::Coordinate, line_string::LineString, polygon::Polygon},
+};
+
 pub trait ConvexHull<'a, T, Z> {
     type ScalarXY: GeoNum;
     type ScalarZ: GeoNum;
@@ -19,26 +36,6 @@ where
     }
 }
 
-pub mod qhull;
-pub use qhull::quick_hull;
-
-pub mod graham;
-pub use graham::graham_hull;
-
-use crate::{
-    algorithm::{
-        kernels::{Orientation, RobustKernel},
-        utils::lex_cmp,
-    },
-    types::{coordinate::Coordinate, line_string::LineString, polygon::Polygon},
-};
-
-use super::{coords_iter::CoordsIter, GeoNum};
-
-// Helper function that outputs the convex hull in the
-// trivial case: input with at most 3 points. It ensures the
-// output is ccw, and does not repeat points unless
-// required.
 fn trivial_hull<T, Z>(points: &mut [Coordinate<T, Z>], include_on_hull: bool) -> LineString<T, Z>
 where
     T: GeoNum,
@@ -66,8 +63,6 @@ where
     let mut ls = LineString::new(ls);
     ls.close();
 
-    // Maintain the CCW invariance
-    use super::winding_order::Winding;
     ls.make_ccw_winding();
     ls
 }


### PR DESCRIPTION
# Overview
Add a new module called `bufferable` to the `geometry` crate. This module provides traits and implementations for buffering geometric objects. It includes methods to convert coordinates, line strings, and polygons into buffered polygons. This addition enhances the functionality of the `geometry` crate and allows for more advanced spatial operations.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `Bufferable` trait to convert geometric entities like coordinates, line strings, and polygons into polygons with specified parameters.

- **Improvements**
	- Enhanced the organization of the convex hull module to improve readability and maintainability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->