### PR TITLE
chore(worker): Update dependencies for plateau-gis-converter

### DIFF
--- a/worker/Cargo.lock
+++ b/worker/Cargo.lock
@@ -1685,7 +1685,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#2007d9c101064f00ae51c10744182fd0064b859d"
+source = "git+https://github.com/reearth/plateau-gis-converter#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1940,7 +1940,7 @@ dependencies = [
 [[package]]
 name = "nusamai-citygml"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#2007d9c101064f00ae51c10744182fd0064b859d"
+source = "git+https://github.com/reearth/plateau-gis-converter#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
 dependencies = [
  "ahash",
  "chrono",
@@ -1959,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "nusamai-geometry"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#2007d9c101064f00ae51c10744182fd0064b859d"
+source = "git+https://github.com/reearth/plateau-gis-converter#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
 dependencies = [
  "num-traits",
  "serde",
@@ -1968,7 +1968,7 @@ dependencies = [
 [[package]]
 name = "nusamai-plateau"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#2007d9c101064f00ae51c10744182fd0064b859d"
+source = "git+https://github.com/reearth/plateau-gis-converter#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
 dependencies = [
  "chrono",
  "hashbrown 0.14.5",
@@ -1986,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "nusamai-projection"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#2007d9c101064f00ae51c10744182fd0064b859d"
+source = "git+https://github.com/reearth/plateau-gis-converter#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
 dependencies = [
  "japan-geoid",
  "thiserror",
@@ -4057,18 +4057,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4222,9 +4222,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f738b6a169a29bca4e39656db89c44a08e09c5b700b896ee9e7459f0652e81dd"
+checksum = "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -112,7 +112,7 @@ slog = {version = "2.7.0", features = ["release_max_level_trace", "max_level_tra
 strum = "0.26.3"
 strum_macros = "0.26.4"
 tempfile = "3.10.1"
-thiserror = "1.0.62"
+thiserror = "1.0.63"
 time = {version = "0.3.36", features = ["formatting"]}
 tokio = {version = "1.38.1", features = ["full", "time"]}
 tokio-stream = {version = "0.1.15", features = ["sync"]}


### PR DESCRIPTION
# Overview
- bump plateau-gis-converter

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `thiserror` dependency from version 1.0.62 to 1.0.63.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->