### PR TITLE
feat(engine): enhance GeometryLodFilter with target_lods parameter and update processing logic

### DIFF
--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -36,6 +36,7 @@ jobs:
           remove-cached-tools: 'true'
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: "1.82"
           components: clippy, rustfmt
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -36,7 +36,6 @@ jobs:
           remove-cached-tools: 'true'
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.82"
           components: clippy, rustfmt
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@v2

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -1752,6 +1752,17 @@ Filter geometry by lod
       ],
       "format": "uint8",
       "minimum": 0.0
+    },
+    "targetLods": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0.0
+      }
     }
   }
 }

--- a/engine/runtime/geometry/src/algorithm/coords_iter.rs
+++ b/engine/runtime/geometry/src/algorithm/coords_iter.rs
@@ -40,8 +40,16 @@ pub trait CoordsIter {
 // └──────────────────────────┘
 
 impl<T: CoordNum, Z: CoordNum> CoordsIter for Point<T, Z> {
-    type Iter<'a>  = iter::Once<Coordinate<T, Z>> where T: 'a, Z: 'a;
-    type ExteriorIter<'a> = Self::Iter<'a> where T: 'a, Z: 'a;
+    type Iter<'a>
+        = iter::Once<Coordinate<T, Z>>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = Self::Iter<'a>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -64,10 +72,16 @@ impl<T: CoordNum, Z: CoordNum> CoordsIter for Point<T, Z> {
 // └─────────────────────────┘
 
 impl<T: CoordNum, Z: CoordNum> CoordsIter for Line<T, Z> {
-    type Iter<'a> = iter::Chain<iter::Once<Coordinate<T, Z>>, iter::Once<Coordinate<T, Z>>>
-    where T: 'a, Z: 'a;
-    type ExteriorIter<'a> = Self::Iter<'a>
-    where T: 'a, Z: 'a;
+    type Iter<'a>
+        = iter::Chain<iter::Once<Coordinate<T, Z>>, iter::Once<Coordinate<T, Z>>>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = Self::Iter<'a>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -92,10 +106,16 @@ impl<T: CoordNum, Z: CoordNum> CoordsIter for Line<T, Z> {
 type LineStringIter<'a, T, Z> = iter::Copied<slice::Iter<'a, Coordinate<T, Z>>>;
 
 impl<T: CoordNum, Z: CoordNum> CoordsIter for LineString<T, Z> {
-    type Iter<'a> = LineStringIter<'a, T, Z>
-    where T: 'a, Z: 'a;
-    type ExteriorIter<'a> = Self::Iter<'a>
-    where T: 'a, Z: 'a;
+    type Iter<'a>
+        = LineStringIter<'a, T, Z>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = Self::Iter<'a>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -123,10 +143,16 @@ type PolygonIter<'a, T, Z> = iter::Chain<
 >;
 
 impl<T: CoordNum, Z: CoordNum> CoordsIter for Polygon<T, Z> {
-    type Iter<'a> = PolygonIter<'a, T, Z>
-    where T: 'a, Z: 'a;
-    type ExteriorIter<'a> = LineStringIter<'a, T, Z>
-    where T: 'a, Z: 'a;
+    type Iter<'a>
+        = PolygonIter<'a, T, Z>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = LineStringIter<'a, T, Z>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -156,10 +182,16 @@ impl<T: CoordNum, Z: CoordNum> CoordsIter for Polygon<T, Z> {
 // └───────────────────────────────┘
 
 impl<T: CoordNum, Z: CoordNum> CoordsIter for MultiPoint<T, Z> {
-    type Iter<'a> = iter::Flatten<MapCoordsIter<'a, T, slice::Iter<'a, Point<T, Z>>, Point<T, Z>>>
-    where T: 'a, Z: 'a;
-    type ExteriorIter<'a> = Self::Iter<'a>
-    where T: 'a, Z: 'a;
+    type Iter<'a>
+        = iter::Flatten<MapCoordsIter<'a, T, slice::Iter<'a, Point<T, Z>>, Point<T, Z>>>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = Self::Iter<'a>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -182,11 +214,16 @@ impl<T: CoordNum, Z: CoordNum> CoordsIter for MultiPoint<T, Z> {
 // └────────────────────────────────────┘
 
 impl<T: CoordNum, Z: CoordNum> CoordsIter for MultiLineString<T, Z> {
-    type Iter<'a> =
-        iter::Flatten<MapCoordsIter<'a, T, slice::Iter<'a, LineString<T, Z>>, LineString<T, Z>>>
-    where T: 'a, Z: 'a;
-    type ExteriorIter<'a> = Self::Iter<'a>
-    where T: 'a, Z: 'a;
+    type Iter<'a>
+        = iter::Flatten<MapCoordsIter<'a, T, slice::Iter<'a, LineString<T, Z>>, LineString<T, Z>>>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = Self::Iter<'a>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -212,11 +249,16 @@ impl<T: CoordNum, Z: CoordNum> CoordsIter for MultiLineString<T, Z> {
 // └─────────────────────────────────┘
 
 impl<T: CoordNum, Z: CoordNum> CoordsIter for MultiPolygon<T, Z> {
-    type Iter<'a> = iter::Flatten<MapCoordsIter<'a, T, slice::Iter<'a, Polygon<T, Z>>, Polygon<T, Z>>>
-    where T: 'a, Z: 'a;
-    type ExteriorIter<'a> =
-        iter::Flatten<MapExteriorCoordsIter<'a, T, slice::Iter<'a, Polygon<T, Z>>, Polygon<T, Z>>>
-    where T: 'a, Z: 'a;
+    type Iter<'a>
+        = iter::Flatten<MapCoordsIter<'a, T, slice::Iter<'a, Polygon<T, Z>>, Polygon<T, Z>>>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = iter::Flatten<MapExteriorCoordsIter<'a, T, slice::Iter<'a, Polygon<T, Z>>, Polygon<T, Z>>>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -239,10 +281,16 @@ impl<T: CoordNum, Z: CoordNum> CoordsIter for MultiPolygon<T, Z> {
 // └───────────────────────────────────────┘
 
 impl<T: CoordNum, Z: CoordNum> CoordsIter for GeometryCollection<T, Z> {
-    type Iter<'a> = Box<dyn Iterator<Item = Coordinate<T, Z>> + 'a>
-    where T: 'a, Z: 'a;
-    type ExteriorIter<'a> = Box<dyn Iterator<Item = Coordinate<T, Z>> + 'a>
-    where T: 'a, Z: 'a;
+    type Iter<'a>
+        = Box<dyn Iterator<Item = Coordinate<T, Z>> + 'a>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = Box<dyn Iterator<Item = Coordinate<T, Z>> + 'a>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -274,10 +322,16 @@ type RectIter<T, Z> = iter::Chain<
 >;
 
 impl<T: CoordNum, Z: CoordNum> CoordsIter for Rect<T, Z> {
-    type Iter<'a> = RectIter<T, Z>
-    where T: 'a, Z: 'a;
-    type ExteriorIter<'a> = Self::Iter<'a>
-    where T: 'a, Z: 'a;
+    type Iter<'a>
+        = RectIter<T, Z>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = Self::Iter<'a>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -299,10 +353,16 @@ impl<T: CoordNum, Z: CoordNum> CoordsIter for Rect<T, Z> {
 // └─────────────────────────────┘
 
 impl<T: CoordNum, Z: CoordNum> CoordsIter for Triangle<T, Z> {
-    type Iter<'a> = iter::Chain<CoordinateChainOnce<T, Z>, iter::Once<Coordinate<T, Z>>>
-    where T: 'a, Z: 'a;
-    type ExteriorIter<'a> = Self::Iter<'a>
-    where T: 'a, Z: 'a;
+    type Iter<'a>
+        = iter::Chain<CoordinateChainOnce<T, Z>, iter::Once<Coordinate<T, Z>>>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = Self::Iter<'a>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -327,10 +387,16 @@ impl<T: CoordNum, Z: CoordNum> CoordsIter for Triangle<T, Z> {
 // └─────────────────────────────┘
 
 impl<T: CoordNum, Z: CoordNum> CoordsIter for Geometry<T, Z> {
-    type Iter<'a> = GeometryCoordsIter<'a, T, Z>
-    where T: 'a, Z: 'a;
-    type ExteriorIter<'a> = GeometryExteriorCoordsIter<'a, T, Z>
-    where T: 'a, Z: 'a;
+    type Iter<'a>
+        = GeometryCoordsIter<'a, T, Z>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = GeometryExteriorCoordsIter<'a, T, Z>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -392,8 +458,16 @@ impl<T: CoordNum, Z: CoordNum> CoordsIter for Geometry<T, Z> {
 // └──────────────────────────┘
 
 impl<const N: usize, T: CoordNum, Z: CoordNum> CoordsIter for [Coordinate<T, Z>; N] {
-    type Iter<'a> = iter::Copied<slice::Iter<'a, Coordinate<T, Z>>> where T: 'a, Z: 'a;
-    type ExteriorIter<'a> = Self::Iter<'a> where T: 'a, Z: 'a;
+    type Iter<'a>
+        = iter::Copied<slice::Iter<'a, Coordinate<T, Z>>>
+    where
+        T: 'a,
+        Z: 'a;
+    type ExteriorIter<'a>
+        = Self::Iter<'a>
+    where
+        T: 'a,
+        Z: 'a;
     type ScalarXY = T;
     type ScalarZ = Z;
 
@@ -415,8 +489,16 @@ impl<const N: usize, T: CoordNum, Z: CoordNum> CoordsIter for [Coordinate<T, Z>;
 // └──────────────────────────┘
 
 impl<'a, T: CoordNum, Z: CoordNum> CoordsIter for &'a [Coordinate<T, Z>] {
-    type Iter<'b> = iter::Copied<slice::Iter<'b, Coordinate<T, Z>>> where T: 'b, 'a: 'b;
-    type ExteriorIter<'b> = Self::Iter<'b> where T: 'b, 'a: 'b;
+    type Iter<'b>
+        = iter::Copied<slice::Iter<'b, Coordinate<T, Z>>>
+    where
+        T: 'b,
+        'a: 'b;
+    type ExteriorIter<'b>
+        = Self::Iter<'b>
+    where
+        T: 'b,
+        'a: 'b;
     type ScalarXY = T;
     type ScalarZ = Z;
 

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -1756,6 +1756,17 @@
             ],
             "format": "uint8",
             "minimum": 0.0
+          },
+          "targetLods": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
           }
         }
       },


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `targetLods` parameter for the `GeometryLodFilter`, allowing users to specify multiple target Levels of Detail (LOD) for enhanced geometry filtering.

- **Bug Fixes**
	- Improved handling of geometries without valid citygml data, ensuring they are logged and sent to the appropriate port.

- **Refactor**
	- Enhanced readability of type declarations in the `CoordsIter` trait implementations across various geometry types without altering their functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->