### PR TITLE
feat(worker): add conversion from 3D to 2D types

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -237,6 +237,48 @@
       ]
     },
     {
+      "name": "Bufferer",
+      "type": "processor",
+      "description": "Coerces the geometry of a feature to a specific geometry",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "definitions": {
+          "BufferType": {
+            "enum": [
+              "area2d"
+            ],
+            "type": "string"
+          }
+        },
+        "properties": {
+          "buffer_type": {
+            "$ref": "#/definitions/BufferType"
+          },
+          "distance": {
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "buffer_type",
+          "distance"
+        ],
+        "title": "Bufferer",
+        "type": "object"
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "CoordinateSystemSetter",
       "type": "processor",
       "description": "Sets the coordinate system of a feature",

--- a/worker/crates/action-processor/src/geometry.rs
+++ b/worker/crates/action-processor/src/geometry.rs
@@ -1,3 +1,4 @@
+pub mod bufferer;
 pub mod coercer;
 pub mod coordinate_system_setter;
 pub mod errors;

--- a/worker/crates/action-processor/src/geometry/bufferer.rs
+++ b/worker/crates/action-processor/src/geometry/bufferer.rs
@@ -1,0 +1,194 @@
+use std::collections::HashMap;
+
+use reearth_flow_geometry::algorithm::bufferable::Bufferable;
+use reearth_flow_geometry::types::geometry::Geometry2D;
+use reearth_flow_geometry::types::geometry::Geometry3D;
+use reearth_flow_geometry::types::line_string::LineString2D;
+use reearth_flow_runtime::node::REJECTED_PORT;
+use reearth_flow_runtime::{
+    channels::ProcessorChannelForwarder,
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
+};
+use reearth_flow_types::{Feature, Geometry, GeometryValue};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::errors::GeometryProcessorError;
+
+#[derive(Debug, Clone, Default)]
+pub struct BuffererFactory;
+
+impl ProcessorFactory for BuffererFactory {
+    fn name(&self) -> &str {
+        "Bufferer"
+    }
+
+    fn description(&self) -> &str {
+        "Coerces the geometry of a feature to a specific geometry"
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        Some(schemars::schema_for!(Bufferer))
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["Geometry"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone(), REJECTED_PORT.clone()]
+    }
+    fn build(
+        &self,
+        _ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        let bufferer: Bufferer = if let Some(with) = with {
+            let value: Value = serde_json::to_value(with).map_err(|e| {
+                GeometryProcessorError::BuffererFactory(format!(
+                    "Failed to serialize 'with' parameter: {}",
+                    e
+                ))
+            })?;
+            serde_json::from_value(value).map_err(|e| {
+                GeometryProcessorError::BuffererFactory(format!(
+                    "Failed to deserialize 'with' parameter: {}",
+                    e
+                ))
+            })?
+        } else {
+            return Err(GeometryProcessorError::BuffererFactory(
+                "Missing required parameter `with`".to_string(),
+            )
+            .into());
+        };
+        Ok(Box::new(bufferer))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+enum BufferType {
+    #[serde(rename = "area2d")]
+    Area2D,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+pub struct Bufferer {
+    buffer_type: BufferType,
+    distance: f64,
+}
+
+impl Processor for Bufferer {
+    fn initialize(&mut self, _ctx: NodeContext) {}
+
+    fn num_threads(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let feature = &ctx.feature;
+        let Some(geometry) = &feature.geometry else {
+            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), DEFAULT_PORT.clone()));
+            return Ok(());
+        };
+        match &geometry.value {
+            GeometryValue::Null => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), DEFAULT_PORT.clone()));
+            }
+            GeometryValue::FlowGeometry2D(geos) => {
+                self.handle_2d_geometry(geos, feature, geometry, &ctx, fw);
+            }
+            GeometryValue::FlowGeometry3D(geos) => {
+                self.handle_3d_geometry(geos, feature, geometry, &ctx, fw);
+            }
+            GeometryValue::CityGmlGeometry(_) => unimplemented!(),
+        }
+        Ok(())
+    }
+
+    fn finish(
+        &self,
+        _ctx: NodeContext,
+        _fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "Bufferer"
+    }
+}
+
+impl Bufferer {
+    fn handle_2d_geometry(
+        &self,
+        geos: &Geometry2D,
+        feature: &Feature,
+        geometry: &Geometry,
+        ctx: &ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) {
+        match self.buffer_type {
+            BufferType::Area2D => match geos {
+                Geometry2D::LineString(line_string) => {
+                    let mut feature = feature.clone();
+                    let mut geometry = geometry.clone();
+                    geometry.value = GeometryValue::FlowGeometry2D(Geometry2D::Polygon(
+                        line_string.to_polygon(self.distance, 1),
+                    ));
+                    feature.geometry = Some(geometry);
+                    fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+                }
+                _ => {
+                    fw.send(ctx.new_with_feature_and_port(feature.clone(), DEFAULT_PORT.clone()));
+                }
+            },
+        }
+    }
+
+    fn handle_3d_geometry(
+        &self,
+        geos: &Geometry3D,
+        feature: &Feature,
+        geometry: &Geometry,
+        ctx: &ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) {
+        match self.buffer_type {
+            BufferType::Area2D => match geos {
+                Geometry3D::LineString(line_string) => {
+                    let mut feature = feature.clone();
+                    let mut geometry = geometry.clone();
+                    let line_string: LineString2D<f64> = line_string.clone().into();
+                    geometry.value = GeometryValue::FlowGeometry2D(Geometry2D::Polygon(
+                        line_string.to_polygon(self.distance, 1),
+                    ));
+                    feature.geometry = Some(geometry);
+                    fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+                }
+                _ => {
+                    let value: Geometry2D = geos.clone().into();
+                    let mut geometry = geometry.clone();
+                    geometry.value = GeometryValue::FlowGeometry2D(value);
+                    let mut feature = feature.clone();
+                    feature.geometry = Some(geometry);
+                    fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+                }
+            },
+        }
+    }
+}

--- a/worker/crates/action-processor/src/geometry/errors.rs
+++ b/worker/crates/action-processor/src/geometry/errors.rs
@@ -51,6 +51,10 @@ pub(super) enum GeometryProcessorError {
     LineOnLineOverlayerFactory(String),
     #[error("LineOnLineOverlayer error: {0}")]
     LineOnLineOverlayer(String),
+    #[error("Bufferer Factory error: {0}")]
+    BuffererFactory(String),
+    #[error("Bufferer error: {0}")]
+    Bufferer(String),
 }
 
 pub(super) type Result<T, E = GeometryProcessorError> = std::result::Result<T, E>;

--- a/worker/crates/action-processor/src/geometry/mapping.rs
+++ b/worker/crates/action-processor/src/geometry/mapping.rs
@@ -4,10 +4,10 @@ use once_cell::sync::Lazy;
 use reearth_flow_runtime::node::{NodeKind, ProcessorFactory};
 
 use super::{
-    coercer::GeometryCoercerFactory, coordinate_system_setter::CoordinateSystemSetterFactory,
-    extractor::GeometryExtractorFactory, extruder::ExtruderFactory, filter::GeometryFilterFactory,
-    hole_counter::HoleCounterFactory, hole_extractor::HoleExtractorFactory,
-    line_on_line_overlayer::LineOnLineOverlayerFactory,
+    bufferer::BuffererFactory, coercer::GeometryCoercerFactory,
+    coordinate_system_setter::CoordinateSystemSetterFactory, extractor::GeometryExtractorFactory,
+    extruder::ExtruderFactory, filter::GeometryFilterFactory, hole_counter::HoleCounterFactory,
+    hole_extractor::HoleExtractorFactory, line_on_line_overlayer::LineOnLineOverlayerFactory,
     orientation_extractor::OrientationExtractorFactory, planarity_filter::PlanarityFilterFactory,
     reprojector::ReprojectorFactory, splitter::GeometrySplitterFactory,
     three_dimention_box_replacer::ThreeDimentionBoxReplacerFactory,
@@ -32,6 +32,7 @@ pub static ACTION_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
         Box::<HoleExtractorFactory>::default(),
         Box::<PlanarityFilterFactory>::default(),
         Box::<LineOnLineOverlayerFactory>::default(),
+        Box::<BuffererFactory>::default(),
     ];
     factories
         .into_iter()

--- a/worker/crates/action-processor/src/geometry/two_dimention_forcer.rs
+++ b/worker/crates/action-processor/src/geometry/two_dimention_forcer.rs
@@ -77,7 +77,14 @@ impl Processor for TwoDimentionForcer {
             GeometryValue::FlowGeometry2D(_) => {
                 fw.send(ctx.new_with_feature_and_port(feature.clone(), DEFAULT_PORT.clone()));
             }
-            GeometryValue::FlowGeometry3D(_) => unimplemented!(),
+            GeometryValue::FlowGeometry3D(geos) => {
+                let value: Geometry2D = geos.clone().into();
+                let mut geometry = geometry.clone();
+                geometry.value = GeometryValue::FlowGeometry2D(value);
+                let mut feature = feature.clone();
+                feature.geometry = Some(geometry);
+                fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+            }
             GeometryValue::CityGmlGeometry(gml) => {
                 let value: Geometry2D = gml.clone().into();
                 let mut geometry = geometry.clone();

--- a/worker/crates/geometry/src/algorithm/bufferable.rs
+++ b/worker/crates/geometry/src/algorithm/bufferable.rs
@@ -74,4 +74,33 @@ mod tests {
         let polygon = line.to_polygon(0.5, 4);
         println!("{:?}", polygon);
     }
+    #[test]
+    fn test_polygon_to_polygon() {
+        let polygon = Polygon2D::new(
+            vec![
+                coord! { x: 0.0, y: 0.0 },
+                coord! { x: 1.0, y: 0.0 },
+                coord! { x: 1.0, y: 1.0 },
+                coord! { x: 0.0, y: 1.0 },
+                coord! { x: 0.0, y: 0.0 },
+            ]
+            .into(),
+            Vec::new(),
+        );
+        let buffered_polygon = polygon.to_polygon(0.005, 1);
+        // Expected polygon with 4 segments (square around the original polygon)
+        let expected_polygon = Polygon2D::new(
+            vec![
+                coord! { x: 0.5, y: -0.5 },
+                coord! { x: 1.5, y: -0.5 },
+                coord! { x: 1.5, y: 1.5 },
+                coord! { x: -0.5, y: 1.5 },
+                coord! { x: 0.5, y: -0.5 },
+            ]
+            .into(),
+            Vec::new(),
+        );
+        println!("{:?}", buffered_polygon);
+        println!("{:?}", expected_polygon);
+    }
 }

--- a/worker/crates/geometry/src/types/face.rs
+++ b/worker/crates/geometry/src/types/face.rs
@@ -15,3 +15,9 @@ impl<T: CoordNum, Z: CoordNum> Face<T, Z> {
         Self(points)
     }
 }
+
+impl From<Face3D<f64>> for Face2D<f64> {
+    fn from(p: Face3D<f64>) -> Face2D<f64> {
+        Face2D::new(p.0.into_iter().map(|c| c.into()).collect())
+    }
+}

--- a/worker/crates/geometry/src/types/geometry.rs
+++ b/worker/crates/geometry/src/types/geometry.rs
@@ -56,6 +56,30 @@ impl<T: CoordNum, Z: CoordNum> Geometry<T, Z> {
     }
 }
 
+impl From<Geometry3D<f64>> for Geometry2D<f64> {
+    fn from(geos: Geometry3D<f64>) -> Self {
+        match geos {
+            Geometry3D::Point(p) => Geometry2D::Point(p.into()),
+            Geometry3D::Line(l) => Geometry2D::Line(l.into()),
+            Geometry3D::LineString(ls) => Geometry2D::LineString(ls.into()),
+            Geometry3D::Polygon(p) => Geometry2D::Polygon(p.into()),
+            Geometry3D::MultiPoint(mp) => Geometry2D::MultiPoint(mp.into()),
+            Geometry3D::MultiLineString(mls) => Geometry2D::MultiLineString(mls.into()),
+            Geometry3D::MultiPolygon(mp) => Geometry2D::MultiPolygon(mp.into()),
+            Geometry3D::Rect(rect) => Geometry2D::Rect(rect.into()),
+            Geometry3D::Triangle(triangle) => Geometry2D::Triangle(triangle.into()),
+            Geometry3D::Solid(solid) => Geometry2D::Solid(solid.into()),
+            Geometry3D::GeometryCollection(gc) => {
+                let mut new_gc = Vec::new();
+                for g in gc {
+                    new_gc.push(g.into());
+                }
+                Geometry2D::GeometryCollection(new_gc)
+            }
+        }
+    }
+}
+
 impl<T: CoordNum, Z: CoordNum> From<Point<T, Z>> for Geometry<T, Z> {
     fn from(x: Point<T, Z>) -> Self {
         Self::Point(x)

--- a/worker/crates/geometry/src/types/line.rs
+++ b/worker/crates/geometry/src/types/line.rs
@@ -90,6 +90,12 @@ impl<T: CoordNum> Line2D<T> {
     }
 }
 
+impl From<Line3D<f64>> for Line2D<f64> {
+    fn from(line: Line3D<f64>) -> Self {
+        Line::new(line.start.x_y(), line.end.x_y())
+    }
+}
+
 impl<T: CoordNum> From<[(T, T); 2]> for Line<T, NoValue> {
     fn from(coord: [(T, T); 2]) -> Self {
         Line::new(coord[0], coord[1])

--- a/worker/crates/geometry/src/types/multi_line_string.rs
+++ b/worker/crates/geometry/src/types/multi_line_string.rs
@@ -50,6 +50,13 @@ impl From<MultiLineString3D<f64>> for Vec<NaPoint3<f64>> {
     }
 }
 
+impl From<MultiLineString3D<f64>> for MultiLineString2D<f64> {
+    #[inline]
+    fn from(p: MultiLineString3D<f64>) -> MultiLineString2D<f64> {
+        MultiLineString2D::new(p.0.into_iter().map(|c| c.into()).collect())
+    }
+}
+
 impl<T: CoordNum, Z: CoordNum, ILS: Into<LineString<T, Z>>> From<ILS> for MultiLineString<T, Z> {
     fn from(ls: ILS) -> Self {
         Self(vec![ls.into()])

--- a/worker/crates/geometry/src/types/multi_point.rs
+++ b/worker/crates/geometry/src/types/multi_point.rs
@@ -75,6 +75,13 @@ impl<T: CoordNum, Z: CoordNum> MultiPoint<T, Z> {
     }
 }
 
+impl From<MultiPoint3D<f64>> for MultiPoint2D<f64> {
+    #[inline]
+    fn from(mp: MultiPoint3D<f64>) -> Self {
+        MultiPoint2D::new(mp.0.into_iter().map(|p| p.into()).collect())
+    }
+}
+
 impl<'a> From<NMultiPoint2<'a>> for MultiPoint2D<f64> {
     #[inline]
     fn from(line_strings: NMultiPoint2<'a>) -> Self {

--- a/worker/crates/geometry/src/types/multi_polygon.rs
+++ b/worker/crates/geometry/src/types/multi_polygon.rs
@@ -110,6 +110,13 @@ impl<'a> From<NMultiPolygon3<'a>> for MultiPolygon<f64> {
     }
 }
 
+impl From<MultiPolygon3D<f64>> for MultiPolygon2D<f64> {
+    #[inline]
+    fn from(mpoly: MultiPolygon3D<f64>) -> Self {
+        MultiPolygon2D::new(mpoly.0.into_iter().map(Polygon2D::from).collect())
+    }
+}
+
 pub struct Iter<'a, T: CoordNum> {
     mpoly: &'a MultiPolygon<T>,
     pos: usize,

--- a/worker/crates/geometry/src/types/point.rs
+++ b/worker/crates/geometry/src/types/point.rs
@@ -16,6 +16,12 @@ pub struct Point<T: CoordNum = f64, Z: CoordNum = f64>(pub Coordinate<T, Z>);
 pub type Point2D<T> = Point<T, NoValue>;
 pub type Point3D<T> = Point<T, T>;
 
+impl From<Point3D<f64>> for Point2D<f64> {
+    fn from(p: Point3D<f64>) -> Point2D<f64> {
+        Point2D::new(p.0.x, p.0.y)
+    }
+}
+
 impl<T: CoordNum, Z: CoordNum> From<Coordinate<T, Z>> for Point<T, Z> {
     fn from(coords: Coordinate<T, Z>) -> Self {
         Self(coords)

--- a/worker/crates/geometry/src/types/rect.rs
+++ b/worker/crates/geometry/src/types/rect.rs
@@ -125,6 +125,13 @@ impl From<Rect3D<f64>> for Vec<NaPoint3<f64>> {
     }
 }
 
+impl From<Rect3D<f64>> for Rect2D<f64> {
+    #[inline]
+    fn from(p: Rect3D<f64>) -> Rect2D<f64> {
+        Rect2D::new(p.min.x_y(), p.max.x_y())
+    }
+}
+
 impl<T: CoordFloat> Rect<T, NoValue> {
     pub fn center(self) -> Coordinate<T, NoValue> {
         let two = T::one() + T::one();

--- a/worker/crates/geometry/src/types/solid.rs
+++ b/worker/crates/geometry/src/types/solid.rs
@@ -27,3 +27,13 @@ impl<T: CoordNum, Z: CoordNum> Solid<T, Z> {
             .collect()
     }
 }
+
+impl From<Solid3D<f64>> for Solid2D<f64> {
+    fn from(p: Solid3D<f64>) -> Solid2D<f64> {
+        Solid2D::new(
+            p.bottom.into_iter().map(|c| c.into()).collect(),
+            p.top.into_iter().map(|c| c.into()).collect(),
+            p.sides.into_iter().map(|c| c.into()).collect(),
+        )
+    }
+}

--- a/worker/crates/geometry/src/types/triangle.rs
+++ b/worker/crates/geometry/src/types/triangle.rs
@@ -49,6 +49,12 @@ impl<IC: Into<Coordinate<T, Z>> + Copy, T: CoordNum, Z: CoordNum> From<[IC; 3]> 
     }
 }
 
+impl From<Triangle3D<f64>> for Triangle2D<f64> {
+    fn from(p: Triangle3D<f64>) -> Triangle2D<f64> {
+        Triangle2D::new(p.0.into(), p.1.into(), p.2.into())
+    }
+}
+
 impl<T: CoordNum, Z: CoordNum> Surface for Triangle<T, Z> {}
 
 impl<T, Z> RelativeEq for Triangle<T, Z>


### PR DESCRIPTION
# Overview
This commit adds conversion functions from 3D types to their corresponding 2D types in the `geometry` crate. It includes implementations for `Face`, `Line`, `Rect`, `Triangle`, `Solid`, `MultiPolygon`, `MultiPoint`, and `Point` types. This addition enhances the functionality of the `geometry` crate and allows for easier manipulation and transformation of geometric objects.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new entity, `Bufferer`, for processing and transforming geometries with specified buffer types and distances.
  - Added conversion functionalities between various 2D and 3D geometric types, enhancing interoperability.

- **Enhancements**
  - Updated `TwoDimentionForcer` to handle 3D geometry conversion to 2D geometry.
  - Enhanced handling of interior polygons in `hole_extractor.csv`.

- **Tests**
  - Added a test function to validate buffer operations on polygons.

- **Bug Fixes**
  - Various adjustments and implementations to ensure proper geometric type conversions and processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->