### PR TITLE
refactor(ui): add key action support for dialog navigation

### DIFF
--- a/ui/src/components/ActionItem/index.tsx
+++ b/ui/src/components/ActionItem/index.tsx
@@ -1,4 +1,4 @@
-import { DragEvent, MouseEvent, useCallback } from "react";
+import { DragEvent, MouseEvent, useCallback, forwardRef } from "react";
 
 import { Action } from "@flow/types";
 
@@ -15,72 +15,79 @@ type Props = {
   onDoubleClick?: (name?: string) => void;
 };
 
-const ActionItem: React.FC<Props> = ({
-  className,
-  action,
-  selected,
-  draggable,
-  onMouseDown,
-  onTypeClick,
-  onCategoryClick,
-  onDragStart,
-  onSingleClick,
-  onDoubleClick,
-}) => {
-  const handleTypeClick = useCallback(
-    (type: string) => (e: MouseEvent) => {
-      if (!onTypeClick) return;
-      e.stopPropagation();
-      onTypeClick(type);
+const ActionItem = forwardRef<HTMLDivElement, Props>(
+  (
+    {
+      className,
+      action,
+      selected,
+      draggable,
+      onMouseDown,
+      onTypeClick,
+      onCategoryClick,
+      onDragStart,
+      onSingleClick,
+      onDoubleClick,
     },
-    [onTypeClick],
-  );
+    ref,
+  ) => {
+    const handleTypeClick = useCallback(
+      (type: string) => (e: MouseEvent) => {
+        if (!onTypeClick) return;
+        e.stopPropagation();
+        onTypeClick(type);
+      },
+      [onTypeClick],
+    );
 
-  const handleCategoryClick = useCallback(
-    (category: string) => (e: MouseEvent) => {
-      e.stopPropagation();
-      onCategoryClick?.(category);
-    },
-    [onCategoryClick],
-  );
-  return (
-    <div
-      key={action.name}
-      className={`group cursor-pointer rounded p-2 ${selected ? "bg-primary text-accent-foreground" : "hover:bg-primary hover:text-accent-foreground"} ${className}`}
-      onClick={() => onSingleClick?.(action.name)}
-      onDoubleClick={() => onDoubleClick?.(action.name)}
-      draggable={draggable}
-      onMouseDown={onMouseDown}
-      onDragStart={(e) => onDragStart?.(e, action.name)}>
-      <div className="flex w-full justify-between gap-1 pb-2">
-        <div className="w-3/5 self-center break-words text-sm">
-          <p className="self-center text-zinc-200">{action.name}</p>
+    const handleCategoryClick = useCallback(
+      (category: string) => (e: MouseEvent) => {
+        e.stopPropagation();
+        onCategoryClick?.(category);
+      },
+      [onCategoryClick],
+    );
+
+    return (
+      <div
+        ref={ref}
+        key={action.name}
+        className={`group cursor-pointer rounded p-2 ${selected ? "bg-primary text-accent-foreground" : "hover:bg-primary hover:text-accent-foreground"} ${className}`}
+        onClick={() => onSingleClick?.(action.name)}
+        onDoubleClick={() => onDoubleClick?.(action.name)}
+        draggable={draggable}
+        onMouseDown={onMouseDown}
+        onDragStart={(e) => onDragStart?.(e, action.name)}>
+        <div className="flex w-full justify-between gap-1 pb-2">
+          <div className="w-3/5 self-center break-words text-sm">
+            <p className="self-center text-zinc-200">{action.name}</p>
+          </div>
+          <div
+            className={`self-center rounded border ${action.type === "transformer" ? "bg-node-transformer/30" : action.type === "reader" ? "bg-node-reader/30" : action.type === "writer" ? "bg-node-writer/30" : "bg-popover"} p-1 align-middle`}
+            onClick={handleTypeClick(action.type)}>
+            <p className="self-center text-xs capitalize text-zinc-200">
+              {action.type}
+            </p>
+          </div>
         </div>
-        <div
-          className={`self-center rounded border ${action.type === "transformer" ? "bg-node-transformer/30" : action.type === "reader" ? "bg-node-reader/30" : action.type === "writer" ? "bg-node-writer/30" : "bg-popover"} p-1 align-middle`}
-          onClick={handleTypeClick(action.type)}>
-          <p className="self-center text-xs capitalize text-zinc-200">
-            {action.type}
-          </p>
+        <div className="group-hover:block">
+          <div className="mb-2 text-xs leading-[0.85rem]">
+            {action.description}
+          </div>
+          <div className="flex flex-wrap gap-1 text-xs">
+            {action.categories.map((c) => (
+              <div
+                className="rounded border bg-popover p-[2px]"
+                key={c}
+                onClick={handleCategoryClick(c)}>
+                <p className="text-zinc-400">{c}</p>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
-      <div className="group-hover:block">
-        <div className="mb-2 text-xs leading-[0.85rem]">
-          {action.description}
-        </div>
-        <div className="flex flex-wrap gap-1 text-xs">
-          {action.categories.map((c) => (
-            <div
-              className="rounded border bg-popover p-[2px]"
-              key={c}
-              onClick={handleCategoryClick(c)}>
-              <p className="text-zinc-400">{c}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-};
+    );
+  },
+);
 
 export default ActionItem;

--- a/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
@@ -120,14 +120,16 @@ const NodePickerDialog: React.FC<Props> = ({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      e.preventDefault();
       if (e.key === "Enter") {
+        e.preventDefault();
         handleDoubleClick(selected);
       } else if (e.key === "ArrowUp") {
+        e.preventDefault();
         setSelectedIndex((prevIndex) =>
           prevIndex === 0 ? prevIndex : prevIndex - 1,
         );
       } else if (e.key === "ArrowDown") {
+        e.preventDefault();
         setSelectedIndex((prevIndex) =>
           prevIndex === (actions?.length || 1) - 1 ? prevIndex : prevIndex + 1,
         );

--- a/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
@@ -1,6 +1,6 @@
 import { XYPosition } from "@xyflow/react";
 import { debounce } from "lodash-es";
-import { Fragment, useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 
 import { Dialog, DialogContent, DialogTitle, Input } from "@flow/components";
 import ActionItem from "@flow/components/ActionItem";
@@ -33,8 +33,10 @@ const NodePickerDialog: React.FC<Props> = ({
   const t = useT();
   const { useGetActionsSegregated } = useAction();
   const { actions: rawActions } = useGetActionsSegregated();
-
   const [actions, setActions] = useState<Action[] | undefined>();
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   useEffect(() => {
     if (rawActions && openedActionType?.nodeType)
@@ -42,6 +44,19 @@ const NodePickerDialog: React.FC<Props> = ({
   }, [rawActions, openedActionType.nodeType]);
 
   const [selected, setSelected] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (actions?.length) {
+      setSelected(actions[selectedIndex]?.name);
+      const selectedItem = itemRefs.current[selectedIndex];
+      if (selectedItem && containerRef.current) {
+        selectedItem.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
+      }
+    }
+  }, [selectedIndex, actions]);
 
   const [handleSingleClick, handleDoubleClick] = useDoubleClick(
     (name?: string) => {
@@ -89,7 +104,7 @@ const NodePickerDialog: React.FC<Props> = ({
       ),
     [],
   );
-  // Don't worry too much about this implementation. It's only placeholder till we get an actual one using API
+
   const handleSearch = debounce((filter: string) => {
     if (!filter) {
       setActions(rawActions?.byType[openedActionType.nodeType]);
@@ -103,6 +118,30 @@ const NodePickerDialog: React.FC<Props> = ({
     setActions(filteredActions);
   }, 200);
 
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Enter") {
+        handleDoubleClick(selected);
+      } else if (e.key === "ArrowUp") {
+        setSelectedIndex((prevIndex) =>
+          prevIndex === 0 ? prevIndex : prevIndex - 1,
+        );
+      } else if (e.key === "ArrowDown") {
+        setSelectedIndex((prevIndex) =>
+          prevIndex === (actions?.length || 1) - 1 ? prevIndex : prevIndex + 1,
+        );
+      }
+    },
+    [handleDoubleClick, selected, actions],
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [actions, selected, handleKeyDown]);
+
   return (
     <Dialog open={!!openedActionType} onOpenChange={(o) => !o && onClose()}>
       <DialogContent>
@@ -113,11 +152,12 @@ const NodePickerDialog: React.FC<Props> = ({
           autoFocus
           onChange={(e) => handleSearch(e.target.value)}
         />
-        <div className="max-h-[50vh] overflow-scroll">
+        <div ref={containerRef} className="max-h-[50vh] overflow-scroll">
           {actions?.map((action, idx) => (
             <Fragment key={action.name}>
               <ActionItem
-                className="m-1"
+                ref={(el) => (itemRefs.current[idx] = el)}
+                className={"m-1"}
                 action={action}
                 selected={selected === action.name}
                 onSingleClick={handleSingleClick}

--- a/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
@@ -120,16 +120,14 @@ const NodePickerDialog: React.FC<Props> = ({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      e.preventDefault();
       if (e.key === "Enter") {
-        e.preventDefault();
         handleDoubleClick(selected);
       } else if (e.key === "ArrowUp") {
-        e.preventDefault();
         setSelectedIndex((prevIndex) =>
           prevIndex === 0 ? prevIndex : prevIndex - 1,
         );
       } else if (e.key === "ArrowDown") {
-        e.preventDefault();
         setSelectedIndex((prevIndex) =>
           prevIndex === (actions?.length || 1) - 1 ? prevIndex : prevIndex + 1,
         );

--- a/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
@@ -121,12 +121,15 @@ const NodePickerDialog: React.FC<Props> = ({
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === "Enter") {
+        e.preventDefault();
         handleDoubleClick(selected);
       } else if (e.key === "ArrowUp") {
+        e.preventDefault();
         setSelectedIndex((prevIndex) =>
           prevIndex === 0 ? prevIndex : prevIndex - 1,
         );
       } else if (e.key === "ArrowDown") {
+        e.preventDefault();
         setSelectedIndex((prevIndex) =>
           prevIndex === (actions?.length || 1) - 1 ? prevIndex : prevIndex + 1,
         );


### PR DESCRIPTION
# Overview
Allow users to be able to navigate using arrows keys and "double click" with enter.
## What I've done
Added key support for navigating the menu with up, down and enter keys.
## What I haven't done

## How I tested
manually
## Screenshot

## Which point I want you to review particularly
- Quality
- Improvements
## Memo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced `ActionItem` component to support direct DOM referencing via `ref`.
  - Improved `NodePickerDialog` with keyboard navigation for selecting actions and automatic scrolling to the selected item.

- **Bug Fixes**
  - Ensured the selected action in `NodePickerDialog` scrolls into view when the selection changes.

- **Refactor**
  - Updated component structures to accommodate new functionality while maintaining existing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->