### PR TITLE
feat(worker): add lineString coercer to GeometryCoercer

### DIFF
--- a/schema/actions.json
+++ b/schema/actions.json
@@ -1030,10 +1030,10 @@
         "title": "GeometryCoercer",
         "type": "object",
         "required": [
-          "coercer_type"
+          "coercerType"
         ],
         "properties": {
-          "coercer_type": {
+          "coercerType": {
             "$ref": "#/definitions/CoercerType"
           }
         },

--- a/worker/docs/mdbook/src/action.md
+++ b/worker/docs/mdbook/src/action.md
@@ -1026,10 +1026,10 @@ Coerces the geometry of a feature to a specific geometry
   "title": "GeometryCoercer",
   "type": "object",
   "required": [
-    "coercer_type"
+    "coercerType"
   ],
   "properties": {
-    "coercer_type": {
+    "coercerType": {
       "$ref": "#/definitions/CoercerType"
     }
   },

--- a/worker/examples/plateau/testdata/workflow/quality-check/02-bldg/l_7_8_9_11_13_lod0.yml
+++ b/worker/examples/plateau/testdata/workflow/quality-check/02-bldg/l_7_8_9_11_13_lod0.yml
@@ -99,6 +99,13 @@ graphs:
         with:
           outputAttribute: outerOrientation
 
+      - id: d4a9c6a6-dd7b-4804-ab03-71b2348a398c
+        name: GeometryCoercer
+        type: action
+        action: GeometryCoercer
+        with:
+          coercerType: lineString
+
       - id: 2f03d753-a8f0-43bc-a85d-0c5554f93ddc
         name: EchoOutershell
         type: action
@@ -162,6 +169,11 @@ graphs:
         toPort: default
       - id: af538fb0-7f59-448b-9a39-f4f381524900
         from: 0361e205-4d43-442d-b004-2ea981dbca84
+        to: d4a9c6a6-dd7b-4804-ab03-71b2348a398c
+        fromPort: default
+        toPort: default
+      - id: be2f6bab-50cf-42dd-95fa-44e32f5ddc1a
+        from: d4a9c6a6-dd7b-4804-ab03-71b2348a398c
         to: 2f03d753-a8f0-43bc-a85d-0c5554f93ddc
         fromPort: default
         toPort: default


### PR DESCRIPTION
# Overview
This commit adds support for the lineString coercer type in the GeometryCoercer module. It modifies the `GeometryCoercer` struct to include a `coercerType` field with the value `lineString`. The code changes in the `impl GeometryCoercer` block handle the conversion of polygon geometries to lineString geometries based on the coercer type. The commit also includes updates to the test data file `02-bldg/l_7_8_9_11_13_lod0.yml` to add a new action with the `coercerType` set to `lineString`.


## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced the `GeometryCoercer` action in workflow configurations, enhancing geometry coercion capabilities.
  - Updated workflow connections to integrate the new `GeometryCoercer` node, improving data flow between actions.

- **Improvements**
  - Standardized serialization format for geometry types, enhancing data consistency.
  - Refined control flow in geometry processing, improving readability and maintainability of the implementation.
  - Updated JSON schema to use camelCase naming conventions for properties, aligning with common coding standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->