### PR TITLE
chore(api): Allow all ports on Localhost

### DIFF
--- a/api/internal/app/app.go
+++ b/api/internal/app/app.go
@@ -142,7 +142,7 @@ func allowedOrigins(cfg *ServerConfig) []string {
 	}
 	origins := append([]string{}, cfg.Config.Origins...)
 	if cfg.Debug {
-		origins = append(origins, "http://localhost:3000", "http://127.0.0.1:3000", "http://localhost:8081")
+		origins = append(origins, "http://localhost:*")
 	}
 	return origins
 }


### PR DESCRIPTION
# Overview
Allow all ports on localhost

## What I've done
- replaced 
	origins = append(origins, "http://localhost:3000", "http://127.0.0.1:3000", "http://localhost:8081")
- with 
	origins = append(origins, "http://localhost:*")	

## What I haven't done
NA

## How I tested
Manually

## Screenshot
NA

## Which point I want you to review particularly
NA

## Memo
No locking ports with the backend 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded allowed origins for the server in debug mode, permitting requests from any service on localhost regardless of the port number, enhancing flexibility during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->