### PR TITLE
feat(engine): replace nusamai_geometry with flatgeom in Cargo.toml and source files

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -692,6 +692,16 @@ dependencies = [
 [[package]]
 name = "cesiumtiles"
 version = "0.0.0"
+source = "git+https://github.com/MIERUNE/cesiumtiles-rs.git#5ec9c251a5f56fd35767fb9f00ba3ff7a4f1741e"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
+name = "cesiumtiles"
+version = "0.0.0"
 source = "git+https://github.com/reearth/cesiumtiles-rs.git#ff090532c77f5e995612dacf4ee318725d49e109"
 dependencies = [
  "serde",
@@ -1460,6 +1470,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flatgeom"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c862c3b8b552c209073f8023f700dff111870ccc5b74a7e407c0a2780655b36"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,6 +1499,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "foreign-types"
@@ -2063,6 +2089,12 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heapless"
@@ -2796,7 +2828,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc9#1b9070bf0a4726d308ec28f10750e305820f37b1"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.1.0#280cba9b3890306c92bb814364e0323a42dd8a3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3127,15 +3159,15 @@ dependencies = [
 
 [[package]]
 name = "nusamai-citygml"
-version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc9#1b9070bf0a4726d308ec28f10750e305820f37b1"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.1.0#280cba9b3890306c92bb814364e0323a42dd8a3e"
 dependencies = [
  "ahash 0.8.11",
  "chrono",
+ "flatgeom",
  "indexmap 2.6.0",
  "log",
  "macros",
- "nusamai-geometry",
  "nusamai-projection",
  "once_cell",
  "quick-xml 0.36.2",
@@ -3147,36 +3179,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "nusamai-geometry"
-version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc9#1b9070bf0a4726d308ec28f10750e305820f37b1"
-dependencies = [
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "nusamai-gltf"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc9#1b9070bf0a4726d308ec28f10750e305820f37b1"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.1.0#280cba9b3890306c92bb814364e0323a42dd8a3e"
 dependencies = [
  "byteorder",
- "clap",
- "earcut",
- "indexmap 2.6.0",
- "nusamai-geometry",
  "nusamai-gltf-json",
- "quick-xml 0.36.2",
  "serde_json",
- "thiserror",
 ]
 
 [[package]]
 name = "nusamai-gltf-json"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc9#1b9070bf0a4726d308ec28f10750e305820f37b1"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.1.0#280cba9b3890306c92bb814364e0323a42dd8a3e"
 dependencies = [
- "cesiumtiles",
+ "cesiumtiles 0.0.0 (git+https://github.com/MIERUNE/cesiumtiles-rs.git)",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3185,7 +3202,7 @@ dependencies = [
 [[package]]
 name = "nusamai-mvt"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc9#1b9070bf0a4726d308ec28f10750e305820f37b1"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.1.0#280cba9b3890306c92bb814364e0323a42dd8a3e"
 dependencies = [
  "ahash 0.8.11",
  "indexmap 2.6.0",
@@ -3195,19 +3212,18 @@ dependencies = [
 
 [[package]]
 name = "nusamai-plateau"
-version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc9#1b9070bf0a4726d308ec28f10750e305820f37b1"
+version = "0.0.0-alpha.0"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.1.0#280cba9b3890306c92bb814364e0323a42dd8a3e"
 dependencies = [
  "chrono",
- "hashbrown 0.14.5",
+ "flatgeom",
+ "hashbrown 0.15.0",
  "indexmap 2.6.0",
  "log",
  "nusamai-citygml",
- "nusamai-geometry",
  "once_cell",
  "quick-xml 0.36.2",
  "serde",
- "serde_json",
  "stretto",
  "url",
 ]
@@ -3215,7 +3231,7 @@ dependencies = [
 [[package]]
 name = "nusamai-projection"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.0.1-rc9#1b9070bf0a4726d308ec28f10750e305820f37b1"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.1.0#280cba9b3890306c92bb814364e0323a42dd8a3e"
 dependencies = [
  "japan-geoid",
  "thiserror",
@@ -4380,13 +4396,14 @@ dependencies = [
  "bincode",
  "byteorder",
  "bytes",
- "cesiumtiles",
+ "cesiumtiles 0.0.0 (git+https://github.com/reearth/cesiumtiles-rs.git)",
  "crossbeam",
  "crossbeam-channel",
  "crossbeam-utils",
  "csv",
  "earcut",
  "flate2",
+ "flatgeom",
  "geojson",
  "hashbrown 0.14.5",
  "image 0.25.2",
@@ -4394,7 +4411,6 @@ dependencies = [
  "itertools",
  "kv-extsort",
  "nusamai-citygml",
- "nusamai-geometry",
  "nusamai-gltf",
  "nusamai-mvt",
  "nusamai-plateau",
@@ -4571,13 +4587,13 @@ dependencies = [
  "approx",
  "bytes",
  "clipper-sys",
+ "flatgeom",
  "float_next_after",
  "geo-buffer",
  "geo-types",
  "geojson",
  "nalgebra",
  "num-traits",
- "nusamai-geometry",
  "nusamai-projection",
  "parking_lot",
  "reearth-flow-common",
@@ -4738,6 +4754,7 @@ dependencies = [
  "bytes",
  "chrono",
  "directories",
+ "flatgeom",
  "futures",
  "geojson",
  "hashbrown 0.14.5",
@@ -4745,7 +4762,6 @@ dependencies = [
  "indexmap 2.6.0",
  "itertools",
  "nusamai-citygml",
- "nusamai-geometry",
  "nusamai-gltf",
  "nusamai-plateau",
  "nusamai-projection",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -61,14 +61,11 @@ reearth-flow-storage = { path = "runtime/storage" }
 reearth-flow-telemetry = { path = "runtime/telemetry" }
 reearth-flow-types = { path = "runtime/types" }
 
-nusamai-citygml = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc9", features = ["serde", "serde_json"] }
-nusamai-geometry = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc9", features = ["serde"] }
-nusamai-gltf = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc9" }
-nusamai-mvt = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc9" }
-nusamai-plateau = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc9", features = ["serde"] }
-nusamai-projection = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.0.1-rc9" }
-
-cesiumtiles = { git = "https://github.com/reearth/cesiumtiles-rs.git" }
+nusamai-citygml = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.1.0", features = ["serde", "serde_json"] }
+nusamai-gltf = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.1.0" }
+nusamai-mvt = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.1.0" }
+nusamai-plateau = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.1.0", features = ["serde"] }
+nusamai-projection = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.1.0" }
 
 Inflector = "0.11.4"
 ahash = "0.8.11"
@@ -81,6 +78,7 @@ base64 = "0.22.1"
 bincode = { version = "2.0.0-rc.3", default-features = false, features = ["serde", "std"] }
 byteorder = "1.5.0"
 bytes = { version = "1.7.2", features = ["serde"] }
+cesiumtiles = { git = "https://github.com/reearth/cesiumtiles-rs.git" }
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.19", features = ["env", "string"] }
 clipper-sys = "0.7.2"
@@ -94,6 +92,7 @@ csv = "1.3.0"
 directories = "5.0.1"
 earcut = "0.4.1"
 flate2 = "1.0.34"
+flatgeom = "0.0.2"
 float_next_after = "1.0.0"
 futures = "0.3.31"
 futures-util = "0.3.31"

--- a/engine/runtime/action-processor/src/feature/reader/citygml.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml.rs
@@ -62,20 +62,20 @@ fn parse_tree_reader<R: BufRead>(
 ) -> Result<(), super::errors::FeatureProcessorError> {
     let mut entities = Vec::new();
     let mut global_appearances = AppearanceStore::default();
+    let mut envelope = Envelope::default();
 
     st.parse_children(|st| {
         let path: &[u8] = &st.current_path();
         match path {
             b"gml:boundedBy" => Ok(()),
             b"gml:boundedBy/gml:Envelope" => {
-                let mut envelope = Envelope::default();
                 envelope.parse(st)?;
                 Ok(())
             }
             b"core:cityObjectMember" => {
                 let mut cityobj: models::TopLevelCityObject = Default::default();
                 cityobj.parse(st)?;
-                let geometry_store = st.collect_geometries();
+                let geometry_store = st.collect_geometries(envelope.crs_uri.clone());
                 let id = cityobj.id();
                 let description = cityobj.description();
                 let bounded_by = cityobj.bounded_by();

--- a/engine/runtime/action-sink/Cargo.toml
+++ b/engine/runtime/action-sink/Cargo.toml
@@ -20,9 +20,9 @@ reearth-flow-state.workspace = true
 reearth-flow-storage.workspace = true
 reearth-flow-types.workspace = true
 
+flatgeom.workspace = true
 kv-extsort = { git = "https://github.com/MIERUNE/kv-extsort-rs.git" }
 nusamai-citygml.workspace = true
-nusamai-geometry.workspace = true
 nusamai-gltf.workspace = true
 nusamai-mvt.workspace = true
 nusamai-plateau.workspace = true

--- a/engine/runtime/action-sink/src/file/mvt/slice.rs
+++ b/engine/runtime/action-sink/src/file/mvt/slice.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use nusamai_geometry::{LineString2, MultiPolygon2, Polygon2};
+use flatgeom::{LineString2, MultiPolygon2, Polygon2};
 use nusamai_mvt::webmercator::lnglat_to_web_mercator;
 use reearth_flow_types::{Attribute, AttributeValue, Feature, GeometryType, GeometryValue};
 use serde::{Deserialize, Serialize};

--- a/engine/runtime/action-sink/src/file/types/slice.rs
+++ b/engine/runtime/action-sink/src/file/types/slice.rs
@@ -12,7 +12,7 @@ use super::material::Material;
 pub(crate) struct SlicedFeature {
     pub(crate) typename: String,
     // polygons [x, y, z, u, v]
-    pub polygons: nusamai_geometry::MultiPolygon<'static, [f64; 5]>,
+    pub polygons: flatgeom::MultiPolygon<'static, [f64; 5]>,
     // material ids for each polygon
     pub(crate) polygon_material_ids: Vec<u32>,
     // materials

--- a/engine/runtime/action-sink/src/file/util.rs
+++ b/engine/runtime/action-sink/src/file/util.rs
@@ -39,7 +39,7 @@ pub(super) fn slice_polygon(
     zoom: u8,
     poly: &Polygon3D<f64>,
     poly_uv: &Polygon2D<f64>,
-    mut send_polygon: impl FnMut(TileZXY, &nusamai_geometry::Polygon<'static, [f64; 5]>),
+    mut send_polygon: impl FnMut(TileZXY, &flatgeom::Polygon<'static, [f64; 5]>),
 ) {
     if poly.exterior().is_empty() {
         return;
@@ -58,7 +58,7 @@ pub(super) fn slice_polygon(
         iter_y_slice(zoom, min_y, max_y)
     };
 
-    let mut y_sliced_polys = nusamai_geometry::MultiPolygon::new();
+    let mut y_sliced_polys = flatgeom::MultiPolygon::new();
 
     for yi in y_range.clone() {
         let (k1, k2) = y_slice_range(zoom, yi);
@@ -127,7 +127,7 @@ pub(super) fn slice_polygon(
     }
 
     // Slice along X-axis
-    let mut poly_buf: nusamai_geometry::Polygon<[f64; 5]> = nusamai_geometry::Polygon::new();
+    let mut poly_buf: flatgeom::Polygon<[f64; 5]> = flatgeom::Polygon::new();
     for (yi, y_sliced_poly) in y_range.zip_eq(y_sliced_polys.iter()) {
         let x_iter = {
             let (min_x, max_x) = y_sliced_poly

--- a/engine/runtime/action-source/src/file/reader/citygml.rs
+++ b/engine/runtime/action-source/src/file/reader/citygml.rs
@@ -56,6 +56,7 @@ async fn parse_tree_reader<'a, 'b, R: BufRead>(
 ) -> Result<(), crate::errors::SourceError> {
     let mut entities = Vec::new();
     let mut global_appearances = AppearanceStore::default();
+    let mut envelope = Envelope::default();
 
     st.parse_children(|st| {
         let path: &[u8] = &st.current_path();
@@ -65,14 +66,13 @@ async fn parse_tree_reader<'a, 'b, R: BufRead>(
                 Ok(())
             }
             b"gml:boundedBy/gml:Envelope" => {
-                let mut envelope = Envelope::default();
                 envelope.parse(st)?;
                 Ok(())
             }
             b"core:cityObjectMember" => {
                 let mut cityobj: models::TopLevelCityObject = Default::default();
                 cityobj.parse(st)?;
-                let geometry_store = st.collect_geometries();
+                let geometry_store = st.collect_geometries(envelope.crs_uri.clone());
                 let id = cityobj.id();
                 let description = cityobj.description();
                 let bounded_by = cityobj.bounded_by();

--- a/engine/runtime/geometry/Cargo.toml
+++ b/engine/runtime/geometry/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 [dependencies]
 reearth-flow-common.workspace = true
 
-nusamai-geometry.workspace = true
+flatgeom.workspace = true
 nusamai-projection.workspace = true
 
 approx.workspace = true

--- a/engine/runtime/geometry/src/types/line_string.rs
+++ b/engine/runtime/geometry/src/types/line_string.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use std::iter::FromIterator;
 use std::ops::{Index, IndexMut};
 
+use flatgeom::{LineString2 as NLineString2, LineString3 as NLineString3};
 use geo_types::LineString as GeoLineString;
-use nusamai_geometry::{LineString2 as NLineString2, LineString3 as NLineString3};
 
 use crate::utils::line_string_bounding_rect;
 
@@ -334,7 +334,7 @@ impl<'a> From<NLineString3<'a>> for LineString3D<f64> {
 }
 
 pub fn from_line_string_5d(
-    line_strings: nusamai_geometry::LineString<[f64; 5]>,
+    line_strings: flatgeom::LineString<[f64; 5]>,
 ) -> (LineString3D<f64>, LineString2D<f64>) {
     let targets = line_strings
         .iter_closed()

--- a/engine/runtime/geometry/src/types/multi_line_string.rs
+++ b/engine/runtime/geometry/src/types/multi_line_string.rs
@@ -7,9 +7,7 @@ use nalgebra::{Point2 as NaPoint2, Point3 as NaPoint3};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 
-use nusamai_geometry::{
-    MultiLineString2 as NMultiLineString2, MultiLineString3 as NMultiLineString3,
-};
+use flatgeom::{MultiLineString2 as NMultiLineString2, MultiLineString3 as NMultiLineString3};
 
 use super::conversion::geojson::{
     create_geo_multi_line_string, create_multi_line_string_type, mismatch_geom_err,

--- a/engine/runtime/geometry/src/types/multi_point.rs
+++ b/engine/runtime/geometry/src/types/multi_point.rs
@@ -1,10 +1,10 @@
 use std::iter::FromIterator;
 
 use approx::{AbsDiffEq, RelativeEq};
+use flatgeom::{MultiPoint2 as NMultiPoint2, MultiPoint3 as NMultiPoint3};
 use geo_types::MultiPoint as GeoMultiPoint;
 use nalgebra::{Point2 as NaPoint2, Point3 as NaPoint3};
 use num_traits::Zero;
-use nusamai_geometry::{MultiPoint2 as NMultiPoint2, MultiPoint3 as NMultiPoint3};
 use serde::{Deserialize, Serialize};
 
 use super::conversion::geojson::{create_geo_point, create_point_type, mismatch_geom_err};

--- a/engine/runtime/geometry/src/types/multi_polygon.rs
+++ b/engine/runtime/geometry/src/types/multi_polygon.rs
@@ -2,10 +2,10 @@ use std::iter::FromIterator;
 use std::ops::Range;
 
 use approx::{AbsDiffEq, RelativeEq};
+use flatgeom::{MultiPolygon2 as NMultiPolygon2, MultiPolygon3 as NMultiPolygon3};
 use geo_types::{MultiPolygon as GeoMultiPolygon, Polygon as GeoPolygon};
 use nalgebra::{Point2 as NaPoint2, Point3 as NaPoint3};
 use num_traits::Zero;
-use nusamai_geometry::{MultiPolygon2 as NMultiPolygon2, MultiPolygon3 as NMultiPolygon3};
 use serde::{Deserialize, Serialize};
 
 use super::conversion::geojson::{

--- a/engine/runtime/geometry/src/types/polygon.rs
+++ b/engine/runtime/geometry/src/types/polygon.rs
@@ -1,10 +1,10 @@
 use std::hash::{Hash, Hasher};
 
 use approx::{AbsDiffEq, RelativeEq};
+use flatgeom::{LineString2 as NLineString2, Polygon2 as NPolygon2, Polygon3 as NPolygon3};
 use geo_types::Polygon as GeoPolygon;
 use nalgebra::{Point2 as NaPoint2, Point3 as NaPoint3};
 use num_traits::Zero;
-use nusamai_geometry::{LineString2 as NLineString2, Polygon2 as NPolygon2, Polygon3 as NPolygon3};
 use nusamai_projection::vshift::Jgd2011ToWgs84;
 use serde::{Deserialize, Serialize};
 
@@ -407,9 +407,7 @@ impl<'a> From<NPolygon3<'a>> for Polygon<f64> {
     }
 }
 
-pub fn from_polygon_5d(
-    polygon: &nusamai_geometry::Polygon<[f64; 5]>,
-) -> (Polygon3D<f64>, Polygon2D<f64>) {
+pub fn from_polygon_5d(polygon: &flatgeom::Polygon<[f64; 5]>) -> (Polygon3D<f64>, Polygon2D<f64>) {
     let (exterior3d, exterior2d) = from_line_string_5d(polygon.exterior());
     let mut interiors3d: Vec<LineString3D<f64>> = Default::default();
     let mut interiors2d: Vec<LineString2D<f64>> = Default::default();

--- a/engine/runtime/types/Cargo.toml
+++ b/engine/runtime/types/Cargo.toml
@@ -15,8 +15,8 @@ reearth-flow-common.workspace = true
 reearth-flow-eval-expr.workspace = true
 reearth-flow-geometry.workspace = true
 
+flatgeom.workspace = true
 nusamai-citygml.workspace = true
-nusamai-geometry.workspace = true
 nusamai-plateau.workspace = true
 nusamai-projection.workspace = true
 

--- a/engine/runtime/types/src/conversion/nusamai.rs
+++ b/engine/runtime/types/src/conversion/nusamai.rs
@@ -140,7 +140,7 @@ impl TryFrom<Entity> for Geometry {
             {
                 let mut ring_id_iter = geoms.ring_ids.iter();
                 let mut poly_textures = Vec::with_capacity(geoms.multipolygon.len());
-                let mut poly_uvs = nusamai_geometry::MultiPolygon::new();
+                let mut poly_uvs = flatgeom::MultiPolygon::new();
 
                 for poly in &geoms.multipolygon {
                     for (i, ring) in poly.rings().enumerate() {
@@ -189,7 +189,7 @@ impl TryFrom<Entity> for Geometry {
             // set 'null' appearance if no theme found
             geometry_entity.polygon_materials = vec![None; geoms.multipolygon.len()];
             geometry_entity.polygon_textures = vec![None; geoms.multipolygon.len()];
-            let mut poly_uvs = nusamai_geometry::MultiPolygon::new();
+            let mut poly_uvs = flatgeom::MultiPolygon::new();
             for poly in &geoms.multipolygon {
                 for (i, ring) in poly.rings().enumerate() {
                     let uv = [[0.0, 0.0]].into_iter().cycle().take(ring.len() + 1);


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the `flatgeom` library, enhancing geometry handling across various components.
	- Introduced new dependencies for improved functionality, including `flatgeom` and `nusamai-citygml`.

- **Bug Fixes**
	- Enhanced the handling of spatial data, specifically with the `Envelope` structure in CityGML parsing.

- **Documentation**
	- Updated dependency management to reflect the transition to `flatgeom`.

- **Chores**
	- Removed outdated dependencies and streamlined the project structure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->