### PR TITLE
chore(worker): Add to_hash function for generating node IDs in xml.rs

### DIFF
--- a/worker/crates/common/src/xml.rs
+++ b/worker/crates/common/src/xml.rs
@@ -7,6 +7,7 @@ use libxml::schemas::SchemaValidationContext;
 use libxml::tree::document;
 use libxml::xpath::Context;
 
+use crate::str::to_hash;
 use crate::uri::Uri;
 
 pub type XmlDocument = document::Document;
@@ -144,7 +145,7 @@ pub fn get_node_id(uri: &Uri, node: &XmlNode) -> String {
         .map(|(k, v)| format!("{}={}", k, v))
         .collect::<Vec<_>>();
     key_values.sort();
-    format!("{}:{}[{}]", uri, tag, key_values.join(","))
+    to_hash(format!("{}:{}[{}]", uri, tag, key_values.join(",")).as_str())
 }
 
 pub fn get_readonly_node_tag(node: &XmlRoNode) -> String {

--- a/worker/examples/plateau/testdata/workflow/lod_splitter_with_dm.yml
+++ b/worker/examples/plateau/testdata/workflow/lod_splitter_with_dm.yml
@@ -88,7 +88,7 @@ graphs:
       - id: ba7d8205-5997-4fa4-be0e-e8ba67a1a9dd
         from: d3773442-1ba8-47c1-b7c1-0bafa23adec9
         to: 3c0bc9cd-284d-4553-83ae-f90365c5930c
-        fromPort: default
+        fromPort: filePath
         toPort: default
       - id: e1c7680d-5830-4e48-8cd8-8d9d762c76ff
         from: 3c0bc9cd-284d-4553-83ae-f90365c5930c


### PR DESCRIPTION
# Overview
- Add to_hash function for generating node IDs in xml.rs

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected an issue in workflow configuration where `fromPort` value was incorrectly set to `default` instead of `filePath`.

- **Improvements**
  - Enhanced internal data handling by optimizing string processing in XML node identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->