### PR TITLE
feat(engine): add layer_name parameter to MVTWriter and update geometry handling

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -716,16 +716,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesiumtiles"
-version = "0.0.0"
-source = "git+https://github.com/reearth/cesiumtiles-rs.git#ff090532c77f5e995612dacf4ee318725d49e109"
-dependencies = [
- "serde",
- "serde_json",
- "serde_repr",
-]
-
-[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,7 +2844,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.2.0#f9883fc0cec3ba38de390f21d2ce60598de0db8c"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.3.1#cb203a47920fc6059eea1a71cac8e080a30befde"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3186,7 +3176,7 @@ dependencies = [
 [[package]]
 name = "nusamai-citygml"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.2.0#f9883fc0cec3ba38de390f21d2ce60598de0db8c"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.3.1#cb203a47920fc6059eea1a71cac8e080a30befde"
 dependencies = [
  "ahash 0.8.11",
  "chrono",
@@ -3207,7 +3197,7 @@ dependencies = [
 [[package]]
 name = "nusamai-gltf"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.2.0#f9883fc0cec3ba38de390f21d2ce60598de0db8c"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.3.1#cb203a47920fc6059eea1a71cac8e080a30befde"
 dependencies = [
  "byteorder",
  "nusamai-gltf-json",
@@ -3217,9 +3207,9 @@ dependencies = [
 [[package]]
 name = "nusamai-gltf-json"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.2.0#f9883fc0cec3ba38de390f21d2ce60598de0db8c"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.3.1#cb203a47920fc6059eea1a71cac8e080a30befde"
 dependencies = [
- "cesiumtiles 0.0.0 (git+https://github.com/MIERUNE/cesiumtiles-rs.git)",
+ "cesiumtiles",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3228,7 +3218,7 @@ dependencies = [
 [[package]]
 name = "nusamai-mvt"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.2.0#f9883fc0cec3ba38de390f21d2ce60598de0db8c"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.3.1#cb203a47920fc6059eea1a71cac8e080a30befde"
 dependencies = [
  "ahash 0.8.11",
  "indexmap 2.6.0",
@@ -3239,7 +3229,7 @@ dependencies = [
 [[package]]
 name = "nusamai-plateau"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.2.0#f9883fc0cec3ba38de390f21d2ce60598de0db8c"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.3.1#cb203a47920fc6059eea1a71cac8e080a30befde"
 dependencies = [
  "chrono",
  "flatgeom",
@@ -3257,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "nusamai-projection"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.2.0#f9883fc0cec3ba38de390f21d2ce60598de0db8c"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.3.1#cb203a47920fc6059eea1a71cac8e080a30befde"
 dependencies = [
  "japan-geoid",
  "thiserror",
@@ -4392,7 +4382,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "bytes",
- "cesiumtiles 0.0.0 (git+https://github.com/reearth/cesiumtiles-rs.git)",
+ "cesiumtiles",
  "crossbeam",
  "crossbeam-channel",
  "crossbeam-utils",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -61,11 +61,11 @@ reearth-flow-storage = { path = "runtime/storage" }
 reearth-flow-telemetry = { path = "runtime/telemetry" }
 reearth-flow-types = { path = "runtime/types" }
 
-nusamai-citygml = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.2.0", features = ["serde", "serde_json"] }
-nusamai-gltf = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.2.0" }
-nusamai-mvt = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.2.0" }
-nusamai-plateau = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.2.0", features = ["serde"] }
-nusamai-projection = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.2.0" }
+nusamai-citygml = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.3.1", features = ["serde", "serde_json"] }
+nusamai-gltf = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.3.1" }
+nusamai-mvt = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.3.1" }
+nusamai-plateau = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.3.1", features = ["serde"] }
+nusamai-projection = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.3.1" }
 
 Inflector = "0.11.4"
 ahash = "0.8.11"
@@ -80,7 +80,7 @@ bincode = { version = "2.0.0-rc.3", default-features = false, features = ["serde
 bytemuck = { version = "1.19.0", features = ["derive"] }
 byteorder = "1.5.0"
 bytes = { version = "1.7.2", features = ["serde"] }
-cesiumtiles = { git = "https://github.com/reearth/cesiumtiles-rs.git" }
+cesiumtiles = { git = "https://github.com/MIERUNE/cesiumtiles-rs.git" }
 chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.20", features = ["env", "string"] }
 clipper-sys = "0.7.2"

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -1914,11 +1914,15 @@ Writes features to a file
   "title": "MVTWriterParam",
   "type": "object",
   "required": [
+    "layerName",
     "maxZoom",
     "minZoom",
     "output"
   ],
   "properties": {
+    "layerName": {
+      "type": "string"
+    },
     "maxZoom": {
       "type": "integer",
       "format": "uint8",

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
@@ -217,7 +217,8 @@ fn geometry_slicing_stage(
 
     upstream.iter().par_bridge().try_for_each(|parcel| {
         slice_to_tiles(parcel, min_zoom, max_zoom, |(z, x, y), feature| {
-            let bytes = bincode::serde::encode_to_vec(&feature, bincode_config).unwrap();
+            let bytes = bincode::serde::encode_to_vec(&feature, bincode_config)
+                .map_err(|e| crate::errors::SinkError::cesium3dtiles_writer(e.to_string()))?;
             // TODO extract feature type from parcel
             let Some(AttributeValue::String(feature_type)) =
                 parcel.get(&"feature_type".to_string())
@@ -317,7 +318,8 @@ fn tile_writing_stage(
     let texture_size_cache = TextureSizeCache::new();
 
     // Use a temporary directory for embedding in glb.
-    let binding = tempdir().unwrap();
+    let binding =
+        tempdir().map_err(|e| crate::errors::SinkError::cesium3dtiles_writer(e.to_string()))?;
     let folder_path = binding.path();
     let texture_folder_name = "textures";
     let atlas_dir = folder_path.join(texture_folder_name);

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/slice.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/slice.rs
@@ -381,14 +381,11 @@ fn slice_polygon(
 }
 
 fn desired_lod(geom_error: f64) -> u8 {
-    if geom_error >= 30.0 {
-        1
-    } else if geom_error >= 20.0 {
-        2
-    } else if geom_error >= 5.0 {
-        3
-    } else {
-        4
+    match geom_error {
+        ge if ge >= 30.0 => 1,
+        ge if ge >= 20.0 => 2,
+        ge if ge >= 5.0 => 3,
+        _ => 4,
     }
 }
 

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/slice.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/slice.rs
@@ -1,8 +1,8 @@
 //! Polygon slicing algorithm based on [geojson-vt](https://github.com/mapbox/geojson-vt).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use flatgeom::{LineString2, MultiPolygon, Polygon, Polygon2, Polygon3};
+use flatgeom::{MultiPolygon, Polygon, Polygon2, Polygon3};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use reearth_flow_types::{AttributeValue, Feature, GeometryType};
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{material::Material, material::Texture, tiling, tiling::zxy_from_lng_lat};
 
-pub type TileZXYName = (u8, u32, u32, String);
+pub type TileZXYName = (u8, u32, u32);
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SlicedFeature {
@@ -37,11 +37,12 @@ pub fn slice_to_tiles<E>(
     else {
         return Ok(());
     };
+
     let ellipsoid = nusamai_projection::ellipsoid::wgs84();
 
     let slicing_enabled = true;
 
-    let mut sliced_tiles: HashMap<(u8, u32, u32, String), SlicedFeature> = HashMap::new();
+    let mut sliced_tiles: HashMap<(u8, u32, u32), SlicedFeature> = HashMap::new();
     let mut materials: IndexSet<Material> = IndexSet::new();
     let default_material = reearth_flow_types::Material::default();
 
@@ -63,20 +64,25 @@ pub fn slice_to_tiles<E>(
     };
     let mut ring_buffer: Vec<[f64; 5]> = Vec::new();
 
+    let available_lods: HashSet<u8> = city_gml
+        .gml_geometries
+        .iter()
+        .flat_map(|entry| entry.lod)
+        .sorted()
+        .dedup()
+        .collect();
+
     for entry in city_gml.gml_geometries.iter() {
-        let Some(feature_type) = entry.feature_type.clone() else {
-            continue;
-        };
         match entry.ty {
             GeometryType::Solid | GeometryType::Surface | GeometryType::Triangle => {
+                // for each polygon
                 for (((poly, poly_uv), poly_mat), poly_tex) in entry
                     .polygons
                     .iter()
                     .zip_eq(
                         city_gml
                             .polygon_uvs
-                            .range(entry.pos as usize..(entry.pos + entry.len) as usize)
-                            .iter(),
+                            .iter_range(entry.pos as usize..(entry.pos + entry.len) as usize),
                     )
                     .zip_eq(
                         city_gml.polygon_materials
@@ -95,6 +101,7 @@ pub fn slice_to_tiles<E>(
                         .unwrap_or(&default_material)
                         .clone();
                     let orig_tex = poly_tex.and_then(|idx| city_gml.textures.get(idx as usize));
+
                     let mat = Material {
                         base_color: orig_mat.diffuse_color.into(),
                         base_texture: orig_tex.map(|tex| Texture {
@@ -104,15 +111,20 @@ pub fn slice_to_tiles<E>(
                     let (mat_idx, _) = materials.insert_full(mat);
                     // Slice polygon for each zoom level
                     for zoom in min_zoom..=max_zoom {
-                        // Skip the feature if the size is small for geometricError.
-                        // TODO: better method ? (bounding sphere, etc.)
-                        if zoom < max_zoom {
+                        if zoom <= max_zoom {
                             let geom_error = {
                                 let (_, _, y) =
                                     tiling::scheme::zxy_from_lng_lat(zoom, lng_center, lat_center);
                                 tiling::scheme::geometric_error(zoom, y)
                             };
-                            let threshold = geom_error / 0.9; // TODO: adjustable
+                            if let Some(lod) = entry.lod {
+                                if !should_process_entry(lod, geom_error, &available_lods) {
+                                    continue;
+                                }
+                            }
+
+                            // Skip the feature if the size is small for geometricError.
+                            let threshold = geom_error * 0.5;
                             if approx_dx < threshold
                                 && approx_dy < threshold
                                 && approx_dh < threshold
@@ -122,51 +134,43 @@ pub fn slice_to_tiles<E>(
                         }
 
                         if slicing_enabled {
-                            // slicing enabled
-                            slice_polygon(
-                                zoom,
-                                &poly,
-                                &poly_uv.clone().into(),
-                                feature_type.clone(),
-                                |(z, x, y, typename), poly| {
-                                    let sliced_feature = sliced_tiles
-                                        .entry((z, x, y, typename))
-                                        .or_insert_with(|| {
-                                            SlicedFeature {
-                                                polygons: MultiPolygon::new(),
-                                                attributes: feature
-                                                    .attributes
-                                                    .clone()
-                                                    .into_iter()
-                                                    .map(|(k, v)| (k.to_string(), v.clone()))
-                                                    .collect(),
-                                                polygon_material_ids: Default::default(),
-                                                materials: Default::default(), // set later
-                                            }
-                                        });
-                                    sliced_feature.polygons.push(poly);
-                                    sliced_feature.polygon_material_ids.push(mat_idx as u32);
-                                },
-                            );
+                            slice_polygon(zoom, &poly, &poly_uv, |(z, x, y), poly| {
+                                let sliced_feature =
+                                    sliced_tiles.entry((z, x, y)).or_insert_with(|| {
+                                        SlicedFeature {
+                                            polygons: MultiPolygon::new(),
+                                            attributes: feature
+                                                .attributes
+                                                .clone()
+                                                .into_iter()
+                                                .map(|(k, v)| (k.to_string(), v.clone()))
+                                                .collect(),
+                                            polygon_material_ids: Default::default(),
+                                            materials: Default::default(), // set later
+                                        }
+                                    });
+                                sliced_feature.polygons.push(poly);
+                                sliced_feature.polygon_material_ids.push(mat_idx as u32);
+                            });
                         } else {
                             // slicing disabled
                             let (z, x, y) = zxy_from_lng_lat(zoom, lng_center, lat_center);
-                            let sliced_feature = sliced_tiles
-                                .entry((z, x, y, feature_type.clone()))
-                                .or_insert_with(|| SlicedFeature {
-                                    polygons: MultiPolygon::new(),
-                                    attributes: feature
-                                        .attributes
-                                        .clone()
-                                        .into_iter()
-                                        .map(|(k, v)| (k.to_string(), v.clone()))
-                                        .collect(),
-                                    polygon_material_ids: Default::default(),
-                                    materials: Default::default(), // set later
-                                });
+                            let sliced_feature =
+                                sliced_tiles
+                                    .entry((z, x, y))
+                                    .or_insert_with(|| SlicedFeature {
+                                        polygons: MultiPolygon::new(),
+                                        attributes: feature
+                                            .attributes
+                                            .clone()
+                                            .into_iter()
+                                            .map(|(k, v)| (k.to_string(), v.clone()))
+                                            .collect(),
+                                        polygon_material_ids: Default::default(),
+                                        materials: Default::default(), // set later
+                                    });
                             poly.rings().zip_eq(poly_uv.rings()).enumerate().for_each(
                                 |(ri, (ring, uv_ring))| {
-                                    let uv_ring: LineString2 = uv_ring.into();
                                     ring.iter_closed().zip_eq(uv_ring.iter_closed()).for_each(
                                         |(c, uv)| {
                                             ring_buffer.push([c[0], c[1], c[2], uv[0], uv[1]]);
@@ -184,19 +188,19 @@ pub fn slice_to_tiles<E>(
                     }
                 }
             }
-            reearth_flow_types::geometry::GeometryType::Curve => {
+            GeometryType::Curve => {
                 unimplemented!()
             }
             GeometryType::Point => {
                 unimplemented!()
             }
-        };
+        }
     }
 
     // Send tiled features
-    for ((z, x, y, typename), mut sliced_feature) in sliced_tiles {
+    for ((z, x, y), mut sliced_feature) in sliced_tiles {
         sliced_feature.materials.clone_from(&materials);
-        send_feature((z, x, y, typename), sliced_feature)?;
+        send_feature((z, x, y), sliced_feature)?;
     }
     Ok(())
 
@@ -208,7 +212,6 @@ fn slice_polygon(
     zoom: u8,
     poly: &Polygon3,
     poly_uv: &Polygon2,
-    typename: String,
     mut send_polygon: impl FnMut(TileZXYName, &Polygon<'static, [f64; 5]>),
 ) {
     if poly.exterior().is_empty() {
@@ -239,7 +242,6 @@ fn slice_polygon(
             if ring.raw_coords().is_empty() {
                 continue;
             }
-
             ring_buffer.clear();
             ring.iter_closed()
                 .zip_eq(uv_ring.iter_closed())
@@ -306,7 +308,6 @@ fn slice_polygon(
                 .fold((f64::MAX, f64::MIN), |(min_x, max_x), c| {
                     (min_x.min(c[0]), max_x.max(c[0]))
                 });
-
             tiling::iter_x_slice(zoom, yi, min_x, max_x)
         };
 
@@ -314,15 +315,12 @@ fn slice_polygon(
             let (k1, k2) = tiling::x_slice_range(zoom, xi, xs);
 
             // todo?: check interior bbox to optimize ...
-
+            let x = xi.rem_euclid(1 << zoom) as u32;
             let key = (
-                zoom,
-                xi.rem_euclid(1 << zoom) as u32, // handling geometry crossing the antimeridian
+                zoom, x, // handling geometry crossing the antimeridian
                 yi,
-                typename.clone(),
             );
             poly_buf.clear();
-
             for ring in y_sliced_poly.rings() {
                 if ring.raw_coords().is_empty() {
                     continue;
@@ -377,8 +375,37 @@ fn slice_polygon(
 
                 poly_buf.add_ring(ring_buffer.drain(..))
             }
-
             send_polygon(key, &poly_buf);
         }
+    }
+}
+
+fn desired_lod(geom_error: f64) -> u8 {
+    if geom_error >= 30.0 {
+        1
+    } else if geom_error >= 20.0 {
+        2
+    } else if geom_error >= 5.0 {
+        3
+    } else {
+        4
+    }
+}
+
+fn should_process_entry(entry_lod: u8, geom_error: f64, available_lods: &HashSet<u8>) -> bool {
+    let desired_lod = desired_lod(geom_error);
+
+    let possible_lods: Vec<u8> = available_lods
+        .iter()
+        .cloned()
+        .filter(|&lod| lod >= desired_lod)
+        .collect();
+
+    if !possible_lods.is_empty() {
+        let selected_lod = *possible_lods.iter().min().unwrap();
+        entry_lod == selected_lod
+    } else {
+        let selected_lod = *available_lods.iter().max().unwrap();
+        entry_lod == selected_lod
     }
 }

--- a/engine/runtime/action-sink/src/file/mvt/sink.rs
+++ b/engine/runtime/action-sink/src/file/mvt/sink.rs
@@ -105,6 +105,7 @@ pub struct MVTWriterCommonParam {
 #[serde(rename_all = "camelCase")]
 pub struct MVTWriterParam {
     pub(super) output: Expr,
+    pub(super) layer_name: String,
     pub(super) min_zoom: u8,
     pub(super) max_zoom: u8,
 }
@@ -187,6 +188,7 @@ fn geometry_slicing_stage(
         let buffer_pixels = 5;
         slice_cityobj_geoms(
             feature,
+            &mvt_options.layer_name,
             mvt_options.min_zoom,
             mvt_options.max_zoom,
             max_detail,

--- a/engine/runtime/action-sink/src/file/mvt/slice.rs
+++ b/engine/runtime/action-sink/src/file/mvt/slice.rs
@@ -16,6 +16,7 @@ pub(super) struct SlicedFeature<'a> {
 
 pub(super) fn slice_cityobj_geoms(
     feature: &Feature,
+    layner_name: &str,
     min_z: u8,
     max_z: u8,
     max_detail: u32,
@@ -53,9 +54,6 @@ pub(super) fn slice_cityobj_geoms(
                         continue;
                     }
                     let area = poly.area();
-                    let Some(typename) = entry.feature_type.as_ref() else {
-                        continue;
-                    };
 
                     for zoom in min_z..=max_z {
                         // Skip if the polygon is smaller than 4 square subpixels
@@ -64,7 +62,7 @@ pub(super) fn slice_cityobj_geoms(
                         if area * (4u64.pow(zoom as u32 + max_detail) as f64) < 4.0 {
                             continue;
                         }
-                        slice_polygon(zoom, extent, buffer, &poly, typename, &mut tiled_mpolys);
+                        slice_polygon(zoom, extent, buffer, &poly, layner_name, &mut tiled_mpolys);
                     }
                 }
             }

--- a/engine/runtime/action-sink/src/file/mvt/slice.rs
+++ b/engine/runtime/action-sink/src/file/mvt/slice.rs
@@ -16,7 +16,7 @@ pub(super) struct SlicedFeature<'a> {
 
 pub(super) fn slice_cityobj_geoms(
     feature: &Feature,
-    layner_name: &str,
+    layer_name: &str,
     min_z: u8,
     max_z: u8,
     max_detail: u32,
@@ -62,7 +62,7 @@ pub(super) fn slice_cityobj_geoms(
                         if area * (4u64.pow(zoom as u32 + max_detail) as f64) < 4.0 {
                             continue;
                         }
-                        slice_polygon(zoom, extent, buffer, &poly, layner_name, &mut tiled_mpolys);
+                        slice_polygon(zoom, extent, buffer, &poly, layer_name, &mut tiled_mpolys);
                     }
                 }
             }

--- a/engine/runtime/action-source/src/file/reader/citygml.rs
+++ b/engine/runtime/action-source/src/file/reader/citygml.rs
@@ -74,22 +74,19 @@ async fn parse_tree_reader<'a, 'b, R: BufRead>(
                 cityobj.parse(st)?;
                 let geometry_store = st.collect_geometries(envelope.crs_uri.clone());
                 let id = cityobj.id();
-                let description = cityobj.description();
+                let typename = cityobj.name();
                 let bounded_by = cityobj.bounded_by();
                 if let Some(root) = cityobj.into_object() {
-                    if let nusamai_citygml::object::Value::Object(obj) = &root {
-                        let entity = Entity {
-                            id,
-                            description,
-                            name: obj.typename.to_string(),
-                            root,
-                            base_url: base_url.clone(),
-                            geometry_store: RwLock::new(geometry_store).into(),
-                            appearance_store: Default::default(),
-                            bounded_by,
-                        };
-                        entities.push(entity);
-                    }
+                    let entity = Entity {
+                        id: Some(id.to_string()),
+                        typename: Some(typename.to_string()),
+                        root,
+                        base_url: base_url.clone(),
+                        geometry_store: RwLock::new(geometry_store).into(),
+                        appearance_store: Default::default(),
+                        bounded_by,
+                    };
+                    entities.push(entity);
                 }
                 Ok(())
             }
@@ -119,8 +116,16 @@ async fn parse_tree_reader<'a, 'b, R: BufRead>(
             );
         }
         let attributes = entity.root.to_attribute_json();
-        let name = entity.name.clone();
-        let gml_id = entity.id.clone();
+        let gml_id = entity
+            .root
+            .id()
+            .map(|id| AttributeValue::String(id.to_string()))
+            .unwrap_or(AttributeValue::Null);
+        let name = entity
+            .root
+            .typename()
+            .map(|name| AttributeValue::String(name.to_string()))
+            .unwrap_or(AttributeValue::Null);
         let geometry: Geometry = entity
             .try_into()
             .map_err(|e| crate::errors::SourceError::FileReader(format!("{:?}", e)))?;
@@ -129,12 +134,8 @@ async fn parse_tree_reader<'a, 'b, R: BufRead>(
         feature
             .attributes
             .insert(Attribute::new("cityGmlAttributes"), attributes.into());
-        feature
-            .attributes
-            .insert(Attribute::new("gmlName"), AttributeValue::String(name));
-        feature
-            .attributes
-            .insert(Attribute::new("gmlId"), AttributeValue::String(gml_id));
+        feature.attributes.insert(Attribute::new("gmlName"), name);
+        feature.attributes.insert(Attribute::new("gmlId"), gml_id);
         feature.attributes.insert(
             Attribute::new("gmlRootId"),
             AttributeValue::String(format!("root_{}", to_hash(base_url.as_str()))),

--- a/engine/runtime/types/src/conversion/nusamai.rs
+++ b/engine/runtime/types/src/conversion/nusamai.rs
@@ -120,7 +120,7 @@ impl TryFrom<Entity> for Geometry {
                 }
                 // apply textures to polygons
                 geometry_entity.polygon_textures = poly_textures;
-                geometry_entity.polygon_uvs = poly_uvs.into();
+                geometry_entity.polygon_uvs = poly_uvs;
             }
         } else {
             // set 'null' appearance if no theme found
@@ -137,7 +137,7 @@ impl TryFrom<Entity> for Geometry {
                     }
                 }
             }
-            geometry_entity.polygon_uvs = poly_uvs.into();
+            geometry_entity.polygon_uvs = poly_uvs;
         }
         Ok(Self::new(
             epsg,

--- a/engine/runtime/types/src/geometry.rs
+++ b/engine/runtime/types/src/geometry.rs
@@ -1,11 +1,11 @@
+use std::fmt::Display;
+use std::hash::Hasher;
+use std::{hash::Hash, path::Path};
+
 use nusamai_plateau::models::appearance::X3DMaterial;
 use nusamai_projection::vshift::Jgd2011ToWgs84;
 use reearth_flow_geometry::types::coordnum::CoordNum;
 use reearth_flow_geometry::types::traits::Elevation;
-use std::fmt::Display;
-use std::hash::Hasher;
-use std::{hash::Hash, path::Path};
-use url::Url;
 
 use nusamai_citygml::Color;
 use nusamai_projection::crs::EpsgCode;
@@ -14,6 +14,7 @@ use reearth_flow_geometry::algorithm::hole::HoleCounter;
 use reearth_flow_geometry::types::polygon::{Polygon2D, Polygon3D};
 use reearth_flow_geometry::utils::are_points_coplanar;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use reearth_flow_geometry::types::geometry::Geometry2D as FlowGeometry2D;
 use reearth_flow_geometry::types::geometry::Geometry3D as FlowGeometry3D;
@@ -221,7 +222,7 @@ pub struct CityGmlGeometry {
     pub textures: Vec<Texture>,
     pub polygon_materials: Vec<Option<u32>>,
     pub polygon_textures: Vec<Option<u32>>,
-    pub polygon_uvs: MultiPolygon2D<f64>,
+    pub polygon_uvs: flatgeom::MultiPolygon<'static, [f64; 2]>,
 }
 
 impl CityGmlGeometry {
@@ -236,7 +237,7 @@ impl CityGmlGeometry {
             textures,
             polygon_materials: Vec::new(),
             polygon_textures: Vec::new(),
-            polygon_uvs: MultiPolygon2D::default(),
+            polygon_uvs: flatgeom::MultiPolygon::default(),
         }
     }
 

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -1924,11 +1924,15 @@
         "title": "MVTWriterParam",
         "type": "object",
         "required": [
+          "layerName",
           "maxZoom",
           "minZoom",
           "output"
         ],
         "properties": {
+          "layerName": {
+            "type": "string"
+          },
           "maxZoom": {
             "type": "integer",
             "format": "uint8",


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced support for specifying a layer name in the MVTWriter, enhancing output organization.
	- Updated polygon slicing algorithm for improved efficiency and clarity in processing geometries.
	- Added new functions for determining appropriate levels of detail (LODs) in geometry processing.

- **Bug Fixes**
	- Enhanced error handling for missing feature types in the geometry processing stages.

- **Documentation**
	- Updated parameter schema to include the new `layerName` property for the MVTWriter.

- **Refactor**
	- Simplified attribute handling and processing logic across various components for better clarity and performance. 
	- Changed the type of `polygon_uvs` in CityGmlGeometry for improved type safety and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->