### PR TITLE
fix(websocket): change `App::new()` to `App::default()`

### DIFF
--- a/websocket/crates/infra/src/main.rs
+++ b/websocket/crates/infra/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> std::io::Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
-    let state = Arc::new(AppState::new());
+    let state = Arc::new(AppState::default());
     let state_err = state.clone();
     let app = Router::new()
         .route("/:room", get(handle_upgrade))


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the application initialization to use a default state, improving consistency upon startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->