### PR TITLE
feat(engine): implement conversions between geo_types and custom geometry types

### DIFF
--- a/engine/runtime/geometry/src/types/coordinate.rs
+++ b/engine/runtime/geometry/src/types/coordinate.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
 use approx::{AbsDiffEq, RelativeEq, UlpsEq};
+use geo_types::Coord as GeoCoord;
 use nalgebra::{Point2 as NaPoint2, Point3 as NaPoint3};
 use num_traits::Zero;
 use nusamai_projection::vshift::Jgd2011ToWgs84;
@@ -432,6 +433,21 @@ impl<Z: CoordFloat> Coordinate<f64, Z> {
             result && (self.z.to_f64().unwrap() - other.z.to_f64().unwrap()).abs() <= epsilon
         } else {
             result
+        }
+    }
+}
+
+impl<T: CoordNum> From<GeoCoord<T>> for Coordinate2D<T> {
+    fn from(coord: GeoCoord<T>) -> Self {
+        Coordinate::new_(coord.x, coord.y)
+    }
+}
+
+impl<T: CoordNum> From<Coordinate2D<T>> for GeoCoord<T> {
+    fn from(coord: Coordinate2D<T>) -> Self {
+        GeoCoord {
+            x: coord.x,
+            y: coord.y,
         }
     }
 }

--- a/engine/runtime/geometry/src/types/line.rs
+++ b/engine/runtime/geometry/src/types/line.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 
 use approx::{AbsDiffEq, RelativeEq};
+use geo_types::Line as GeoLine;
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -285,5 +286,17 @@ impl Hash for Line3DFloat {
 impl From<Line3DFloat> for LineString3D<f64> {
     fn from(line: Line3DFloat) -> Self {
         LineString3D::new(vec![line.0.start, line.0.end])
+    }
+}
+
+impl<T: CoordNum> From<GeoLine<T>> for Line2D<T> {
+    fn from(line: GeoLine<T>) -> Self {
+        Line2D::new(line.start, line.end)
+    }
+}
+
+impl<T: CoordNum> From<Line2D<T>> for GeoLine<T> {
+    fn from(line: Line2D<T>) -> Self {
+        GeoLine::new(line.start, line.end)
     }
 }

--- a/engine/runtime/geometry/src/types/line_string.rs
+++ b/engine/runtime/geometry/src/types/line_string.rs
@@ -492,12 +492,6 @@ impl<T: CoordNum> From<LineString2D<T>> for GeoLineString<T> {
 
 impl<T: CoordNum> From<GeoLineString<T>> for LineString2D<T> {
     fn from(line_string: GeoLineString<T>) -> Self {
-        LineString2D::new(
-            line_string
-                .0
-                .into_iter()
-                .map(|c| coordinate::Coordinate2D::new_(c.x, c.y))
-                .collect(),
-        )
+        LineString2D::new(line_string.0.into_iter().map(Into::into).collect())
     }
 }

--- a/engine/runtime/geometry/src/types/multi_line_string.rs
+++ b/engine/runtime/geometry/src/types/multi_line_string.rs
@@ -1,6 +1,8 @@
 use std::iter::FromIterator;
 
 use approx::{AbsDiffEq, RelativeEq};
+use geo_types::LineString as GeoLineString;
+use geo_types::MultiLineString as GeoMultiLineString;
 use nalgebra::{Point2 as NaPoint2, Point3 as NaPoint3};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
@@ -217,6 +219,18 @@ where
     #[inline]
     fn is_elevation_zero(&self) -> bool {
         self.iter().all(LineString::is_elevation_zero)
+    }
+}
+
+impl<T: CoordNum> From<GeoMultiLineString<T>> for MultiLineString2D<T> {
+    fn from(line: GeoMultiLineString<T>) -> Self {
+        MultiLineString2D::new(line.into_iter().map(LineString::from).collect())
+    }
+}
+
+impl<T: CoordNum> From<MultiLineString2D<T>> for GeoMultiLineString<T> {
+    fn from(line: MultiLineString2D<T>) -> Self {
+        GeoMultiLineString::new(line.0.into_iter().map(GeoLineString::from).collect())
     }
 }
 

--- a/engine/runtime/geometry/src/types/multi_point.rs
+++ b/engine/runtime/geometry/src/types/multi_point.rs
@@ -1,6 +1,7 @@
 use std::iter::FromIterator;
 
 use approx::{AbsDiffEq, RelativeEq};
+use geo_types::MultiPoint as GeoMultiPoint;
 use nalgebra::{Point2 as NaPoint2, Point3 as NaPoint3};
 use num_traits::Zero;
 use nusamai_geometry::{MultiPoint2 as NMultiPoint2, MultiPoint3 as NMultiPoint3};
@@ -204,6 +205,18 @@ where
     #[inline]
     fn is_elevation_zero(&self) -> bool {
         self.0.iter().all(|p| p.is_elevation_zero())
+    }
+}
+
+impl<T: CoordNum> From<GeoMultiPoint<T>> for MultiPoint2D<T> {
+    fn from(coord: GeoMultiPoint<T>) -> Self {
+        MultiPoint::new(coord.0.into_iter().map(|p| p.into()).collect())
+    }
+}
+
+impl<T: CoordNum> From<MultiPoint2D<T>> for GeoMultiPoint<T> {
+    fn from(coord: MultiPoint2D<T>) -> Self {
+        GeoMultiPoint(coord.0.into_iter().map(|p| p.into()).collect())
     }
 }
 

--- a/engine/runtime/geometry/src/types/point.rs
+++ b/engine/runtime/geometry/src/types/point.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use approx::{AbsDiffEq, RelativeEq};
+use geo_types::Point as GeoPoint;
 use nalgebra::{Point2 as NaPoint2, Point3 as NaPoint3};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
@@ -434,5 +435,17 @@ where
 impl<Z: CoordFloat> Point<f64, Z> {
     pub fn approx_eq(&self, other: &Point<f64, Z>, epsilon: f64) -> bool {
         self.0.approx_eq(&other.0, epsilon)
+    }
+}
+
+impl<T: CoordNum> From<GeoPoint<T>> for Point2D<T> {
+    fn from(coord: GeoPoint<T>) -> Self {
+        Point2D::from((coord.x(), coord.y()))
+    }
+}
+
+impl<T: CoordNum> From<Point2D<T>> for GeoPoint<T> {
+    fn from(coord: Point2D<T>) -> Self {
+        GeoPoint::new(coord.x(), coord.y())
     }
 }


### PR DESCRIPTION


# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added conversion capabilities between various geometric types and their corresponding geographic types, enhancing interoperability with the `geo_types` library.
	- Implemented conversions for `Coordinate`, `Line`, `LineString`, `MultiLineString`, `MultiPoint`, and `Point` types.
  
- **Bug Fixes**
	- Improved the `approx_eq` method for better accuracy in point comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->