### PR TITLE
feat(websocket): add process_state_vector to return diff

### DIFF
--- a/websocket/Cargo.lock
+++ b/websocket/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "envy",
  "flow-websocket-infra",
  "flow-websocket-services",
+ "futures",
  "futures-util",
  "rand",
  "redis",
@@ -661,12 +662,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -674,6 +691,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -710,6 +738,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",

--- a/websocket/Cargo.toml
+++ b/websocket/Cargo.toml
@@ -46,6 +46,7 @@ bb8-redis = "0.17.0"
 chrono = { version = "0.4", features = ["serde"] }
 dotenv = "0.15.0"
 envy = "0.4.2"
+futures = "0.3.4"
 futures-util = "0.3"
 google-cloud-storage = "0.22.1"
 lru = "0.12.4"

--- a/websocket/app/Cargo.toml
+++ b/websocket/app/Cargo.toml
@@ -39,3 +39,4 @@ url.workspace = true
 base64.workspace = true
 rand.workspace = true
 serde_yaml.workspace = true
+futures.workspace = true

--- a/websocket/app/examples/room_client.rs
+++ b/websocket/app/examples/room_client.rs
@@ -5,7 +5,6 @@ use tokio_tungstenite::{connect_async_with_config, tungstenite::http::Request};
 use tracing::error;
 use tracing::info;
 use url::Url;
-// Add these struct definitions at the top
 #[derive(Serialize)]
 struct Event<T> {
     event: EventData<T>,

--- a/websocket/app/examples/room_client.rs
+++ b/websocket/app/examples/room_client.rs
@@ -34,15 +34,15 @@ struct EmitContent {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let project_id = "test_project";
     let user_id = "test_user";
     let room_id = "room123";
+    let token = "nyaan";
 
     let url = Url::parse(&format!(
-        "ws://127.0.0.1:8080/{room_id}?user_id={user_id}&project_id={project_id}",
+        "ws://127.0.0.1:8080/{room_id}?user_id={user_id}&token={token}",
         room_id = room_id,
         user_id = user_id,
-        project_id = project_id
+        token = token,
     ))?;
 
     let request = Request::builder()

--- a/websocket/app/examples/session_client.rs
+++ b/websocket/app/examples/session_client.rs
@@ -51,6 +51,7 @@ pub enum SessionCommand {
     ListAllSnapshotsVersions {
         project_id: String,
     },
+    #[warn(dead_code)]
     MergeUpdates {
         project_id: String,
         data: Vec<u8>,

--- a/websocket/app/examples/session_client.rs
+++ b/websocket/app/examples/session_client.rs
@@ -76,16 +76,14 @@ fn create_binary_message(msg_type: MessageType, data: Vec<u8>) -> Vec<u8> {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
-    let project_id = "test_project";
     let user_id = "test_user";
     let room_id = "room123";
     let auth_token = "nyaan";
 
     let url = Url::parse(&format!(
-        "ws://127.0.0.1:8080/{room_id}?user_id={user_id}&project_id={project_id}&token={token}",
+        "ws://127.0.0.1:8080/{room_id}?user_id={user_id}&token={token}",
         room_id = room_id,
         user_id = user_id,
-        project_id = project_id,
         token = auth_token
     ))?;
 
@@ -144,7 +142,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //     tenant_id: "test_tenant".to_string(),
     // };
 
-    let project_id = "test_project".to_string();
+    let project_id = "test_project3".to_string();
     let user = User::new(
         user_id.to_string(),
         None, // email

--- a/websocket/app/examples/session_client.rs
+++ b/websocket/app/examples/session_client.rs
@@ -24,8 +24,9 @@ struct FlowMessage {
     session_command: Option<SessionCommand>,
 }
 
-#[derive(Serialize)]
-enum SessionCommand {
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "tag", content = "content")]
+pub enum SessionCommand {
     Start {
         project_id: String,
         user: User,
@@ -54,6 +55,10 @@ enum SessionCommand {
         project_id: String,
         data: Vec<u8>,
         updated_by: Option<String>,
+    },
+    ProcessStateVector {
+        project_id: String,
+        state_vector: Vec<u8>,
     },
 }
 

--- a/websocket/app/src/errors.rs
+++ b/websocket/app/src/errors.rs
@@ -1,7 +1,7 @@
 use flow_websocket_infra::persistence::{
     gcs::gcs_client::GcsError, redis::errors::FlowProjectRedisDataManagerError,
 };
-use flow_websocket_services::manage_project_edit_session::SessionCommand;
+use flow_websocket_services::SessionCommand;
 use thiserror::Error;
 use tokio::sync::broadcast;
 
@@ -40,4 +40,6 @@ pub enum WsError {
     GcsStorage(#[from] GcsError),
     #[error(transparent)]
     Room(#[from] crate::room::RoomError),
+    #[error(transparent)]
+    Axum(#[from] axum::Error),
 }

--- a/websocket/app/src/handlers/cleanup.rs
+++ b/websocket/app/src/handlers/cleanup.rs
@@ -29,7 +29,6 @@ pub fn perform_cleanup(
             if let Some(project_id) = project_id {
                 if let Err(e) = state.command_tx.send(SessionCommand::End {
                     project_id: project_id.clone(),
-                    user: user.clone(),
                 }) {
                     debug!("Failed to send End command: {:?}", e);
                 }

--- a/websocket/app/src/handlers/cleanup.rs
+++ b/websocket/app/src/handlers/cleanup.rs
@@ -1,6 +1,7 @@
 use crate::state::AppState;
 use flow_websocket_infra::types::user::User;
-use flow_websocket_services::manage_project_edit_session::SessionCommand;
+use flow_websocket_services::SessionCommand;
+
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -15,40 +16,32 @@ pub fn perform_cleanup(
     project_id: Option<String>,
     state: Arc<AppState>,
     cleanup_tx: Sender<()>,
-) -> impl Fn() {
-    move || {
-        if is_cleaning_up
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .is_ok()
-        {
-            let state = state.clone();
-            let room_id = room_id.clone();
-            let user = user.clone();
-            let project_id = project_id.clone();
-            let cleanup_tx = cleanup_tx.clone();
+) {
+    if is_cleaning_up
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        tokio::spawn(async move {
+            if let Err(e) = state.leave(&room_id, &user.id).await {
+                debug!("Cleanup error: {:?}", e);
+            }
 
-            tokio::spawn(async move {
-                if let Err(e) = state.leave(&room_id, &user.id).await {
-                    debug!("Cleanup error: {:?}", e);
+            if let Some(project_id) = project_id {
+                if let Err(e) = state.command_tx.send(SessionCommand::End {
+                    project_id: project_id.clone(),
+                    user: user.clone(),
+                }) {
+                    debug!("Failed to send End command: {:?}", e);
                 }
 
-                if let Some(project_id) = project_id {
-                    if let Err(e) = state.command_tx.send(SessionCommand::End {
-                        project_id: project_id.clone(),
-                        user: user.clone(),
-                    }) {
-                        debug!("Failed to send End command: {:?}", e);
-                    }
-
-                    if let Err(e) = state.command_tx.send(SessionCommand::RemoveTask {
-                        project_id: project_id.clone(),
-                    }) {
-                        debug!("Failed to send RemoveTask command: {:?}", e);
-                    }
+                if let Err(e) = state.command_tx.send(SessionCommand::RemoveTask {
+                    project_id: project_id.clone(),
+                }) {
+                    debug!("Failed to send RemoveTask command: {:?}", e);
                 }
+            }
 
-                let _ = cleanup_tx.send(()).await;
-            });
-        }
+            let _ = cleanup_tx.send(()).await;
+        });
     }
 }

--- a/websocket/app/src/handlers/message_handler.rs
+++ b/websocket/app/src/handlers/message_handler.rs
@@ -1,12 +1,13 @@
 use crate::{errors::WsError, state::AppState};
 use axum::extract::ws::Message;
 use flow_websocket_infra::types::user::User;
-use flow_websocket_services::manage_project_edit_session::SessionCommand;
+use flow_websocket_services::SessionCommand;
 use std::{net::SocketAddr, sync::Arc};
-use tracing::{debug, warn};
+use tracing::debug;
 
 use super::{
     room_handler::{handle_room_event, handle_session_command},
+    socket_handler::ConnectionState,
     types::{parse_message, FlowMessage, MessageType},
 };
 
@@ -14,7 +15,7 @@ pub async fn handle_message(
     msg: Message,
     addr: SocketAddr,
     room_id: &str,
-    project_id: Option<String>,
+    conn_state: &ConnectionState,
     state: Arc<AppState>,
     user: User,
 ) -> Result<Option<Message>, WsError> {
@@ -23,7 +24,10 @@ pub async fn handle_message(
             let msg: FlowMessage = serde_json::from_str(&t)?;
 
             if let Some(command) = msg.session_command {
-                handle_session_command(command, project_id, &user, &state).await?;
+                handle_session_command(command.clone(), conn_state, &user, &state).await?;
+                if matches!(command, SessionCommand::End { .. }) {
+                    conn_state.start_cleanup();
+                }
             } else {
                 handle_room_event(&msg.event, room_id, &state, &user).await?;
             }
@@ -32,42 +36,46 @@ pub async fn handle_message(
         Message::Binary(d) => {
             debug!("{} sent {} bytes: {:?}", addr, d.len(), d);
 
-            if let Some(project_id) = project_id {
-                if let Some((msg_type, payload)) = parse_message(&d) {
-                    match msg_type {
-                        MessageType::UPDATE => {
-                            state.command_tx.send(SessionCommand::MergeUpdates {
-                                project_id: project_id.clone(),
-                                data: payload.to_vec(),
-                                updated_by: Some(user.id.clone()),
-                            })?;
-                        }
-                        MessageType::SYNC => {
-                            state.command_tx.send(SessionCommand::ProcessStateVector {
-                                project_id: project_id.clone(),
-                                state_vector: payload.to_vec(),
-                            })?;
-                        }
-                        _ => {
-                            warn!("Unsupported message type: {:?}", msg_type);
-                        }
-                    }
-                } else {
-                    warn!("Invalid binary message format from {}", addr);
-                }
+            if let Some(response) = process_binary_message(d, conn_state, &user, &state).await? {
+                conn_state.send_message(response).await?;
             }
             Ok(None)
         }
         Message::Close(_) => {
             debug!("Client {addr} sent close message");
-            if let Some(project_id) = project_id {
-                state.command_tx.send(SessionCommand::End {
-                    project_id: project_id.clone(),
-                    user: user.clone(),
-                })?;
-            }
+            conn_state.start_cleanup();
             Ok(None)
         }
-        _ => Ok(None),
+        Message::Ping(data) => Ok(Some(Message::Pong(data))),
+        Message::Pong(_) => Ok(None),
     }
+}
+
+async fn process_binary_message(
+    data: Vec<u8>,
+    conn_state: &ConnectionState,
+    user: &User,
+    state: &Arc<AppState>,
+) -> Result<Option<Message>, WsError> {
+    if let Some((msg_type, payload)) = parse_message(&data) {
+        let project_id = conn_state.current_project_id.lock().await.clone();
+        if let Some(pid) = project_id {
+            match msg_type {
+                MessageType::Update => {
+                    state.command_tx.send(SessionCommand::MergeUpdates {
+                        project_id: pid,
+                        data: payload.to_vec(),
+                        updated_by: Some(user.id.clone()),
+                    })?;
+                }
+                MessageType::Sync => {
+                    state.command_tx.send(SessionCommand::ProcessStateVector {
+                        project_id: pid,
+                        state_vector: payload.to_vec(),
+                    })?;
+                }
+            }
+        }
+    }
+    Ok(None)
 }

--- a/websocket/app/src/handlers/mod.rs
+++ b/websocket/app/src/handlers/mod.rs
@@ -5,6 +5,8 @@ mod room_handler;
 mod socket_handler;
 mod types;
 
+pub use types::MessageType;
+
 use crate::handlers::socket_handler::handle_socket;
 use crate::state::AppState;
 use axum::extract::{ws::WebSocketUpgrade, ConnectInfo, Path, Query, State};
@@ -29,7 +31,6 @@ pub async fn handle_upgrade(
             query.token().to_string(),
             room_id,
             state,
-            query.project_id(),
             user,
         )
     })

--- a/websocket/app/src/handlers/room_handler.rs
+++ b/websocket/app/src/handlers/room_handler.rs
@@ -1,9 +1,10 @@
 use flow_websocket_infra::types::user::User;
-use flow_websocket_services::manage_project_edit_session::SessionCommand;
+use flow_websocket_services::SessionCommand;
 
 use crate::{errors::WsError, state::AppState};
 use std::sync::Arc;
 
+use super::socket_handler::ConnectionState;
 use super::types::Event;
 
 pub async fn handle_room_event(
@@ -31,72 +32,92 @@ pub async fn handle_room_event(
 
 pub async fn handle_session_command(
     command: SessionCommand,
-    project_id: Option<String>,
+    conn_state: &ConnectionState,
     user: &User,
     state: &Arc<AppState>,
 ) -> Result<(), WsError> {
-    let command = if let Some(pid) = project_id {
-        match command {
-            SessionCommand::Start { .. } => SessionCommand::Start {
-                project_id: pid.clone(),
+    let mut project_id = conn_state.current_project_id.lock().await;
+
+    let command = match command {
+        SessionCommand::Start {
+            project_id: pid, ..
+        } => {
+            *project_id = Some(pid.clone());
+            SessionCommand::Start {
+                project_id: pid,
                 user: user.clone(),
-            },
-            SessionCommand::End { .. } => SessionCommand::End {
-                project_id: pid.clone(),
-                user: user.clone(),
-            },
-            SessionCommand::Complete { .. } => SessionCommand::Complete {
-                project_id: pid.clone(),
-                user: user.clone(),
-            },
-            SessionCommand::CheckStatus { .. } => SessionCommand::CheckStatus {
-                project_id: pid.clone(),
-            },
-            SessionCommand::AddTask { .. } => SessionCommand::AddTask {
-                project_id: pid.clone(),
-            },
-            SessionCommand::RemoveTask { .. } => SessionCommand::RemoveTask {
-                project_id: pid.clone(),
-            },
-            SessionCommand::ListAllSnapshotsVersions { .. } => {
-                SessionCommand::ListAllSnapshotsVersions {
-                    project_id: pid.clone(),
-                }
             }
-            SessionCommand::MergeUpdates { data, .. } => SessionCommand::MergeUpdates {
-                project_id: pid.clone(),
-                data,
-                updated_by: Some(user.id.clone()),
-            },
-            SessionCommand::ProcessStateVector { state_vector, .. } => {
-                SessionCommand::ProcessStateVector {
-                    project_id: pid.clone(),
-                    state_vector,
-                }
-            }
-            _ => command,
         }
-    } else {
-        match command {
-            SessionCommand::CreateWorkspace { workspace } => {
-                SessionCommand::CreateWorkspace { workspace }
-            }
-            SessionCommand::DeleteWorkspace { workspace_id } => {
-                SessionCommand::DeleteWorkspace { workspace_id }
-            }
-            SessionCommand::UpdateWorkspace { workspace } => {
-                SessionCommand::UpdateWorkspace { workspace }
-            }
-            SessionCommand::ListWorkspaceProjectsIds { workspace_id } => {
-                SessionCommand::ListWorkspaceProjectsIds { workspace_id }
-            }
-            SessionCommand::CreateProject { project } => SessionCommand::CreateProject { project },
-            SessionCommand::DeleteProject { project_id } => {
-                SessionCommand::DeleteProject { project_id }
-            }
-            SessionCommand::UpdateProject { project } => SessionCommand::UpdateProject { project },
-            _ => {
+        SessionCommand::End { .. } => {
+            if let Some(pid) = project_id.clone() {
+                *project_id = None;
+                SessionCommand::End {
+                    project_id: pid,
+                    user: user.clone(),
+                }
+            } else {
                 return Ok(());
+            }
+        }
+        cmd => {
+            if let Some(pid) = project_id.clone() {
+                match cmd {
+                    SessionCommand::Complete { .. } => SessionCommand::Complete {
+                        project_id: pid.clone(),
+                        user: user.clone(),
+                    },
+                    SessionCommand::CheckStatus { .. } => SessionCommand::CheckStatus {
+                        project_id: pid.clone(),
+                    },
+                    SessionCommand::AddTask { .. } => SessionCommand::AddTask {
+                        project_id: pid.clone(),
+                    },
+                    SessionCommand::RemoveTask { .. } => SessionCommand::RemoveTask {
+                        project_id: pid.clone(),
+                    },
+                    SessionCommand::ListAllSnapshotsVersions { .. } => {
+                        SessionCommand::ListAllSnapshotsVersions {
+                            project_id: pid.clone(),
+                        }
+                    }
+                    SessionCommand::MergeUpdates { data, .. } => SessionCommand::MergeUpdates {
+                        project_id: pid.clone(),
+                        data,
+                        updated_by: Some(user.id.clone()),
+                    },
+                    SessionCommand::ProcessStateVector { state_vector, .. } => {
+                        SessionCommand::ProcessStateVector {
+                            project_id: pid.clone(),
+                            state_vector,
+                        }
+                    }
+                    _ => cmd,
+                }
+            } else {
+                match cmd {
+                    SessionCommand::CreateWorkspace { workspace } => {
+                        SessionCommand::CreateWorkspace { workspace }
+                    }
+                    SessionCommand::DeleteWorkspace { workspace_id } => {
+                        SessionCommand::DeleteWorkspace { workspace_id }
+                    }
+                    SessionCommand::UpdateWorkspace { workspace } => {
+                        SessionCommand::UpdateWorkspace { workspace }
+                    }
+                    SessionCommand::ListWorkspaceProjectsIds { workspace_id } => {
+                        SessionCommand::ListWorkspaceProjectsIds { workspace_id }
+                    }
+                    SessionCommand::CreateProject { project } => {
+                        SessionCommand::CreateProject { project }
+                    }
+                    SessionCommand::DeleteProject { project_id } => {
+                        SessionCommand::DeleteProject { project_id }
+                    }
+                    SessionCommand::UpdateProject { project } => {
+                        SessionCommand::UpdateProject { project }
+                    }
+                    _ => return Ok(()),
+                }
             }
         }
     };

--- a/websocket/app/src/handlers/room_handler.rs
+++ b/websocket/app/src/handlers/room_handler.rs
@@ -1,4 +1,5 @@
 use flow_websocket_infra::types::user::User;
+use flow_websocket_services::manage_project_edit_session::SessionCommand;
 
 use crate::{errors::WsError, state::AppState};
 use std::sync::Arc;
@@ -25,5 +26,114 @@ pub async fn handle_room_event(
             state.emit(data).await;
         }
     }
+    Ok(())
+}
+
+pub async fn handle_session_command(
+    command: SessionCommand,
+    project_id: Option<String>,
+    user: &User,
+    state: &Arc<AppState>,
+) -> Result<(), WsError> {
+    let command = match command {
+        SessionCommand::Start { .. } => {
+            if let Some(pid) = project_id {
+                SessionCommand::Start {
+                    project_id: pid,
+                    user: user.clone(),
+                }
+            } else {
+                return Ok(());
+            }
+        }
+        SessionCommand::End { .. } => {
+            if let Some(pid) = project_id {
+                SessionCommand::End {
+                    project_id: pid,
+                    user: user.clone(),
+                }
+            } else {
+                return Ok(());
+            }
+        }
+        SessionCommand::Complete { .. } => {
+            if let Some(pid) = project_id {
+                SessionCommand::Complete {
+                    project_id: pid,
+                    user: user.clone(),
+                }
+            } else {
+                return Ok(());
+            }
+        }
+        SessionCommand::CheckStatus { .. } => {
+            if let Some(pid) = project_id {
+                SessionCommand::CheckStatus { project_id: pid }
+            } else {
+                return Ok(());
+            }
+        }
+        SessionCommand::AddTask { .. } => {
+            if let Some(pid) = project_id {
+                SessionCommand::AddTask { project_id: pid }
+            } else {
+                return Ok(());
+            }
+        }
+        SessionCommand::RemoveTask { .. } => {
+            if let Some(pid) = project_id {
+                SessionCommand::RemoveTask { project_id: pid }
+            } else {
+                return Ok(());
+            }
+        }
+        SessionCommand::ListAllSnapshotsVersions { .. } => {
+            if let Some(pid) = project_id {
+                SessionCommand::ListAllSnapshotsVersions { project_id: pid }
+            } else {
+                return Ok(());
+            }
+        }
+        SessionCommand::MergeUpdates { data, .. } => {
+            if let Some(pid) = project_id {
+                SessionCommand::MergeUpdates {
+                    project_id: pid,
+                    data,
+                    updated_by: Some(user.id.clone()),
+                }
+            } else {
+                return Ok(());
+            }
+        }
+        SessionCommand::ProcessStateVector { state_vector, .. } => {
+            if let Some(pid) = project_id {
+                SessionCommand::ProcessStateVector {
+                    project_id: pid,
+                    state_vector,
+                }
+            } else {
+                return Ok(());
+            }
+        }
+        SessionCommand::CreateWorkspace { workspace } => {
+            SessionCommand::CreateWorkspace { workspace }
+        }
+        SessionCommand::DeleteWorkspace { workspace_id } => {
+            SessionCommand::DeleteWorkspace { workspace_id }
+        }
+        SessionCommand::UpdateWorkspace { workspace } => {
+            SessionCommand::UpdateWorkspace { workspace }
+        }
+        SessionCommand::ListWorkspaceProjectsIds { workspace_id } => {
+            SessionCommand::ListWorkspaceProjectsIds { workspace_id }
+        }
+        SessionCommand::CreateProject { project } => SessionCommand::CreateProject { project },
+        SessionCommand::DeleteProject { project_id } => {
+            SessionCommand::DeleteProject { project_id }
+        }
+        SessionCommand::UpdateProject { project } => SessionCommand::UpdateProject { project },
+    };
+
+    state.command_tx.send(command).map_err(WsError::from)?;
     Ok(())
 }

--- a/websocket/app/src/handlers/room_handler.rs
+++ b/websocket/app/src/handlers/room_handler.rs
@@ -35,103 +35,70 @@ pub async fn handle_session_command(
     user: &User,
     state: &Arc<AppState>,
 ) -> Result<(), WsError> {
-    let command = match command {
-        SessionCommand::Start { .. } => {
-            if let Some(pid) = project_id {
-                SessionCommand::Start {
-                    project_id: pid,
-                    user: user.clone(),
+    let command = if let Some(pid) = project_id {
+        match command {
+            SessionCommand::Start { .. } => SessionCommand::Start {
+                project_id: pid.clone(),
+                user: user.clone(),
+            },
+            SessionCommand::End { .. } => SessionCommand::End {
+                project_id: pid.clone(),
+                user: user.clone(),
+            },
+            SessionCommand::Complete { .. } => SessionCommand::Complete {
+                project_id: pid.clone(),
+                user: user.clone(),
+            },
+            SessionCommand::CheckStatus { .. } => SessionCommand::CheckStatus {
+                project_id: pid.clone(),
+            },
+            SessionCommand::AddTask { .. } => SessionCommand::AddTask {
+                project_id: pid.clone(),
+            },
+            SessionCommand::RemoveTask { .. } => SessionCommand::RemoveTask {
+                project_id: pid.clone(),
+            },
+            SessionCommand::ListAllSnapshotsVersions { .. } => {
+                SessionCommand::ListAllSnapshotsVersions {
+                    project_id: pid.clone(),
                 }
-            } else {
-                return Ok(());
             }
-        }
-        SessionCommand::End { .. } => {
-            if let Some(pid) = project_id {
-                SessionCommand::End {
-                    project_id: pid,
-                    user: user.clone(),
-                }
-            } else {
-                return Ok(());
-            }
-        }
-        SessionCommand::Complete { .. } => {
-            if let Some(pid) = project_id {
-                SessionCommand::Complete {
-                    project_id: pid,
-                    user: user.clone(),
-                }
-            } else {
-                return Ok(());
-            }
-        }
-        SessionCommand::CheckStatus { .. } => {
-            if let Some(pid) = project_id {
-                SessionCommand::CheckStatus { project_id: pid }
-            } else {
-                return Ok(());
-            }
-        }
-        SessionCommand::AddTask { .. } => {
-            if let Some(pid) = project_id {
-                SessionCommand::AddTask { project_id: pid }
-            } else {
-                return Ok(());
-            }
-        }
-        SessionCommand::RemoveTask { .. } => {
-            if let Some(pid) = project_id {
-                SessionCommand::RemoveTask { project_id: pid }
-            } else {
-                return Ok(());
-            }
-        }
-        SessionCommand::ListAllSnapshotsVersions { .. } => {
-            if let Some(pid) = project_id {
-                SessionCommand::ListAllSnapshotsVersions { project_id: pid }
-            } else {
-                return Ok(());
-            }
-        }
-        SessionCommand::MergeUpdates { data, .. } => {
-            if let Some(pid) = project_id {
-                SessionCommand::MergeUpdates {
-                    project_id: pid,
-                    data,
-                    updated_by: Some(user.id.clone()),
-                }
-            } else {
-                return Ok(());
-            }
-        }
-        SessionCommand::ProcessStateVector { state_vector, .. } => {
-            if let Some(pid) = project_id {
+            SessionCommand::MergeUpdates { data, .. } => SessionCommand::MergeUpdates {
+                project_id: pid.clone(),
+                data,
+                updated_by: Some(user.id.clone()),
+            },
+            SessionCommand::ProcessStateVector { state_vector, .. } => {
                 SessionCommand::ProcessStateVector {
-                    project_id: pid,
+                    project_id: pid.clone(),
                     state_vector,
                 }
-            } else {
+            }
+            _ => command,
+        }
+    } else {
+        match command {
+            SessionCommand::CreateWorkspace { workspace } => {
+                SessionCommand::CreateWorkspace { workspace }
+            }
+            SessionCommand::DeleteWorkspace { workspace_id } => {
+                SessionCommand::DeleteWorkspace { workspace_id }
+            }
+            SessionCommand::UpdateWorkspace { workspace } => {
+                SessionCommand::UpdateWorkspace { workspace }
+            }
+            SessionCommand::ListWorkspaceProjectsIds { workspace_id } => {
+                SessionCommand::ListWorkspaceProjectsIds { workspace_id }
+            }
+            SessionCommand::CreateProject { project } => SessionCommand::CreateProject { project },
+            SessionCommand::DeleteProject { project_id } => {
+                SessionCommand::DeleteProject { project_id }
+            }
+            SessionCommand::UpdateProject { project } => SessionCommand::UpdateProject { project },
+            _ => {
                 return Ok(());
             }
         }
-        SessionCommand::CreateWorkspace { workspace } => {
-            SessionCommand::CreateWorkspace { workspace }
-        }
-        SessionCommand::DeleteWorkspace { workspace_id } => {
-            SessionCommand::DeleteWorkspace { workspace_id }
-        }
-        SessionCommand::UpdateWorkspace { workspace } => {
-            SessionCommand::UpdateWorkspace { workspace }
-        }
-        SessionCommand::ListWorkspaceProjectsIds { workspace_id } => {
-            SessionCommand::ListWorkspaceProjectsIds { workspace_id }
-        }
-        SessionCommand::CreateProject { project } => SessionCommand::CreateProject { project },
-        SessionCommand::DeleteProject { project_id } => {
-            SessionCommand::DeleteProject { project_id }
-        }
-        SessionCommand::UpdateProject { project } => SessionCommand::UpdateProject { project },
     };
 
     state.command_tx.send(command).map_err(WsError::from)?;

--- a/websocket/app/src/handlers/room_handler.rs
+++ b/websocket/app/src/handlers/room_handler.rs
@@ -51,10 +51,7 @@ pub async fn handle_session_command(
         SessionCommand::End { .. } => {
             if let Some(pid) = project_id.clone() {
                 *project_id = None;
-                SessionCommand::End {
-                    project_id: pid,
-                    user: user.clone(),
-                }
+                SessionCommand::End { project_id: pid }
             } else {
                 return Ok(());
             }

--- a/websocket/app/src/handlers/socket_handler.rs
+++ b/websocket/app/src/handlers/socket_handler.rs
@@ -1,9 +1,13 @@
+use crate::errors::WsError;
 use crate::handlers::message_handler::handle_message;
 use crate::state::AppState;
 use axum::extract::ws::{Message, WebSocket};
 use flow_websocket_infra::types::user::User;
+use futures::SinkExt;
+use futures_util::stream::SplitSink;
 use futures_util::StreamExt;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::{mpsc, Mutex};
 use tracing::debug;
@@ -11,13 +15,37 @@ use tracing::debug;
 use super::cleanup::perform_cleanup;
 use super::heartbeat::start_heartbeat;
 
+pub struct ConnectionState {
+    pub sender: Arc<Mutex<SplitSink<WebSocket, Message>>>,
+    pub is_cleaning_up: Arc<AtomicBool>,
+    pub cleanup_tx: mpsc::Sender<()>,
+    pub current_project_id: Arc<Mutex<Option<String>>>,
+}
+
+impl ConnectionState {
+    pub async fn send_message(&self, message: Message) -> Result<(), WsError> {
+        let mut sender = self.sender.lock().await;
+        sender.send(message).await?;
+        Ok(())
+    }
+
+    pub fn start_cleanup(&self) {
+        if self
+            .is_cleaning_up
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            let _ = self.cleanup_tx.try_send(());
+        }
+    }
+}
+
 pub async fn handle_socket(
     mut socket: WebSocket,
     addr: SocketAddr,
     token: String,
     room_id: String,
     state: Arc<AppState>,
-    project_id: Option<String>,
     user: User,
 ) {
     if !verify_connection(&mut socket, &addr, &token).await {
@@ -28,24 +56,36 @@ pub async fn handle_socket(
     let sender = Arc::new(Mutex::new(sender));
     let is_cleaning_up = Arc::new(AtomicBool::new(false));
     let (cleanup_tx, mut cleanup_rx) = mpsc::channel(1);
+    let current_project_id = Arc::new(Mutex::new(None));
+
+    let conn_state = ConnectionState {
+        sender: sender.clone(),
+        is_cleaning_up: is_cleaning_up.clone(),
+        cleanup_tx: cleanup_tx.clone(),
+        current_project_id: current_project_id.clone(),
+    };
 
     let cleanup = {
         let is_cleaning_up = is_cleaning_up.clone();
         let room_id = room_id.clone();
         let user = user.clone();
-        let project_id = project_id.clone();
         let state = state.clone();
         let cleanup_tx = cleanup_tx.clone();
+        let current_project_id = current_project_id.clone();
 
         Arc::new(move || {
-            let _ = perform_cleanup(
-                is_cleaning_up.clone(),
-                room_id.clone(),
-                user.clone(),
-                project_id.clone(),
-                state.clone(),
-                cleanup_tx.clone(),
-            );
+            let is_cleaning_up = is_cleaning_up.clone();
+            let room_id = room_id.clone();
+            let user = user.clone();
+            let state = state.clone();
+            let cleanup_tx = cleanup_tx.clone();
+            let current_project_id = current_project_id.clone();
+
+            tokio::spawn(async move {
+                let mut project_id_lock = current_project_id.lock().await;
+                let project_id = project_id_lock.take();
+                perform_cleanup(is_cleaning_up, room_id, user, project_id, state, cleanup_tx);
+            });
         }) as Arc<dyn Fn() + Send + Sync>
     };
 
@@ -58,7 +98,7 @@ pub async fn handle_socket(
                     msg,
                     addr,
                     &room_id,
-                    project_id.clone(),
+                    &conn_state,
                     state.clone(),
                     user.clone(),
                 )

--- a/websocket/app/src/handlers/types.rs
+++ b/websocket/app/src/handlers/types.rs
@@ -40,3 +40,39 @@ impl WebSocketQuery {
         &self.token
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MessageType(u8);
+
+impl MessageType {
+    pub const UPDATE: MessageType = MessageType(1);
+    pub const SYNC: MessageType = MessageType(2);
+
+    pub fn from_byte(byte: u8) -> Option<Self> {
+        match byte {
+            1 => Some(Self::UPDATE),
+            2 => Some(Self::SYNC),
+            _ => None,
+        }
+    }
+
+    pub fn _as_byte(&self) -> u8 {
+        self.0
+    }
+
+    pub fn _is_update(&self) -> bool {
+        *self == Self::UPDATE
+    }
+
+    pub fn _is_sync(&self) -> bool {
+        *self == Self::SYNC
+    }
+}
+
+pub fn parse_message(data: &[u8]) -> Option<(MessageType, &[u8])> {
+    if data.is_empty() {
+        return None;
+    }
+
+    MessageType::from_byte(data[0]).map(|msg_type| (msg_type, &data[1..]))
+}

--- a/websocket/app/src/handlers/types.rs
+++ b/websocket/app/src/handlers/types.rs
@@ -69,10 +69,19 @@ impl MessageType {
     }
 }
 
+/// Parses a binary message according to the Flow protocol format:
+/// - Byte 0: Message type (1 = UPDATE, 2 = SYNC)
+/// - Bytes 1+: Message payload
+///
+/// Returns None if the input is empty or has an invalid message type.
+/// Returns Some((message_type, payload)) on successful parsing.
 pub fn parse_message(data: &[u8]) -> Option<(MessageType, &[u8])> {
-    if data.is_empty() {
-        return None;
-    }
+    // Ensure we have at least one byte for the message type
+    let type_byte = *data.first()?;
 
-    MessageType::from_byte(data[0]).map(|msg_type| (msg_type, &data[1..]))
+    // Parse and validate message type
+    let msg_type = MessageType::from_byte(type_byte)?;
+
+    // Return message type and remaining payload
+    Some((msg_type, &data[1..]))
 }

--- a/websocket/app/src/handlers/types.rs
+++ b/websocket/app/src/handlers/types.rs
@@ -1,4 +1,4 @@
-use flow_websocket_services::manage_project_edit_session::SessionCommand;
+use flow_websocket_services::SessionCommand;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -20,20 +20,11 @@ pub struct FlowMessage {
 pub struct WebSocketQuery {
     token: String,
     user_id: String,
-    project_id: Option<String>,
 }
 
 impl WebSocketQuery {
     pub fn user_id(&self) -> &str {
         &self.user_id
-    }
-
-    pub fn project_id(&self) -> Option<String> {
-        self.project_id.clone()
-    }
-
-    pub fn _update_project_id(&mut self, project_id: Option<String>) {
-        self.project_id = project_id;
     }
 
     pub fn token(&self) -> &str {
@@ -42,30 +33,22 @@ impl WebSocketQuery {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct MessageType(u8);
+pub enum MessageType {
+    Update = 1,
+    Sync = 2,
+}
 
 impl MessageType {
-    pub const UPDATE: MessageType = MessageType(1);
-    pub const SYNC: MessageType = MessageType(2);
-
     pub fn from_byte(byte: u8) -> Option<Self> {
         match byte {
-            1 => Some(Self::UPDATE),
-            2 => Some(Self::SYNC),
+            1 => Some(Self::Update),
+            2 => Some(Self::Sync),
             _ => None,
         }
     }
 
     pub fn _as_byte(&self) -> u8 {
-        self.0
-    }
-
-    pub fn _is_update(&self) -> bool {
-        *self == Self::UPDATE
-    }
-
-    pub fn _is_sync(&self) -> bool {
-        *self == Self::SYNC
+        *self as u8
     }
 }
 

--- a/websocket/app/src/lib.rs
+++ b/websocket/app/src/lib.rs
@@ -6,5 +6,6 @@ mod room;
 pub mod state;
 pub use config::Config;
 mod routes;
+pub use handlers::MessageType;
 pub use middleware::add_middleware;
 pub use routes::create_router;

--- a/websocket/app/src/state.rs
+++ b/websocket/app/src/state.rs
@@ -11,7 +11,7 @@ use flow_websocket_infra::persistence::ProjectGcsRepository;
 #[allow(unused_imports)]
 use flow_websocket_infra::persistence::ProjectLocalRepository;
 use flow_websocket_services::manage_project_edit_session::ManageEditSessionService;
-use flow_websocket_services::manage_project_edit_session::SessionCommand;
+use flow_websocket_services::SessionCommand;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::broadcast;

--- a/websocket/crates/infra/src/persistence/redis/flow_project_redis_data_manager.rs
+++ b/websocket/crates/infra/src/persistence/redis/flow_project_redis_data_manager.rs
@@ -164,9 +164,7 @@ impl RedisDataManagerImpl for FlowProjectRedisDataManager {
     type Error = FlowProjectRedisDataManagerError;
 
     async fn get_current_state(&self, project_id: &str) -> Result<Option<Vec<u8>>, Self::Error> {
-        let state_key = self.key_manager.state_key(project_id)?;
-        let current_state: Option<Vec<u8>> = self.redis_pool.get().await?.get(state_key).await?;
-        Ok(current_state)
+        self.update_manager.get_current_state(project_id).await
     }
 
     async fn get_state_updates_by(&self, project_id: &str) -> Result<Option<String>, Self::Error> {
@@ -244,6 +242,16 @@ impl RedisDataManagerImpl for FlowProjectRedisDataManager {
             .get(self.key_manager.active_editing_session_id_key(project_id))
             .await?;
         Ok(result)
+    }
+
+    async fn process_state_vector(
+        &self,
+        project_id: &str,
+        state_vector: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.update_manager
+            .handle_state_vector(project_id, state_vector)
+            .await
     }
 }
 

--- a/websocket/crates/infra/src/persistence/redis/flow_project_redis_data_manager.rs
+++ b/websocket/crates/infra/src/persistence/redis/flow_project_redis_data_manager.rs
@@ -94,8 +94,8 @@ impl FlowProjectRedisDataManager {
         debug!("Update data: {:?}", update_data);
 
         let data_in_redis = self.get_state_in_redis(project_id).await?;
-        debug!("State updates in redis--------------");
-        debug!("State updates in redis: {:?}", data_in_redis);
+        debug!("State data in redis--------------");
+        debug!("State data in redis: {:?}", data_in_redis);
 
         let (new_merged_update, new_updates_by) = self
             .update_manager

--- a/websocket/crates/infra/src/persistence/redis/updates.rs
+++ b/websocket/crates/infra/src/persistence/redis/updates.rs
@@ -163,7 +163,7 @@ impl UpdateManager {
                     Err(e) => return Err(FlowProjectRedisDataManagerError::from(e)),
                 }
 
-                let client_state_vector = StateVector::decode_v1(&state_vector)?;
+                let client_state_vector = StateVector::decode_v2(&state_vector)?;
 
                 let diff = txn.encode_state_as_update_v2(&client_state_vector);
                 Ok(diff)

--- a/websocket/crates/infra/src/persistence/repository.rs
+++ b/websocket/crates/infra/src/persistence/repository.rs
@@ -46,6 +46,11 @@ pub trait RedisDataManagerImpl {
         update_data: Vec<u8>,
         updated_by: Option<String>,
     ) -> Result<(Vec<u8>, Vec<String>), Self::Error>;
+    async fn process_state_vector(
+        &self,
+        project_id: &str,
+        state_vector: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, Self::Error>;
     async fn clear_data(
         &self,
         project_id: &str,

--- a/websocket/crates/services/examples/edit_session_service.rs
+++ b/websocket/crates/services/examples/edit_session_service.rs
@@ -12,8 +12,8 @@ use flow_websocket_infra::{
     },
     types::user::User,
 };
-use flow_websocket_services::manage_project_edit_session::{
-    ManageEditSessionService, SessionCommand,
+use flow_websocket_services::{
+    manage_project_edit_session::ManageEditSessionService, SessionCommand,
 };
 use std::sync::Arc;
 use tokio::sync::broadcast;

--- a/websocket/crates/services/examples/edit_session_service.rs
+++ b/websocket/crates/services/examples/edit_session_service.rs
@@ -172,7 +172,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // End session
     tx.send(SessionCommand::End {
         project_id: project_id.clone(),
-        user: test_user.clone(),
     })?;
 
     info!("Removing task");

--- a/websocket/crates/services/examples/edit_session_service.rs
+++ b/websocket/crates/services/examples/edit_session_service.rs
@@ -18,7 +18,7 @@ use flow_websocket_services::manage_project_edit_session::{
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::info;
-use yrs::{Doc, Text, Transact};
+use yrs::{updates::encoder::Encode, Doc, ReadTxn, Text, Transact};
 
 ///export REDIS_URL="redis://default:my_redis_password@localhost:6379/0"
 ///RUST_LOG=debug cargo run --example edit_session_service  --features local-storage
@@ -151,6 +151,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     })?;
 
     info!("Ending session");
+
+    info!("Processing state vector");
+    info!("--------------------------------");
+    info!("Processing state vector");
+    let doc2 = Doc::new();
+    let state_vector = {
+        let txn = doc2.transact();
+        txn.state_vector().encode_v2()
+    };
+
+    tx.send(SessionCommand::ProcessStateVector {
+        project_id: project_id.clone(),
+        state_vector,
+    })?;
+
+    info!("Ending session");
+    info!("--------------------------------");
 
     // End session
     tx.send(SessionCommand::End {

--- a/websocket/crates/services/src/lib.rs
+++ b/websocket/crates/services/src/lib.rs
@@ -5,3 +5,4 @@ pub mod project;
 pub use error::ProjectServiceError;
 pub mod types;
 pub use types::ManageProjectEditSessionTaskData;
+pub use types::SessionCommand;

--- a/websocket/crates/services/src/manage_project_edit_session.rs
+++ b/websocket/crates/services/src/manage_project_edit_session.rs
@@ -72,6 +72,10 @@ pub enum SessionCommand {
         data: Vec<u8>,
         updated_by: Option<String>,
     },
+    ProcessStateVector {
+        project_id: String,
+        state_vector: Vec<u8>,
+    },
     CreateWorkspace {
         workspace: Workspace,
     },
@@ -172,6 +176,14 @@ where
                 } => {
                     self.project_service
                         .merge_updates(&project_id, data, updated_by)
+                        .await?;
+                }
+                SessionCommand::ProcessStateVector {
+                    project_id,
+                    state_vector,
+                } => {
+                    self.project_service
+                        .process_state_vector(&project_id, state_vector)
                         .await?;
                 }
                 SessionCommand::CheckStatus { project_id } => {

--- a/websocket/crates/services/src/manage_project_edit_session.rs
+++ b/websocket/crates/services/src/manage_project_edit_session.rs
@@ -98,8 +98,8 @@ where
                     self.handle_session_start(&project_id, user).await?;
                     Ok(None)
                 }
-                SessionCommand::End { project_id, user } => {
-                    self.handle_session_end(&project_id, user).await?;
+                SessionCommand::End { project_id } => {
+                    self.handle_session_end(&project_id).await?;
                     Ok(None)
                 }
                 SessionCommand::Complete { project_id, user } => {
@@ -240,11 +240,7 @@ where
         Ok(())
     }
 
-    async fn handle_session_end(
-        &self,
-        project_id: &str,
-        _user: User,
-    ) -> Result<(), ProjectServiceError> {
+    async fn handle_session_end(&self, project_id: &str) -> Result<(), ProjectServiceError> {
         if let Some(task_data) = self.get_task_data(project_id).await {
             self.update_client_count(&task_data, false).await;
 

--- a/websocket/crates/services/src/manage_project_edit_session.rs
+++ b/websocket/crates/services/src/manage_project_edit_session.rs
@@ -1,3 +1,4 @@
+use super::SessionCommand;
 use chrono::Utc;
 use flow_websocket_infra::persistence::editing_session::ProjectEditingSession;
 use flow_websocket_infra::persistence::project_repository::ProjectRepositoryError;
@@ -6,11 +7,8 @@ use flow_websocket_infra::persistence::repository::{
     ProjectEditingSessionImpl, ProjectImpl, ProjectSnapshotImpl, RedisDataManagerImpl,
     WorkspaceImpl,
 };
-use flow_websocket_infra::types::project::Project;
 use flow_websocket_infra::types::user::User;
-use flow_websocket_infra::types::workspace::Workspace;
 use mockall::automock;
-use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::broadcast;
@@ -39,64 +37,6 @@ where
 {
     pub project_service: ProjectService<R, S, M, P, W>,
     tasks: Arc<Mutex<HashMap<String, ManageProjectEditSessionTaskData>>>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum SessionCommand {
-    Start {
-        project_id: String,
-        user: User,
-    },
-    End {
-        project_id: String,
-        user: User,
-    },
-    Complete {
-        project_id: String,
-        user: User,
-    },
-    CheckStatus {
-        project_id: String,
-    },
-    AddTask {
-        project_id: String,
-    },
-    RemoveTask {
-        project_id: String,
-    },
-    ListAllSnapshotsVersions {
-        project_id: String,
-    },
-    MergeUpdates {
-        project_id: String,
-        data: Vec<u8>,
-        updated_by: Option<String>,
-    },
-    ProcessStateVector {
-        project_id: String,
-        state_vector: Vec<u8>,
-    },
-    CreateWorkspace {
-        workspace: Workspace,
-    },
-    DeleteWorkspace {
-        workspace_id: String,
-    },
-    UpdateWorkspace {
-        workspace: Workspace,
-    },
-    ListWorkspaceProjectsIds {
-        workspace_id: String,
-    },
-    CreateProject {
-        project: Project,
-    },
-    DeleteProject {
-        project_id: String,
-    },
-    UpdateProject {
-        project: Project,
-    },
 }
 
 #[automock]

--- a/websocket/crates/services/src/manage_project_edit_session.rs
+++ b/websocket/crates/services/src/manage_project_edit_session.rs
@@ -91,14 +91,16 @@ where
     async fn handle_command(
         &self,
         result: Result<SessionCommand, broadcast::error::RecvError>,
-    ) -> Result<(), ProjectServiceError> {
+    ) -> Result<Option<Vec<u8>>, ProjectServiceError> {
         match result {
             Ok(command) => match command {
                 SessionCommand::Start { project_id, user } => {
                     self.handle_session_start(&project_id, user).await?;
+                    Ok(None)
                 }
                 SessionCommand::End { project_id, user } => {
                     self.handle_session_end(&project_id, user).await?;
+                    Ok(None)
                 }
                 SessionCommand::Complete { project_id, user } => {
                     if let Some(mut session) = self.get_latest_session(&project_id).await? {
@@ -108,6 +110,7 @@ where
                             user.id, project_id
                         );
                     }
+                    Ok(None)
                 }
                 SessionCommand::MergeUpdates {
                     project_id,
@@ -117,23 +120,30 @@ where
                     self.project_service
                         .merge_updates(&project_id, data, updated_by)
                         .await?;
+                    Ok(None)
                 }
                 SessionCommand::ProcessStateVector {
                     project_id,
                     state_vector,
                 } => {
-                    self.project_service
+                    let updates = self
+                        .project_service
                         .process_state_vector(&project_id, state_vector)
                         .await?;
+                    debug!("Processed state vector for project: {}", project_id);
+                    Ok(updates)
                 }
                 SessionCommand::CheckStatus { project_id } => {
                     debug!("Checking session status for project: {}", project_id);
+                    Ok(None)
                 }
                 SessionCommand::AddTask { project_id } => {
                     self.add_task(&project_id).await?;
+                    Ok(None)
                 }
                 SessionCommand::RemoveTask { project_id } => {
                     self.remove_task(&project_id).await?;
+                    Ok(None)
                 }
                 SessionCommand::ListAllSnapshotsVersions { project_id } => {
                     let versions = self
@@ -144,16 +154,20 @@ where
                         "Snapshots versions for project {}: {:?}",
                         project_id, versions
                     );
+                    Ok(None)
                 }
                 // Workspace related commands
                 SessionCommand::CreateWorkspace { workspace } => {
                     self.project_service.create_workspace(workspace).await?;
+                    Ok(None)
                 }
                 SessionCommand::DeleteWorkspace { workspace_id } => {
                     self.project_service.delete_workspace(&workspace_id).await?;
+                    Ok(None)
                 }
                 SessionCommand::UpdateWorkspace { workspace } => {
                     self.project_service.update_workspace(workspace).await?;
+                    Ok(None)
                 }
                 SessionCommand::ListWorkspaceProjectsIds { workspace_id } => {
                     let projects = self
@@ -161,27 +175,32 @@ where
                         .list_workspace_projects_ids(&workspace_id)
                         .await?;
                     debug!("Projects for workspace {}: {:?}", workspace_id, projects);
+                    Ok(None)
                 }
                 // Project related commands
                 SessionCommand::CreateProject { project } => {
                     self.project_service.create_project(project).await?;
+                    Ok(None)
                 }
                 SessionCommand::DeleteProject { project_id } => {
                     self.project_service.delete_project(&project_id).await?;
+                    Ok(None)
                 }
                 SessionCommand::UpdateProject { project } => {
                     self.project_service.update_project(project).await?;
+                    Ok(None)
                 }
             },
             Err(broadcast::error::RecvError::Closed) => {
                 debug!("Command channel closed");
                 sleep(Duration::from_secs(1)).await;
+                Ok(None)
             }
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 debug!("Receiver lagged behind by {} messages", n);
+                Ok(None)
             }
         }
-        Ok(())
     }
 
     async fn check_tasks_conditions(&self) -> Result<(), ProjectServiceError> {

--- a/websocket/crates/services/src/project.rs
+++ b/websocket/crates/services/src/project.rs
@@ -102,6 +102,17 @@ where
         Ok(())
     }
 
+    pub async fn process_state_vector(
+        &self,
+        project_id: &str,
+        state_vector: Vec<u8>,
+    ) -> Result<(), ProjectServiceError> {
+        self.redis_data_manager
+            .process_state_vector(project_id, state_vector)
+            .await?;
+        Ok(())
+    }
+
     pub async fn get_or_create_editing_session(
         &self,
         project_id: &str,

--- a/websocket/crates/services/src/project.rs
+++ b/websocket/crates/services/src/project.rs
@@ -106,11 +106,12 @@ where
         &self,
         project_id: &str,
         state_vector: Vec<u8>,
-    ) -> Result<(), ProjectServiceError> {
-        self.redis_data_manager
+    ) -> Result<Option<Vec<u8>>, ProjectServiceError> {
+        let ret = self
+            .redis_data_manager
             .process_state_vector(project_id, state_vector)
             .await?;
-        Ok(())
+        Ok(ret)
     }
 
     pub async fn get_or_create_editing_session(

--- a/websocket/crates/services/src/types.rs
+++ b/websocket/crates/services/src/types.rs
@@ -13,7 +13,6 @@ pub enum SessionCommand {
     },
     End {
         project_id: String,
-        user: User,
     },
     Complete {
         project_id: String,

--- a/websocket/crates/services/src/types.rs
+++ b/websocket/crates/services/src/types.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "tag", content = "content")]
 pub enum SessionCommand {
     Start {
         project_id: String,

--- a/websocket/crates/services/src/types.rs
+++ b/websocket/crates/services/src/types.rs
@@ -1,6 +1,66 @@
 use chrono::{DateTime, Utc};
+use flow_websocket_infra::types::{project::Project, user::User, workspace::Workspace};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SessionCommand {
+    Start {
+        project_id: String,
+        user: User,
+    },
+    End {
+        project_id: String,
+        user: User,
+    },
+    Complete {
+        project_id: String,
+        user: User,
+    },
+    CheckStatus {
+        project_id: String,
+    },
+    AddTask {
+        project_id: String,
+    },
+    RemoveTask {
+        project_id: String,
+    },
+    ListAllSnapshotsVersions {
+        project_id: String,
+    },
+    MergeUpdates {
+        project_id: String,
+        data: Vec<u8>,
+        updated_by: Option<String>,
+    },
+    ProcessStateVector {
+        project_id: String,
+        state_vector: Vec<u8>,
+    },
+    CreateWorkspace {
+        workspace: Workspace,
+    },
+    DeleteWorkspace {
+        workspace_id: String,
+    },
+    UpdateWorkspace {
+        workspace: Workspace,
+    },
+    ListWorkspaceProjectsIds {
+        workspace_id: String,
+    },
+    CreateProject {
+        project: Project,
+    },
+    DeleteProject {
+        project_id: String,
+    },
+    UpdateProject {
+        project: Project,
+    },
+}
 
 #[derive(Clone, Debug)]
 pub struct ManageProjectEditSessionTaskData {


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new command variant `ProcessStateVector` for enhanced state vector processing.
	- Added methods for processing state vectors in `ProjectService`, `UpdateManager`, and `RedisDataManagerImpl`.
	- Enhanced WebSocket client functionality with new event structures and a streamlined message sending process.
	- Added `MessageType` enum for improved message handling and parsing.
	- Introduced `ConnectionState` struct for better management of WebSocket connection state.

- **Improvements**
	- Streamlined WebSocket message sending with a new `send_event` function.
	- Enhanced binary message handling in the message handler.
	- Updated session management capabilities with a new `command_tx` field in `AppState`.

- **Bug Fixes**
	- Improved clarity in debug logging for state data.

- **Refactor**
	- Simplified state management logic in `FlowProjectRedisDataManager`.
	- Restructured imports and command handling for better organization and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->