### PR TITLE
feat(ui): improve canvas navigation panel

### DIFF
--- a/ui/src/features/Editor/components/Canvas/components/Nodes/NoteNode/index.tsx
+++ b/ui/src/features/Editor/components/Canvas/components/Nodes/NoteNode/index.tsx
@@ -1,5 +1,5 @@
 import { NodeProps, NodeResizer } from "@xyflow/react";
-import { memo, useState } from "react";
+import { memo, useState, useCallback } from "react";
 
 import { Node } from "@flow/types";
 
@@ -17,7 +17,6 @@ export const baseNoteNode = {
 };
 
 const minSize = { width: 250, height: 150 };
-
 const NoteNode: React.FC<NoteNodeProps> = ({ data, ...props }) => {
   const [_width, _setWidth] = useState(data.width ?? initialSize.width);
   const [_height, _setHeight] = useState(data.height);
@@ -31,6 +30,17 @@ const NoteNode: React.FC<NoteNodeProps> = ({ data, ...props }) => {
   // console.log(width, height);
 
   // console.log("ADS props: ", props);
+
+  const [content, setContent] = useState(data.content);
+
+  const handleContentChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const newValue = event.target.value;
+      setContent(newValue);
+      data.content = newValue;
+    },
+    [data],
+  );
   return (
     <>
       {props.selected && (
@@ -71,6 +81,8 @@ const NoteNode: React.FC<NoteNodeProps> = ({ data, ...props }) => {
         <textarea
           className="nowheel size-full resize-none bg-transparent focus-visible:outline-none"
           defaultValue={data.content}
+          value={content}
+          onChange={handleContentChange}
           onMouseDown={(e) => e.stopPropagation()}
           // onMouseUp={e => e.}
         />

--- a/ui/src/features/Editor/components/Canvas/index.tsx
+++ b/ui/src/features/Editor/components/Canvas/index.tsx
@@ -8,7 +8,6 @@ import {
   XYPosition,
 } from "@xyflow/react";
 import { MouseEvent, memo } from "react";
-
 import type { ActionNodeType, Edge, Node } from "@flow/types";
 
 import {
@@ -18,13 +17,12 @@ import {
   nodeTypes,
 } from "./components";
 import useHooks, { defaultEdgeOptions } from "./hooks";
+import { useLocker } from "../../useInteractionLocker";
 
 import "@xyflow/react/dist/style.css";
 
 const gridSize = 30;
-
 const snapGrid: SnapGrid = [gridSize, gridSize];
-
 const proOptions: ProOptions = { hideAttribution: true };
 
 type Props = {
@@ -71,8 +69,20 @@ const Canvas: React.FC<Props> = ({
     onNodePickerOpen,
   });
 
+  const { interactionLockedNodes } = useLocker();
+
+  const isNodeDraggable = (nodeId: string) =>
+    !interactionLockedNodes.some((lockedNode) => lockedNode.id === nodeId);
+
+  const updatedNodes = nodes.map((node) => ({
+    ...node,
+    draggable: isNodeDraggable(node.id),
+  }));
+
   return (
     <ReactFlow
+      nodes={updatedNodes}
+      edges={edges}
       // minZoom={0.7}
       // maxZoom={1}
       // defaultViewport={{ zoom: 0.8, x: 200, y: 200 }}
@@ -102,12 +112,9 @@ const Canvas: React.FC<Props> = ({
       zoomOnDoubleClick={!canvasLock}
       connectOnClick={!canvasLock}
       // Locking props END
-
       snapGrid={snapGrid}
       selectionMode={SelectionMode["Partial"]}
-      nodes={nodes}
       nodeTypes={nodeTypes}
-      edges={edges}
       edgeTypes={edgeTypes}
       defaultEdgeOptions={defaultEdgeOptions}
       connectionLineComponent={CustomConnectionLine}

--- a/ui/src/features/Editor/components/Canvas/useDnd.ts
+++ b/ui/src/features/Editor/components/Canvas/useDnd.ts
@@ -10,7 +10,7 @@ import {
   type Node,
   type NodeType,
 } from "@flow/types";
-import { randomID } from "@flow/utils";
+import { randomID, randomIDshort } from "@flow/utils";
 
 import { baseBatchNode } from "./components/Nodes/BatchNode";
 import { baseNoteNode } from "./components/Nodes/NoteNode";
@@ -71,13 +71,14 @@ export default ({
 
       if (nodeTypes.includes(d as NodeType)) {
         console.log("actionName is a NodeType", d);
+        console.log("nodetype = " + nodeTypes);
 
         newNode = {
           ...newNode,
           type: d,
           data: {
             ...newNode.data,
-            name: d,
+            name: d + "-" + randomIDshort(),
           },
         };
 

--- a/ui/src/features/Editor/components/LeftPanel/index.tsx
+++ b/ui/src/features/Editor/components/LeftPanel/index.tsx
@@ -106,9 +106,6 @@ const LeftPanel: React.FC<Props> = ({
                 id: n.id,
                 name: n.data.name ?? "untitled",
                 icon: isNodeLocked(n.id) ? Lock : Note,
-                style: isNodeLocked(n.id)
-                  ? { color: "red", cursor: "not-allowed" }
-                  : undefined, // 잠긴 노드는 회색 및 커서 변경
                 children: {
                   id: n.id,
                   name: n.data.content ?? "untitled",
@@ -175,7 +172,7 @@ const LeftPanel: React.FC<Props> = ({
     }
   }
 
-  var idContainer = "";
+  let idContainer = "";
 
   const tabs: {
     id: Tab;

--- a/ui/src/features/Editor/components/LeftPanel/index.tsx
+++ b/ui/src/features/Editor/components/LeftPanel/index.tsx
@@ -15,7 +15,7 @@ import { Link, useParams } from "@tanstack/react-router";
 import { memo, useEffect, useState } from "react";
 
 import { FlowLogo, Tree, TreeDataItem, IconButton } from "@flow/components";
-import { UserNavigation } from "@flow/features/TopNavigation/components";
+import { UserNavigation } from "@flow/features/WorkspaceTopNavigation/components";
 import { useShortcuts } from "@flow/hooks";
 import { useT } from "@flow/lib/i18n";
 import type { Node } from "@flow/types";

--- a/ui/src/features/Editor/index.tsx
+++ b/ui/src/features/Editor/index.tsx
@@ -5,6 +5,7 @@ import {
   OverlayUI,
   RightPanel,
 } from "./components";
+import { LockerProvider } from "./useInteractionLocker";
 import useHooks from "./hooks";
 
 export default function Editor() {
@@ -35,50 +36,52 @@ export default function Editor() {
   } = useHooks();
 
   return (
-    <div className="flex h-screen flex-col">
-      <div className="relative flex flex-1">
-        <LeftPanel
-          nodes={nodes}
-          isOpen={openPanel === "left" && !locallyLockedNode}
-          onOpen={handlePanelOpen}
-          onNodesChange={handleNodesUpdate}
-          onNodeLocking={handleNodeLocking}
-        />
-        <div className="flex flex-1 flex-col">
-          <OverlayUI
-            hoveredDetails={hoveredDetails}
-            nodePickerOpen={nodePickerOpen}
+    <LockerProvider>
+      <div className="flex h-screen flex-col">
+        <div className="relative flex flex-1">
+          <LeftPanel
             nodes={nodes}
-            onWorkflowDeployment={handleWorkflowDeployment}
-            onWorkflowUndo={handleWorkflowUndo}
-            onWorkflowRedo={handleWorkflowRedo}
+            isOpen={openPanel === "left" && !locallyLockedNode}
+            onOpen={handlePanelOpen}
             onNodesChange={handleNodesUpdate}
             onNodeLocking={handleNodeLocking}
-            onNodePickerClose={handleNodePickerClose}>
-            <Canvas
-              nodes={nodes}
-              edges={edges}
-              canvasLock={!!locallyLockedNode}
-              onWorkflowAdd={handleWorkflowAdd}
-              onNodesUpdate={handleNodesUpdate}
-              onNodeHover={handleNodeHover}
-              onNodeLocking={handleNodeLocking}
-              onNodePickerOpen={handleNodePickerOpen}
-              onEdgesUpdate={handleEdgesUpdate}
-              onEdgeHover={handleEdgeHover}
-            />
-          </OverlayUI>
-          <BottomPanel
-            currentWorkflowId={currentWorkflowId}
-            openWorkflows={openWorkflows}
-            isOpen={openPanel === "bottom" && !locallyLockedNode}
-            onOpen={handlePanelOpen}
-            onWorkflowClose={handleWorkflowClose}
-            onWorkflowChange={handleWorkflowChange}
           />
+          <div className="flex flex-1 flex-col">
+            <OverlayUI
+              hoveredDetails={hoveredDetails}
+              nodePickerOpen={nodePickerOpen}
+              nodes={nodes}
+              onWorkflowDeployment={handleWorkflowDeployment}
+              onWorkflowUndo={handleWorkflowUndo}
+              onWorkflowRedo={handleWorkflowRedo}
+              onNodesChange={handleNodesUpdate}
+              onNodeLocking={handleNodeLocking}
+              onNodePickerClose={handleNodePickerClose}>
+              <Canvas
+                nodes={nodes}
+                edges={edges}
+                canvasLock={!!locallyLockedNode}
+                onWorkflowAdd={handleWorkflowAdd}
+                onNodesUpdate={handleNodesUpdate}
+                onNodeHover={handleNodeHover}
+                onNodeLocking={handleNodeLocking}
+                onNodePickerOpen={handleNodePickerOpen}
+                onEdgesUpdate={handleEdgesUpdate}
+                onEdgeHover={handleEdgeHover}
+              />
+            </OverlayUI>
+            <BottomPanel
+              currentWorkflowId={currentWorkflowId}
+              openWorkflows={openWorkflows}
+              isOpen={openPanel === "bottom" && !locallyLockedNode}
+              onOpen={handlePanelOpen}
+              onWorkflowClose={handleWorkflowClose}
+              onWorkflowChange={handleWorkflowChange}
+            />
+          </div>
+          <RightPanel selected={locallyLockedNode} />
         </div>
-        <RightPanel selected={locallyLockedNode} />
       </div>
-    </div>
+    </LockerProvider>
   );
 }

--- a/ui/src/features/Editor/useInteractionLocker.tsx
+++ b/ui/src/features/Editor/useInteractionLocker.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useContext, useState, useCallback } from "react";
+import { useReactFlow } from "@xyflow/react";
+import type { Node } from "@flow/types";
+
+type LockerContextType = {
+  interactionLockedNodes: Node[];
+  lockNodeInteraction: (node: Node) => void;
+  unlockNodeInteraction: (node: Node) => void;
+  unlockAllNodes: () => void;
+};
+
+const LockerContext = createContext<LockerContextType | undefined>(undefined);
+
+export const LockerProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [interactionLockedNodes, setInteractionLockedNodes] = useState<Node[]>(
+    [],
+  );
+  const { fitView } = useReactFlow();
+
+  const lockNodeInteraction = useCallback(
+    (node: Node) => {
+      setInteractionLockedNodes((currentLockedNodes) => {
+        if (currentLockedNodes.some((n) => n.id === node.id))
+          return currentLockedNodes;
+
+        const updatedLockedNodes = [...currentLockedNodes, node];
+        fitView({
+          nodes: [{ id: node.id }],
+          duration: 500,
+          padding: 2,
+        });
+        return updatedLockedNodes;
+      });
+    },
+    [fitView],
+  );
+
+  const unlockNodeInteraction = useCallback((node: Node) => {
+    setInteractionLockedNodes((currentLockedNodes) =>
+      currentLockedNodes.filter((n) => n.id !== node.id),
+    );
+  }, []);
+
+  const unlockAllNodes = useCallback(() => {
+    setInteractionLockedNodes([]);
+  }, []);
+
+  return (
+    <LockerContext.Provider
+      value={{
+        interactionLockedNodes,
+        lockNodeInteraction,
+        unlockNodeInteraction,
+        unlockAllNodes,
+      }}>
+      {children}
+    </LockerContext.Provider>
+  );
+};
+
+export const useLocker = () => {
+  const context = useContext(LockerContext);
+  if (!context) {
+    throw new Error("useLocker must be used within a LockerProvider");
+  }
+  return context;
+};

--- a/ui/src/lib/i18n/locales/en.json
+++ b/ui/src/lib/i18n/locales/en.json
@@ -227,5 +227,6 @@
   "Member has been successfully removed from the workspace.": "",
   "Empty workflow detected": "",
   "You cannot create a deployment without a workflow.": "",
-  "Reload": ""
+  "Reload": "",
+  "Subworkflow": ""
 }

--- a/ui/src/lib/i18n/locales/es.json
+++ b/ui/src/lib/i18n/locales/es.json
@@ -227,5 +227,6 @@
   "Member has been successfully removed from the workspace.": "El miembro ha sido eliminado exitosamente del espacio de trabajo.",
   "Empty workflow detected": "Se detectó un flujo de trabajo vacío",
   "You cannot create a deployment without a workflow.": "No puedes crear un despliegue sin un flujo de trabajo.",
-  "Reload": "Recargar"
+  "Reload": "Recargar",
+  "Subworkflow": ""
 }

--- a/ui/src/lib/i18n/locales/fr.json
+++ b/ui/src/lib/i18n/locales/fr.json
@@ -227,5 +227,6 @@
   "Member has been successfully removed from the workspace.": "Le membre a été supprimé avec succès de l'espace de travail.",
   "Empty workflow detected": "Flux de travail vide détecté",
   "You cannot create a deployment without a workflow.": "Vous ne pouvez pas créer de déploiement sans flux de travail.",
-  "Reload": "Recharger"
+  "Reload": "Recharger",
+  "Subworkflow": ""
 }

--- a/ui/src/lib/i18n/locales/ja.json
+++ b/ui/src/lib/i18n/locales/ja.json
@@ -227,5 +227,6 @@
   "Member has been successfully removed from the workspace.": "メンバーがワークスペースから正常に削除されました。",
   "Empty workflow detected": "空のワークフローが検出されました",
   "You cannot create a deployment without a workflow.": "ワークフローがないとデプロイメントを作成できません。",
-  "Reload": "リロード"
+  "Reload": "リロード",
+  "Subworkflow": "サブワークフロー"
 }

--- a/ui/src/lib/i18n/locales/zh.json
+++ b/ui/src/lib/i18n/locales/zh.json
@@ -227,5 +227,6 @@
   "Member has been successfully removed from the workspace.": "成员已成功从工作区中移除。",
   "Empty workflow detected": "检测到空工作流",
   "You cannot create a deployment without a workflow.": "没有工作流，您无法创建部署。",
-  "Reload": "重新加载"
+  "Reload": "重新加载",
+  "Subworkflow": ""
 }

--- a/ui/src/utils/index.ts
+++ b/ui/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from "./fullscreen";
 export * from "./date";
 export * from "./randomID";
+export * from "./randomIDshort";
 export * from "./cancellableDebounce";
 export * from "./isDefined";
 export * from "./lastOfUrl";

--- a/ui/src/utils/randomIDshort.ts
+++ b/ui/src/utils/randomIDshort.ts
@@ -1,0 +1,12 @@
+export const randomIDshort = (length = 6): string => {
+  let result = "";
+  const characters =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const charactersLength = characters.length;
+
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
+  }
+
+  return result;
+};


### PR DESCRIPTION
# Overview
I made LeftPanel instantly reflect the nodes on the current canvas, and I created a new lock that works with LeftPanel.
## What I've done

- Hide Transformers folder when no transformers
- Show notes, batches, subworkflows on left panel
- Give unique ID to distinguish the same node on LeftPanel
- Double click on item to lock it
- make unlock button in LeftPanel
- zoom canvas to selected item on lock

## What I haven't done
Lock still allows certain interactions on some nodes
## How I tested
Manually
## Screenshot
![image](https://github.com/user-attachments/assets/e85ea59a-1a45-4fb8-82f7-f03932fb0e79)
![image](https://github.com/user-attachments/assets/e7d907bb-2990-4161-9f95-04f8468f7cee)

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced node locking functionality in the editor, enhancing user control over node interactions.
  - Added a new `LockerProvider` to manage locking state across components.
  - Enhanced note editing with real-time updates to content.
  - New icons and improved rendering logic in the LeftPanel for various node types.

- **Localization**
  - Added "Subworkflow" entries in English, Spanish, French, Japanese, and Chinese localization files.

- **Bug Fixes**
  - Improved node creation process to ensure unique names for new nodes.

- **Chores**
  - Cleaned up code by removing commented-out sections and reorganizing props in components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->