### PR TITLE
feat(worker): Add json and xml modules 

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -24,8 +24,26 @@
       "description": "Aggregates features by attributes",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeAggregatorParam",
+        "type": "object",
+        "required": [
+          "aggregations"
+        ],
+        "properties": {
+          "aggregations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Aggregation"
+            }
+          }
+        },
         "definitions": {
           "Aggregation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
             "properties": {
               "attribute": {
                 "$ref": "#/definitions/Attribute"
@@ -33,39 +51,21 @@
               "method": {
                 "$ref": "#/definitions/Method"
               }
-            },
-            "required": [
-              "attribute",
-              "method"
-            ],
-            "type": "object"
+            }
           },
           "Attribute": {
             "type": "string"
           },
           "Method": {
+            "type": "string",
             "enum": [
               "max",
               "min",
               "sum",
               "avg"
-            ],
-            "type": "string"
+            ]
           }
-        },
-        "properties": {
-          "aggregations": {
-            "items": {
-              "$ref": "#/definitions/Aggregation"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "aggregations"
-        ],
-        "title": "AttributeAggregatorParam",
-        "type": "object"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -84,24 +84,24 @@
       "description": "Filters features by duplicate attributes",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeDuplicateFilterParam",
+        "type": "object",
+        "required": [
+          "filterBy"
+        ],
+        "properties": {
+          "filterBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
         "definitions": {
           "Attribute": {
             "type": "string"
           }
-        },
-        "properties": {
-          "filterBy": {
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "filterBy"
-        ],
-        "title": "AttributeDuplicateFilterParam",
-        "type": "object"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -120,21 +120,21 @@
       "description": "Extracts file path information from attributes",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          }
-        },
+        "title": "AttributeFilePathInfoExtractor",
+        "type": "object",
+        "required": [
+          "attribute"
+        ],
         "properties": {
           "attribute": {
             "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "attribute"
-        ],
-        "title": "AttributeFilePathInfoExtractor",
-        "type": "object"
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -154,24 +154,24 @@
       "description": "Keeps only specified attributes",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeKeeper",
+        "type": "object",
+        "required": [
+          "keepAttributes"
+        ],
+        "properties": {
+          "keepAttributes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
         "definitions": {
           "Attribute": {
             "type": "string"
           }
-        },
-        "properties": {
-          "keepAttributes": {
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "keepAttributes"
-        ],
-        "title": "AttributeKeeper",
-        "type": "object"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -190,20 +190,38 @@
       "description": "Manages attributes",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeManagerParam",
+        "type": "object",
+        "required": [
+          "operations"
+        ],
+        "properties": {
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Operation"
+            }
+          }
+        },
         "definitions": {
           "Expr": {
             "type": "string"
           },
           "Method": {
+            "type": "string",
             "enum": [
               "convert",
               "create",
               "rename",
               "remove"
-            ],
-            "type": "string"
+            ]
           },
           "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
             "properties": {
               "attribute": {
                 "type": "string"
@@ -221,27 +239,9 @@
                   }
                 ]
               }
-            },
-            "required": [
-              "attribute",
-              "method"
-            ],
-            "type": "object"
+            }
           }
-        },
-        "properties": {
-          "operations": {
-            "items": {
-              "$ref": "#/definitions/Operation"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "operations"
-        ],
-        "title": "AttributeManagerParam",
-        "type": "object"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -260,29 +260,29 @@
       "description": "Buffers a geometry",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "BufferType": {
-            "enum": [
-              "area2d"
-            ],
-            "type": "string"
-          }
-        },
+        "title": "Bufferer",
+        "type": "object",
+        "required": [
+          "buffer_type",
+          "distance"
+        ],
         "properties": {
           "buffer_type": {
             "$ref": "#/definitions/BufferType"
           },
           "distance": {
-            "format": "double",
-            "type": "number"
+            "type": "number",
+            "format": "double"
           }
         },
-        "required": [
-          "buffer_type",
-          "distance"
-        ],
-        "title": "Bufferer",
-        "type": "object"
+        "definitions": {
+          "BufferType": {
+            "type": "string",
+            "enum": [
+              "area2d"
+            ]
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -337,18 +337,18 @@
       "description": "Sets the coordinate system of a feature",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "properties": {
-          "epsgCode": {
-            "format": "uint16",
-            "minimum": 0.0,
-            "type": "integer"
-          }
-        },
+        "title": "CoordinateSystemSetter",
+        "type": "object",
         "required": [
           "epsgCode"
         ],
-        "title": "CoordinateSystemSetter",
-        "type": "object"
+        "properties": {
+          "epsgCode": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -367,21 +367,21 @@
       "description": "Extrudes a polygon by a distance",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          }
-        },
+        "title": "ExtruderParam",
+        "type": "object",
+        "required": [
+          "distance"
+        ],
         "properties": {
           "distance": {
             "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "distance"
-        ],
-        "title": "ExtruderParam",
-        "type": "object"
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -400,35 +400,35 @@
       "description": "Counts features",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          }
-        },
+        "title": "FeatureCounterParam",
+        "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
         "properties": {
           "countStart": {
-            "format": "int64",
-            "type": "integer"
+            "type": "integer",
+            "format": "int64"
           },
           "groupBy": {
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            },
             "type": [
               "array",
               "null"
-            ]
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
-        "title": "FeatureCounterParam",
-        "type": "object"
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -447,8 +447,26 @@
       "description": "Filters features based on conditions",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureFilterParam",
+        "type": "object",
+        "required": [
+          "conditions"
+        ],
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Condition"
+            }
+          }
+        },
         "definitions": {
           "Condition": {
+            "type": "object",
+            "required": [
+              "expr",
+              "outputPort"
+            ],
             "properties": {
               "expr": {
                 "$ref": "#/definitions/Expr"
@@ -456,12 +474,7 @@
               "outputPort": {
                 "$ref": "#/definitions/Port"
               }
-            },
-            "required": [
-              "expr",
-              "outputPort"
-            ],
-            "type": "object"
+            }
           },
           "Expr": {
             "type": "string"
@@ -469,20 +482,7 @@
           "Port": {
             "type": "string"
           }
-        },
-        "properties": {
-          "conditions": {
-            "items": {
-              "$ref": "#/definitions/Condition"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "conditions"
-        ],
-        "title": "FeatureFilterParam",
-        "type": "object"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -501,11 +501,26 @@
       "description": "Merges features by attributes",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureMergerParam",
+        "type": "object",
+        "required": [
+          "join"
+        ],
+        "properties": {
+          "join": {
+            "$ref": "#/definitions/Join"
+          }
+        },
         "definitions": {
           "Attribute": {
             "type": "string"
           },
           "Join": {
+            "type": "object",
+            "required": [
+              "requestor",
+              "supplier"
+            ],
             "properties": {
               "requestor": {
                 "$ref": "#/definitions/Attribute"
@@ -513,24 +528,9 @@
               "supplier": {
                 "$ref": "#/definitions/Attribute"
               }
-            },
-            "required": [
-              "requestor",
-              "supplier"
-            ],
-            "type": "object"
+            }
           }
-        },
-        "properties": {
-          "join": {
-            "$ref": "#/definitions/Join"
-          }
-        },
-        "required": [
-          "join"
-        ],
-        "title": "FeatureMergerParam",
-        "type": "object"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -551,84 +551,84 @@
       "description": "Filters features based on conditions",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureReaderParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          }
+        ],
         "definitions": {
           "Expr": {
             "type": "string"
           }
-        },
-        "oneOf": [
-          {
-            "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
-              "format": {
-                "enum": [
-                  "citygml"
-                ],
-                "type": "string"
-              }
-            },
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "type": "object"
-          },
-          {
-            "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
-              "format": {
-                "enum": [
-                  "csv"
-                ],
-                "type": "string"
-              },
-              "offset": {
-                "format": "uint",
-                "minimum": 0.0,
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "type": "object"
-          },
-          {
-            "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
-              "format": {
-                "enum": [
-                  "tsv"
-                ],
-                "type": "string"
-              },
-              "offset": {
-                "format": "uint",
-                "minimum": 0.0,
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "type": "object"
-          }
-        ],
-        "title": "FeatureReaderParam"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -647,18 +647,36 @@
       "description": "Sorts features by attributes",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureSorterParam",
+        "type": "object",
+        "required": [
+          "sortBy"
+        ],
+        "properties": {
+          "sortBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SortBy"
+            }
+          }
+        },
         "definitions": {
           "Attribute": {
             "type": "string"
           },
           "Order": {
+            "type": "string",
             "enum": [
               "ascending",
               "descending"
-            ],
-            "type": "string"
+            ]
           },
           "SortBy": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "order"
+            ],
             "properties": {
               "attribute": {
                 "$ref": "#/definitions/Attribute"
@@ -666,27 +684,9 @@
               "order": {
                 "$ref": "#/definitions/Order"
               }
-            },
-            "required": [
-              "attribute",
-              "order"
-            ],
-            "type": "object"
+            }
           }
-        },
-        "properties": {
-          "sortBy": {
-            "items": {
-              "$ref": "#/definitions/SortBy"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "sortBy"
-        ],
-        "title": "FeatureSorterParam",
-        "type": "object"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -705,35 +705,35 @@
       "description": "Transforms features by expressions",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureTransformerParam",
+        "type": "object",
+        "required": [
+          "transformers"
+        ],
+        "properties": {
+          "transformers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Transform"
+            }
+          }
+        },
         "definitions": {
           "Expr": {
             "type": "string"
           },
           "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
             "properties": {
               "expr": {
                 "$ref": "#/definitions/Expr"
               }
-            },
-            "required": [
-              "expr"
-            ],
-            "type": "object"
+            }
           }
-        },
-        "properties": {
-          "transformers": {
-            "items": {
-              "$ref": "#/definitions/Transform"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "transformers"
-        ],
-        "title": "FeatureTransformerParam",
-        "type": "object"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -752,11 +752,12 @@
       "description": "Extracts files from a directory or an archive",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          }
-        },
+        "title": "FilePathExtractor",
+        "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
           "extractArchive": {
             "type": "boolean"
@@ -765,12 +766,11 @@
             "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
-        "title": "FilePathExtractor",
-        "type": "object"
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [],
@@ -787,102 +787,102 @@
       "description": "Reads features from a file",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FileReader",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          }
+        ],
         "definitions": {
           "Expr": {
             "type": "string"
           }
-        },
-        "oneOf": [
-          {
-            "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
-              "format": {
-                "enum": [
-                  "csv"
-                ],
-                "type": "string"
-              },
-              "offset": {
-                "format": "uint",
-                "minimum": 0.0,
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "type": "object"
-          },
-          {
-            "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
-              "format": {
-                "enum": [
-                  "tsv"
-                ],
-                "type": "string"
-              },
-              "offset": {
-                "format": "uint",
-                "minimum": 0.0,
-                "type": [
-                  "integer",
-                  "null"
-                ]
-              }
-            },
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "type": "object"
-          },
-          {
-            "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
-              "format": {
-                "enum": [
-                  "json"
-                ],
-                "type": "string"
-              }
-            },
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "type": "object"
-          },
-          {
-            "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
-              "format": {
-                "enum": [
-                  "citygml"
-                ],
-                "type": "string"
-              }
-            },
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "type": "object"
-          }
-        ],
-        "title": "FileReader"
+        }
       },
       "builtin": true,
       "inputPorts": [],
@@ -899,20 +899,12 @@
       "description": "Writes features to a file",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
-          "Format": {
-            "enum": [
-              "csv",
-              "tsv",
-              "json",
-              "excel"
-            ],
-            "type": "string"
-          }
-        },
+        "title": "FileWriterParam",
+        "type": "object",
+        "required": [
+          "format",
+          "output"
+        ],
         "properties": {
           "format": {
             "$ref": "#/definitions/Format"
@@ -921,12 +913,20 @@
             "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "format",
-          "output"
-        ],
-        "title": "FileWriterParam",
-        "type": "object"
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Format": {
+            "type": "string",
+            "enum": [
+              "csv",
+              "tsv",
+              "json",
+              "excel"
+            ]
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -943,24 +943,24 @@
       "description": "Coerces the geometry of a feature to a specific geometry",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "CoercerType": {
-            "enum": [
-              "lineString"
-            ],
-            "type": "string"
-          }
-        },
+        "title": "GeometryCoercer",
+        "type": "object",
+        "required": [
+          "coercer_type"
+        ],
         "properties": {
           "coercer_type": {
             "$ref": "#/definitions/CoercerType"
           }
         },
-        "required": [
-          "coercer_type"
-        ],
-        "title": "GeometryCoercer",
-        "type": "object"
+        "definitions": {
+          "CoercerType": {
+            "type": "string",
+            "enum": [
+              "lineString"
+            ]
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -979,21 +979,21 @@
       "description": "Extracts geometry from a feature and adds it as an attribute.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          }
-        },
+        "title": "GeometryExtractor",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "outputAttribute": {
             "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "title": "GeometryExtractor",
-        "type": "object"
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1012,51 +1012,51 @@
       "description": "Filter geometry by type",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryFilterParam",
         "oneOf": [
           {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
+                "type": "string",
                 "enum": [
                   "none"
-                ],
-                "type": "string"
+                ]
               }
-            },
+            }
+          },
+          {
+            "type": "object",
             "required": [
               "filterType"
             ],
-            "type": "object"
-          },
-          {
             "properties": {
               "filterType": {
+                "type": "string",
                 "enum": [
                   "multiple"
-                ],
-                "type": "string"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ],
-            "type": "object"
+            }
           },
           {
-            "properties": {
-              "filterType": {
-                "enum": [
-                  "featureType"
-                ],
-                "type": "string"
-              }
-            },
+            "type": "object",
             "required": [
               "filterType"
             ],
-            "type": "object"
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "featureType"
+                ]
+              }
+            }
           }
-        ],
-        "title": "GeometryFilterParam"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1098,21 +1098,21 @@
       "description": "Replaces the geometry of a feature with a new geometry.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          }
-        },
+        "title": "GeometryReplacer",
+        "type": "object",
+        "required": [
+          "sourceAttribute"
+        ],
         "properties": {
           "sourceAttribute": {
             "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "sourceAttribute"
-        ],
-        "title": "GeometryReplacer",
-        "type": "object"
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1147,29 +1147,29 @@
       "description": "Validates the geometry of a feature",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryValidator",
+        "type": "object",
+        "required": [
+          "validationTypes"
+        ],
+        "properties": {
+          "validationTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/ValidationType"
+            }
+          }
+        },
         "definitions": {
           "ValidationType": {
+            "type": "string",
             "enum": [
               "duplicatePoints",
               "corruptGeometry",
               "selfIntersection"
-            ],
-            "type": "string"
+            ]
           }
-        },
-        "properties": {
-          "validationTypes": {
-            "items": {
-              "$ref": "#/definitions/ValidationType"
-            },
-            "type": "array"
-          }
-        },
-        "required": [
-          "validationTypes"
-        ],
-        "title": "GeometryValidator",
-        "type": "object"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1190,21 +1190,21 @@
       "description": "Counts the number of holes in a geometry and adds it as an attribute.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          }
-        },
+        "title": "HoleCounterParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "outputAttribute": {
             "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "title": "HoleCounterParam",
-        "type": "object"
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1241,21 +1241,21 @@
       "description": "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          }
-        },
+        "title": "LineOnLineOverlayerParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "outputAttribute": {
             "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "title": "LineOnLineOverlayerParam",
-        "type": "object"
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1276,21 +1276,21 @@
       "description": "Extracts the orientation of a geometry from a feature and adds it as an attribute.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          }
-        },
+        "title": "OrientationExtractorParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "outputAttribute": {
             "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "title": "OrientationExtractorParam",
-        "type": "object"
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1445,18 +1445,18 @@
       "description": "Reprojects the geometry of a feature to a specified coordinate system",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ReprojectorParam",
+        "type": "object",
         "properties": {
           "epsgCode": {
-            "format": "uint16",
-            "minimum": 0.0,
             "type": [
               "integer",
               "null"
-            ]
+            ],
+            "format": "uint16",
+            "minimum": 0.0
           }
-        },
-        "title": "ReprojectorParam",
-        "type": "object"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1475,16 +1475,16 @@
       "description": "Action for last port forwarding for sub-workflows.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Router",
+        "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ],
-        "title": "Router",
-        "type": "object"
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1499,11 +1499,16 @@
       "description": "Replaces a three dimention box with a polygon.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          }
-        },
+        "title": "ThreeDimentionBoxReplacer",
+        "type": "object",
+        "required": [
+          "maxX",
+          "maxY",
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
+        ],
         "properties": {
           "maxX": {
             "$ref": "#/definitions/Attribute"
@@ -1524,16 +1529,11 @@
             "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "maxX",
-          "maxY",
-          "maxZ",
-          "minX",
-          "minY",
-          "minZ"
-        ],
-        "title": "ThreeDimentionBoxReplacer",
-        "type": "object"
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1552,11 +1552,17 @@
       "description": "Replaces a three dimention box with a polygon.",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          }
-        },
+        "title": "ThreeDimentionRotatorParam",
+        "type": "object",
+        "required": [
+          "angleDegree",
+          "directionX",
+          "directionY",
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
+        ],
         "properties": {
           "angleDegree": {
             "$ref": "#/definitions/Expr"
@@ -1580,17 +1586,11 @@
             "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "angleDegree",
-          "directionX",
-          "directionY",
-          "directionZ",
-          "originX",
-          "originY",
-          "originZ"
-        ],
-        "title": "ThreeDimentionRotatorParam",
-        "type": "object"
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1642,16 +1642,16 @@
       "description": "Fragment XML",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Expr": {
-            "type": "string"
-          }
-        },
+        "title": "XmlFragmenterParam",
         "oneOf": [
           {
+            "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
             "properties": {
               "attribute": {
                 "$ref": "#/definitions/Attribute"
@@ -1663,22 +1663,22 @@
                 "$ref": "#/definitions/Expr"
               },
               "source": {
+                "type": "string",
                 "enum": [
                   "url"
-                ],
-                "type": "string"
+                ]
               }
-            },
-            "required": [
-              "attribute",
-              "elementsToExclude",
-              "elementsToMatch",
-              "source"
-            ],
-            "type": "object"
+            }
           }
         ],
-        "title": "XmlFragmenterParam"
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1697,26 +1697,13 @@
       "description": "Validates XML content",
       "parameter": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "ValidationType": {
-            "enum": [
-              "syntax",
-              "syntaxAndNamespace",
-              "syntaxAndSchema"
-            ],
-            "type": "string"
-          },
-          "XmlInputType": {
-            "enum": [
-              "file",
-              "text"
-            ],
-            "type": "string"
-          }
-        },
+        "title": "XmlValidatorParam",
+        "type": "object",
+        "required": [
+          "attribute",
+          "inputType",
+          "validationType"
+        ],
         "properties": {
           "attribute": {
             "$ref": "#/definitions/Attribute"
@@ -1728,13 +1715,26 @@
             "$ref": "#/definitions/ValidationType"
           }
         },
-        "required": [
-          "attribute",
-          "inputType",
-          "validationType"
-        ],
-        "title": "XmlValidatorParam",
-        "type": "object"
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "ValidationType": {
+            "type": "string",
+            "enum": [
+              "syntax",
+              "syntaxAndNamespace",
+              "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          }
+        }
       },
       "builtin": true,
       "inputPorts": [

--- a/worker/Cargo.lock
+++ b/worker/Cargo.lock
@@ -1616,6 +1616,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath_lib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,6 +2878,7 @@ dependencies = [
  "directories",
  "futures",
  "home",
+ "jsonpath_lib",
  "libxml",
  "parking_lot",
  "petgraph",

--- a/worker/crates/common/Cargo.toml
+++ b/worker/crates/common/Cargo.toml
@@ -19,6 +19,7 @@ colorsys.workspace = true
 directories.workspace = true
 futures.workspace = true
 home = "0.5.9"
+jsonpath_lib.workspace = true
 libxml.workspace = true
 parking_lot.workspace = true
 petgraph.workspace = true

--- a/worker/crates/common/src/json.rs
+++ b/worker/crates/common/src/json.rs
@@ -1,0 +1,68 @@
+use jsonpath_lib::Selector;
+
+pub fn find_by_json_path(
+    content: serde_json::Value,
+    json_path: &str,
+) -> crate::Result<Vec<serde_json::Value>> {
+    let mut selector = Selector::new();
+    let selector = selector.str_path(json_path).map_err(crate::Error::json)?;
+    selector
+        .value(&content)
+        .select()
+        .map_err(crate::Error::json)
+        .map(|values| values.into_iter().cloned().collect())
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_find_by_json_path() {
+        // Test case 1: Valid JSON path with multiple matches
+        let content = serde_json::json!({
+            "data": {
+                "users": [
+                    { "name": "Alice", "age": 25 },
+                    { "name": "Bob", "age": 30 },
+                    { "name": "Charlie", "age": 35 }
+                ]
+            }
+        });
+        let json_path = "$.data.users[*].name";
+        let expected_result = vec![
+            serde_json::json!("Alice"),
+            serde_json::json!("Bob"),
+            serde_json::json!("Charlie"),
+        ];
+        assert_eq!(
+            find_by_json_path(content, json_path).unwrap(),
+            expected_result
+        );
+
+        // Test case 2: Valid JSON path with no matches
+        let content = serde_json::json!({
+            "data": {
+                "users": []
+            }
+        });
+        let json_path = "$.data.users[*].name";
+        let expected_result: Vec<serde_json::Value> = vec![];
+        assert_eq!(
+            find_by_json_path(content, json_path).unwrap(),
+            expected_result
+        );
+
+        // Test case 3: Invalid JSON path
+        let content = serde_json::json!({
+            "data": {
+                "users": [
+                    { "name": "Alice", "age": 25 },
+                    { "name": "Bob", "age": 30 },
+                    { "name": "Charlie", "age": 35 }
+                ]
+            }
+        });
+        let json_path = "$.data.users[*].email"; // Invalid path, 'email' does not exist
+        assert!(find_by_json_path(content, json_path).unwrap().is_empty());
+    }
+}

--- a/worker/crates/common/src/lib.rs
+++ b/worker/crates/common/src/lib.rs
@@ -23,6 +23,9 @@ pub enum Error {
 
     #[error("StrError: {0}")]
     Str(String),
+
+    #[error("JsonError: {0}")]
+    Json(String),
 }
 
 impl Error {
@@ -53,6 +56,10 @@ impl Error {
     pub fn dir<T: ToString>(message: T) -> Self {
         Self::Dir(message.to_string())
     }
+
+    pub fn json<T: ToString>(message: T) -> Self {
+        Self::Json(message.to_string())
+    }
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -63,6 +70,7 @@ pub mod csv;
 pub mod dir;
 pub mod fs;
 pub mod future;
+pub mod json;
 pub mod serde;
 pub mod str;
 pub mod uri;

--- a/worker/crates/eval-expr/src/engine.rs
+++ b/worker/crates/eval-expr/src/engine.rs
@@ -6,6 +6,7 @@ use super::module::console::console_module;
 use super::module::env::{env_module, scope_module};
 use super::module::file::file_module;
 use super::module::str::str_module;
+use crate::module::json::json_module;
 use crate::module::xml::xml_module;
 use crate::{error::Error, scope::Scope, ShareLock, Value, Vars};
 
@@ -39,6 +40,7 @@ impl Engine {
         script_engine.register_static_module("file", rhai::exported_module!(file_module).into());
         script_engine.register_static_module("str", rhai::exported_module!(str_module).into());
         script_engine.register_static_module("xml", rhai::exported_module!(xml_module).into());
+        script_engine.register_static_module("json", rhai::exported_module!(json_module).into());
 
         let engine = Self {
             script_engine: Arc::new(script_engine),

--- a/worker/crates/eval-expr/src/engine.rs
+++ b/worker/crates/eval-expr/src/engine.rs
@@ -6,6 +6,7 @@ use super::module::console::console_module;
 use super::module::env::{env_module, scope_module};
 use super::module::file::file_module;
 use super::module::str::str_module;
+use crate::module::xml::xml_module;
 use crate::{error::Error, scope::Scope, ShareLock, Value, Vars};
 
 #[derive(Debug, Default, Clone)]
@@ -37,6 +38,7 @@ impl Engine {
             .register_static_module("console", rhai::exported_module!(console_module).into());
         script_engine.register_static_module("file", rhai::exported_module!(file_module).into());
         script_engine.register_static_module("str", rhai::exported_module!(str_module).into());
+        script_engine.register_static_module("xml", rhai::exported_module!(xml_module).into());
 
         let engine = Self {
             script_engine: Arc::new(script_engine),

--- a/worker/crates/eval-expr/src/module.rs
+++ b/worker/crates/eval-expr/src/module.rs
@@ -1,4 +1,6 @@
 pub(crate) mod console;
 pub(crate) mod env;
 pub(crate) mod file;
+pub(crate) mod json;
 pub(crate) mod str;
+pub(crate) mod xml;

--- a/worker/crates/eval-expr/src/module/json.rs
+++ b/worker/crates/eval-expr/src/module/json.rs
@@ -1,0 +1,28 @@
+use rhai::export_module;
+
+#[export_module]
+pub(crate) mod json_module {
+    use std::collections::HashMap;
+
+    use reearth_flow_common::json;
+    use rhai::plugin::*;
+
+    pub fn find_value_by_json_path(
+        content: HashMap<String, serde_json::Value>,
+        json_path: &str,
+    ) -> Vec<serde_json::Value> {
+        let content: serde_json::Map<String, serde_json::Value> = content.into_iter().collect();
+        let Ok(result) = json::find_by_json_path(serde_json::Value::Object(content), json_path)
+        else {
+            return vec![];
+        };
+        result
+    }
+
+    pub fn exists_value_by_json_path(
+        content: HashMap<String, serde_json::Value>,
+        json_path: &str,
+    ) -> bool {
+        !find_value_by_json_path(content, json_path).is_empty()
+    }
+}

--- a/worker/crates/eval-expr/src/module/xml.rs
+++ b/worker/crates/eval-expr/src/module/xml.rs
@@ -1,0 +1,66 @@
+use rhai::export_module;
+
+#[export_module]
+pub(crate) mod xml_module {
+    use reearth_flow_common::xml;
+    use rhai::plugin::*;
+
+    pub fn find_node_tags_by_xpath(content: &str, xpath: &str) -> Vec<String> {
+        let Ok(document) = xml::parse(content) else {
+            return vec![];
+        };
+        let Ok(ctx) = xml::create_context(&document) else {
+            return vec![];
+        };
+        let Ok(root) = xml::get_root_readonly_node(&document) else {
+            return vec![];
+        };
+        let Ok(nodes) = xml::find_readonly_nodes_by_xpath(&ctx, xpath, &root) else {
+            return vec![];
+        };
+        nodes.iter().map(xml::get_readonly_node_tag).collect()
+    }
+
+    pub fn exists_node_by_xpath(content: &str, xpath: &str) -> bool {
+        !find_node_tags_by_xpath(content, xpath).is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::xml_module::*;
+
+    #[test]
+    fn test_find_node_tags_by_xpath() {
+        let content = r#"
+            <root>
+                <node1>Value 1</node1>
+                <node2>Value 2</node2>
+                <node3>Value 3</node3>
+            </root>
+        "#;
+
+        // Test case 1: Valid XPath expression
+        let xpath = "//node2";
+        let expected_result = vec!["node2".to_string()];
+        assert_eq!(find_node_tags_by_xpath(content, xpath), expected_result);
+
+        // Test case 2: Empty content
+        let content = "";
+        let xpath = "//node";
+        let expected_result: Vec<String> = vec![];
+        assert_eq!(find_node_tags_by_xpath(content, xpath), expected_result);
+
+        // Test case 3: Non-existent node
+        let content = r#"
+            <root>
+                <node1>Value 1</node1>
+                <node2>Value 2</node2>
+                <node3>Value 3</node3>
+            </root>
+        "#;
+        let xpath = "//node4";
+        let expected_result: Vec<String> = vec![];
+        assert_eq!(find_node_tags_by_xpath(content, xpath), expected_result);
+    }
+}


### PR DESCRIPTION
# Overview
This commit adds the `json` and `xml` modules to the `eval-expr` crate.
The `json` module provides functions for working with JSON data, including finding values by JSON path and checking if a value exists by JSON path. The `xml` module provides functions for working with XML data, including finding node tags by XPath and checking if a node exists by XPath.

Based on the recent user commits and repository commits, the established convention for commit messages in this repository is to use a prefix indicating the type of change (e.g., feat for a new feature, fix for a bug fix, chore for maintenance tasks). The commit messages are concise and provide a clear description of the code changes.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced JSON path extraction functionality to enhance JSON data handling.
  - Added support for XML and JSON modules allowing advanced script handling through XPath and JSON path queries.

- **Bug Fixes**
  - Restructured error handling to include JSON-specific errors, improving clarity and debugging.

- **Documentation**
  - Updated parameter schemas in the actions JSON file for better structure and constraints.

- **Tests**
  - Added tests for new JSON and XML module functionalities to ensure reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->