### PR TITLE
chore(websocket): implement Default trait for AppState and simplify error handling

### DIFF
--- a/websocket/.gitignore
+++ b/websocket/.gitignore
@@ -13,3 +13,4 @@ out/
 out.json
 .idea
 .vscode
+.idea

--- a/websocket/crates/domain/src/project.rs
+++ b/websocket/crates/domain/src/project.rs
@@ -50,7 +50,9 @@ impl ProjectEditingSession {
         let session_id = generate_id(14, "editor-session");
         self.session_id = Some(session_id.clone());
         if !self.session_setup_complete {
-            let latest_snapshot_state = snapshot_repo.get_latest_snapshot_state(&self.project_id).await?;
+            let _latest_snapshot_state = snapshot_repo
+                .get_latest_snapshot_state(&self.project_id)
+                .await?;
             // Initialize Redis with latest snapshot state
         }
         self.session_setup_complete = true;
@@ -108,7 +110,7 @@ impl ProjectEditingSession {
         snapshot_repo: &impl ProjectSnapshotRepository,
         data: SnapshotData,
     ) -> Result<(), Box<dyn Error>> {
-        let merged_state = self.merge_updates().await?;
+        self.merge_updates().await?;
         let snapshot = ProjectSnapshot {
             id: generate_id(14, "snap"),
             project_id: self.project_id.clone(),

--- a/websocket/crates/infra/src/persistence/redis/flow_project_redis_data_manager.rs
+++ b/websocket/crates/infra/src/persistence/redis/flow_project_redis_data_manager.rs
@@ -38,7 +38,7 @@ impl FlowProjectRedisDataManager {
         redis_client: Arc<RedisClient>,
     ) -> Self {
         let redis_url = redis_client.redis_url();
-        let global_lock = FlowProjectLock::new(&redis_url);
+        let global_lock = FlowProjectLock::new(redis_url);
         Self {
             redis_client,
             project_id,

--- a/websocket/crates/infra/src/socket/errors.rs
+++ b/websocket/crates/infra/src/socket/errors.rs
@@ -5,12 +5,18 @@ pub type Result<T> = std::result::Result<T, WsError>;
 #[derive(Debug, Clone, PartialEq)]
 pub enum WsError {
     WsError,
+    RoomNotFound(String),
+    JoinError(String),
 }
 
 impl Error for WsError {}
 
 impl std::fmt::Display for WsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "WebSocket error")
+        match self {
+            WsError::WsError => write!(f, "WebSocket error"),
+            WsError::RoomNotFound(room_id) => write!(f, "Room not found: {}", room_id),
+            WsError::JoinError(err) => write!(f, "Failed to join room: {}", err),
+        }
     }
 }


### PR DESCRIPTION

# Overview

## What I've done

impl default func for room and AppState

## What I haven't done

## How I tested

cargo test

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a default constructor for the `Room` and `AppState` structs, simplifying their instantiation.

- **Bug Fixes**
	- Improved error handling in the `handle_error` function and `join` method to enhance responsiveness and clarity.
	- Enhanced error reporting in WebSocket operations with new error variants for better diagnostics.
	- Updated locking mechanisms in `Room`, `AppState`, and related methods for better reliability in state management.

- **Chores**
	- Updated `.gitignore` to exclude IDE-specific files, maintaining a cleaner repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->