### PR TITLE
feat(worker): Update attribute merger parameters in actions schema

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -568,31 +568,20 @@
         "title": "FeatureMergerParam",
         "type": "object",
         "required": [
-          "join"
+          "requestorAttribute",
+          "supplierAttribute"
         ],
         "properties": {
-          "join": {
-            "$ref": "#/definitions/Join"
+          "requestorAttribute": {
+            "$ref": "#/definitions/Expr"
+          },
+          "supplierAttribute": {
+            "$ref": "#/definitions/Expr"
           }
         },
         "definitions": {
-          "Attribute": {
+          "Expr": {
             "type": "string"
-          },
-          "Join": {
-            "type": "object",
-            "required": [
-              "requestor",
-              "supplier"
-            ],
-            "properties": {
-              "requestor": {
-                "$ref": "#/definitions/Attribute"
-              },
-              "supplier": {
-                "$ref": "#/definitions/Attribute"
-              }
-            }
           }
         }
       },


### PR DESCRIPTION
# Overview
The attribute merger parameters in the actions schema have been updated to include new properties such as `requestorAttribute` and `supplierAttribute`. This change improves the functionality and flexibility of the attribute merger feature.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a more flexible attribute handling system in the feature merging process.
	- Added support for dynamic evaluation of attributes, enhancing the merging functionality.

- **Bug Fixes**
	- Improved error handling with specific messages for attribute compilation failures.

- **Refactor**
	- Simplified the data structure for feature merging parameters, moving from a join-based to attribute-based model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->