### PR TITLE
feat(worker): add cityGmlAttributes to Feature attributes in citygml.rs and citygml.rs

### DIFF
--- a/worker/crates/action-processor/src/feature/reader/citygml.rs
+++ b/worker/crates/action-processor/src/feature/reader/citygml.rs
@@ -10,7 +10,7 @@ use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::{
     channels::ProcessorChannelForwarder, executor_operation::ExecutorContext, node::DEFAULT_PORT,
 };
-use reearth_flow_types::{geometry::Geometry, Feature};
+use reearth_flow_types::{geometry::Geometry, Attribute, Feature};
 use url::Url;
 
 use super::CompiledCommonPropertySchema;
@@ -124,11 +124,15 @@ fn parse_tree_reader<R: BufRead>(
                 &geom_store.surface_spans,
             );
         }
+        let attributes = entity.root.to_attribute_json();
         let geometry: Geometry = entity.try_into().map_err(|e| {
             super::errors::FeatureProcessorError::FileCityGmlReader(format!("{:?}", e))
         })?;
         let mut feature = Feature::new_with_attributes(ctx.feature.attributes.clone());
         feature.geometry = Some(geometry);
+        feature
+            .attributes
+            .insert(Attribute::new("cityGmlAttributes"), attributes.into());
         fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
     }
     Ok(())

--- a/worker/crates/action-source/src/file/reader/citygml.rs
+++ b/worker/crates/action-source/src/file/reader/citygml.rs
@@ -11,7 +11,7 @@ use reearth_flow_runtime::{
     executor_operation::NodeContext,
     node::{IngestionMessage, Port, DEFAULT_PORT},
 };
-use reearth_flow_types::{geometry::Geometry, Feature};
+use reearth_flow_types::{geometry::Geometry, Attribute, Feature};
 use tokio::sync::mpsc::Sender;
 use url::Url;
 
@@ -117,10 +117,14 @@ async fn parse_tree_reader<'a, 'b, R: BufRead>(
                 &geom_store.surface_spans,
             );
         }
+        let attributes = entity.root.to_attribute_json();
         let geometry: Geometry = entity
             .try_into()
             .map_err(|e| crate::errors::SourceError::FileReader(format!("{:?}", e)))?;
-        let feature: Feature = geometry.into();
+        let mut feature: Feature = geometry.into();
+        feature
+            .attributes
+            .insert(Attribute::new("cityGmlAttributes"), attributes.into());
         sender
             .send((
                 DEFAULT_PORT.clone(),

--- a/worker/crates/types/src/geometry.rs
+++ b/worker/crates/types/src/geometry.rs
@@ -34,7 +34,6 @@ pub struct Geometry {
     pub name: Option<String>,
     pub epsg: Option<EpsgCode>,
     pub value: GeometryValue,
-    pub attributes: Option<serde_json::Value>,
 }
 
 impl TryFrom<Entity> for Geometry {
@@ -58,7 +57,6 @@ impl TryFrom<Entity> for Geometry {
         let ObjectStereotype::Feature { id, geometries } = &obj.stereotype else {
             return Err(Error::unsupported_feature("no feature found"));
         };
-        let attributes = entity.root.to_attribute_json();
         let mut geometry_features = Vec::<GeometryFeature>::new();
         let operation = |geometry: &GeometryRef| -> Option<GeometryFeature> {
             match geometry.ty {
@@ -225,7 +223,6 @@ impl TryFrom<Entity> for Geometry {
             Some(name),
             epsg,
             GeometryValue::CityGmlGeometry(geometry_entity),
-            Some(attributes),
         ))
     }
 }
@@ -237,25 +234,17 @@ impl Default for Geometry {
             name: Some("".to_string()),
             epsg: None,
             value: GeometryValue::Null,
-            attributes: None,
         }
     }
 }
 
 impl Geometry {
-    pub fn new(
-        id: String,
-        name: Option<String>,
-        epsg: EpsgCode,
-        value: GeometryValue,
-        attributes: Option<serde_json::Value>,
-    ) -> Self {
+    pub fn new(id: String, name: Option<String>, epsg: EpsgCode, value: GeometryValue) -> Self {
         Self {
             id,
             name,
             epsg: Some(epsg),
             value,
-            attributes,
         }
     }
 
@@ -265,7 +254,6 @@ impl Geometry {
             name: None,
             epsg: None,
             value,
-            attributes: None,
         }
     }
 }

--- a/worker/examples/plateau/testdata/workflow/domain_of_definition_validator.yml
+++ b/worker/examples/plateau/testdata/workflow/domain_of_definition_validator.yml
@@ -4,7 +4,7 @@ name: "PLATEAU.DomainOfDefinitionValidator"
 entryGraphId: 3e3450c8-2344-4728-afa9-5fdb81eec33a
 with:
   cityGmlPath:
-  cityCode: "11234"
+  cityCode:
   codelistsPath:
   schemasPath:
   schemaJson: !include ../config/schema.txt

--- a/worker/examples/plateau/testdata/workflow/lod_splitter_with_dm.yml
+++ b/worker/examples/plateau/testdata/workflow/lod_splitter_with_dm.yml
@@ -4,7 +4,7 @@ name: "lod_splitter_with_dm"
 entryGraphId: 3e3450c8-2344-4728-afa9-5fdb81eec33a
 with:
   cityGmlPath:
-  cityCode: "11234"
+  cityCode:
   codelistsPath:
   schemasPath:
   schemaJson: !include ../config/schema.txt


### PR DESCRIPTION
# Overview
The code changes add the "cityGmlAttributes" attribute to the Feature struct in the citygml.rs and citygml.rs files. This attribute is populated with the attributes of the root entity in the CityGML file.

Based on the recent user commits and repository commits, the established convention for commit messages in this repository is to use a prefix indicating the type of change (e.g., feat for a new feature, fix for a bug fix, chore for maintenance tasks). The commit messages are concise and provide a clear description of the code changes.

Please note that the commit message provided above is a suggestion based on the code changes and established conventions. Feel free to modify it as needed.


## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `cityGmlAttributes` to the `Feature` entity.

- **Bug Fixes**
  - Corrected `cityCode` values in configuration files for data initialization. 

- **Refactor**
  - Simplified the `Geometry` struct by removing the `attributes` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->