### PR TITLE
chore(worker): Update worker Dockerfile to use --no-install-recommends flag

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -8,7 +8,7 @@ ENV CARGO_TARGET_DIR=/tmp/target \
     LC_CTYPE=ja_JP.utf8 \
     LANG=ja_JP.utf8
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     locales \
     git \
@@ -36,14 +36,16 @@ RUN cargo build --release
 
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     openssl \
     libxml2 \
     ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
 
 WORKDIR /app
-
 COPY --from=builder /tmp/target/release/reearth-flow /app
+RUN useradd -d /home/flow -m -s /bin/bash flow && chown -R flow:flow /app
+USER flow
 
 ENTRYPOINT [ "/app/reearth-flow" ]


### PR DESCRIPTION
# Overview
- Update worker Dockerfile to use --no-install-recommends flag

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved security by adding a non-root user for application execution.
  
- **Enhancements**
	- Optimized the installation process to reduce unnecessary packages, resulting in a leaner Docker image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->