### PR TITLE
feat(worker): add vertex remover module for geometry processing

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -1530,6 +1530,23 @@
       ]
     },
     {
+      "name": "VertexRemover",
+      "type": "processor",
+      "description": "Removes specific vertices from a feature’s geometry",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "XMLFragmenter",
       "type": "processor",
       "description": "Fragment XML",

--- a/worker/crates/action-processor/src/geometry.rs
+++ b/worker/crates/action-processor/src/geometry.rs
@@ -20,3 +20,4 @@ pub mod three_dimention_box_replacer;
 pub mod two_dimention_forcer;
 pub(super) mod types;
 pub mod validator;
+pub mod vertex_remover;

--- a/worker/crates/action-processor/src/geometry/mapping.rs
+++ b/worker/crates/action-processor/src/geometry/mapping.rs
@@ -14,6 +14,7 @@ use super::{
     splitter::GeometrySplitterFactory,
     three_dimention_box_replacer::ThreeDimentionBoxReplacerFactory,
     two_dimention_forcer::TwoDimentionForcerFactory, validator::GeometryValidatorFactory,
+    vertex_remover::VertexRemoverFactory,
 };
 
 pub static ACTION_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
@@ -38,6 +39,7 @@ pub static ACTION_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
         Box::<AreaOnAreaOverlayerFactory>::default(),
         Box::<GeometryReplacerFactory>::default(),
         Box::<ClosedCurveFilterFactory>::default(),
+        Box::<VertexRemoverFactory>::default(),
     ];
     factories
         .into_iter()

--- a/worker/crates/action-processor/src/geometry/vertex_remover.rs
+++ b/worker/crates/action-processor/src/geometry/vertex_remover.rs
@@ -1,0 +1,186 @@
+use std::collections::HashMap;
+
+use reearth_flow_geometry::algorithm::simplify::Simplify;
+use reearth_flow_geometry::types::geometry::Geometry2D;
+use reearth_flow_geometry::types::geometry::Geometry3D;
+use reearth_flow_geometry::types::line_string::{LineString2D, LineString3D};
+use reearth_flow_runtime::node::REJECTED_PORT;
+use reearth_flow_runtime::{
+    channels::ProcessorChannelForwarder,
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
+};
+use reearth_flow_types::Geometry;
+use reearth_flow_types::{Feature, GeometryValue};
+use serde_json::Value;
+
+const EPSILON: f64 = 0.0001;
+
+#[derive(Debug, Clone, Default)]
+pub struct VertexRemoverFactory;
+
+impl ProcessorFactory for VertexRemoverFactory {
+    fn name(&self) -> &str {
+        "VertexRemover"
+    }
+
+    fn description(&self) -> &str {
+        "Removes specific vertices from a feature’s geometry"
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        None
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["Geometry"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone(), REJECTED_PORT.clone()]
+    }
+
+    fn build(
+        &self,
+        _ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        _with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        Ok(Box::new(VertexRemover))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct VertexRemover;
+
+impl Processor for VertexRemover {
+    fn initialize(&mut self, _ctx: NodeContext) {}
+
+    fn num_threads(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let feature = &ctx.feature;
+        let Some(geometry) = &feature.geometry else {
+            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
+            return Ok(());
+        };
+        match &geometry.value {
+            GeometryValue::Null => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+            GeometryValue::FlowGeometry2D(geos) => {
+                self.handle_2d_geometry(geos, feature, geometry, &ctx, fw);
+            }
+            GeometryValue::FlowGeometry3D(geos) => {
+                self.handle_3d_geometry(geos, feature, geometry, &ctx, fw);
+            }
+            GeometryValue::CityGmlGeometry(_) => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(
+        &self,
+        _ctx: NodeContext,
+        _fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "VertexRemover"
+    }
+}
+
+impl VertexRemover {
+    fn handle_2d_geometry(
+        &self,
+        geos: &Geometry2D,
+        feature: &Feature,
+        geometry: &Geometry,
+        ctx: &ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) {
+        match geos {
+            Geometry2D::LineString(line_string) => {
+                let mut feature = feature.clone();
+                let mut geometry = geometry.clone();
+                let line_string: LineString2D<f64> = line_string.clone();
+                geometry.value = GeometryValue::FlowGeometry2D(Geometry2D::LineString(
+                    line_string.simplify(&EPSILON),
+                ));
+                feature.geometry = Some(geometry);
+                fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+            }
+            Geometry2D::MultiLineString(mline_string) => {
+                let mut feature = feature.clone();
+                let mut geometry = geometry.clone();
+                let line_strings: Vec<LineString2D<f64>> = mline_string.iter().cloned().collect();
+                geometry.value = GeometryValue::FlowGeometry2D(Geometry2D::MultiLineString(
+                    line_strings
+                        .iter()
+                        .map(|line_string| line_string.simplify(&EPSILON))
+                        .collect(),
+                ));
+                feature.geometry = Some(geometry);
+                fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+            }
+            _ => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+        }
+    }
+
+    fn handle_3d_geometry(
+        &self,
+        geos: &Geometry3D,
+        feature: &Feature,
+        geometry: &Geometry,
+        ctx: &ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) {
+        match geos {
+            Geometry3D::LineString(line_string) => {
+                let mut feature = feature.clone();
+                let mut geometry = geometry.clone();
+                let line_string: LineString3D<f64> = line_string.clone();
+                geometry.value = GeometryValue::FlowGeometry3D(Geometry3D::LineString(
+                    line_string.simplify(&EPSILON),
+                ));
+                feature.geometry = Some(geometry);
+                fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+            }
+            Geometry3D::MultiLineString(mline_string) => {
+                let mut feature = feature.clone();
+                let mut geometry = geometry.clone();
+                let line_strings: Vec<LineString3D<f64>> = mline_string.iter().cloned().collect();
+                geometry.value = GeometryValue::FlowGeometry3D(Geometry3D::MultiLineString(
+                    line_strings
+                        .iter()
+                        .map(|line_string| line_string.simplify(&EPSILON))
+                        .collect(),
+                ));
+                feature.geometry = Some(geometry);
+                fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+            }
+            _ => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+        }
+    }
+}

--- a/worker/crates/geometry/src/algorithm/simplify.rs
+++ b/worker/crates/geometry/src/algorithm/simplify.rs
@@ -43,7 +43,6 @@ where
             .into_iter()
             .map(|rdpindex| rdpindex.coord)
             .collect();
-    debug_assert_eq!(simplified_coords.len(), simplified_len);
     simplified_coords
 }
 
@@ -64,13 +63,11 @@ where
     }
 
     let mut simplified_len = rdp_indices.len();
-    let simplified_coords =
-        compute_rdp::<T, Z, INITIAL_MIN>(rdp_indices, &mut simplified_len, epsilon)
-            .into_iter()
-            .map(|rdpindex| rdpindex.index)
-            .collect::<Vec<usize>>();
-    debug_assert_eq!(simplified_len, simplified_coords.len());
-    simplified_coords
+
+    compute_rdp::<T, Z, INITIAL_MIN>(rdp_indices, &mut simplified_len, epsilon)
+        .into_iter()
+        .map(|rdpindex| rdpindex.index)
+        .collect::<Vec<usize>>()
 }
 
 fn compute_rdp<T, Z, const INITIAL_MIN: usize>(


### PR DESCRIPTION
# Overview
- add vertex remover module for geometry processing

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new processor named `VertexRemover` to the application. This feature allows users to remove specific vertices from a feature's geometry, supporting both 2D and 3D geometries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->