### PR TITLE
feat(worker): Add support for null values in epsgCode field

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -1433,12 +1433,12 @@
           "epsgCode": {
             "format": "uint16",
             "minimum": 0.0,
-            "type": "integer"
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
-        "required": [
-          "epsgCode"
-        ],
         "title": "ReprojectorParam",
         "type": "object"
       },

--- a/worker/crates/action-processor/src/geometry/reprojector.rs
+++ b/worker/crates/action-processor/src/geometry/reprojector.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
-use nusamai_projection::{crs::*, etmerc::ExtendedTransverseMercatorProjection, jprect::JPRZone};
-use reearth_flow_geometry::algorithm::proj::Projection;
+use nusamai_projection::{
+    crs::*, ellipsoid::wgs84, etmerc::ExtendedTransverseMercatorProjection, jprect::JPRZone,
+};
+use reearth_flow_geometry::algorithm::{centroid::Centroid, proj::Projection};
 use reearth_flow_runtime::{
     channels::ProcessorChannelForwarder,
     errors::BoxedError,
@@ -15,6 +17,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::{errors::GeometryProcessorError, types::SUPPORT_EPSG_CODE};
+
+const K: f64 = 0.9999;
 
 #[derive(Debug, Clone, Default)]
 pub struct ReprojectorFactory;
@@ -69,21 +73,24 @@ impl ProcessorFactory for ReprojectorFactory {
             )
             .into());
         };
-        if !SUPPORT_EPSG_CODE.contains(&params.epsg_code) {
-            return Err(GeometryProcessorError::ReprojectorFactory(
-                "Unsupported EPSG code".to_string(),
-            )
-            .into());
-        }
-        let zone = JPRZone::from_epsg(params.epsg_code).ok_or(
-            GeometryProcessorError::ReprojectorFactory(format!(
-                "Failed to create JPRZone from EPSG code: {}",
-                params.epsg_code,
-            )),
-        )?;
+        let projection = if let Some(epsg_code) = params.epsg_code {
+            if !SUPPORT_EPSG_CODE.contains(&epsg_code) {
+                return Err(GeometryProcessorError::ReprojectorFactory(
+                    "Unsupported EPSG code".to_string(),
+                )
+                .into());
+            }
+            let zone =
+                JPRZone::from_epsg(epsg_code).ok_or(GeometryProcessorError::ReprojectorFactory(
+                    format!("Failed to create JPRZone from EPSG code: {}", epsg_code,),
+                ))?;
+            Some(zone.projection())
+        } else {
+            None
+        };
         Ok(Box::new(Reprojector {
             epsg_code: params.epsg_code,
-            projection: zone.projection(),
+            projection,
         }))
     }
 }
@@ -91,13 +98,13 @@ impl ProcessorFactory for ReprojectorFactory {
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ReprojectorParam {
-    epsg_code: EpsgCode,
+    epsg_code: Option<EpsgCode>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Reprojector {
-    epsg_code: EpsgCode,
-    projection: ExtendedTransverseMercatorProjection,
+    epsg_code: Option<EpsgCode>,
+    projection: Option<ExtendedTransverseMercatorProjection>,
 }
 
 impl Processor for Reprojector {
@@ -112,22 +119,98 @@ impl Processor for Reprojector {
         ctx: ExecutorContext,
         fw: &mut dyn ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
-        let mut feature = ctx.feature.clone();
-        if let Some(ref mut geometry) = feature.geometry {
-            geometry.epsg = Some(self.epsg_code);
-            match &mut geometry.value {
+        let feature = &ctx.feature;
+        if let Some(geometry) = &feature.geometry {
+            match &geometry.value {
                 GeometryValue::CityGmlGeometry(v) => {
-                    for feature in &mut v.features {
+                    let mut feature = feature.clone();
+                    let mut geometry = geometry.clone();
+                    let Some(projection) = &self.projection else {
+                        fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+                        return Ok(());
+                    };
+                    geometry.epsg = self.epsg_code;
+                    let mut geometry_value = v.clone();
+                    for feature in &mut geometry_value.features {
                         for polygon in &mut feature.polygons {
-                            polygon.projection(&self.projection)?;
+                            polygon.projection(projection)?;
                         }
                     }
+                    geometry.value = GeometryValue::CityGmlGeometry(geometry_value);
+                    feature.geometry = Some(geometry);
+                    fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
                 }
-                GeometryValue::Null => {}
-                _ => unimplemented!(),
+                GeometryValue::FlowGeometry2D(geos) => {
+                    let projection =
+                        if let Some(projection) = &self.projection {
+                            projection.clone()
+                        } else {
+                            let Some(centroid) = geos.centroid() else {
+                                fw.send(ctx.new_with_feature_and_port(
+                                    feature.clone(),
+                                    DEFAULT_PORT.clone(),
+                                ));
+                                return Ok(());
+                            };
+                            ExtendedTransverseMercatorProjection::new(
+                                centroid.x(),
+                                centroid.y(),
+                                K,
+                                &wgs84(),
+                            )
+                        };
+                    let epsg = if let Some(epsg_code) = self.epsg_code {
+                        Some(epsg_code)
+                    } else {
+                        Some(EPSG_JGD2011_GEOGRAPHIC_2D)
+                    };
+                    let mut feature = feature.clone();
+                    let mut geometry = geometry.clone();
+                    let mut geos = geos.clone();
+                    geos.projection(&projection)?;
+                    geometry.value = GeometryValue::FlowGeometry2D(geos);
+                    geometry.epsg = epsg;
+                    feature.geometry = Some(geometry);
+                    fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+                }
+                GeometryValue::FlowGeometry3D(geos) => {
+                    let projection =
+                        if let Some(projection) = &self.projection {
+                            projection.clone()
+                        } else {
+                            let Some(centroid) = geos.centroid() else {
+                                fw.send(ctx.new_with_feature_and_port(
+                                    feature.clone(),
+                                    DEFAULT_PORT.clone(),
+                                ));
+                                return Ok(());
+                            };
+                            ExtendedTransverseMercatorProjection::new(
+                                centroid.x(),
+                                centroid.y(),
+                                K,
+                                &wgs84(),
+                            )
+                        };
+                    let epsg = if let Some(epsg_code) = self.epsg_code {
+                        Some(epsg_code)
+                    } else {
+                        Some(EPSG_JGD2011_GEOGRAPHIC_3D)
+                    };
+                    let mut feature = feature.clone();
+                    let mut geometry = geometry.clone();
+                    let mut geos = geos.clone();
+                    geos.projection(&projection)?;
+                    geometry.value = GeometryValue::FlowGeometry3D(geos);
+                    geometry.epsg = epsg;
+                    feature.geometry = Some(geometry);
+                    fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+                }
+                GeometryValue::Null => {
+                    fw.send(ctx.new_with_feature_and_port(feature.clone(), DEFAULT_PORT.clone()))
+                }
             }
         }
-        fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
         Ok(())
     }
 


### PR DESCRIPTION
# Overview
The code changes modify the "epsgCode" field in the "ReprojectorParam" object schema to allow for null values in addition to integers. This change provides flexibility in handling cases where the epsgCode is not applicable or unknown.

Based on the recent user commits and repository commits, the established convention for commit messages in this repository is to use a prefix indicating the type of change (e.g., feat for a new feature, fix for a bug fix, chore for maintenance tasks). The commit messages are concise and provide a clear description of the code changes.

Please note that the commit message provided above is a suggestion based on the code changes and established conventions. Feel free to modify it as needed.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced geometry reprojector to handle optional EPSG codes and projections.

- **Bug Fixes**
  - Improved stability and flexibility in geometry processing by allowing `epsg_code` to be null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->