### PR TITLE
feat(worker): Update example feature transformer to use l_bldg_04_05.yml instead of t_bldg_06.yml

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -1388,7 +1388,7 @@
     {
       "name": "PLATEAU.BuildingUsageAttributeValidator",
       "type": "processor",
-      "description": "Validates Building Usage attributes",
+      "description": "This processor validates building usage attributes by checking for the presence of required attributes and ensuring the correctness of city codes. It outputs errors through the lBldgError and codeError ports if any issues are found.",
       "parameter": null,
       "builtin": true,
       "inputPorts": [

--- a/schema/actions.json
+++ b/schema/actions.json
@@ -1386,6 +1386,24 @@
       ]
     },
     {
+      "name": "PLATEAU.BuildingUsageAttributeValidator",
+      "type": "processor",
+      "description": "Validates Building Usage attributes",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "lBldgError",
+        "codeError",
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
       "name": "PLATEAU.DictionariesInitiator",
       "type": "processor",
       "description": "Initializes dictionaries for PLATEAU",

--- a/worker/crates/action-processor/src/plateau.rs
+++ b/worker/crates/action-processor/src/plateau.rs
@@ -1,5 +1,6 @@
 pub mod attribute_flattener;
 pub mod building_installation_geometry_type_extractor;
+pub mod building_usage_attribute_validator;
 pub mod dictionaries_initiator;
 pub mod domain_of_definition_validator;
 pub mod errors;

--- a/worker/crates/action-processor/src/plateau/building_installation_geometry_type_extractor.rs
+++ b/worker/crates/action-processor/src/plateau/building_installation_geometry_type_extractor.rs
@@ -56,7 +56,7 @@ impl ProcessorFactory for BuildingInstallationGeometryTypeExtractorFactory {
 }
 
 #[derive(Debug, Clone)]
-pub struct BuildingInstallationGeometryTypeExtractor {}
+pub struct BuildingInstallationGeometryTypeExtractor;
 
 impl Processor for BuildingInstallationGeometryTypeExtractor {
     fn initialize(&mut self, _ctx: NodeContext) {}

--- a/worker/crates/action-processor/src/plateau/building_usage_attribute_validator.rs
+++ b/worker/crates/action-processor/src/plateau/building_usage_attribute_validator.rs
@@ -1,0 +1,327 @@
+use std::str::FromStr;
+use std::{collections::HashMap, path::Path};
+
+use once_cell::sync::Lazy;
+use reearth_flow_common::{uri::Uri, xml};
+use reearth_flow_runtime::{
+    channels::ProcessorChannelForwarder,
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
+};
+use reearth_flow_types::{Attribute, AttributeValue, Feature};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::errors::PlateauProcessorError;
+
+pub static L_BLDG_ERROR_PORT: Lazy<Port> = Lazy::new(|| Port::new("lBldgError"));
+pub static CODE_ERROR_PORT: Lazy<Port> = Lazy::new(|| Port::new("codeError"));
+
+static USAGE_ATTRIBUTES: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
+    HashMap::from([
+        ("uro:majorUsage2", "uro:majorUsage"),
+        ("uro:detailedUsage2", "uro:detailedUsage"),
+        ("uro:detailedUsage3", "uro:detailedUsage2"),
+        ("uro:secondFloorUsage", "uro:groundFloorUsage"),
+        ("uro:thirdFloorUsage", "uro:secondFloorUsage"),
+        ("uro:basementSecondUsage", "uro:basementFirstUsage"),
+    ])
+});
+
+static MAJOR_CITY_CODES: Lazy<Vec<&'static str>> = Lazy::new(|| {
+    vec![
+        "01100", "04100", "11100", "12100", "13100", "14100", "14130", "14150", "15100", "22100",
+        "22130", "23100", "26100", "27100", "27140", "28100", "33100", "34100", "40100", "40130",
+        "43100",
+    ]
+});
+
+#[derive(Debug, Clone, Default)]
+pub struct BuildingUsageAttributeValidatorFactory;
+
+impl ProcessorFactory for BuildingUsageAttributeValidatorFactory {
+    fn name(&self) -> &str {
+        "PLATEAU.BuildingUsageAttributeValidator"
+    }
+
+    fn description(&self) -> &str {
+        "Validates Building Usage attributes"
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        None
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["PLATEAU"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![
+            L_BLDG_ERROR_PORT.clone(),
+            CODE_ERROR_PORT.clone(),
+            DEFAULT_PORT.clone(),
+        ]
+    }
+
+    fn build(
+        &self,
+        ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        let param: BuildingUsageAttributeValidatorParam = if let Some(with) = with {
+            let value: Value = serde_json::to_value(with).map_err(|e| {
+                PlateauProcessorError::BuildingUsageAttributeValidatorFactory(format!(
+                    "Failed to serialize with: {}",
+                    e
+                ))
+            })?;
+            serde_json::from_value(value).map_err(|e| {
+                PlateauProcessorError::BuildingUsageAttributeValidatorFactory(format!(
+                    "Failed to deserialize with: {}",
+                    e
+                ))
+            })?
+        } else {
+            return Err(
+                PlateauProcessorError::BuildingUsageAttributeValidatorFactory(
+                    "Missing required parameter `with`".to_string(),
+                )
+                .into(),
+            );
+        };
+        let mut city_name_to_code = HashMap::new();
+        println!("{:?}", param.codelists_path);
+        if let Some(codelists_path) = param.codelists_path {
+            let dir = Uri::from_str(&codelists_path).map_err(|e| {
+                PlateauProcessorError::BuildingUsageAttributeValidatorFactory(format!(
+                    "Failed to parse codelists path: {}",
+                    e
+                ))
+            })?;
+            let code_list_name = dir
+                .join(Path::new("Common_localPublicAuthorities.xml"))
+                .map_err(|e| {
+                    PlateauProcessorError::BuildingUsageAttributeValidatorFactory(format!(
+                        "Failed to join codelists path: {}",
+                        e
+                    ))
+                })?;
+            let storage = ctx.storage_resolver.resolve(&code_list_name).map_err(|e| {
+                PlateauProcessorError::BuildingUsageAttributeValidatorFactory(format!(
+                    "Failed to resolve storage: {}",
+                    e
+                ))
+            })?;
+            let common_local_public =
+                storage
+                    .get_sync(code_list_name.path().as_path())
+                    .map_err(|e| {
+                        PlateauProcessorError::BuildingUsageAttributeValidatorFactory(format!(
+                            "Failed to get storage: {}",
+                            e
+                        ))
+                    })?;
+            let document = xml::parse(common_local_public).map_err(|e| {
+                PlateauProcessorError::BuildingUsageAttributeValidatorFactory(format!(
+                    "Failed to parse xml: {}",
+                    e
+                ))
+            })?;
+            let root_node = xml::get_root_readonly_node(&document).map_err(|e| {
+                PlateauProcessorError::BuildingUsageAttributeValidatorFactory(format!(
+                    "Failed to get root node: {}",
+                    e
+                ))
+            })?;
+            let xml_ctx = xml::create_context(&document).map_err(|e| {
+                PlateauProcessorError::BuildingUsageAttributeValidatorFactory(format!(
+                    "Failed to create context: {}",
+                    e
+                ))
+            })?;
+            let nodes =
+                xml::find_readonly_nodes_by_xpath(&xml_ctx, ".//gml:Definition", &root_node)
+                    .map_err(|e| {
+                        PlateauProcessorError::BuildingUsageAttributeValidatorFactory(format!(
+                            "Failed to find nodes: {}",
+                            e
+                        ))
+                    })?;
+            for node in nodes {
+                let mut name = None;
+                let mut code = None;
+                for child in &node.get_child_nodes() {
+                    match xml::get_readonly_node_tag(child).as_str() {
+                        "gml:description" => {
+                            name = Some(child.get_content());
+                        }
+                        "gml:name" => {
+                            code = Some(child.get_content());
+                        }
+                        _ => {}
+                    }
+                }
+                if let (Some(name), Some(code)) = (name, code) {
+                    city_name_to_code.insert(name, code);
+                }
+            }
+        }
+        Ok(Box::new(BuildingUsageAttributeValidator {
+            city_name_to_code,
+        }))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BuildingUsageAttributeValidatorParam {
+    codelists_path: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BuildingUsageAttributeValidator {
+    city_name_to_code: HashMap<String, String>,
+}
+
+impl Processor for BuildingUsageAttributeValidator {
+    fn initialize(&mut self, _ctx: NodeContext) {}
+
+    fn num_threads(&self) -> usize {
+        4
+    }
+
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let feature = &ctx.feature;
+        let attributes = &feature.attributes;
+        let Some(AttributeValue::Map(gml_attributes)) =
+            attributes.get(&Attribute::new("cityGmlAttributes"))
+        else {
+            return Err(PlateauProcessorError::BuildingUsageAttributeValidator(
+                "cityGmlAttributes key empty".to_string(),
+            )
+            .into());
+        };
+        let survey_year = if let Some(AttributeValue::Array(detail_attributes)) =
+            gml_attributes.get("uro:buildingDetailAttribute")
+        {
+            detail_attributes.first().map(|detail_attribute| {
+                if let AttributeValue::Map(details_attribute) = detail_attribute {
+                    if let Some(AttributeValue::String(survey_year)) =
+                        details_attribute.get("uro:surveyYear")
+                    {
+                        survey_year.clone()
+                    } else {
+                        "".to_string()
+                    }
+                } else {
+                    "".to_string()
+                }
+            })
+        } else {
+            None
+        };
+        let mut error_messages = Vec::<String>::new();
+        let all_keys = feature.all_attribute_keys();
+        for (key, value) in USAGE_ATTRIBUTES.iter() {
+            if !all_keys.contains(&key.to_string()) && all_keys.contains(&value.to_string()) {
+                error_messages.push(format!(
+                    "{}年建物利用現況: '{}' が存在しますが '{}' が存在しません。",
+                    survey_year.clone().unwrap_or_default(),
+                    key,
+                    value
+                ));
+            }
+        }
+        let city_name = if let Some(AttributeValue::Array(detail_attributes)) =
+            gml_attributes.get("uro:buildingIDAttribute")
+        {
+            detail_attributes.first().map(|detail_attribute| {
+                if let AttributeValue::Map(details_attribute) = detail_attribute {
+                    if let Some(AttributeValue::String(city)) = details_attribute.get("uro:city") {
+                        city.clone()
+                    } else {
+                        "".to_string()
+                    }
+                } else {
+                    "".to_string()
+                }
+            })
+        } else {
+            None
+        };
+        let city_code_error = if let Some(city) = city_name {
+            if let Some(code) = self.city_name_to_code.get(&city) {
+                if MAJOR_CITY_CODES.contains(&code.as_str()) {
+                    Some(format!("{} {}:要修正（区のコードとする）", code, city))
+                } else {
+                    None
+                }
+            } else {
+                Some(format!("{}: コードリストに該当なし", city))
+            }
+        } else {
+            Some("<未設定>".to_string())
+        };
+        let mut attributes = feature.attributes.clone();
+        let mut ports = Vec::<Port>::new();
+        if !error_messages.is_empty() {
+            attributes.insert(
+                Attribute::new("errors"),
+                AttributeValue::Array(
+                    error_messages
+                        .into_iter()
+                        .map(AttributeValue::String)
+                        .collect(),
+                ),
+            );
+            ports.push(L_BLDG_ERROR_PORT.clone());
+        }
+        if let Some(city_code_error) = city_code_error {
+            attributes.insert(
+                Attribute::new("cityCodeError"),
+                AttributeValue::String(city_code_error),
+            );
+            ports.push(CODE_ERROR_PORT.clone());
+        }
+
+        if ports.is_empty() {
+            ports.push(DEFAULT_PORT.clone());
+        }
+
+        for port in ports {
+            fw.send(ctx.new_with_feature_and_port(
+                Feature {
+                    attributes: attributes.clone(),
+                    ..feature.clone()
+                },
+                port,
+            ));
+        }
+        Ok(())
+    }
+
+    fn finish(
+        &self,
+        _ctx: NodeContext,
+        _fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "BuildingUsageAttributeValidator"
+    }
+}

--- a/worker/crates/action-processor/src/plateau/errors.rs
+++ b/worker/crates/action-processor/src/plateau/errors.rs
@@ -31,6 +31,10 @@ pub(super) enum PlateauProcessorError {
     AttributeFlattener(String),
     #[error("BuildingInstallationGeometryTypeExtractor error: {0}")]
     BuildingInstallationGeometryTypeExtractor(String),
+    #[error("BuildingUsageAttributeValidatorFactory error: {0}")]
+    BuildingUsageAttributeValidatorFactory(String),
+    #[error("BuildingUsageAttributeValidator error: {0}")]
+    BuildingUsageAttributeValidator(String),
 }
 
 pub(super) type Result<T, E = PlateauProcessorError> = std::result::Result<T, E>;

--- a/worker/crates/action-processor/src/plateau/mapping.rs
+++ b/worker/crates/action-processor/src/plateau/mapping.rs
@@ -6,6 +6,7 @@ use reearth_flow_runtime::node::{NodeKind, ProcessorFactory};
 use super::{
     attribute_flattener::AttributeFlattenerFactory,
     building_installation_geometry_type_extractor::BuildingInstallationGeometryTypeExtractorFactory,
+    building_usage_attribute_validator::BuildingUsageAttributeValidatorFactory,
     dictionaries_initiator::DictionariesInitiatorFactory,
     domain_of_definition_validator::DomainOfDefinitionValidatorFactory,
     max_lod_extractor::MaxLodExtractorFactory, udx_folder_extractor::UdxFolderExtractorFactory,
@@ -23,6 +24,7 @@ pub static ACTION_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
         Box::<MaxLodExtractorFactory>::default(),
         Box::<AttributeFlattenerFactory>::default(),
         Box::<BuildingInstallationGeometryTypeExtractorFactory>::default(),
+        Box::<BuildingUsageAttributeValidatorFactory>::default(),
     ];
     factories
         .into_iter()

--- a/worker/crates/types/src/attribute.rs
+++ b/worker/crates/types/src/attribute.rs
@@ -477,10 +477,11 @@ mod tests {
         );
         map.insert("nested".to_string(), AttributeValue::Map(nested_map));
 
-        let keys = all_attribute_keys(&map);
+        let mut keys = all_attribute_keys(&map);
+        keys.sort();
         assert_eq!(
             keys,
-            vec!["key1".to_string(), "nested".to_string(), "key2".to_string()]
+            vec!["key1".to_string(), "key2".to_string(), "nested".to_string()]
         );
     }
 }

--- a/worker/crates/types/src/attribute.rs
+++ b/worker/crates/types/src/attribute.rs
@@ -376,6 +376,17 @@ fn compare_numbers(n1: &Number, n2: &Number) -> Option<Ordering> {
     None
 }
 
+pub(crate) fn all_attribute_keys(items: &HashMap<String, AttributeValue>) -> Vec<String> {
+    let mut keys = Vec::new();
+    for (key, value) in items {
+        keys.push(key.clone());
+        if let AttributeValue::Map(map) = value {
+            keys.extend(all_attribute_keys(map));
+        }
+    }
+    keys
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/worker/crates/types/src/attribute.rs
+++ b/worker/crates/types/src/attribute.rs
@@ -462,4 +462,25 @@ mod tests {
         let number2 = Number::from(42);
         assert_eq!(compare_numbers(&number1, &number2), Some(Ordering::Greater));
     }
+
+    #[test]
+    fn test_all_attribute_keys() {
+        let mut map = HashMap::new();
+        map.insert(
+            "key1".to_string(),
+            AttributeValue::String("value1".to_string()),
+        );
+        let mut nested_map = HashMap::new();
+        nested_map.insert(
+            "key2".to_string(),
+            AttributeValue::String("value2".to_string()),
+        );
+        map.insert("nested".to_string(), AttributeValue::Map(nested_map));
+
+        let keys = all_attribute_keys(&map);
+        assert_eq!(
+            keys,
+            vec!["key1".to_string(), "nested".to_string(), "key2".to_string()]
+        );
+    }
 }

--- a/worker/crates/types/src/feature.rs
+++ b/worker/crates/types/src/feature.rs
@@ -5,7 +5,7 @@ use reearth_flow_eval_expr::{engine::Engine, scope::Scope};
 use serde::{Deserialize, Serialize};
 
 pub use crate::attribute::AttributeValue;
-use crate::{attribute::Attribute, geometry::Geometry};
+use crate::{all_attribute_keys, attribute::Attribute, geometry::Geometry};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Feature {
@@ -262,5 +262,16 @@ impl Feature {
         );
         scope.set("__value", value);
         scope
+    }
+
+    pub fn all_attribute_keys(&self) -> Vec<String> {
+        let mut keys = Vec::new();
+        for (key, value) in &self.attributes {
+            keys.push(key.clone().to_string());
+            if let AttributeValue::Map(map) = value {
+                keys.extend(all_attribute_keys(map));
+            }
+        }
+        keys
     }
 }

--- a/worker/examples/plateau/example_feature_transformer.rs
+++ b/worker/examples/plateau/example_feature_transformer.rs
@@ -1,5 +1,5 @@
 mod helper;
 
 fn main() {
-    helper::execute("quality-check/02-bldg/t_bldg_06.yml");
+    helper::execute("quality-check/02-bldg/l_bldg_04_05.yml");
 }

--- a/worker/examples/plateau/testdata/workflow/quality-check/02-bldg/l_bldg_04_05.yml
+++ b/worker/examples/plateau/testdata/workflow/quality-check/02-bldg/l_bldg_04_05.yml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reearth/reearth-flow/main/schema/workflow.json
+id: fefb4c7e-3b0e-4a34-a672-cb564cefa14a
+name: "QualityCheck-02-bldg-l-bldg-04-05"
+entryGraphId: 3e3450c8-2344-4728-afa9-5fdb81eec33a
+with:
+  cityGmlPath:
+  cityCode:
+  codelistsPath:
+  schemasPath:
+  schemaJson: !include ../../../config/schema.txt
+  targetPackages:
+    - bldg
+  addNsprefixToFeatureTypes: true
+  extractDmGeometryAsXmlFragment: false
+  outputPath:
+graphs:
+  - !include ../../../graphs/folder_and_file_path_reader.yml
+  - id: 3e3450c8-2344-4728-afa9-5fdb81eec33a
+    name: entry_point
+    nodes:
+      - id: d3773442-1ba8-47c1-b7c1-0bafa23adec9
+        name: FolderAndfilePathReader01
+        type: subGraph
+        subGraphId: c6863b71-953b-4d15-af56-396fc93fc617
+
+      - id: 3c0bc9cd-284d-4553-83ae-f90365c5930c
+        name: featureReader_01
+        type: action
+        action: FeatureReader
+        with:
+          format: citygml
+          dataset: |
+            env.get("__value").cityGmlPath
+
+      - id: 64bce9d0-9e72-4109-a8ce-22ecdc0fab29
+        name: "PLATEAU.BuildingUsageAttributeValidator01"
+        type: action
+        action: PLATEAU.BuildingUsageAttributeValidator
+
+      - id: 0361e205-4d43-442d-b004-2ea981dbca84
+        name: echo01
+        type: action
+        action: Echo
+
+    edges:
+      - id: c064cf52-705f-443a-b2de-6795266c540d
+        from: d3773442-1ba8-47c1-b7c1-0bafa23adec9
+        to: 3c0bc9cd-284d-4553-83ae-f90365c5930c
+        fromPort: default
+        toPort: default
+
+      - id: f23b1f56-c5d8-4311-9239-6dd205b538ab
+        from: 3c0bc9cd-284d-4553-83ae-f90365c5930c
+        to: 64bce9d0-9e72-4109-a8ce-22ecdc0fab29
+        fromPort: default
+        toPort: default
+
+      - id: 7436b0a3-a658-49f6-a576-5b45abb2bd25
+        from: 64bce9d0-9e72-4109-a8ce-22ecdc0fab29
+        to: 0361e205-4d43-442d-b004-2ea981dbca84
+        fromPort: codeError
+        toPort: default


### PR DESCRIPTION
# Overview
- Update example feature transformer to use l_bldg_04_05.yml instead of t_bldg_06.yml

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new processor for validating Building Usage attributes, enhancing data integrity within the PLATEAU system.
	- Added a public method to retrieve all attribute keys from the `Feature` struct and a new function for accessing all attribute keys in a `HashMap`.
	- New workflow configuration for automated quality checks on building data.

- **Bug Fixes**
	- Enhanced error handling with new error variants for the Building Usage Attribute Validator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->