### PR TITLE
refactor(engine): update parameter names and enhance CityGML processing

### DIFF
--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -996,6 +996,12 @@ Filters features based on conditions
         "dataset": {
           "$ref": "#/definitions/Expr"
         },
+        "flatten": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "format": {
           "type": "string",
           "enum": [
@@ -1331,6 +1337,12 @@ Reads features from a file
       "properties": {
         "dataset": {
           "$ref": "#/definitions/Expr"
+        },
+        "flatten": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "format": {
           "type": "string",

--- a/engine/runtime/action-processor/src/feature/reader/citygml.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml.rs
@@ -1,10 +1,13 @@
 use std::{
+    collections::HashMap,
     io::{BufRead, BufReader, Cursor},
     sync::{Arc, RwLock},
 };
 
 use nusamai_citygml::{CityGmlElement, CityGmlReader, Envelope, ParseError, SubTreeReader};
-use nusamai_plateau::{appearance::AppearanceStore, models, Entity, GeometricMergedownTransform};
+use nusamai_plateau::{
+    appearance::AppearanceStore, models, Entity, FlattenTreeTransform, GeometricMergedownTransform,
+};
 use quick_xml::NsReader;
 use reearth_flow_common::str::to_hash;
 use reearth_flow_common::uri::Uri;
@@ -12,12 +15,21 @@ use reearth_flow_runtime::{
     channels::ProcessorChannelForwarder, executor_operation::ExecutorContext, node::DEFAULT_PORT,
 };
 use reearth_flow_types::{geometry::Geometry, Attribute, AttributeValue, Feature};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
-use super::CompiledCommonPropertySchema;
+use super::CompiledCommonReaderParam;
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CityGmlReaderParam {
+    pub(super) flatten: Option<bool>,
+}
 
 pub(crate) fn read_citygml(
-    params: &CompiledCommonPropertySchema,
+    params: &CompiledCommonReaderParam,
+    citygml_params: &CityGmlReaderParam,
     ctx: ExecutorContext,
     fw: &mut dyn ProcessorChannelForwarder,
 ) -> Result<(), super::errors::FeatureProcessorError> {
@@ -49,13 +61,20 @@ pub(crate) fn read_citygml(
     let mut st = citygml_reader
         .start_root(&mut xml_reader)
         .map_err(|e| super::errors::FeatureProcessorError::FileCityGmlReader(format!("{:?}", e)))?;
-    parse_tree_reader(&mut st, base_url, ctx, fw)
-        .map_err(|e| super::errors::FeatureProcessorError::FileCityGmlReader(format!("{:?}", e)))?;
+    parse_tree_reader(
+        &mut st,
+        citygml_params.flatten.unwrap_or(false),
+        base_url,
+        ctx,
+        fw,
+    )
+    .map_err(|e| super::errors::FeatureProcessorError::FileCityGmlReader(format!("{:?}", e)))?;
     Ok(())
 }
 
 fn parse_tree_reader<R: BufRead>(
     st: &mut SubTreeReader<'_, '_, R>,
+    flatten: bool,
     base_url: Url,
     ctx: ExecutorContext,
     fw: &mut dyn ProcessorChannelForwarder,
@@ -126,10 +145,8 @@ fn parse_tree_reader<R: BufRead>(
                 (v[0], v[1], v[2]) = (v[1], v[0], v[2]);
             });
         }
-        transformer.transform(&mut entity);
 
         let attributes = entity.root.to_attribute_json();
-
         let gml_id = entity
             .root
             .id()
@@ -140,23 +157,35 @@ fn parse_tree_reader<R: BufRead>(
             .typename()
             .map(|name| AttributeValue::String(name.to_string()))
             .unwrap_or(AttributeValue::Null);
-
-        let geometry: Geometry = entity.try_into().map_err(|e| {
-            super::errors::FeatureProcessorError::FileCityGmlReader(format!("{:?}", e))
-        })?;
-        let mut feature = Feature::new_with_attributes(ctx.feature.attributes.clone());
-        feature
-            .attributes
-            .insert(Attribute::new("cityGmlAttributes"), attributes.into());
-        feature.attributes.insert(Attribute::new("gmlName"), name);
-        feature.attributes.insert(Attribute::new("gmlId"), gml_id);
-
-        feature.attributes.insert(
-            Attribute::new("gmlRootId"),
-            AttributeValue::String(format!("root_{}", to_hash(base_url.as_str()))),
-        );
-        feature.geometry = Some(geometry);
-        fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+        let mut attributes = HashMap::<Attribute, AttributeValue>::from([
+            (Attribute::new("cityGmlAttributes"), attributes.into()),
+            (Attribute::new("gmlName"), name),
+            (Attribute::new("gmlId"), gml_id),
+            (
+                Attribute::new("gmlRootId"),
+                AttributeValue::String(format!("root_{}", to_hash(base_url.as_str()))),
+            ),
+        ]);
+        attributes.extend(ctx.feature.attributes.clone());
+        if flatten {
+            for mut child in FlattenTreeTransform::transform(entity) {
+                transformer.transform(&mut child);
+                let geometry: Geometry = child.try_into().map_err(|e| {
+                    super::errors::FeatureProcessorError::FileCityGmlReader(format!("{:?}", e))
+                })?;
+                let mut feature: Feature = geometry.into();
+                feature.extend(attributes.clone());
+                fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+            }
+        } else {
+            transformer.transform(&mut entity);
+            let geometry: Geometry = entity.try_into().map_err(|e| {
+                super::errors::FeatureProcessorError::FileCityGmlReader(format!("{:?}", e))
+            })?;
+            let mut feature: Feature = geometry.into();
+            feature.extend(attributes.clone());
+            fw.send(ctx.new_with_feature_and_port(feature, DEFAULT_PORT.clone()));
+        }
     }
     Ok(())
 }

--- a/engine/runtime/action-processor/src/feature/reader/csv.rs
+++ b/engine/runtime/action-processor/src/feature/reader/csv.rs
@@ -8,18 +8,18 @@ use reearth_flow_types::{Attribute, AttributeValue};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::CompiledCommonPropertySchema;
+use super::CompiledCommonReaderParam;
 
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct CsvPropertySchema {
+pub struct CsvReaderParam {
     pub(super) offset: Option<usize>,
 }
 
 pub(crate) fn read_csv(
     delimiter: Delimiter,
-    params: &CompiledCommonPropertySchema,
-    csv_params: &CsvPropertySchema,
+    params: &CompiledCommonReaderParam,
+    csv_params: &CsvReaderParam,
     ctx: ExecutorContext,
     fw: &mut dyn ProcessorChannelForwarder,
 ) -> Result<(), super::errors::FeatureProcessorError> {

--- a/engine/runtime/action-source/src/file/reader/runner.rs
+++ b/engine/runtime/action-source/src/file/reader/runner.rs
@@ -41,6 +41,8 @@ pub enum FileReader {
     Citygml {
         #[serde(flatten)]
         common_property: FileReaderCommonParam,
+        #[serde(flatten)]
+        property: citygml::CityGmlReaderParam,
     },
 }
 
@@ -107,9 +109,12 @@ impl Source for FileReader {
                     Err(e) => Err(Box::new(e)),
                 }
             }
-            Self::Citygml { common_property } => {
+            Self::Citygml {
+                common_property,
+                property,
+            } => {
                 let input_path = get_input_path(&ctx, common_property)?;
-                let result = citygml::read_citygml(input_path, ctx, sender).await;
+                let result = citygml::read_citygml(input_path, property, ctx, sender).await;
                 match result {
                     Ok(_) => Ok(()),
                     Err(e) => Err(Box::new(e)),

--- a/engine/runtime/action-source/src/file/reader/runner.rs
+++ b/engine/runtime/action-source/src/file/reader/runner.rs
@@ -114,7 +114,8 @@ impl Source for FileReader {
                 property,
             } => {
                 let input_path = get_input_path(&ctx, common_property)?;
-                let result = citygml::read_citygml(input_path, property, ctx, sender).await;
+                let result =
+                    citygml::read_citygml(input_path, property, storage_resolver, sender).await;
                 match result {
                     Ok(_) => Ok(()),
                     Err(e) => Err(Box::new(e)),

--- a/engine/runtime/examples/plateau/example_feature_transformer.rs
+++ b/engine/runtime/examples/plateau/example_feature_transformer.rs
@@ -1,5 +1,5 @@
 mod helper;
 
 fn main() {
-    helper::execute("data-convert/01-bldg/workflow.yml");
+    helper::execute("data-convert/04-luse-lsld/workflow.yml");
 }

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -1004,6 +1004,12 @@
               "dataset": {
                 "$ref": "#/definitions/Expr"
               },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
               "format": {
                 "type": "string",
                 "enum": [
@@ -1338,6 +1344,12 @@
             "properties": {
               "dataset": {
                 "$ref": "#/definitions/Expr"
+              },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               },
               "format": {
                 "type": "string",


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new `flatten` parameter for `FeatureReader` and `FileReader` processors, allowing for flexible data structure handling during processing.
  - Enhanced `CityGmlReaderParam` to include an optional `flatten` field for improved parsing control.
  
- **Bug Fixes**
  - Adjusted logic in the `read_citygml` function to utilize the `flatten` parameter, refining data processing.

- **Documentation**
  - Updated schemas to reflect the addition of the `flatten` parameter in both `FeatureReader` and `FileReader`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->