### PR TITLE
chore(ui): Account Dialog bug fix:

### DIFF
--- a/ui/src/features/TopNavigation/components/AccountUpdateDialog.tsx
+++ b/ui/src/features/TopNavigation/components/AccountUpdateDialog.tsx
@@ -16,7 +16,7 @@ import {
 import { useUser } from "@flow/lib/gql";
 import { useT } from "@flow/lib/i18n";
 
-type Errors = "failed" | "passwordNotSame" | "passwordFailed" | "emailFailed";
+type Errors = "failed" | "passwordNotSame" | "passwordFailed";
 
 type Props = {
   isOpen: boolean;
@@ -55,15 +55,17 @@ const AccountUpdateDialog: React.FC<Props> = ({ isOpen, onOpenChange }) => {
       const { me: user } = await updateMe(input);
       if (!user) {
         setShowError("passwordFailed");
+        setLoading(false);
+        return;
       }
     }
 
     const input = { name, email };
     const { me: user } = await updateMe(input);
-    if (!user && showError === "passwordFailed") {
+    if (!user) {
       setShowError("failed");
-    } else {
-      setShowError("emailFailed");
+      setLoading(false);
+      return;
     }
     setLoading(false);
   };
@@ -132,7 +134,6 @@ const AccountUpdateDialog: React.FC<Props> = ({ isOpen, onOpenChange }) => {
           {showError === "passwordNotSame" &&
             t("Password and Confirm password are not the same")}
           {showError === "passwordFailed" && t("Failed to update the password")}
-          {showError === "emailFailed" && t("Failed to update email and name")}
         </div>
         <DialogFooter>
           <Button

--- a/ui/src/lib/i18n/locales/en.json
+++ b/ui/src/lib/i18n/locales/en.json
@@ -148,7 +148,6 @@
   "Failed to update the user": "Failed to update the user",
   "Password and Confirm password are not the same": "Password and Confirm password are not the same",
   "Failed to update the password": "Failed to update the password",
-  "Failed to update email and name": "Failed to update email and name",
   "New workspace": "",
   "Workspace name": "",
   "Workspace name...": "",

--- a/ui/src/lib/i18n/locales/es.json
+++ b/ui/src/lib/i18n/locales/es.json
@@ -148,7 +148,6 @@
   "Failed to update the user": "Error al actualizar el usuario",
   "Password and Confirm password are not the same": "La contraseña y la confirmación de la contraseña no son iguales",
   "Failed to update the password": "Error al actualizar la contraseña",
-  "Failed to update email and name": "Error al actualizar el correo electrónico y el nombre",
   "New workspace": "Nuevo espacio de trabajo",
   "Workspace name": "Nombre del espacio de trabajo",
   "Workspace name...": "Nombre del espacio de trabajo...",

--- a/ui/src/lib/i18n/locales/fr.json
+++ b/ui/src/lib/i18n/locales/fr.json
@@ -148,7 +148,6 @@
   "Failed to update the user": "Échec de la mise à jour de l'utilisateur",
   "Password and Confirm password are not the same": "Le mot de passe et la confirmation du mot de passe ne sont pas identiques",
   "Failed to update the password": "Échec de la mise à jour du mot de passe",
-  "Failed to update email and name": "Échec de la mise à jour de l'email et du nom",
   "New workspace": "Nouvel espace de travail",
   "Workspace name": "Nom de l'espace de travail",
   "Workspace name...": "Nom de l'espace de travail...",

--- a/ui/src/lib/i18n/locales/ja.json
+++ b/ui/src/lib/i18n/locales/ja.json
@@ -148,7 +148,6 @@
   "Failed to update the user": "ユーザーの更新に失敗しました",
   "Password and Confirm password are not the same": "パスワードと確認用パスワードが一致しません",
   "Failed to update the password": "パスワードの更新に失敗しました",
-  "Failed to update email and name": "メールアドレスと名前の更新に失敗しました",
   "New workspace": "新規ワークスペース",
   "Workspace name": "ワークスペース名",
   "Workspace name...": "ワークスペース名...",

--- a/ui/src/lib/i18n/locales/zh.json
+++ b/ui/src/lib/i18n/locales/zh.json
@@ -148,7 +148,6 @@
   "Failed to update the user": "更新用户失败",
   "Password and Confirm password are not the same": "密码和确认密码不一致",
   "Failed to update the password": "更新密码失败",
-  "Failed to update email and name": "更新电子邮件和名称失败",
   "New workspace": "新工作区",
   "Workspace name": "工作区名称",
   "Workspace name...": "工作区名称...",


### PR DESCRIPTION
# Overview
Small bug fix in account dialog

## What I've done

## What I haven't done

## How I tested
Manually

## Screenshot
NA

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified error handling for user updates, now setting a general "failed" state without differentiating between password and email errors.
	- Adjusted loading state management to improve user experience during update failures.

- **Localization Updates**
	- Removed the error message "Failed to update email and name" from English, Spanish, French, Japanese, and Chinese localization files, impacting user feedback during update failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->