### PR TITLE
chore(worker): Add Cesium 3D Tiles support to worker tools

### DIFF
--- a/worker/.gitattributes
+++ b/worker/.gitattributes
@@ -1,2 +1,3 @@
 examples/plateau/testdata/**/* linguist-vendored
 tests/fixture/**/* linguist-vendored
+tools/**/* linguist-vendored

--- a/worker/.gitignore
+++ b/worker/.gitignore
@@ -14,3 +14,8 @@ out.json
 .idea
 .vscode
 docs/mdbook/book
+
+tools/cesium/3dtiles/**
+!tools/cesium/3dtiles/.gitkeep
+tools/mvt/dist/**
+!tools/mvt/dist/.gitkeep

--- a/worker/tools/README.md
+++ b/worker/tools/README.md
@@ -1,0 +1,30 @@
+# Tools
+
+## Cesium
+
+1. Copy to cesium/3dtiles
+
+Move the folder folder to be distributed under examples/3dtiles.
+examples/3dtiles/tiles.json and should be
+
+2. Start local web server:
+
+    ```bash
+    cd cesium
+    python -m http.server
+    ```
+
+3. Open the browser and visit `http://localhost:8000/`
+
+## mvt
+
+1. Copy to mvt/dist
+
+2. Start local web server:
+
+    ```bash
+    cd mvt
+    python -m http.server
+    ```
+
+3. Open the browser and visit `http://localhost:8000/`

--- a/worker/tools/cesium/3dtiles.html
+++ b/worker/tools/cesium/3dtiles.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cesium</title>
+    <script src="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Cesium.js"></script>
+    <link
+      href="https://cesium.com/downloads/cesiumjs/releases/1.115/Build/Cesium/Widgets/widgets.css"
+      rel="stylesheet"
+    />
+    <style>
+      #cesiumContainer {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        margin: 0;
+        overflow: hidden;
+        padding: 0;
+        font-family: sans-serif;
+      }
+      html {
+        height: 100%;
+      }
+      body {
+        padding: 0;
+        margin: 0;
+        overflow: hidden;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="cesiumContainer"></div>
+    <script>
+      // Cesium ion token for the plateau-terrain-streaming
+      // https://github.com/Project-PLATEAU/plateau-streaming-tutorial/blob/main/terrain/plateau-terrain-streaming.md
+      Cesium.Ion.defaultAccessToken =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI5N2UyMjcwOS00MDY1LTQxYjEtYjZjMy00YTU0ZTg5MmViYWQiLCJpZCI6ODAzMDYsImlhdCI6MTY0Mjc0ODI2MX0.dkwAL1CcljUV7NA7fDbhXXnmyZQU_c-G5zRx8PtEcxE";
+
+      async function setup() {
+        const viewer = new Cesium.Viewer("cesiumContainer", {
+          terrainProvider: await Cesium.CesiumTerrainProvider.fromIonAssetId(
+            770371,
+            { requestVertexNormals: true }
+          ),
+          shadows: true,
+        });
+
+        const ambientOcclusion =
+          viewer.scene.postProcessStages.ambientOcclusion;
+        ambientOcclusion.enabled = true;
+        ambientOcclusion.uniforms.intensity = 0.5;
+        ambientOcclusion.uniforms.lengthCap = 5;
+        // ambientOcclusion.uniforms.ambientOcclusionOnly = true;
+
+        viewer.shadowMap.size = 8192;
+        viewer.shadowMap.darkness = 0.6;
+
+        viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
+
+        var imageProvider = new Cesium.UrlTemplateImageryProvider({
+          url: "https://gic-plateau.s3.ap-northeast-1.amazonaws.com/2020/ortho/tiles/{z}/{x}/{y}.png",
+          maximumLevel: 19,
+        });
+        var currentImage =
+          viewer.scene.imageryLayers.addImageryProvider(imageProvider);
+
+        viewer.scene.screenSpaceCameraController.enableCollisionDetection = false;
+        viewer.scene.globe.depthTestAgainstTerrain = true;
+
+        const tileset = await Cesium.Cesium3DTileset.fromUrl(
+          "/3dtiles/tileset.json"
+        );
+        viewer.scene.primitives.add(tileset);
+        viewer.zoomTo(tileset);
+
+        // const tileset2 = await Cesium.Cesium3DTileset.fromUrl(
+        //   "https://assets.cms.plateau.reearth.io/assets/2a/361f69-cc77-4bb4-a468-cd0f4e93a376/22203_numazu-shi_2021_3dtiles_5_op_bldg_lod2/tileset.json"
+        // );
+        // viewer.scene.primitives.add(tileset2);
+        // viewer.zoomTo(tileset2);
+      }
+
+      setup();
+    </script>
+  </body>
+</html>

--- a/worker/tools/cesium/index.html
+++ b/worker/tools/cesium/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<head>
+  <title>Cesium</title>
+</head>
+<body>
+  <ul>
+    <li><a href="3dtiles.html">3D Tiles</a></li>
+  </ul>
+</body>

--- a/worker/tools/mvt/index.html
+++ b/worker/tools/mvt/index.html
@@ -1,0 +1,54 @@
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>PLATEAU-3DTiles/MVT、PLATEAU-Ortho、PLATEAU-TerrainをCesiumで表示</title>
+  <script src="https://cesium.com/downloads/cesiumjs/releases/1.117/Build/Cesium/Cesium.js"></script>
+  <link href="https://cesium.com/downloads/cesiumjs/releases/1.117/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+  <script src="https://unpkg.com/cesium-mvt-imagery-provider@1.4.1/dist/cesium-mvt-imagery-provider.umd.js"></script>
+  <style>
+    #cesiumContainer {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+      margin: 0;
+      overflow: hidden;
+      padding: 0;
+      font-family: sans-serif;
+    }
+    html {
+      height: 100%;
+    }
+    body {
+      padding: 0;
+      margin: 0;
+      overflow: hidden;
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <div id="cesiumContainer"></div>
+  <script>
+    Cesium.Ion.defaultAccessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJlNjk0MTM4NC1lMWI0LTQxNTgtYjcxZS01ZWJhMGJlMTE1MWQiLCJpZCI6MTQ5ODk3LCJpYXQiOjE3MTUxNTEyODZ9.2aUmEQ2-fDsjf-XeC6-hZpwkgwLse3yXoXF4xTOvPAY";
+
+    const viewer = new Cesium.Viewer("cesiumContainer", {});
+
+    const yourMvt = new CesiumMVTImageryProvider.CesiumMVTImageryProvider({
+      urlTemplate: "http://localhost:8000/dist/{z}/{x}/{y}.mvt",
+      layerName: "luse",
+      style: feature => {
+        return {
+          fillStyle: "white" // 白で塗りつぶす
+        };
+      },
+    });
+    viewer.scene.imageryLayers.addImageryProvider(yourMvt);
+
+    viewer.camera.setView({
+      destination: Cesium.Cartesian3.fromDegrees(139.8393542,35.8249542, 5000.0)
+    });
+  </script>
+</body>
+</html>

--- a/worker/tools/mvt/style.json
+++ b/worker/tools/mvt/style.json
@@ -1,0 +1,45 @@
+{
+    "version": 8,
+    "sources": {
+        "plateau": {
+            "type": "vector",
+            "tiles": [
+                "http://localhost:8080/mvt/{z}/{x}/{y}.pbf"
+            ],
+            "minzoom": 7,
+            "maxzoom": 15
+        }
+    },
+    "layers": [
+        {
+            "id": "bldg:Building",
+            "type": "fill",
+            "source": "plateau",
+            "source-layer": "bldg:Building",
+            "paint": {
+                "fill-outline-color": "black",
+                "fill-color": "#aa0000"
+            }
+        },
+        {
+            "id": "tran:Road",
+            "type": "fill",
+            "source": "plateau",
+            "source-layer": "tran:Road",
+            "paint": {
+                "fill-outline-color": "black",
+                "fill-color": "#009900"
+            }
+        },
+        {
+            "id": "brid:Bridge",
+            "type": "fill",
+            "source": "plateau",
+            "source-layer": "brid:Bridge",
+            "paint": {
+                "fill-outline-color": "black",
+                "fill-color": "#0000aa"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new web applications for visualizing 3D geospatial data using the CesiumJS library.
	- Added navigation functionality with links to access various 3D Tiles resources.
	- Implemented a style configuration for vector tiles to enhance mapping visuals.

- **Chores**
	- Updated `.gitattributes` to classify the `tools` directory as vendor code.
	- Enhanced `.gitignore` to exclude specific tool directories while retaining essential files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->