### PR TITLE
feat(worker): add area on area overlayer processor

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -1,6 +1,24 @@
 {
   "actions": [
     {
+      "name": "AreaOnAreaOverlayer",
+      "type": "processor",
+      "description": "Overlays an area on another area",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "remnants",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "AttributeAggregator",
       "type": "processor",
       "description": "Aggregates features by attributes",
@@ -239,7 +257,7 @@
     {
       "name": "Bufferer",
       "type": "processor",
-      "description": "Coerces the geometry of a feature to a specific geometry",
+      "description": "Buffers a geometry",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "definitions": {

--- a/worker/Cargo.lock
+++ b/worker/Cargo.lock
@@ -2715,6 +2715,7 @@ dependencies = [
  "bytes",
  "chrono",
  "csv",
+ "itertools 0.13.0",
  "num-traits",
  "nusamai-citygml",
  "nusamai-plateau",

--- a/worker/crates/action-processor/Cargo.toml
+++ b/worker/crates/action-processor/Cargo.toml
@@ -29,6 +29,7 @@ approx.workspace = true
 async-trait.workspace = true
 chrono.workspace = true
 csv.workspace = true
+itertools.workspace = true
 num-traits.workspace = true
 once_cell.workspace = true
 opentelemetry.workspace = true

--- a/worker/crates/action-processor/src/geometry.rs
+++ b/worker/crates/action-processor/src/geometry.rs
@@ -1,3 +1,4 @@
+pub mod area_on_area_overlayer;
 pub mod bufferer;
 pub mod coercer;
 pub mod coordinate_system_setter;

--- a/worker/crates/action-processor/src/geometry/area_on_area_overlayer.rs
+++ b/worker/crates/action-processor/src/geometry/area_on_area_overlayer.rs
@@ -1,0 +1,207 @@
+use std::collections::HashMap;
+
+use itertools::Itertools;
+use once_cell::sync::Lazy;
+use reearth_flow_geometry::algorithm::bool_ops::BooleanOps;
+use reearth_flow_geometry::types::geometry::Geometry2D;
+use reearth_flow_geometry::types::multi_polygon::MultiPolygon2D;
+use reearth_flow_geometry::types::polygon::Polygon2D;
+use reearth_flow_runtime::node::REJECTED_PORT;
+use reearth_flow_runtime::{
+    channels::ProcessorChannelForwarder,
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
+};
+use reearth_flow_types::Attribute;
+use reearth_flow_types::AttributeValue;
+use reearth_flow_types::{Feature, Geometry, GeometryValue};
+use serde::{Deserialize, Serialize};
+use serde_json::Number;
+use serde_json::Value;
+
+pub static AREA_PORT: Lazy<Port> = Lazy::new(|| Port::new("area"));
+pub static REMNANTS_PORT: Lazy<Port> = Lazy::new(|| Port::new("remnants"));
+
+#[derive(Debug, Clone, Default)]
+pub struct AreaOnAreaOverlayerFactory;
+
+impl ProcessorFactory for AreaOnAreaOverlayerFactory {
+    fn name(&self) -> &str {
+        "AreaOnAreaOverlayer"
+    }
+
+    fn description(&self) -> &str {
+        "Overlays an area on another area"
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        None
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["Geometry"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![
+            AREA_PORT.clone(),
+            REMNANTS_PORT.clone(),
+            REJECTED_PORT.clone(),
+        ]
+    }
+    fn build(
+        &self,
+        _ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        _with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        Ok(Box::new(AreaOnAreaOverlayer))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AreaOnAreaOverlayer;
+
+impl Processor for AreaOnAreaOverlayer {
+    fn initialize(&mut self, _ctx: NodeContext) {}
+
+    fn num_threads(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let feature = &ctx.feature;
+        let Some(geometry) = &feature.geometry else {
+            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
+            return Ok(());
+        };
+        match &geometry.value {
+            GeometryValue::Null => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+            GeometryValue::FlowGeometry2D(geos) => {
+                self.handle_2d_geometry(geos, feature, geometry, &ctx, fw);
+            }
+            GeometryValue::FlowGeometry3D(_) => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+            GeometryValue::CityGmlGeometry(_) => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()))
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(
+        &self,
+        _ctx: NodeContext,
+        _fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "AreaOnAreaOverlayer"
+    }
+}
+
+impl AreaOnAreaOverlayer {
+    fn handle_2d_geometry(
+        &self,
+        geos: &Geometry2D,
+        feature: &Feature,
+        geometry: &Geometry,
+        ctx: &ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) {
+        match geos {
+            Geometry2D::Polygon(_) => {
+                let mut feature = feature.clone();
+                feature.attributes.insert(
+                    Attribute::new("overlap"),
+                    AttributeValue::Number(Number::from(1)),
+                );
+                fw.send(ctx.new_with_feature_and_port(feature, AREA_PORT.clone()));
+            }
+            Geometry2D::MultiPolygon(mpoly) => {
+                let mut overlap = 1;
+                let mut intersections = Vec::<MultiPolygon2D<f64>>::new();
+                let mut remnants = Vec::<MultiPolygon2D<f64>>::new();
+                let mut areas = Vec::<Polygon2D<f64>>::new();
+                let polygons: Vec<Polygon2D<f64>> = mpoly.iter().cloned().collect();
+                for combo in polygons.iter().combinations(2) {
+                    let inter = combo[0].intersection(combo[1]);
+                    if inter.is_empty() {
+                        continue;
+                    }
+                    overlap += 1;
+                    areas.extend(
+                        combo
+                            .iter()
+                            .map(|&p| p.clone())
+                            .collect::<Vec<Polygon2D<f64>>>(),
+                    );
+                    intersections.push(inter);
+                    let diff1 = combo[0].difference(combo[1]);
+                    let diff2 = combo[1].difference(combo[0]);
+                    remnants.push(diff1);
+                    remnants.push(diff2);
+                }
+                for intersection in intersections.iter() {
+                    let mut feature = feature.clone();
+                    feature.attributes.insert(
+                        Attribute::new("overlap"),
+                        AttributeValue::Number(Number::from(overlap)),
+                    );
+                    let mut geometry = geometry.clone();
+                    geometry.value = GeometryValue::FlowGeometry2D(Geometry2D::MultiPolygon(
+                        intersection.clone(),
+                    ));
+                    feature.geometry = Some(geometry);
+                    fw.send(ctx.new_with_feature_and_port(feature, AREA_PORT.clone()));
+                }
+                for remnant in remnants.iter() {
+                    let mut feature = feature.clone();
+                    feature.attributes.insert(
+                        Attribute::new("overlap"),
+                        AttributeValue::Number(Number::from(overlap)),
+                    );
+                    let mut geometry = geometry.clone();
+                    geometry.value =
+                        GeometryValue::FlowGeometry2D(Geometry2D::MultiPolygon(remnant.clone()));
+                    feature.geometry = Some(geometry);
+                    fw.send(ctx.new_with_feature_and_port(feature, REMNANTS_PORT.clone()));
+                }
+                for polygon in polygons.iter() {
+                    if areas.contains(polygon) {
+                        continue;
+                    }
+                    let mut feature = feature.clone();
+                    feature.attributes.insert(
+                        Attribute::new("overlap"),
+                        AttributeValue::Number(Number::from(overlap)),
+                    );
+                    let mut geometry = geometry.clone();
+                    geometry.value =
+                        GeometryValue::FlowGeometry2D(Geometry2D::Polygon(polygon.clone()));
+                    feature.geometry = Some(geometry);
+                    fw.send(ctx.new_with_feature_and_port(feature, AREA_PORT.clone()));
+                }
+            }
+            _ => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+        }
+    }
+}

--- a/worker/crates/action-processor/src/geometry/bufferer.rs
+++ b/worker/crates/action-processor/src/geometry/bufferer.rs
@@ -28,7 +28,7 @@ impl ProcessorFactory for BuffererFactory {
     }
 
     fn description(&self) -> &str {
-        "Coerces the geometry of a feature to a specific geometry"
+        "Buffers a geometry"
     }
 
     fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {

--- a/worker/crates/action-processor/src/geometry/errors.rs
+++ b/worker/crates/action-processor/src/geometry/errors.rs
@@ -55,6 +55,10 @@ pub(super) enum GeometryProcessorError {
     BuffererFactory(String),
     #[error("Bufferer error: {0}")]
     Bufferer(String),
+    #[error("AreaOnAreaOverlayer Factory error: {0}")]
+    AreaOnAreaOverlayerFactory(String),
+    #[error("AreaOnAreaOverlayer error: {0}")]
+    AreaOnAreaOverlayer(String),
 }
 
 pub(super) type Result<T, E = GeometryProcessorError> = std::result::Result<T, E>;

--- a/worker/crates/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/worker/crates/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -165,7 +165,7 @@ impl LineOnLineOverlayer {
                 let lines = line_string.lines();
                 self.handle_2d_lines(feature, geometry, lines.into_iter().collect(), ctx, fw);
             }
-            _ => unimplemented!(),
+            _ => fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone())),
         }
         fw.send(ctx.new_with_feature_and_port(feature.clone(), DEFAULT_PORT.clone()));
     }
@@ -240,7 +240,7 @@ impl LineOnLineOverlayer {
                 let lines = line_string.lines();
                 self.handle_3d_lines(feature, geometry, lines.into_iter().collect(), ctx, fw);
             }
-            _ => unimplemented!(),
+            _ => fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone())),
         }
         fw.send(ctx.new_with_feature_and_port(feature.clone(), DEFAULT_PORT.clone()));
     }

--- a/worker/crates/action-processor/src/geometry/mapping.rs
+++ b/worker/crates/action-processor/src/geometry/mapping.rs
@@ -4,10 +4,11 @@ use once_cell::sync::Lazy;
 use reearth_flow_runtime::node::{NodeKind, ProcessorFactory};
 
 use super::{
-    bufferer::BuffererFactory, coercer::GeometryCoercerFactory,
-    coordinate_system_setter::CoordinateSystemSetterFactory, extractor::GeometryExtractorFactory,
-    extruder::ExtruderFactory, filter::GeometryFilterFactory, hole_counter::HoleCounterFactory,
-    hole_extractor::HoleExtractorFactory, line_on_line_overlayer::LineOnLineOverlayerFactory,
+    area_on_area_overlayer::AreaOnAreaOverlayerFactory, bufferer::BuffererFactory,
+    coercer::GeometryCoercerFactory, coordinate_system_setter::CoordinateSystemSetterFactory,
+    extractor::GeometryExtractorFactory, extruder::ExtruderFactory, filter::GeometryFilterFactory,
+    hole_counter::HoleCounterFactory, hole_extractor::HoleExtractorFactory,
+    line_on_line_overlayer::LineOnLineOverlayerFactory,
     orientation_extractor::OrientationExtractorFactory, planarity_filter::PlanarityFilterFactory,
     reprojector::ReprojectorFactory, splitter::GeometrySplitterFactory,
     three_dimention_box_replacer::ThreeDimentionBoxReplacerFactory,
@@ -33,6 +34,7 @@ pub static ACTION_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
         Box::<PlanarityFilterFactory>::default(),
         Box::<LineOnLineOverlayerFactory>::default(),
         Box::<BuffererFactory>::default(),
+        Box::<AreaOnAreaOverlayerFactory>::default(),
     ];
     factories
         .into_iter()

--- a/worker/crates/geometry/src/types/multi_polygon.rs
+++ b/worker/crates/geometry/src/types/multi_polygon.rs
@@ -88,6 +88,10 @@ impl<T: CoordNum, Z: CoordNum> MultiPolygon<T, Z> {
             .unwrap()
             .interiors_mut(|interiors| interiors.push(iter));
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl<T: CoordNum, Z: CoordNum> Default for MultiPolygon<T, Z> {


### PR DESCRIPTION
# Overview
- add area on area overlayer processor

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced "AreaOnAreaOverlayer" action for overlaying areas within the "Geometry" category.
  - Added a new method `is_empty` to the `MultiPolygon` struct to check for emptiness.

- **Improvements**
  - Updated the description of the "Bufferer" action to "Buffers a geometry."
  - Enhanced `LineOnLineOverlayer` to handle 2D and 3D lines more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->