### PR TITLE
feat(engine): add walkdir dependency and implement artifact upload functionality

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5119,6 +5119,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -170,4 +170,5 @@ uuid = { version = "1.11.0", features = [
   "serde",
   "v4",
 ] }
+walkdir = "2.5.0"
 zstd = "0.13.0"

--- a/engine/runtime/runner/src/runner.rs
+++ b/engine/runtime/runner/src/runner.rs
@@ -10,6 +10,12 @@ use tracing::{error, info, info_span};
 
 use crate::orchestrator::Orchestrator;
 
+/// Controls the number of worker threads in the Tokio runtime.
+///
+/// # Environment Variable
+/// - FLOW_RUNTIME_WORKER_NUM: Number of worker threads (default: 30)
+///
+/// # Notes
 static WORKER_NUM: Lazy<usize> = Lazy::new(|| {
     env::var("FLOW_RUNTIME_WORKER_NUM")
         .ok()

--- a/engine/runtime/runner/src/runner.rs
+++ b/engine/runtime/runner/src/runner.rs
@@ -1,5 +1,6 @@
-use std::{collections::HashMap, sync::Arc, time::Instant};
+use std::{collections::HashMap, env, sync::Arc, time::Instant};
 
+use once_cell::sync::Lazy;
 use reearth_flow_action_log::factory::LoggerFactory;
 use reearth_flow_runtime::{event::EventHandler, node::NodeKind, shutdown};
 use reearth_flow_state::State;
@@ -8,6 +9,13 @@ use reearth_flow_types::workflow::Workflow;
 use tracing::{error, info, info_span};
 
 use crate::orchestrator::Orchestrator;
+
+static WORKER_NUM: Lazy<usize> = Lazy::new(|| {
+    env::var("FLOW_RUNTIME_WORKER_NUM")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(30)
+});
 
 pub struct Runner;
 
@@ -38,10 +46,15 @@ impl Runner {
         event_handlers: Vec<Arc<dyn EventHandler>>,
     ) -> Result<(), crate::errors::Error> {
         let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(30)
+            .worker_threads(*WORKER_NUM)
             .enable_all()
             .build()
-            .unwrap();
+            .map_err(|e| {
+                crate::errors::Error::RuntimeError(format!(
+                    "Failed to init tokio runtime with {:?}",
+                    e
+                ))
+            })?;
 
         let start = Instant::now();
         let span = info_span!(
@@ -71,7 +84,7 @@ impl Runner {
         });
 
         if let Err(e) = &result {
-            error!("Failed to workflow: {:?}", e);
+            error!(parent: &span, "Failed to workflow: {:?}", e);
         }
         info!(parent: &span, "Finish workflow = {:?}, duration = {:?}", workflow_name.as_str(), start.elapsed());
         result

--- a/engine/worker/Cargo.toml
+++ b/engine/worker/Cargo.toml
@@ -49,3 +49,4 @@ tracing.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
+walkdir.workspace = true

--- a/engine/worker/src/artifact.rs
+++ b/engine/worker/src/artifact.rs
@@ -49,15 +49,15 @@ pub(crate) async fn upload_artifact(
             async move {
                 let storage = storage_resolver
                     .resolve(uri)
-                    .map_err(crate::errors::Error::failed_to_download_asset_files)?;
+                    .map_err(crate::errors::Error::failed_to_upload_artifact)?;
                 let bytes = storage
                     .get(uri.path().as_path())
                     .await
-                    .map_err(crate::errors::Error::failed_to_download_asset_files)?;
+                    .map_err(crate::errors::Error::failed_to_upload_artifact)?;
                 let bytes = bytes
                     .bytes()
                     .await
-                    .map_err(crate::errors::Error::failed_to_download_asset_files)?;
+                    .map_err(crate::errors::Error::failed_to_upload_artifact)?;
 
                 let s = uri.to_string();
                 let s = s.replace(&local_artifact_root_path.to_string(), "");
@@ -70,11 +70,11 @@ pub(crate) async fn upload_artifact(
                     .map_err(crate::errors::Error::failed_to_upload_artifact)?;
                 let root_storage = storage_resolver
                     .resolve(&location)
-                    .map_err(crate::errors::Error::failed_to_download_asset_files)?;
+                    .map_err(crate::errors::Error::failed_to_upload_artifact)?;
                 root_storage
                     .put(location.path().as_path(), Bytes::from(bytes.to_vec()))
                     .await
-                    .map_err(crate::errors::Error::failed_to_download_asset_files)?;
+                    .map_err(crate::errors::Error::failed_to_upload_artifact)?;
                 Ok(())
             }
         })

--- a/engine/worker/src/artifact.rs
+++ b/engine/worker/src/artifact.rs
@@ -1,0 +1,84 @@
+use std::{path::MAIN_SEPARATOR, str::FromStr, sync::Arc};
+
+use bytes::Bytes;
+use reearth_flow_common::{dir, uri::Uri};
+use reearth_flow_storage::resolve::StorageResolver;
+use walkdir::WalkDir;
+
+use crate::types::metadata::Metadata;
+
+pub(crate) async fn upload_artifact(
+    storage_resolver: &Arc<StorageResolver>,
+    metadata: &Metadata,
+) -> crate::errors::Result<()> {
+    let local_artifact_root_path =
+        dir::get_job_root_dir_path("workers", metadata.job_id).map_err(|e| {
+            crate::errors::Error::failed_to_upload_artifact(format!(
+                "Failed to get job root dir: {}",
+                e
+            ))
+        })?;
+    let remote_artifact_root_path = Uri::from_str(metadata.artifact_base_url.as_str())
+        .map_err(crate::errors::Error::failed_to_upload_artifact)?;
+    let uris = WalkDir::new(local_artifact_root_path.clone())
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.path().is_file()
+                && !e
+                    .path()
+                    .starts_with(local_artifact_root_path.join("assets"))
+        })
+        .filter_map(|entry| entry.path().as_os_str().to_str().map(String::from))
+        .map(|entry| Uri::from_str(entry.as_str()))
+        .flat_map(Result::ok)
+        .collect::<Vec<_>>();
+
+    let local_artifact_root_path = Uri::from_str(
+        local_artifact_root_path
+            .to_string_lossy()
+            .to_string()
+            .as_str(),
+    )
+    .map_err(crate::errors::Error::failed_to_upload_artifact)?;
+    let futures = uris
+        .iter()
+        .map(|uri| {
+            let local_artifact_root_path = local_artifact_root_path.clone();
+            let remote_artifact_root_path = remote_artifact_root_path.clone();
+            async move {
+                let storage = storage_resolver
+                    .resolve(uri)
+                    .map_err(crate::errors::Error::failed_to_download_asset_files)?;
+                let bytes = storage
+                    .get(uri.path().as_path())
+                    .await
+                    .map_err(crate::errors::Error::failed_to_download_asset_files)?;
+                let bytes = bytes
+                    .bytes()
+                    .await
+                    .map_err(crate::errors::Error::failed_to_download_asset_files)?;
+
+                let s = uri.to_string();
+                let s = s.replace(&local_artifact_root_path.to_string(), "");
+                let s = s.trim_start_matches(MAIN_SEPARATOR).to_string();
+                let location = remote_artifact_root_path
+                    .join(metadata.job_id.to_string())
+                    .map_err(crate::errors::Error::failed_to_upload_artifact)?;
+                let location = location
+                    .join(s)
+                    .map_err(crate::errors::Error::failed_to_upload_artifact)?;
+                let root_storage = storage_resolver
+                    .resolve(&location)
+                    .map_err(crate::errors::Error::failed_to_download_asset_files)?;
+                root_storage
+                    .put(location.path().as_path(), Bytes::from(bytes.to_vec()))
+                    .await
+                    .map_err(crate::errors::Error::failed_to_download_asset_files)?;
+                Ok(())
+            }
+        })
+        .collect::<Vec<_>>();
+    futures::future::try_join_all(futures).await?;
+    Ok(())
+}

--- a/engine/worker/src/errors.rs
+++ b/engine/worker/src/errors.rs
@@ -18,14 +18,14 @@ pub enum Error {
     #[error("Failed to encode: {0}")]
     FailedToEncode(#[source] serde_json::Error),
 
+    #[error("Failed to upload artifact: {0}")]
+    FailedToUploadArtifact(String),
+
     #[error("Failed to initialize cli: {0}")]
     Init(String),
 
     #[error("Failed to run cli: {0}")]
     Run(String),
-
-    #[error("Failed to cleanup: {0}")]
-    Cleanup(String),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -47,7 +47,7 @@ impl Error {
         Self::FailedToDownloadAssetFiles(message.to_string())
     }
 
-    pub(crate) fn cleanup<T: ToString>(message: T) -> Self {
-        Self::Cleanup(message.to_string())
+    pub(crate) fn failed_to_upload_artifact<T: ToString>(message: T) -> Self {
+        Self::FailedToUploadArtifact(message.to_string())
     }
 }

--- a/engine/worker/src/main.rs
+++ b/engine/worker/src/main.rs
@@ -1,3 +1,4 @@
+mod artifact;
 mod asset;
 mod command;
 mod errors;


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new asynchronous function for uploading artifacts to remote storage.
	- Added a new dependency, `walkdir`, enhancing directory traversal capabilities.

- **Bug Fixes**
	- Improved error handling during the Tokio runtime initialization and workflow execution.

- **Refactor**
	- Updated command-line argument handling with new environment variable prefixes.
	- Streamlined the cleanup process by encapsulating logic in the new upload function.

- **Documentation**
	- Enhanced error reporting for artifact upload failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->