### PR TITLE
feat(worker): add insert_map_element function to collection module

### DIFF
--- a/worker/crates/common/src/collection.rs
+++ b/worker/crates/common/src/collection.rs
@@ -138,3 +138,25 @@ where
         }
     }
 }
+
+pub fn insert_map_element<K, V>(
+    map: &mut HashMap<K, HashMap<K, V>>,
+    source_key: K,
+    key: K,
+    value: V,
+) where
+    K: Eq + Hash,
+{
+    match map.entry(source_key) {
+        Entry::Occupied(mut entry) => {
+            entry.get_mut().insert(key, value);
+        }
+        Entry::Vacant(entry) => {
+            entry.insert({
+                let mut new_map = HashMap::new();
+                new_map.insert(key, value);
+                new_map
+            });
+        }
+    }
+}

--- a/worker/crates/common/src/xml.rs
+++ b/worker/crates/common/src/xml.rs
@@ -7,6 +7,8 @@ use libxml::schemas::SchemaValidationContext;
 use libxml::tree::document;
 use libxml::xpath::Context;
 
+use crate::uri::Uri;
+
 pub type XmlDocument = document::Document;
 pub type XmlXpathValue = libxml::xpath::Object;
 pub type XmlContext = libxml::xpath::Context;
@@ -132,6 +134,17 @@ pub fn get_node_tag(node: &XmlNode) -> String {
         Some(ns) => format!("{}:{}", ns.get_prefix(), node.get_name()).to_string(),
         None => node.get_name(),
     }
+}
+
+pub fn get_node_id(uri: &Uri, node: &XmlNode) -> String {
+    let tag = get_node_tag(node);
+    let mut key_values = node
+        .get_properties()
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect::<Vec<_>>();
+    key_values.sort();
+    format!("{}:{}[{}]", uri, tag, key_values.join(","))
 }
 
 pub fn get_readonly_node_tag(node: &XmlRoNode) -> String {


### PR DESCRIPTION
# Overview
Add a new function called `insert_map_element` to the `collection`
module in the `common` crate. This function allows inserting an element
into a nested HashMap based on the source key. If the source key already
exists, the element is inserted into the existing HashMap. If the source
key does not exist, a new HashMap is created and the element is inserted
into it. This function enhances the functionality of the `collection`
module and provides a convenient way to work with nested HashMaps.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved efficiency and control flow in methods handling XML elements and node attributes.

- **New Features**
  - Added support for handling `lod0` in multiple functions and data structures.
  - Introduced new utility functions for XML node ID generation and map element insertion.

- **Enhancements**
  - Enhanced `Attributes` struct with `Debug` trait for better debugging.
  - Updated various functions to utilize newly added fields and parameters for more robust data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->