### PR TITLE
feat(websocket): use edit_session_service in msg handler

### DIFF
--- a/websocket/app/src/errors.rs
+++ b/websocket/app/src/errors.rs
@@ -1,6 +1,5 @@
+use flow_websocket_services::manage_project_edit_session::SessionCommand;
 use thiserror::Error;
-
-pub type Result<T> = std::result::Result<T, WsError>;
 
 #[derive(Debug, Error)]
 pub enum WsError {
@@ -20,4 +19,6 @@ pub enum WsError {
     UpdateDecode(#[from] yrs::encoding::read::Error),
     #[error(transparent)]
     AwarenessUpdate(#[from] yrs::sync::awareness::Error),
+    #[error(transparent)]
+    MpscSendError(#[from] tokio::sync::mpsc::error::SendError<SessionCommand>),
 }

--- a/websocket/app/src/room.rs
+++ b/websocket/app/src/room.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use yrs::Doc;
 
-use super::errors::Result;
 use tokio::sync::{broadcast, Mutex};
 
 pub struct Room {
@@ -26,17 +25,15 @@ impl Room {
         Room::default()
     }
 
-    pub async fn join(&self, user_id: String) -> Result<()> {
+    pub async fn join(&self, user_id: String) {
         self.users.lock().await.insert(user_id);
-        Ok(())
     }
 
-    pub async fn _leave(&self, user_id: String) -> Result<()> {
+    pub async fn _leave(&self, user_id: String) {
         self.users.lock().await.remove(&user_id);
-        Ok(())
     }
 
-    pub fn _broadcast(&self, msg: String) -> Result<()> {
+    pub fn _broadcast(&self, msg: String) -> Result<(), broadcast::error::SendError<String>> {
         self._tx.send(msg)?;
         Ok(())
     }

--- a/websocket/crates/infra/src/persistence/project_repository.rs
+++ b/websocket/crates/infra/src/persistence/project_repository.rs
@@ -80,7 +80,7 @@ where
     ) -> Result<String, Self::Error> {
         let session_id = session
             .session_id
-            .get_or_insert_with(|| generate_id!("editor-session"))
+            .get_or_insert_with(|| generate_id!("editor-session:"))
             .clone();
 
         let session_key = format!("session:{}", session_id);

--- a/websocket/crates/infra/src/persistence/redis/default_key_manager.rs
+++ b/websocket/crates/infra/src/persistence/redis/default_key_manager.rs
@@ -1,6 +1,3 @@
-use flow_websocket_domain::generate_id;
-
-use super::errors::FlowProjectRedisDataManagerError;
 use super::keys::RedisKeyManager;
 use crate::define_key_methods;
 
@@ -10,22 +7,6 @@ pub struct DefaultKeyManager;
 impl RedisKeyManager for DefaultKeyManager {
     fn project_prefix(&self, project_id: &str) -> String {
         project_id.to_string()
-    }
-
-    fn session_prefix(
-        &self,
-        project_id: &str,
-        session_id: Option<&str>,
-    ) -> Result<String, FlowProjectRedisDataManagerError> {
-        let sid = match session_id {
-            Some(sid) => sid.to_string(),
-            None => generate_id!("session"),
-        };
-        Ok(format!(
-            "{}:session:{}",
-            self.project_prefix(project_id),
-            sid
-        ))
     }
 
     fn active_editing_session_id_key(&self, project_id: &str) -> String {

--- a/websocket/crates/infra/src/persistence/redis/default_key_manager.rs
+++ b/websocket/crates/infra/src/persistence/redis/default_key_manager.rs
@@ -1,3 +1,5 @@
+use flow_websocket_domain::generate_id;
+
 use super::errors::FlowProjectRedisDataManagerError;
 use super::keys::RedisKeyManager;
 use crate::define_key_methods;
@@ -15,10 +17,15 @@ impl RedisKeyManager for DefaultKeyManager {
         project_id: &str,
         session_id: Option<&str>,
     ) -> Result<String, FlowProjectRedisDataManagerError> {
-        match session_id {
-            Some(sid) => Ok(format!("{}:{}", self.project_prefix(project_id), sid)),
-            None => Err(FlowProjectRedisDataManagerError::SessionNotSet),
-        }
+        let sid = match session_id {
+            Some(sid) => sid.to_string(),
+            None => generate_id!("session"),
+        };
+        Ok(format!(
+            "{}:session:{}",
+            self.project_prefix(project_id),
+            sid
+        ))
     }
 
     fn active_editing_session_id_key(&self, project_id: &str) -> String {

--- a/websocket/crates/infra/src/persistence/redis/errors.rs
+++ b/websocket/crates/infra/src/persistence/redis/errors.rs
@@ -18,8 +18,8 @@ pub enum FlowProjectRedisDataManagerError {
     LastUpdateId,
     #[error("Missing state update - Key: {key}, Context: {context}")]
     MissingStateUpdate { key: String, context: String },
-    #[error("Session not set")]
-    SessionNotSet,
+    #[error("Session not set for project {project_id}")]
+    SessionNotSet { project_id: String },
     #[error(transparent)]
     DecodeUpdate(#[from] yrs::encoding::read::Error),
     #[error(transparent)]

--- a/websocket/crates/infra/src/persistence/redis/flow_project_redis_data_manager.rs
+++ b/websocket/crates/infra/src/persistence/redis/flow_project_redis_data_manager.rs
@@ -21,7 +21,7 @@ pub struct FlowProjectRedisDataManager {
 }
 
 impl FlowProjectRedisDataManager {
-    pub async fn new(redis_url: &str) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn new(redis_url: &str) -> Result<Self, FlowProjectRedisDataManagerError> {
         let manager = RedisConnectionManager::new(redis_url)?;
         let redis_pool = Pool::builder().build(manager).await?;
         let global_lock = FlowProjectLock::new(redis_url);

--- a/websocket/crates/infra/src/persistence/redis/keys.rs
+++ b/websocket/crates/infra/src/persistence/redis/keys.rs
@@ -4,11 +4,6 @@ use async_trait::async_trait;
 #[async_trait]
 pub trait RedisKeyManager: Send + Sync {
     fn project_prefix(&self, project_id: &str) -> String;
-    fn session_prefix(
-        &self,
-        project_id: &str,
-        session_id: Option<&str>,
-    ) -> Result<String, FlowProjectRedisDataManagerError>;
     fn active_editing_session_id_key(&self, project_id: &str) -> String;
     fn state_key(&self, project_id: &str) -> Result<String, FlowProjectRedisDataManagerError>;
     fn state_updated_by_key(

--- a/websocket/crates/infra/src/persistence/redis/keys.rs
+++ b/websocket/crates/infra/src/persistence/redis/keys.rs
@@ -30,7 +30,7 @@ macro_rules! define_key_methods {
     ($($method:ident => $suffix:expr),* $(,)?) => {
         $(
             fn $method(&self, project_id: &str) -> Result<String, $crate::persistence::redis::errors::FlowProjectRedisDataManagerError> {
-                Ok(format!("{}:{}", self.session_prefix(project_id, None)?, $suffix))
+                Ok(format!("{}:{}", self.project_prefix(project_id), $suffix))
             }
         )*
     };

--- a/websocket/crates/infra/src/persistence/redis/updates.rs
+++ b/websocket/crates/infra/src/persistence/redis/updates.rs
@@ -118,19 +118,7 @@ impl UpdateManager {
                     FlowProjectRedisDataManagerError::Unknown("Missing value field".to_string())
                 })?;
 
-            let format = items
-                .iter()
-                .find(|(key, _)| key == "format")
-                .map(|(_, v)| v)
-                .ok_or_else(|| {
-                    FlowProjectRedisDataManagerError::Unknown("Missing format field".to_string())
-                })?;
-
-            let encoded_update: FlowEncodedUpdate = if format == "json" {
-                serde_json::from_str(value)?
-            } else {
-                continue;
-            };
+            let encoded_update: FlowEncodedUpdate = serde_json::from_str(value)?;
 
             if encoded_update.update.is_empty() || encoded_update.update == "[]" {
                 continue;

--- a/websocket/crates/services/examples/edit_session_service.rs
+++ b/websocket/crates/services/examples/edit_session_service.rs
@@ -62,16 +62,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Simulate session lifecycle
     debug!("Starting session simulation");
 
-    // Add task data
-    let task_data = ManageProjectEditSessionTaskData {
+    tx.send(SessionCommand::AddTask {
         project_id: project_id.clone(),
-        last_merged_at: Arc::new(tokio::sync::RwLock::new(None)),
-        last_snapshot_at: Arc::new(tokio::sync::RwLock::new(None)),
-        clients_disconnected_at: Arc::new(tokio::sync::RwLock::new(None)),
-        client_count: Arc::new(tokio::sync::RwLock::new(Some(0))),
-    };
-
-    tx.send(SessionCommand::AddTask { task_data }).await?;
+    })
+    .await?;
 
     // Start session
     tx.send(SessionCommand::Start {

--- a/websocket/crates/services/examples/edit_session_service.rs
+++ b/websocket/crates/services/examples/edit_session_service.rs
@@ -107,18 +107,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     })
     .await?;
 
-    // Remove task
-    tx.send(SessionCommand::RemoveTask {
-        project_id: project_id.clone(),
-    })
-    .await?;
+    // // Remove task
+    // tx.send(SessionCommand::RemoveTask {
+    //     project_id: project_id.clone(),
+    // })
+    // .await?;
 
-    // Complete session
-    tx.send(SessionCommand::Complete {
-        project_id,
-        user: test_user,
-    })
-    .await?;
+    // // Complete session
+    // tx.send(SessionCommand::Complete {
+    //     project_id,
+    //     user: test_user,
+    // })
+    // .await?;
 
     // Drop sender to terminate service
     drop(tx);

--- a/websocket/crates/services/examples/edit_session_service.rs
+++ b/websocket/crates/services/examples/edit_session_service.rs
@@ -92,6 +92,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     })
     .await?;
 
+    // Push update
+    tx.send(SessionCommand::PushUpdate {
+        project_id: project_id.clone(),
+        update: vec![1, 2, 3],
+        updated_by: Some(test_user.name.clone()),
+    })
+    .await?;
+
     // End session
     tx.send(SessionCommand::End {
         project_id: project_id.clone(),

--- a/websocket/crates/services/examples/edit_session_service.rs
+++ b/websocket/crates/services/examples/edit_session_service.rs
@@ -5,9 +5,8 @@ use flow_websocket_infra::persistence::{
         flow_project_redis_data_manager::FlowProjectRedisDataManager, redis_client::RedisClient,
     },
 };
-use flow_websocket_services::{
-    manage_project_edit_session::{ManageEditSessionService, SessionCommand},
-    types::ManageProjectEditSessionTaskData,
+use flow_websocket_services::manage_project_edit_session::{
+    ManageEditSessionService, SessionCommand,
 };
 use std::sync::Arc;
 use tokio::sync::mpsc;

--- a/websocket/crates/services/src/lib.rs
+++ b/websocket/crates/services/src/lib.rs
@@ -4,3 +4,4 @@ pub mod project;
 //pub mod snapshot;
 pub use error::ProjectServiceError;
 pub mod types;
+pub use types::ManageProjectEditSessionTaskData;

--- a/websocket/crates/services/src/manage_project_edit_session.rs
+++ b/websocket/crates/services/src/manage_project_edit_session.rs
@@ -10,6 +10,7 @@ use flow_websocket_infra::persistence::{
     project_repository::ProjectRepositoryError, redis::errors::FlowProjectRedisDataManagerError,
 };
 use mockall::automock;
+use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::{mpsc, Mutex};
@@ -38,7 +39,7 @@ where
     tasks: Arc<Mutex<HashMap<String, ManageProjectEditSessionTaskData>>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SessionCommand {
     Start {
         project_id: String,
@@ -56,7 +57,7 @@ pub enum SessionCommand {
         project_id: String,
     },
     AddTask {
-        task_data: ManageProjectEditSessionTaskData,
+        project_id: String,
     },
     RemoveTask {
         project_id: String,
@@ -182,7 +183,8 @@ where
                         SessionCommand::CheckStatus { project_id } => {
                             debug!("Checking session status for project: {}", project_id);
                         },
-                        SessionCommand::AddTask { task_data } => {
+                        SessionCommand::AddTask { project_id } => {
+                            let task_data = ManageProjectEditSessionTaskData::new(project_id);
                             let mut tasks = self.tasks.lock().await;
                             tasks.insert(task_data.project_id.clone(), task_data.clone());
                             debug!("Added task for project: {}", task_data.project_id);

--- a/websocket/crates/services/src/project.rs
+++ b/websocket/crates/services/src/project.rs
@@ -9,6 +9,7 @@ use flow_websocket_domain::user::User;
 use flow_websocket_infra::persistence::project_repository::ProjectRepositoryError;
 use flow_websocket_infra::persistence::redis::errors::FlowProjectRedisDataManagerError;
 use std::sync::Arc;
+use tracing::debug;
 
 #[derive(Debug, Clone)]
 pub struct ProjectService<E, S, R> {
@@ -60,7 +61,10 @@ where
             None => ProjectEditingSession::new(project_id.to_string()),
         };
 
+        debug!("Session ID: {:?}", session.session_id);
+
         if session.session_id.is_none() {
+            debug!("Starting new session for project: {}", project_id);
             session
                 .start_or_join_session(
                     &*self.snapshot_repository,

--- a/websocket/crates/services/src/types.rs
+++ b/websocket/crates/services/src/types.rs
@@ -12,17 +12,12 @@ pub struct ManageProjectEditSessionTaskData {
 }
 
 impl ManageProjectEditSessionTaskData {
-    pub fn new(
-        project_id: String,
-        last_merged_at: Option<DateTime<Utc>>,
-        last_snapshot_at: Option<DateTime<Utc>>,
-        clients_disconnected_at: Option<DateTime<Utc>>,
-    ) -> Self {
+    pub fn new(project_id: String) -> Self {
         Self {
             project_id,
-            last_merged_at: Arc::new(RwLock::new(last_merged_at)),
-            last_snapshot_at: Arc::new(RwLock::new(last_snapshot_at)),
-            clients_disconnected_at: Arc::new(RwLock::new(clients_disconnected_at)),
+            last_merged_at: Arc::new(RwLock::new(None)),
+            last_snapshot_at: Arc::new(RwLock::new(None)),
+            clients_disconnected_at: Arc::new(RwLock::new(None)),
             client_count: Arc::new(RwLock::new(None)),
         }
     }


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced WebSocket session management with the addition of commands for managing project editing sessions, including `PushUpdate`.
	- Introduced a new data structure for managing project edit session tasks.
	- Improved session ID handling by generating a new ID format when not provided.
	- Added debug logging for better observability during session management operations.
	- New error handling capabilities for session command processing.

- **Bug Fixes**
	- Streamlined error handling for session management and update processing.

- **Documentation**
	- Updated public exports to include new session management types and commands.

These improvements enhance user experience by providing better session tracking and update management within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->