### PR TITLE
feat(worker): Add three-dimensional rotation module for geometry processing

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -1531,6 +1531,63 @@
       ]
     },
     {
+      "name": "ThreeDimentionRotator",
+      "type": "processor",
+      "description": "Replaces a three dimention box with a polygon.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "required": [
+          "angleDegree",
+          "directionX",
+          "directionY",
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
+        ],
+        "title": "ThreeDimentionRotatorParam",
+        "type": "object"
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "TwoDimentionForcer",
       "type": "processor",
       "description": "Forces a geometry to be two dimentional.",

--- a/worker/crates/action-processor/src/geometry.rs
+++ b/worker/crates/action-processor/src/geometry.rs
@@ -18,6 +18,7 @@ pub mod replacer;
 pub mod reprojector;
 pub mod splitter;
 pub mod three_dimention_box_replacer;
+pub mod three_dimention_rotator;
 pub mod two_dimention_forcer;
 pub(super) mod types;
 pub mod validator;

--- a/worker/crates/action-processor/src/geometry/errors.rs
+++ b/worker/crates/action-processor/src/geometry/errors.rs
@@ -63,6 +63,10 @@ pub(super) enum GeometryProcessorError {
     GeometryReplacerFactory(String),
     #[error("GeometryReplacer error: {0}")]
     GeometryReplacer(String),
+    #[error("ThreeDimentionRotator Factory error: {0}")]
+    ThreeDimentionRotatorFactory(String),
+    #[error("ThreeDimentionRotator error: {0}")]
+    ThreeDimentionRotator(String),
 }
 
 pub(super) type Result<T, E = GeometryProcessorError> = std::result::Result<T, E>;

--- a/worker/crates/action-processor/src/geometry/mapping.rs
+++ b/worker/crates/action-processor/src/geometry/mapping.rs
@@ -14,6 +14,7 @@ use super::{
     replacer::GeometryReplacerFactory, reprojector::ReprojectorFactory,
     splitter::GeometrySplitterFactory,
     three_dimention_box_replacer::ThreeDimentionBoxReplacerFactory,
+    three_dimention_rotator::ThreeDimentionRotatorFactory,
     two_dimention_forcer::TwoDimentionForcerFactory, validator::GeometryValidatorFactory,
     vertex_remover::VertexRemoverFactory,
 };
@@ -42,6 +43,7 @@ pub static ACTION_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
         Box::<ClosedCurveFilterFactory>::default(),
         Box::<VertexRemoverFactory>::default(),
         Box::<CenterPointReplacerFactory>::default(),
+        Box::<ThreeDimentionRotatorFactory>::default(),
     ];
     factories
         .into_iter()

--- a/worker/crates/action-processor/src/geometry/three_dimention_rotator.rs
+++ b/worker/crates/action-processor/src/geometry/three_dimention_rotator.rs
@@ -1,0 +1,195 @@
+use std::{collections::HashMap, sync::Arc};
+
+use reearth_flow_geometry::{algorithm::rotate_3d::Rotate3D, types::point::Point3D};
+use reearth_flow_runtime::{
+    channels::ProcessorChannelForwarder,
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
+};
+use reearth_flow_types::{Expr, GeometryValue};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::errors::GeometryProcessorError;
+
+#[derive(Debug, Clone, Default)]
+pub struct ThreeDimentionRotatorFactory;
+
+impl ProcessorFactory for ThreeDimentionRotatorFactory {
+    fn name(&self) -> &str {
+        "ThreeDimentionRotator"
+    }
+
+    fn description(&self) -> &str {
+        "Replaces a three dimention box with a polygon."
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        Some(schemars::schema_for!(ThreeDimentionRotatorParam))
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["Geometry"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn build(
+        &self,
+        ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        let params: ThreeDimentionRotatorParam = if let Some(with) = with {
+            let value = serde_json::to_value(with).map_err(|e| {
+                GeometryProcessorError::ThreeDimentionRotatorFactory(format!(
+                    "Failed to serialize with: {}",
+                    e
+                ))
+            })?;
+            serde_json::from_value(value).map_err(|e| {
+                GeometryProcessorError::LineOnLineOverlayerFactory(format!(
+                    "Failed to deserialize with: {}",
+                    e
+                ))
+            })?
+        } else {
+            return Err(GeometryProcessorError::ThreeDimentionRotatorFactory(
+                "Missing required parameter `with`".to_string(),
+            )
+            .into());
+        };
+        let expr_engine = Arc::clone(&ctx.expr_engine);
+        let angle_degree = expr_engine
+            .compile(params.angle_degree.as_ref())
+            .map_err(|e| {
+                GeometryProcessorError::ThreeDimentionRotatorFactory(format!("{:?}", e))
+            })?;
+        let origin_x = expr_engine.compile(params.origin_x.as_ref()).map_err(|e| {
+            GeometryProcessorError::ThreeDimentionRotatorFactory(format!("{:?}", e))
+        })?;
+        let origin_y = expr_engine.compile(params.origin_y.as_ref()).map_err(|e| {
+            GeometryProcessorError::ThreeDimentionRotatorFactory(format!("{:?}", e))
+        })?;
+        let origin_z = expr_engine.compile(params.origin_z.as_ref()).map_err(|e| {
+            GeometryProcessorError::ThreeDimentionRotatorFactory(format!("{:?}", e))
+        })?;
+        let direction_x = expr_engine
+            .compile(params.direction_x.as_ref())
+            .map_err(|e| {
+                GeometryProcessorError::ThreeDimentionRotatorFactory(format!("{:?}", e))
+            })?;
+        let direction_y = expr_engine
+            .compile(params.direction_y.as_ref())
+            .map_err(|e| {
+                GeometryProcessorError::ThreeDimentionRotatorFactory(format!("{:?}", e))
+            })?;
+        let direction_z = expr_engine
+            .compile(params.direction_z.as_ref())
+            .map_err(|e| {
+                GeometryProcessorError::ThreeDimentionRotatorFactory(format!("{:?}", e))
+            })?;
+        Ok(Box::new(ThreeDimentionRotator {
+            angle_degree,
+            origin_x,
+            origin_y,
+            origin_z,
+            direction_x,
+            direction_y,
+            direction_z,
+        }))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ThreeDimentionRotatorParam {
+    angle_degree: Expr,
+    origin_x: Expr,
+    origin_y: Expr,
+    origin_z: Expr,
+    direction_x: Expr,
+    direction_y: Expr,
+    direction_z: Expr,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThreeDimentionRotator {
+    angle_degree: rhai::AST,
+    origin_x: rhai::AST,
+    origin_y: rhai::AST,
+    origin_z: rhai::AST,
+    direction_x: rhai::AST,
+    direction_y: rhai::AST,
+    direction_z: rhai::AST,
+}
+
+impl Processor for ThreeDimentionRotator {
+    fn initialize(&mut self, _ctx: NodeContext) {}
+
+    fn num_threads(&self) -> usize {
+        5
+    }
+
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let feature = &ctx.feature;
+        let scope = &ctx.expr_engine.new_scope();
+        for (k, v) in &feature.attributes {
+            scope.set(k.inner().as_str(), v.clone().into());
+        }
+        let angle_degree = scope.eval_ast::<f64>(&self.angle_degree)?;
+        let origin_x = scope.eval_ast::<f64>(&self.origin_x)?;
+        let origin_y = scope.eval_ast::<f64>(&self.origin_y)?;
+        let origin_z = scope.eval_ast::<f64>(&self.origin_z)?;
+        let direction_x = scope.eval_ast::<f64>(&self.direction_x)?;
+        let direction_y = scope.eval_ast::<f64>(&self.direction_y)?;
+        let direction_z = scope.eval_ast::<f64>(&self.direction_z)?;
+        let geometry = match &feature.geometry {
+            Some(geometry) => match &geometry.value {
+                GeometryValue::FlowGeometry3D(geos) => {
+                    let rotate = geos.rotate_3d(
+                        angle_degree,
+                        Some(Point3D::new_(origin_x, origin_y, origin_z)),
+                        Point3D::new_(direction_x, direction_y, direction_z),
+                    );
+                    let mut geometry = geometry.clone();
+                    geometry.value = GeometryValue::FlowGeometry3D(rotate);
+                    Some(geometry)
+                }
+                _ => Some(geometry.clone()),
+            },
+            None => None,
+        };
+
+        let mut feature = ctx.feature.clone();
+        feature.geometry = geometry;
+        fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+        Ok(())
+    }
+
+    fn finish(
+        &self,
+        _ctx: NodeContext,
+        _fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "ThreeDimentionRotator"
+    }
+}

--- a/worker/crates/geometry/src/algorithm.rs
+++ b/worker/crates/geometry/src/algorithm.rs
@@ -26,6 +26,7 @@ pub mod line_intersection;
 pub mod map_coords;
 pub mod relate;
 pub mod remove_repeated_points;
+pub mod rotate_3d;
 pub mod simplify;
 pub mod sweep;
 pub mod utils;

--- a/worker/crates/geometry/src/algorithm/rotate_3d.rs
+++ b/worker/crates/geometry/src/algorithm/rotate_3d.rs
@@ -1,0 +1,226 @@
+use crate::{
+    types::{
+        coordinate::Coordinate3D, geometry::Geometry3D, geometry_collection::GeometryCollection3D,
+        line::Line3D, line_string::LineString3D, multi_line_string::MultiLineString3D,
+        multi_point::MultiPoint3D, multi_polygon::MultiPolygon3D, point::Point3D,
+        polygon::Polygon3D, rect::Rect3D, triangle::Triangle3D,
+    },
+    utils::rotate_3d_custom_axis,
+};
+
+pub trait Rotate3D {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self;
+}
+
+impl Rotate3D for Coordinate3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        let result = rotate_3d_custom_axis(
+            vec![nalgebra::Point3::new(self.x, self.y, self.z)],
+            angle_degrees,
+            origin,
+            direction,
+        );
+        Coordinate3D::new__(result[0].x, result[0].y, result[0].z)
+    }
+}
+
+impl Rotate3D for Point3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        let result = rotate_3d_custom_axis(
+            vec![nalgebra::Point3::new(self.x(), self.y(), self.z())],
+            angle_degrees,
+            origin,
+            direction,
+        );
+        Point3D::new_(result[0].x, result[0].y, result[0].z)
+    }
+}
+
+impl Rotate3D for LineString3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        LineString3D::new(
+            self.coords()
+                .map(|c| c.rotate_3d(angle_degrees, origin, direction))
+                .collect(),
+        )
+    }
+}
+
+impl Rotate3D for Line3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        let start = self.start.rotate_3d(angle_degrees, origin, direction);
+        let end = self.end.rotate_3d(angle_degrees, origin, direction);
+        Line3D::new_(start, end)
+    }
+}
+
+impl Rotate3D for Polygon3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        Polygon3D::new(
+            self.exterior().rotate_3d(angle_degrees, origin, direction),
+            self.interiors()
+                .iter()
+                .map(|ls| ls.rotate_3d(angle_degrees, origin, direction))
+                .collect(),
+        )
+    }
+}
+
+impl Rotate3D for MultiPoint3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        MultiPoint3D::new(
+            self.0
+                .iter()
+                .map(|p| p.rotate_3d(angle_degrees, origin, direction))
+                .collect(),
+        )
+    }
+}
+
+impl Rotate3D for MultiLineString3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        MultiLineString3D::new(
+            self.0
+                .iter()
+                .map(|ls| ls.rotate_3d(angle_degrees, origin, direction))
+                .collect(),
+        )
+    }
+}
+
+impl Rotate3D for MultiPolygon3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        MultiPolygon3D::new(
+            self.0
+                .iter()
+                .map(|p| p.rotate_3d(angle_degrees, origin, direction))
+                .collect(),
+        )
+    }
+}
+
+impl Rotate3D for Rect3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        Rect3D::new(
+            self.min().rotate_3d(angle_degrees, origin, direction),
+            self.max().rotate_3d(angle_degrees, origin, direction),
+        )
+    }
+}
+
+impl Rotate3D for Triangle3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        Triangle3D::new(
+            self.0.rotate_3d(angle_degrees, origin, direction),
+            self.1.rotate_3d(angle_degrees, origin, direction),
+            self.2.rotate_3d(angle_degrees, origin, direction),
+        )
+    }
+}
+
+impl Rotate3D for Geometry3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        match self {
+            Geometry3D::Point(p) => {
+                Geometry3D::Point(p.rotate_3d(angle_degrees, origin, direction))
+            }
+            Geometry3D::Line(l) => Geometry3D::Line(l.rotate_3d(angle_degrees, origin, direction)),
+            Geometry3D::LineString(ls) => {
+                Geometry3D::LineString(ls.rotate_3d(angle_degrees, origin, direction))
+            }
+            Geometry3D::Polygon(p) => {
+                Geometry3D::Polygon(p.rotate_3d(angle_degrees, origin, direction))
+            }
+            Geometry3D::MultiPoint(mp) => {
+                Geometry3D::MultiPoint(mp.rotate_3d(angle_degrees, origin, direction))
+            }
+            Geometry3D::MultiLineString(mls) => {
+                Geometry3D::MultiLineString(mls.rotate_3d(angle_degrees, origin, direction))
+            }
+            Geometry3D::MultiPolygon(mp) => {
+                Geometry3D::MultiPolygon(mp.rotate_3d(angle_degrees, origin, direction))
+            }
+            Geometry3D::Rect(r) => Geometry3D::Rect(r.rotate_3d(angle_degrees, origin, direction)),
+            Geometry3D::Triangle(t) => {
+                Geometry3D::Triangle(t.rotate_3d(angle_degrees, origin, direction))
+            }
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl Rotate3D for GeometryCollection3D<f64> {
+    fn rotate_3d(
+        &self,
+        angle_degrees: f64,
+        origin: Option<Point3D<f64>>,
+        direction: Point3D<f64>,
+    ) -> Self {
+        GeometryCollection3D::new(
+            self.0
+                .iter()
+                .map(|g| g.rotate_3d(angle_degrees, origin, direction))
+                .collect(),
+        )
+    }
+}

--- a/worker/crates/geometry/src/utils.rs
+++ b/worker/crates/geometry/src/utils.rs
@@ -327,3 +327,40 @@ pub fn are_points_coplanar(
         None
     }
 }
+
+pub(crate) fn rotate_3d_custom_axis(
+    points: Vec<nalgebra::Point3<f64>>,
+    angle_degrees: f64,
+    origin: Option<Point3D<f64>>,
+    direction: Point3D<f64>,
+) -> Vec<nalgebra::Point3<f64>> {
+    // Origin of rotation
+    let angle_degrees = angle_degrees.to_radians();
+    let origin = origin.map(|p| nalgebra::Vector3::new(p.x(), p.y(), p.z()));
+
+    // Rotational axis vector
+    let direction = nalgebra::Vector3::new(direction.x(), direction.y(), direction.z()).normalize();
+
+    // Create a rotation matrix around the rotation axis.
+    let rotation = nalgebra::Rotation3::from_axis_angle(
+        &nalgebra::Unit::new_normalize(direction),
+        angle_degrees,
+    );
+
+    points
+        .iter()
+        .map(|point| {
+            let translated_point = if let Some(origin) = origin {
+                point.coords - origin
+            } else {
+                point.coords
+            };
+            let rotated_point = if let Some(origin) = origin {
+                rotation * translated_point + origin
+            } else {
+                rotation * translated_point
+            };
+            nalgebra::Point3::from(rotated_point)
+        })
+        .collect()
+}


### PR DESCRIPTION
# Overview
- Add three-dimensional rotation module for geometry processing

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new processor, `ThreeDimentionRotator`, that replaces a three-dimensional box with a polygon. This feature supports rotation around custom axes with configurable parameters for angle, direction, and origin.

- **Enhancements**
  - Added new methods for rotating 3D geometric entities such as coordinates, points, lines, polygons, and more.
  - Implemented a `rotate_3d_custom_axis` function for performing 3D rotations around a specified axis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->