### PR TITLE
feat(worker): add lineString coercer to GeometryCoercer

### DIFF
--- a/worker/crates/action-processor/src/geometry/coercer.rs
+++ b/worker/crates/action-processor/src/geometry/coercer.rs
@@ -148,11 +148,17 @@ impl GeometryCoercer {
                 match self.coercer_type {
                     CoercerType::LineString => {
                         let line_strings = polygon.rings().to_vec();
-                        let geo = GeometryValue::FlowGeometry2D(Geometry2D::MultiLineString(
-                            MultiLineString2D::new(line_strings),
-                        ));
+                        let geo = if let Some(first) = line_strings.first() {
+                            if line_strings.len() == 1 {
+                                Geometry2D::LineString(first.clone())
+                            } else {
+                                Geometry2D::MultiLineString(MultiLineString2D::new(line_strings))
+                            }
+                        } else {
+                            return;
+                        };
                         let mut geometry = geometry.clone();
-                        geometry.value = geo;
+                        geometry.value = GeometryValue::FlowGeometry2D(geo);
                         feature.geometry = Some(geometry);
                     }
                 }
@@ -165,15 +171,28 @@ impl GeometryCoercer {
                         let mut geometries = Vec::<Geometry2D>::new();
                         for polygon in polygons.iter() {
                             let line_strings = polygon.rings().to_vec();
-                            geometries.push(Geometry2D::MultiLineString(MultiLineString2D::new(
-                                line_strings,
-                            )));
+                            if let Some(first) = line_strings.first() {
+                                let geometry = if line_strings.len() == 1 {
+                                    Geometry2D::LineString(first.clone())
+                                } else {
+                                    Geometry2D::MultiLineString(MultiLineString2D::new(
+                                        line_strings,
+                                    ))
+                                };
+                                geometries.push(geometry);
+                            }
                         }
-                        let geo = GeometryValue::FlowGeometry2D(Geometry2D::GeometryCollection(
-                            geometries,
-                        ));
+                        let geo = if let Some(first) = geometries.first() {
+                            if geometries.len() == 1 {
+                                first.clone()
+                            } else {
+                                Geometry2D::GeometryCollection(geometries)
+                            }
+                        } else {
+                            return;
+                        };
                         let mut geometry = geometry.clone();
-                        geometry.value = geo;
+                        geometry.value = GeometryValue::FlowGeometry2D(geo);
                         feature.geometry = Some(geometry);
                     }
                 }
@@ -197,11 +216,17 @@ impl GeometryCoercer {
                 match self.coercer_type {
                     CoercerType::LineString => {
                         let line_strings = polygon.rings().to_vec();
-                        let geo = GeometryValue::FlowGeometry3D(Geometry3D::MultiLineString(
-                            MultiLineString3D::new(line_strings),
-                        ));
+                        let geo = if let Some(first) = line_strings.first() {
+                            if line_strings.len() == 1 {
+                                Geometry3D::LineString(first.clone())
+                            } else {
+                                Geometry3D::MultiLineString(MultiLineString3D::new(line_strings))
+                            }
+                        } else {
+                            return;
+                        };
                         let mut geometry = geometry.clone();
-                        geometry.value = geo;
+                        geometry.value = GeometryValue::FlowGeometry3D(geo);
                         feature.geometry = Some(geometry);
                     }
                 }
@@ -214,15 +239,28 @@ impl GeometryCoercer {
                         let mut geometries = Vec::<Geometry3D>::new();
                         for polygon in polygons.iter() {
                             let line_strings = polygon.rings().to_vec();
-                            geometries.push(Geometry3D::MultiLineString(MultiLineString3D::new(
-                                line_strings,
-                            )));
+                            if let Some(first) = line_strings.first() {
+                                let geometry = if line_strings.len() == 1 {
+                                    Geometry3D::LineString(first.clone())
+                                } else {
+                                    Geometry3D::MultiLineString(MultiLineString3D::new(
+                                        line_strings,
+                                    ))
+                                };
+                                geometries.push(geometry);
+                            }
                         }
-                        let geo = GeometryValue::FlowGeometry3D(Geometry3D::GeometryCollection(
-                            geometries,
-                        ));
+                        let geo = if let Some(first) = geometries.first() {
+                            if geometries.len() == 1 {
+                                first.clone()
+                            } else {
+                                Geometry3D::GeometryCollection(geometries)
+                            }
+                        } else {
+                            return;
+                        };
                         let mut geometry = geometry.clone();
-                        geometry.value = geo;
+                        geometry.value = GeometryValue::FlowGeometry3D(geo);
                         feature.geometry = Some(geometry);
                     }
                 }
@@ -246,29 +284,26 @@ impl GeometryCoercer {
                 CoercerType::LineString => {
                     for polygon in geo_feature.polygons.iter() {
                         let line_strings = polygon.rings().to_vec();
-                        geometries.push(Geometry3D::MultiLineString(MultiLineString3D::new(
-                            line_strings,
-                        )));
+                        if let Some(first) = line_strings.first() {
+                            let geometry = if line_strings.len() == 1 {
+                                Geometry3D::LineString(first.clone())
+                            } else {
+                                Geometry3D::MultiLineString(MultiLineString3D::new(line_strings))
+                            };
+                            geometries.push(geometry);
+                        }
                     }
-                    if geometries.is_empty() {
-                        fw.send(
-                            ctx.new_with_feature_and_port(feature.clone(), DEFAULT_PORT.clone()),
-                        );
-                        return;
-                    }
-                    let geo = if geometries.len() == 1 {
-                        let Some(Geometry3D::MultiLineString(line_string)) = geometries.first()
-                        else {
-                            return;
-                        };
-                        GeometryValue::FlowGeometry3D(Geometry3D::MultiLineString(
-                            line_string.clone(),
-                        ))
+                    let geo = if let Some(first) = geometries.first() {
+                        if geometries.len() == 1 {
+                            first.clone()
+                        } else {
+                            Geometry3D::GeometryCollection(geometries)
+                        }
                     } else {
-                        GeometryValue::FlowGeometry3D(Geometry3D::GeometryCollection(geometries))
+                        return;
                     };
                     let mut geometry = geometry.clone();
-                    geometry.value = geo;
+                    geometry.value = GeometryValue::FlowGeometry3D(geo);
                     let mut feature = feature.clone();
                     feature.id = uuid::Uuid::new_v4();
                     feature.geometry = Some(geometry);

--- a/worker/examples/plateau/testdata/workflow/quality-check/02-bldg/l_7_8_9_11_13_lod0.yml
+++ b/worker/examples/plateau/testdata/workflow/quality-check/02-bldg/l_7_8_9_11_13_lod0.yml
@@ -100,7 +100,14 @@ graphs:
           outputAttribute: outerOrientation
 
       - id: d4a9c6a6-dd7b-4804-ab03-71b2348a398c
-        name: GeometryCoercer
+        name: GeometryCoercer_Outershell
+        type: action
+        action: GeometryCoercer
+        with:
+          coercerType: lineString
+
+      - id: ba7c5dd4-5333-4477-b1e8-f85905ac2d60
+        name: GeometryCoercer_Hole
         type: action
         action: GeometryCoercer
         with:
@@ -167,6 +174,11 @@ graphs:
         to: 0361e205-4d43-442d-b004-2ea981dbca84
         fromPort: outershell
         toPort: default
+      - id: cebc93c1-c510-4995-a529-90cad8f5c37c
+        from: 52a4bcab-854d-41e8-a9b3-e391c79631a9
+        to: ba7c5dd4-5333-4477-b1e8-f85905ac2d60
+        fromPort: hole
+        toPort: default
       - id: af538fb0-7f59-448b-9a39-f4f381524900
         from: 0361e205-4d43-442d-b004-2ea981dbca84
         to: d4a9c6a6-dd7b-4804-ab03-71b2348a398c
@@ -178,7 +190,7 @@ graphs:
         fromPort: default
         toPort: default
       - id: baec53de-12fa-4e37-8a49-def1afe8e547
-        from: 52a4bcab-854d-41e8-a9b3-e391c79631a9
+        from: ba7c5dd4-5333-4477-b1e8-f85905ac2d60
         to: 565d0851-fc27-46b5-961d-9c2499b2eafb
-        fromPort: hole
+        fromPort: default
         toPort: default


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced geometry processing logic for `LineString` and `MultiLineString`, improving accuracy of geometric representations.
	- Introduced a new action `GeometryCoercer_Hole` in the workflow for better handling of geometry types.
	- Updated existing action `GeometryCoercer` to `GeometryCoercer_Outershell` for clearer functionality distinction.

- **Bug Fixes**
	- Improved handling of empty geometries to prevent unnecessary operations and potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->