### PR TITLE
feat(engine): update plateau-gis-converter dependency to v0.7.0 and add support for Curve geometry type

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -3777,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "macros"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.6.0#1864e7535a9072627ff8d53c69aa5d42f402485a"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.7.0#d424f63f7437b6b191bde6930bf9a9edf7535569"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4221,7 +4221,7 @@ dependencies = [
 [[package]]
 name = "nusamai-citygml"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.6.0#1864e7535a9072627ff8d53c69aa5d42f402485a"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.7.0#d424f63f7437b6b191bde6930bf9a9edf7535569"
 dependencies = [
  "ahash 0.8.11",
  "chrono",
@@ -4242,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "nusamai-gltf"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.6.0#1864e7535a9072627ff8d53c69aa5d42f402485a"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.7.0#d424f63f7437b6b191bde6930bf9a9edf7535569"
 dependencies = [
  "byteorder",
  "nusamai-gltf-json",
@@ -4252,7 +4252,7 @@ dependencies = [
 [[package]]
 name = "nusamai-gltf-json"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.6.0#1864e7535a9072627ff8d53c69aa5d42f402485a"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.7.0#d424f63f7437b6b191bde6930bf9a9edf7535569"
 dependencies = [
  "cesiumtiles",
  "serde",
@@ -4263,7 +4263,7 @@ dependencies = [
 [[package]]
 name = "nusamai-plateau"
 version = "0.0.0-alpha.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.6.0#1864e7535a9072627ff8d53c69aa5d42f402485a"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.7.0#d424f63f7437b6b191bde6930bf9a9edf7535569"
 dependencies = [
  "chrono",
  "flatgeom",
@@ -4281,7 +4281,7 @@ dependencies = [
 [[package]]
 name = "nusamai-projection"
 version = "0.1.0"
-source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.6.0#1864e7535a9072627ff8d53c69aa5d42f402485a"
+source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.7.0#d424f63f7437b6b191bde6930bf9a9edf7535569"
 dependencies = [
  "japan-geoid",
  "thiserror 2.0.3",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -63,10 +63,10 @@ reearth-flow-storage = { path = "runtime/storage" }
 reearth-flow-telemetry = { path = "runtime/telemetry" }
 reearth-flow-types = { path = "runtime/types" }
 
-nusamai-citygml = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.6.0", features = ["serde", "serde_json"] }
-nusamai-gltf = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.6.0" }
-nusamai-plateau = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.6.0", features = ["serde"] }
-nusamai-projection = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.6.0" }
+nusamai-citygml = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.7.0", features = ["serde", "serde_json"] }
+nusamai-gltf = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.7.0" }
+nusamai-plateau = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.7.0", features = ["serde"] }
+nusamai-projection = { git = "https://github.com/reearth/plateau-gis-converter", tag = "v0.7.0" }
 
 Inflector = "0.11.4"
 ahash = "0.8.11"

--- a/engine/runtime/examples/plateau/example_feature_transformer.rs
+++ b/engine/runtime/examples/plateau/example_feature_transformer.rs
@@ -1,5 +1,5 @@
 mod helper;
 
 fn main() {
-    helper::execute("data-convert/08-ubld/workflow.yml");
+    helper::execute("data-convert/10-wtr/workflow.yml");
 }

--- a/engine/runtime/examples/plateau/testdata/workflow/data-convert/10-wtr/workflow.yml
+++ b/engine/runtime/examples/plateau/testdata/workflow/data-convert/10-wtr/workflow.yml
@@ -1,0 +1,90 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/workflow.json
+id: 08c6ab83-f903-492e-9c58-e36678e39b00
+name: "DataConvert-10-wtr-workflow"
+entryGraphId: d43daf2e-69f9-44fb-a67d-ad974960fd1a
+with:
+  cityGmlPath:
+  cityCode:
+  codelistsPath:
+  schemasPath:
+  schemaJson: !include ../../../config/schema.txt
+  targetPackages:
+    - wtr
+  addNsprefixToFeatureTypes: true
+  extractDmGeometryAsXmlFragment: false
+  outputPath:
+graphs:
+  - !include ../../../graphs/folder_and_file_path_reader.yml
+  - id: d43daf2e-69f9-44fb-a67d-ad974960fd1a
+    name: entry_point
+    nodes:
+      - id: d5fa7732-ef20-45ec-a331-e6d57571354b
+        name: FolderAndfilePathReader
+        type: subGraph
+        subGraphId: c6863b71-953b-4d15-af56-396fc93fc617
+
+      - id: 254d6287-7649-4647-9ab5-0c1c423f356a
+        name: FeatureReaderByCityGml
+        type: action
+        action: FeatureReader
+        with:
+          format: citygml
+          dataset: |
+            env.get("__value").cityGmlPath
+
+      - id: 6e5ed9fc-006e-4dbe-8699-4663dba795cb
+        name: AttributeMapperwtr
+        type: action
+        action: AttributeMapper
+        with:
+          mappers:
+            - attribute: meshcode
+              valueAttribute: meshCode
+            - attribute: city_code
+              valueAttribute: cityCode
+            - attribute: city_name
+              valueAttribute: cityName
+            - attribute: feature_type
+              valueAttribute: gmlName
+            - attribute: gml_id
+              valueAttribute: gmlId
+
+      - id: 928e21d9-fc30-4876-ba03-41338cfa47ed
+        name: VerticalReprojectorwtr
+        type: action
+        action: VerticalReprojector
+        with:
+          reprojectorType: jgd2011ToWgs84
+
+      - id: b4862d31-4bb2-49b1-8f0d-6d58dd4cb385
+        name: Cesium3DTilesWriterBywtr
+        type: action
+        action: Cesium3DTilesWriter
+        with:
+          minZoom: 15
+          maxZoom: 18
+          attachTexture: true
+          output: |
+             file::join_path(env.get("outputPath"), "wtr")
+
+    edges:
+      - id: a4751655-5956-4e27-a976-e35f8914ad31
+        from: d5fa7732-ef20-45ec-a331-e6d57571354b
+        to: 254d6287-7649-4647-9ab5-0c1c423f356a
+        fromPort: default
+        toPort: default
+      - id: 86ec56d6-cefb-48ca-a72d-0c57a33d198a
+        from: 254d6287-7649-4647-9ab5-0c1c423f356a
+        to: 6e5ed9fc-006e-4dbe-8699-4663dba795cb
+        fromPort: default
+        toPort: default
+      - id: 6b857fe4-c6c1-4ed3-ac6e-f7eef19c9248
+        from: 6e5ed9fc-006e-4dbe-8699-4663dba795cb
+        to: 928e21d9-fc30-4876-ba03-41338cfa47ed
+        fromPort: default
+        toPort: default
+      - id: e862f11a-88a6-4c1b-a743-ba80253039df
+        from: 928e21d9-fc30-4876-ba03-41338cfa47ed
+        to: b4862d31-4bb2-49b1-8f0d-6d58dd4cb385
+        fromPort: default
+        toPort: default

--- a/engine/runtime/types/src/conversion/nusamai.rs
+++ b/engine/runtime/types/src/conversion/nusamai.rs
@@ -1,6 +1,7 @@
 use nusamai_citygml::GeometryRef;
 use nusamai_citygml::{object::ObjectStereotype, GeometryType, Value};
 use nusamai_plateau::Entity;
+use reearth_flow_geometry::types::line_string::LineString3D;
 use reearth_flow_geometry::types::polygon::Polygon3D;
 
 use crate::error::Error;
@@ -43,7 +44,19 @@ impl TryFrom<Entity> for Geometry {
                     geometry_feature.polygons.extend(polygons);
                     Some(geometry_feature)
                 }
-                GeometryType::Curve => unimplemented!(),
+                GeometryType::Curve => {
+                    let mut linestrings = Vec::<LineString3D<f64>>::new();
+                    for idx_linestring in geoms
+                        .multilinestring
+                        .iter_range(geometry.pos as usize..(geometry.pos + geometry.len) as usize)
+                    {
+                        let linestring = idx_linestring.transform(|c| geoms.vertices[*c as usize]);
+                        linestrings.push(linestring.into());
+                    }
+                    let mut geometry_feature = GmlGeometry::from(geometry.clone());
+                    geometry_feature.line_strings.extend(linestrings);
+                    Some(geometry_feature)
+                }
                 GeometryType::Point => unimplemented!(),
             }
         };

--- a/engine/runtime/types/src/geometry.rs
+++ b/engine/runtime/types/src/geometry.rs
@@ -271,22 +271,30 @@ impl GmlGeometry {
         self.polygons
             .iter_mut()
             .for_each(|poly| poly.transform_inplace(jgd2wgs));
+        self.line_strings
+            .iter_mut()
+            .for_each(|line| line.transform_inplace(jgd2wgs));
     }
 
     pub fn transform_offset(&mut self, x: f64, y: f64, z: f64) {
         self.polygons
             .iter_mut()
             .for_each(|poly| poly.transform_offset(x, y, z));
+        self.line_strings
+            .iter_mut()
+            .for_each(|line| line.transform_offset(x, y, z));
     }
 }
 
 impl From<GmlGeometry> for Vec<geojson::Value> {
     fn from(feature: GmlGeometry) -> Self {
-        feature
+        let mut values = feature
             .polygons
             .into_iter()
             .map(|poly| poly.into())
-            .collect()
+            .collect::<Vec<_>>();
+        values.extend(feature.line_strings.into_iter().map(|line| line.into()));
+        values
     }
 }
 

--- a/engine/runtime/types/src/geometry.rs
+++ b/engine/runtime/types/src/geometry.rs
@@ -3,6 +3,7 @@ use std::hash::Hash;
 
 use nusamai_projection::vshift::Jgd2011ToWgs84;
 use reearth_flow_geometry::types::coordnum::CoordNum;
+use reearth_flow_geometry::types::line_string::LineString3D;
 use reearth_flow_geometry::types::traits::Elevation;
 
 use nusamai_projection::crs::EpsgCode;
@@ -255,6 +256,7 @@ pub struct GmlGeometry {
     pub pos: u32,
     pub len: u32,
     pub polygons: Vec<Polygon3D<f64>>,
+    pub line_strings: Vec<LineString3D<f64>>,
     pub feature_id: Option<String>,
     pub feature_type: Option<String>,
     pub composite_surfaces: Vec<GmlGeometry>,
@@ -381,6 +383,7 @@ impl From<nusamai_citygml::geometry::GeometryRef> for GmlGeometry {
             pos: geometry.pos,
             len: geometry.len,
             polygons: Vec::new(),
+            line_strings: Vec::new(),
             feature_id: geometry.feature_id,
             feature_type: geometry.feature_type,
             composite_surfaces: Vec::new(),


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Updated dependencies to version `v0.7.0` for enhanced functionality.
	- Introduced a new YAML workflow for data conversion processes targeting city GML data.
	- Enhanced geometry handling to support 3D line string geometries.

- **Bug Fixes**
	- Improved handling of curve geometries in the conversion process.

- **Documentation**
	- Added detailed descriptions for new workflow actions and their interconnections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->