### PR TITLE
chore(worker): Update dependencies to use specific git tags

### DIFF
--- a/worker/Cargo.lock
+++ b/worker/Cargo.lock
@@ -1676,7 +1676,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc1#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1931,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "nusamai-citygml"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc1#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
 dependencies = [
  "ahash",
  "chrono",
@@ -1950,7 +1950,7 @@ dependencies = [
 [[package]]
 name = "nusamai-geometry"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc1#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
 dependencies = [
  "num-traits",
  "serde",
@@ -1959,7 +1959,7 @@ dependencies = [
 [[package]]
 name = "nusamai-plateau"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc1#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
 dependencies = [
  "chrono",
  "hashbrown 0.14.5",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "nusamai-projection"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc1#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
 dependencies = [
  "japan-geoid",
  "thiserror",

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -53,10 +53,10 @@ reearth-flow-storage = {path = "crates/storage"}
 reearth-flow-telemetry = {path = "crates/telemetry"}
 reearth-flow-types = {path = "crates/types"}
 
-nusamai-citygml = {git = "https://github.com/reearth/plateau-gis-converter", features = ["serde", "serde_json"]}
-nusamai-geometry = {git = "https://github.com/reearth/plateau-gis-converter", features = ["serde"]}
-nusamai-plateau = {git = "https://github.com/reearth/plateau-gis-converter", features = ["serde"]}
-nusamai-projection = {git = "https://github.com/reearth/plateau-gis-converter"}
+nusamai-citygml = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc1", features = ["serde", "serde_json"]}
+nusamai-geometry = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc1", features = ["serde"]}
+nusamai-plateau = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc1", features = ["serde"]}
+nusamai-projection = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc1"}
 
 Inflector = "0.11.4"
 approx = "0.5.1"


### PR DESCRIPTION
# Overview
This commit updates the dependencies in the `Cargo.toml` and `Cargo.lock` files to use specific git tags for the `nusamai-citygml`, `nusamai-geometry`, `nusamai-plateau`, and `nusamai-projection` packages. The tags `v0.0.1-rc1` are used to ensure a specific version of the packages is used. This change improves the stability and reproducibility of the project.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced dependency management by specifying stable versioning for `nusamai` packages, promoting reliability in builds.

- **Chores**
  - Updated dependency references from `git` to `tag` attributes for a more structured release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->