### PR TITLE
feat(ui): allow edges to be reconnected

### DIFF
--- a/ui/src/features/Editor/components/Canvas/hooks.ts
+++ b/ui/src/features/Editor/components/Canvas/hooks.ts
@@ -55,7 +55,7 @@ export default ({
     onNodePickerOpen,
   });
 
-  const { handleEdgesChange, handleConnect } = useEdges({
+  const { handleEdgesChange, handleConnect, handleReconnect } = useEdges({
     edges,
     onEdgeChange: onEdgesUpdate,
   });
@@ -68,5 +68,6 @@ export default ({
     handleNodeDrop,
     handleEdgesChange,
     handleConnect,
+    handleReconnect,
   };
 };

--- a/ui/src/features/Editor/components/Canvas/index.tsx
+++ b/ui/src/features/Editor/components/Canvas/index.tsx
@@ -58,6 +58,7 @@ const Canvas: React.FC<Props> = ({
     handleNodeDrop,
     handleEdgesChange,
     handleConnect,
+    handleReconnect,
   } = useHooks({
     nodes,
     edges,
@@ -119,6 +120,7 @@ const Canvas: React.FC<Props> = ({
       onEdgeMouseEnter={onEdgeHover}
       onEdgeMouseLeave={onEdgeHover}
       onConnect={handleConnect}
+      onReconnect={handleReconnect}
       proOptions={proOptions}>
       <Background
         variant={BackgroundVariant["Lines"]}

--- a/ui/src/features/Editor/components/Canvas/useEdges.ts
+++ b/ui/src/features/Editor/components/Canvas/useEdges.ts
@@ -1,8 +1,10 @@
 import {
   OnConnect,
   OnEdgesChange,
+  OnReconnect,
   addEdge,
   applyEdgeChanges,
+  reconnectEdge,
 } from "@xyflow/react";
 import { useCallback } from "react";
 
@@ -24,8 +26,15 @@ export default ({ edges, onEdgeChange }: Props) => {
     [edges, onEdgeChange],
   );
 
+  const handleReconnect: OnReconnect = useCallback(
+    (oldEdge, newConnection) =>
+      onEdgeChange(reconnectEdge(oldEdge, newConnection, edges)),
+    [edges, onEdgeChange],
+  );
+
   return {
     handleEdgesChange,
     handleConnect,
+    handleReconnect,
   };
 };


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the canvas component to handle reconnections of edges, improving interactivity and user experience.
	- Introduced a new `handleReconnect` function to manage edge reconnections effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->