### PR TITLE
chore(worker): remove typetag.workspace from Cargo.toml files

### DIFF
--- a/worker/Cargo.lock
+++ b/worker/Cargo.lock
@@ -402,9 +402,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 dependencies = [
  "serde",
 ]
@@ -901,16 +901,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "erased-serde"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
-dependencies = [
- "serde",
- "typeid",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,7 +1146,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1433,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -1466,12 +1456,6 @@ checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "inventory"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f958d3d68f4167080a18141e10381e7634563984a537f2a49a30fd8e53ac5767"
 
 [[package]]
 name = "ipnet"
@@ -1682,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc1#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc2#ae9164cf8ee64c88dba074b2c91039934fbf1e8c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1766,13 +1750,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1925,28 +1910,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "nusamai-citygml"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc1#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc2#ae9164cf8ee64c88dba074b2c91039934fbf1e8c"
 dependencies = [
  "ahash",
  "chrono",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "log",
  "macros",
  "nusamai-geometry",
  "nusamai-projection",
- "quick-xml 0.36.0",
+ "quick-xml",
  "serde",
  "serde_json",
  "thiserror",
@@ -1956,7 +1931,7 @@ dependencies = [
 [[package]]
 name = "nusamai-geometry"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc1#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc2#ae9164cf8ee64c88dba074b2c91039934fbf1e8c"
 dependencies = [
  "num-traits",
  "serde",
@@ -1965,15 +1940,15 @@ dependencies = [
 [[package]]
 name = "nusamai-plateau"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc1#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc2#ae9164cf8ee64c88dba074b2c91039934fbf1e8c"
 dependencies = [
  "chrono",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "log",
  "nusamai-citygml",
  "nusamai-geometry",
- "quick-xml 0.36.0",
+ "quick-xml",
  "serde",
  "serde_json",
  "stretto",
@@ -1983,7 +1958,7 @@ dependencies = [
 [[package]]
 name = "nusamai-projection"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc1#eebdc95e9ee450687b2867216cc9b15a7b244c8e"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc2#ae9164cf8ee64c88dba074b2c91039934fbf1e8c"
 dependencies = [
  "japan-geoid",
  "thiserror",
@@ -2050,9 +2025,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opendal"
-version = "0.47.3"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac4826fe3d5482a49b92955b0f6b06ce45b46ec84484176588209bfbf996870"
+checksum = "615d41187deea0ea7fab5b48e9afef6ae8fc742fdcfa248846ee3d92ff71e986"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2069,7 +2044,7 @@ dependencies = [
  "metrics",
  "once_cell",
  "percent-encoding",
- "quick-xml 0.31.0",
+ "quick-xml",
  "reqsign",
  "reqwest",
  "serde",
@@ -2124,20 +2099,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
@@ -2159,9 +2120,9 @@ dependencies = [
  "async-trait",
  "futures-core",
  "http",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.24.0",
+ "opentelemetry_sdk",
  "prost",
  "thiserror",
  "tokio",
@@ -2174,8 +2135,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
 dependencies = [
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
 ]
@@ -2195,8 +2156,8 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures-util",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "ordered-float",
  "serde",
  "serde_json",
@@ -2204,29 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "lazy_static",
- "once_cell",
- "opentelemetry 0.23.0",
- "ordered-float",
- "percent-encoding",
- "rand",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48618fd69580af9aeb349369c07f7ca9d3c30c3cd91dc274f2882a7a5a18599"
+checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -2234,7 +2175,7 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "percent-encoding",
  "rand",
  "serde_json",
@@ -2341,7 +2282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
 ]
 
 [[package]]
@@ -2491,21 +2432,12 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
 dependencies = [
  "memchr",
  "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4091e032efecb09d7b1f711f487b85ab925632a842627e3200fb088382cde32c"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2677,11 +2609,11 @@ dependencies = [
  "nusamai-plateau",
  "nusamai-projection",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "parking_lot",
  "petgraph",
  "pretty_assertions",
- "quick-xml 0.36.0",
+ "quick-xml",
  "reearth-flow-action-log",
  "reearth-flow-common",
  "reearth-flow-eval-expr",
@@ -2699,7 +2631,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typetag",
  "url",
  "uuid",
 ]
@@ -2720,11 +2651,11 @@ dependencies = [
  "nusamai-plateau",
  "nusamai-projection",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "parking_lot",
  "petgraph",
  "pretty_assertions",
- "quick-xml 0.36.0",
+ "quick-xml",
  "reearth-flow-action-log",
  "reearth-flow-common",
  "reearth-flow-eval-expr",
@@ -2742,7 +2673,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typetag",
  "url",
  "uuid",
 ]
@@ -2755,7 +2685,7 @@ dependencies = [
  "bytes",
  "csv",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "petgraph",
  "pretty_assertions",
  "reearth-flow-action-log",
@@ -2775,7 +2705,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typetag",
  "uuid",
 ]
 
@@ -2792,10 +2721,10 @@ dependencies = [
  "nusamai-plateau",
  "nusamai-projection",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "petgraph",
  "pretty_assertions",
- "quick-xml 0.36.0",
+ "quick-xml",
  "reearth-flow-action-log",
  "reearth-flow-common",
  "reearth-flow-eval-expr",
@@ -2812,7 +2741,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typetag",
  "url",
  "uuid",
 ]
@@ -2827,8 +2755,8 @@ dependencies = [
  "directories",
  "indoc",
  "once_cell",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "reearth-flow-action-log",
  "reearth-flow-action-plateau-processor",
  "reearth-flow-action-processor",
@@ -2975,7 +2903,7 @@ dependencies = [
  "futures",
  "futures-util",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "petgraph",
  "pretty_assertions",
  "reearth-flow-action-log",
@@ -3009,7 +2937,7 @@ dependencies = [
  "futures-util",
  "nutype",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "parking_lot",
  "petgraph",
  "pretty_assertions",
@@ -3075,11 +3003,11 @@ name = "reearth-flow-telemetry"
 version = "0.1.0"
 dependencies = [
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry-stdout",
- "opentelemetry_sdk 0.24.0",
+ "opentelemetry_sdk",
  "serde",
  "serde_json",
  "thiserror",
@@ -3123,7 +3051,7 @@ dependencies = [
  "directories",
  "futures",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "itertools",
  "nusamai-citygml",
  "nusamai-geometry",
@@ -3147,15 +3075,14 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
- "typetag",
  "uuid",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3197,9 +3124,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqsign"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70fe66d4cd0b5ed9b1abbfe639bf6baeaaf509f7da2d51b31111ba945be59286"
+checksum = "03dd4ba7c3901dd43e6b8c7446a760d45bc1ea4301002e1a6fa48f97c3a796fa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3415,9 +3342,9 @@ dependencies = [
 
 [[package]]
 name = "rust_xlsxwriter"
-version = "0.70.0"
+version = "0.73.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5183b3255e7f59906fb5630f7b5a3d46c0c27848ca947312011ac03b496f26b"
+checksum = "4850a507b7ecd741796f7dfb87dbe63f6ed25c5ddb45d3d61bc6c464ef652db6"
 dependencies = [
  "regex",
  "zip",
@@ -3656,12 +3583,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -3688,7 +3616,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3714,7 +3642,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "itoa",
  "ryu",
  "serde",
@@ -4078,12 +4006,13 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "b8fcd239983515c23a32fb82099f97d0b11b8c72f654ed659363a95c3dad7a53"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "once_cell",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -4195,28 +4124,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4380,14 +4308,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
+checksum = "a9784ed4da7d921bc8df6963f8c80a0e4ce34ba6ba76668acadd3edbd985ff3b"
 dependencies = [
  "js-sys",
  "once_cell",
- "opentelemetry 0.23.0",
- "opentelemetry_sdk 0.23.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -4451,40 +4379,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typeid"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059d83cc991e7a42fc37bd50941885db0888e34209f8cfd9aab07ddec03bc9cf"
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "typetag"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661d18414ec032a49ece2d56eee03636e43c4e8d577047ab334c0ba892e29aaf"
-dependencies = [
- "erased-serde",
- "inventory",
- "once_cell",
- "serde",
- "typetag-impl",
-]
-
-[[package]]
-name = "typetag-impl"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac73887f47b9312552aa90ef477927ff014d63d1920ca8037c6c1951eab64bb1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.71",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -5033,7 +4931,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "memchr",
  "thiserror",
  "zopfli",

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -53,16 +53,16 @@ reearth-flow-storage = {path = "crates/storage"}
 reearth-flow-telemetry = {path = "crates/telemetry"}
 reearth-flow-types = {path = "crates/types"}
 
-nusamai-citygml = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc1", features = ["serde", "serde_json"]}
-nusamai-geometry = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc1", features = ["serde"]}
-nusamai-plateau = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc1", features = ["serde"]}
-nusamai-projection = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc1"}
+nusamai-citygml = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc2", features = ["serde", "serde_json"]}
+nusamai-geometry = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc2", features = ["serde"]}
+nusamai-plateau = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc2", features = ["serde"]}
+nusamai-projection = {git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc2"}
 
 Inflector = "0.11.4"
 approx = "0.5.1"
 async-trait = "0.1.81"
 async_zip = {version = "0.0.17", features = ["full"]}
-bytes = {version = "1.6.1", features = ["serde"]}
+bytes = {version = "1.7.1", features = ["serde"]}
 chrono = {version = "0.4.38", features = ["serde"]}
 color-eyre = "0.6.3"
 colorsys = "0.6.7"
@@ -74,7 +74,7 @@ float_next_after = "1.0.0"
 futures = "0.3.30"
 futures-util = "0.3.30"
 hashbrown = "0.14.5"
-indexmap = "2.2.6"
+indexmap = "2.3.0"
 indoc = "2.0.5"
 itertools = "0.13.0"
 jsonpath_lib = "0.3.0"
@@ -82,52 +82,51 @@ libxml = "0.3.3"
 nalgebra = "0.33.0"
 nalgebra-glm = "0.19.0"
 num-traits = "0.2.19"
-nutype = {version = "0.4.2", features = ["serde", "schemars08"]}
+nutype = {version = "0.4.3", features = ["serde", "schemars08"]}
 object_store = "0.10.2"
 once_cell = "1.19.0"
-opendal = {version = "0.47.3", features = ["layers-metrics", "services-fs", "services-gcs", "services-http"]}
+opendal = {version = "0.48.0", features = ["layers-metrics", "services-fs", "services-gcs", "services-http"]}
 opentelemetry = {version = "0.24.0", default-features = false, features = ["trace", "metrics"]}
 opentelemetry-otlp = {version = "0.17.0", default-features = false, features = ["grpc-tonic", "trace", "metrics"]}
 opentelemetry-semantic-conventions = "0.16.0"
 opentelemetry-stdout = {version = "0.5.0", default-features = false, features = ["trace", "metrics"]}
-opentelemetry_sdk = {version = "0.24.0", default-features = false, features = ["trace", "rt-tokio", "metrics"]}
+opentelemetry_sdk = {version = "0.24.1", default-features = false, features = ["trace", "rt-tokio", "metrics"]}
 parking_lot = "0.12.3"
 petgraph = "0.6.5"
 pretty_assertions = "1.4.0"
-quick-xml = "0.36.0"
+quick-xml = "0.36.1"
 rand = "0.8.5"
 rayon = "1.10.0"
-regex = "1.10.5"
+regex = "1.10.6"
 rhai = {version = "1.19.0", features = ["internals", "sync", "serde", "metadata"]}
 robust = "1.1.0"
 rstar = "0.12.0"
-rstest = "0.21.0"
-rust_xlsxwriter = "0.70.0"
+rstest = "0.22.0"
+rust_xlsxwriter = "0.73.0"
 schemars = {version = "0.8.21", features = ["uuid1"]}
 serde = {version = "1.0.204", features = ["derive"]}
 serde_derive = "1.0.204"
-serde_json = {version = "1.0.120", features = ["arbitrary_precision"]}
+serde_json = {version = "1.0.122", features = ["arbitrary_precision"]}
 serde_with = "3.9.0"
 serde_yaml = "0.9.34"
 sha2 = "0.10.8"
 slog = {version = "2.7.0", features = ["release_max_level_trace", "max_level_trace"]}
 strum = "0.26.3"
 strum_macros = "0.26.4"
-tempfile = "3.10.1"
+tempfile = "3.11.0"
 thiserror = "1.0.63"
 time = {version = "0.3.36", features = ["formatting"]}
-tokio = {version = "1.38.1", features = ["full", "time"]}
+tokio = {version = "1.39.2", features = ["full", "time"]}
 tokio-stream = {version = "0.1.15", features = ["sync"]}
 tokio-util = {version = "0.7.11", features = ["full"]}
-toml = "0.8.14"
+toml = "0.8.19"
 tracing = "0.1.40"
-tracing-opentelemetry = {version = "0.24.0", default-features = false, features = ["tracing-log", "metrics"]}
+tracing-opentelemetry = {version = "0.25.0", default-features = false, features = ["tracing-log", "metrics"]}
 tracing-subscriber = {version = "0.3.18", features = [
   "env-filter",
   "std",
   "time",
 ]}
-typetag = "0.2.16"
 url = "2.5.2"
 uuid = {version = "1.10.0", features = [
   "v4",

--- a/worker/crates/action-plateau-processor/Cargo.toml
+++ b/worker/crates/action-plateau-processor/Cargo.toml
@@ -45,7 +45,6 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-typetag.workspace = true
 url.workspace = true
 uuid.workspace = true
 

--- a/worker/crates/action-processor/Cargo.toml
+++ b/worker/crates/action-processor/Cargo.toml
@@ -45,7 +45,6 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-typetag.workspace = true
 url.workspace = true
 uuid.workspace = true
 

--- a/worker/crates/action-sink/Cargo.toml
+++ b/worker/crates/action-sink/Cargo.toml
@@ -35,7 +35,6 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-typetag.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]

--- a/worker/crates/action-source/Cargo.toml
+++ b/worker/crates/action-source/Cargo.toml
@@ -41,7 +41,6 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-typetag.workspace = true
 url.workspace = true
 uuid.workspace = true
 

--- a/worker/crates/storage/src/operator.rs
+++ b/worker/crates/storage/src/operator.rs
@@ -44,20 +44,18 @@ pub(crate) fn build_operator<B: Builder>(builder: B) -> Result<Operator> {
 
 /// init_fs_operator will init a opendal fs operator.
 fn init_fs_operator(uri: &Uri) -> impl Builder {
-    let mut builder = services::Fs::default();
+    let builder = services::Fs::default();
     let root = match uri.root() {
         "" => "/",
         _ => uri.root(),
     };
-    builder.root(root);
-    builder
+    builder.root(root)
 }
 
 /// init_gcs_operator will init a opendal gcs operator.
 fn init_gcs_operator(uri: &Uri) -> impl Builder {
-    let mut builder = services::Gcs::default();
-    builder.bucket(uri.root());
-    builder
+    let builder = services::Gcs::default();
+    builder.bucket(uri.root())
 }
 
 /// init_memory_operator will init a opendal memory operator.
@@ -66,17 +64,17 @@ fn init_memory_operator() -> impl Builder {
 }
 
 fn init_https_operator(uri: &Uri) -> impl Builder {
-    let mut builder = services::Http::default();
+    let builder = services::Http::default();
     debug!("init_https_operator: {}", uri.root());
-    builder.endpoint(&format!("https://{}", uri.root()));
-    builder.root("/");
     builder
+        .endpoint(&format!("https://{}", uri.root()))
+        .root("/")
 }
 
 fn init_http_operator(uri: &Uri) -> impl Builder {
-    let mut builder = services::Http::default();
+    let builder = services::Http::default();
     debug!("init_http_operator: {}", uri.root());
-    builder.endpoint(&format!("http://{}", uri.root()));
-    builder.root("/");
     builder
+        .endpoint(&format!("http://{}", uri.root()))
+        .root("/")
 }

--- a/worker/crates/types/Cargo.toml
+++ b/worker/crates/types/Cargo.toml
@@ -44,5 +44,4 @@ tokio-stream.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
-typetag.workspace = true
 uuid.workspace = true


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated multiple dependencies to their latest versions, enhancing functionality and stability.
- **Bug Fixes**
	- Removed the `typetag` crate from several configurations, streamlining dependency management.
- **Refactor**
	- Improved operator initialization processes by adopting immutable variables and method chaining for clearer code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->