### PR TITLE
feat(geometry): add ClipperFactory and Clipper to handle geometry 

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -314,6 +314,25 @@
       ]
     },
     {
+      "name": "Clipper",
+      "type": "processor",
+      "description": "Divides Candidate features using Clipper features, so that Candidates and parts of Candidates that are inside or outside of the Clipper features are output separately",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "clipper",
+        "candidate"
+      ],
+      "outputPorts": [
+        "inside",
+        "outside",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "ClosedCurveFilter",
       "type": "processor",
       "description": "Checks if curves form closed loops",

--- a/worker/crates/action-processor/src/geometry.rs
+++ b/worker/crates/action-processor/src/geometry.rs
@@ -1,6 +1,7 @@
 pub mod area_on_area_overlayer;
 pub mod bufferer;
 pub mod center_point_replacer;
+pub mod clipper;
 pub mod closed_curve_filter;
 pub mod coercer;
 pub mod coordinate_system_setter;

--- a/worker/crates/action-processor/src/geometry/clipper.rs
+++ b/worker/crates/action-processor/src/geometry/clipper.rs
@@ -1,0 +1,401 @@
+use std::collections::HashMap;
+
+use itertools::Itertools;
+use once_cell::sync::Lazy;
+use reearth_flow_geometry::algorithm::clipper::{Clipper2D, Clipper3D};
+use reearth_flow_geometry::types::geometry::{Geometry2D, Geometry3D};
+use reearth_flow_geometry::types::multi_polygon::{MultiPolygon2D, MultiPolygon3D};
+use reearth_flow_geometry::types::polygon::{Polygon2D, Polygon3D};
+use reearth_flow_runtime::node::REJECTED_PORT;
+use reearth_flow_runtime::{
+    channels::ProcessorChannelForwarder,
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    node::{Port, Processor, ProcessorFactory},
+};
+use reearth_flow_types::{Feature, Geometry, GeometryValue};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub static CLIPPER_PORT: Lazy<Port> = Lazy::new(|| Port::new("clipper"));
+pub static CANDIDATE_PORT: Lazy<Port> = Lazy::new(|| Port::new("candidate"));
+pub static INSIDE_PORT: Lazy<Port> = Lazy::new(|| Port::new("inside"));
+pub static OUTSIDE_PORT: Lazy<Port> = Lazy::new(|| Port::new("outside"));
+
+#[derive(Debug, Clone, Default)]
+pub struct ClipperFactory;
+
+impl ProcessorFactory for ClipperFactory {
+    fn name(&self) -> &str {
+        "Clipper"
+    }
+
+    fn description(&self) -> &str {
+        "Divides Candidate features using Clipper features, so that Candidates and parts of Candidates that are inside or outside of the Clipper features are output separately"
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        None
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["Geometry"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![CLIPPER_PORT.clone(), CANDIDATE_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![
+            INSIDE_PORT.clone(),
+            OUTSIDE_PORT.clone(),
+            REJECTED_PORT.clone(),
+        ]
+    }
+
+    fn build(
+        &self,
+        _ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        _with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        Ok(Box::new(Clipper {
+            clippers: Vec::new(),
+            candidates: Vec::new(),
+        }))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Clipper {
+    clippers: Vec<Feature>,
+    candidates: Vec<Feature>,
+}
+
+impl Processor for Clipper {
+    fn initialize(&mut self, _ctx: NodeContext) {}
+
+    fn num_threads(&self) -> usize {
+        2
+    }
+
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let feature = &ctx.feature;
+        let Some(geometry) = &feature.geometry else {
+            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
+            return Ok(());
+        };
+        match &geometry.value {
+            GeometryValue::Null => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+            GeometryValue::FlowGeometry2D(_) | GeometryValue::FlowGeometry3D(_) => {
+                match &ctx.port {
+                    port if port == &*CLIPPER_PORT => self.clippers.push(feature.clone()),
+                    port if port == &*CANDIDATE_PORT => self.candidates.push(feature.clone()),
+                    _ => {
+                        fw.send(
+                            ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()),
+                        );
+                    }
+                }
+            }
+            GeometryValue::CityGmlGeometry(_) => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()))
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(
+        &self,
+        ctx: NodeContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let clip_regions2d = self
+            .clippers
+            .iter()
+            .filter_map(|clip| clip.geometry.as_ref().map(|g| g.value.clone()))
+            .filter_map(|g| match g {
+                GeometryValue::FlowGeometry2D(geos) => Some(geos),
+                _ => None,
+            })
+            .collect_vec();
+        let clip_regions2d = clip_regions2d
+            .iter()
+            .flat_map(|g| match g {
+                Geometry2D::Polygon(poly) => Some(poly.clone()),
+                _ => None,
+            })
+            .collect_vec();
+        let clip_regions3d = self
+            .clippers
+            .iter()
+            .filter_map(|clip| clip.geometry.as_ref().map(|g| g.value.clone()))
+            .filter_map(|g| match g {
+                GeometryValue::FlowGeometry3D(geos) => Some(geos),
+                _ => None,
+            })
+            .collect_vec();
+        let clip_regions3d = clip_regions3d
+            .iter()
+            .flat_map(|g| match g {
+                Geometry3D::Polygon(poly) => Some(poly.clone()),
+                _ => None,
+            })
+            .collect_vec();
+        if clip_regions2d.is_empty() && clip_regions3d.is_empty() {
+            for candidate in &self.candidates {
+                fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                    &ctx,
+                    candidate.clone(),
+                    REJECTED_PORT.clone(),
+                ));
+            }
+            for clip in &self.clippers {
+                fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                    &ctx,
+                    clip.clone(),
+                    REJECTED_PORT.clone(),
+                ));
+            }
+            return Ok(());
+        }
+        for candidate in &self.candidates {
+            let geometry = candidate.geometry.as_ref().map(|g| g.value.clone());
+            match geometry {
+                Some(GeometryValue::FlowGeometry2D(geos)) => {
+                    handle_2d_geometry(
+                        &geos,
+                        &clip_regions2d,
+                        candidate,
+                        candidate.geometry.as_ref().unwrap(),
+                        &ctx,
+                        fw,
+                    );
+                }
+                Some(GeometryValue::FlowGeometry3D(geos)) => {
+                    handle_3d_geometry(
+                        &geos,
+                        &clip_regions3d,
+                        candidate,
+                        candidate.geometry.as_ref().unwrap(),
+                        &ctx,
+                        fw,
+                    );
+                }
+                _ => {
+                    fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                        &ctx,
+                        candidate.clone(),
+                        REJECTED_PORT.clone(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "Clipper"
+    }
+}
+
+fn handle_2d_geometry(
+    geos: &Geometry2D,
+    clip_regions: &[Polygon2D<f64>],
+    feature: &Feature,
+    geometry: &Geometry,
+    ctx: &NodeContext,
+    fw: &mut dyn ProcessorChannelForwarder,
+) {
+    match geos {
+        Geometry2D::Polygon(poly) => {
+            let (insides, outsides) = clip_polygon2d(poly, clip_regions);
+            forward_polygon2d(&insides, &outsides, feature, geometry, ctx, fw);
+        }
+        Geometry2D::MultiPolygon(mpoly) => {
+            let (insides, outsides) = clip_mpolygon2d(mpoly, clip_regions);
+            forward_polygon2d(&insides, &outsides, feature, geometry, ctx, fw);
+        }
+        Geometry2D::GeometryCollection(collection) => {
+            for single in collection {
+                handle_2d_geometry(single, clip_regions, feature, geometry, ctx, fw)
+            }
+        }
+        _ => {
+            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                ctx,
+                feature.clone(),
+                REJECTED_PORT.clone(),
+            ));
+        }
+    }
+}
+
+fn forward_polygon2d(
+    insides: &[Polygon2D<f64>],
+    outsides: &[Polygon2D<f64>],
+    feature: &Feature,
+    geometry: &Geometry,
+    ctx: &NodeContext,
+    fw: &mut dyn ProcessorChannelForwarder,
+) {
+    for inside in insides {
+        let mut feature = feature.clone();
+        let mut geometry = geometry.clone();
+        geometry.value = GeometryValue::FlowGeometry2D(Geometry2D::Polygon(inside.clone()));
+        feature.geometry = Some(geometry);
+        fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+            ctx,
+            feature,
+            INSIDE_PORT.clone(),
+        ));
+    }
+    for outside in outsides {
+        let mut feature = feature.clone();
+        let mut geometry = geometry.clone();
+        geometry.value = GeometryValue::FlowGeometry2D(Geometry2D::Polygon(outside.clone()));
+        feature.geometry = Some(geometry);
+        fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+            ctx,
+            feature,
+            OUTSIDE_PORT.clone(),
+        ));
+    }
+}
+
+fn handle_3d_geometry(
+    geos: &Geometry3D,
+    clip_regions: &[Polygon3D<f64>],
+    feature: &Feature,
+    geometry: &Geometry,
+    ctx: &NodeContext,
+    fw: &mut dyn ProcessorChannelForwarder,
+) {
+    match geos {
+        Geometry3D::Polygon(poly) => {
+            let (insides, outsides) = clip_polygon3d(poly, clip_regions);
+            forward_polygon3d(&insides, &outsides, feature, geometry, ctx, fw);
+        }
+        Geometry3D::MultiPolygon(mpoly) => {
+            let (insides, outsides) = clip_mpolygon3d(mpoly, clip_regions);
+            forward_polygon3d(&insides, &outsides, feature, geometry, ctx, fw);
+        }
+        Geometry3D::GeometryCollection(collection) => {
+            for single in collection {
+                handle_3d_geometry(single, clip_regions, feature, geometry, ctx, fw)
+            }
+        }
+        _ => {
+            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                ctx,
+                feature.clone(),
+                REJECTED_PORT.clone(),
+            ));
+        }
+    }
+}
+
+fn forward_polygon3d(
+    insides: &[Polygon3D<f64>],
+    outsides: &[Polygon3D<f64>],
+    feature: &Feature,
+    geometry: &Geometry,
+    ctx: &NodeContext,
+    fw: &mut dyn ProcessorChannelForwarder,
+) {
+    for inside in insides {
+        let mut feature = feature.clone();
+        let mut geometry = geometry.clone();
+        geometry.value = GeometryValue::FlowGeometry3D(Geometry3D::Polygon(inside.clone()));
+        feature.geometry = Some(geometry);
+        fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+            ctx,
+            feature,
+            INSIDE_PORT.clone(),
+        ));
+    }
+    for outside in outsides {
+        let mut feature = feature.clone();
+        let mut geometry = geometry.clone();
+        geometry.value = GeometryValue::FlowGeometry3D(Geometry3D::Polygon(outside.clone()));
+        feature.geometry = Some(geometry);
+        fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+            ctx,
+            feature,
+            OUTSIDE_PORT.clone(),
+        ));
+    }
+}
+
+fn clip_polygon2d(
+    polygon: &Polygon2D<f64>,
+    clip_regions: &[Polygon2D<f64>],
+) -> (Vec<Polygon2D<f64>>, Vec<Polygon2D<f64>>) {
+    let mut inside = MultiPolygon2D::new(vec![polygon.clone()]);
+    let mut outside = MultiPolygon2D::new(vec![polygon.clone()]);
+    for clip in clip_regions {
+        inside = inside.intersection2d(clip, 1.0);
+        outside = outside.difference2d(clip, 1.0);
+    }
+    (
+        inside.iter().cloned().collect(),
+        outside.iter().cloned().collect(),
+    )
+}
+
+fn clip_mpolygon2d(
+    mpolygon: &MultiPolygon2D<f64>,
+    clip_regions: &[Polygon2D<f64>],
+) -> (Vec<Polygon2D<f64>>, Vec<Polygon2D<f64>>) {
+    let mut inside = mpolygon.clone();
+    let mut outside = mpolygon.clone();
+    for clip in clip_regions {
+        inside = inside.intersection2d(clip, 1.0);
+        outside = outside.difference2d(clip, 1.0);
+    }
+    (
+        inside.iter().cloned().collect(),
+        outside.iter().cloned().collect(),
+    )
+}
+
+fn clip_polygon3d(
+    polygon: &Polygon3D<f64>,
+    clip_regions: &[Polygon3D<f64>],
+) -> (Vec<Polygon3D<f64>>, Vec<Polygon3D<f64>>) {
+    let mut inside = MultiPolygon3D::new(vec![polygon.clone()]);
+    let mut outside = MultiPolygon3D::new(vec![polygon.clone()]);
+    for clip in clip_regions {
+        inside = inside.intersection3d(clip, 1.0);
+        outside = outside.difference3d(clip, 1.0);
+    }
+    (
+        inside.iter().cloned().collect(),
+        outside.iter().cloned().collect(),
+    )
+}
+
+fn clip_mpolygon3d(
+    mpolygon: &MultiPolygon3D<f64>,
+    clip_regions: &[Polygon3D<f64>],
+) -> (Vec<Polygon3D<f64>>, Vec<Polygon3D<f64>>) {
+    let mut inside = mpolygon.clone();
+    let mut outside = mpolygon.clone();
+    for clip in clip_regions {
+        inside = inside.intersection3d(clip, 1.0);
+        outside = outside.difference3d(clip, 1.0);
+    }
+    (
+        inside.iter().cloned().collect(),
+        outside.iter().cloned().collect(),
+    )
+}

--- a/worker/crates/action-processor/src/geometry/errors.rs
+++ b/worker/crates/action-processor/src/geometry/errors.rs
@@ -67,6 +67,10 @@ pub(super) enum GeometryProcessorError {
     ThreeDimentionRotatorFactory(String),
     #[error("ThreeDimentionRotator error: {0}")]
     ThreeDimentionRotator(String),
+    #[error("Clipper Factory error: {0}")]
+    ClipperFactory(String),
+    #[error("Clipper error: {0}")]
+    Clipper(String),
 }
 
 pub(super) type Result<T, E = GeometryProcessorError> = std::result::Result<T, E>;

--- a/worker/crates/action-processor/src/geometry/mapping.rs
+++ b/worker/crates/action-processor/src/geometry/mapping.rs
@@ -5,7 +5,7 @@ use reearth_flow_runtime::node::{NodeKind, ProcessorFactory};
 
 use super::{
     area_on_area_overlayer::AreaOnAreaOverlayerFactory, bufferer::BuffererFactory,
-    center_point_replacer::CenterPointReplacerFactory,
+    center_point_replacer::CenterPointReplacerFactory, clipper::ClipperFactory,
     closed_curve_filter::ClosedCurveFilterFactory, coercer::GeometryCoercerFactory,
     coordinate_system_setter::CoordinateSystemSetterFactory, extractor::GeometryExtractorFactory,
     extruder::ExtruderFactory, filter::GeometryFilterFactory, hole_counter::HoleCounterFactory,
@@ -44,6 +44,7 @@ pub static ACTION_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
         Box::<VertexRemoverFactory>::default(),
         Box::<CenterPointReplacerFactory>::default(),
         Box::<ThreeDimentionRotatorFactory>::default(),
+        Box::<ClipperFactory>::default(),
     ];
     factories
         .into_iter()


### PR DESCRIPTION
# Overview
The code changes add the ClipperFactory and Clipper modules to handle
geometry division. The ClipperFactory is responsible for creating
instances of the Clipper module, which divides candidate features using
Clipper features. This division separates Candidates and parts of
Candidates that are inside or outside of the Clipper features, and
outputs them separately.

Based on the recent user commits and repository commits, the established
convention for commit messages in this repository is to use a prefix
indicating the type of change (e.g., feat for a new feature, fix for a
bug fix, chore for maintenance tasks). The commit messages are concise
and provide a clear description of the code changes.

Please note that the commit message provided above is a suggestion based
on the code changes and established conventions. Feel free to modify it
as needed.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Clipper" processor that divides candidate features into inside, outside, and rejected segments based on clipper features. This processor is now available under the "Geometry" category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->