### PR TITLE
fix(ui): Disable Redo & Undo if no actions available

### DIFF
--- a/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
@@ -27,12 +27,13 @@ type CanvasAction = "undo" | "redo";
 type Action = ToolboxItem<CanvasAction>;
 
 type Props = {
-  undoDisabled?: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
   onRedo?: () => void;
   onUndo?: () => void;
 };
 
-const Toolbox: React.FC<Props> = ({ onRedo, onUndo }) => {
+const Toolbox: React.FC<Props> = ({ canUndo, canRedo, onRedo, onUndo }) => {
   const t = useT();
 
   const availableTools: Tool[] = [
@@ -134,6 +135,7 @@ const Toolbox: React.FC<Props> = ({ onRedo, onUndo }) => {
               tooltipPosition="right"
               tooltipText={action.name}
               icon={action.icon}
+              disabled={action.id === "undo" ? !canUndo : !canRedo}
               onClick={() =>
                 action.id === "redo"
                   ? onRedo?.()

--- a/ui/src/features/Editor/components/OverlayUI/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/index.tsx
@@ -19,6 +19,8 @@ type OverlayUIProps = {
     nodeType: ActionNodeType;
   };
   nodes: Node[];
+  canUndo: boolean;
+  canRedo: boolean;
   onWorkflowDeployment: (
     deploymentId?: string,
     description?: string,
@@ -34,6 +36,8 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
   hoveredDetails,
   nodePickerOpen,
   nodes,
+  canUndo,
+  canRedo,
   onWorkflowDeployment,
   onNodesChange,
   onNodePickerClose,
@@ -49,7 +53,12 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
         {/* {devMode && <DevTools />} */}
         {canvas}
         <Breadcrumb />
-        <Toolbox onRedo={onWorkflowRedo} onUndo={onWorkflowUndo} />
+        <Toolbox
+          canUndo={canUndo}
+          canRedo={canRedo}
+          onRedo={onWorkflowRedo}
+          onUndo={onWorkflowUndo}
+        />
         <ActionBar
           allowedToDeploy={allowedToDeploy}
           onWorkflowDeployment={onWorkflowDeployment}

--- a/ui/src/features/Editor/hooks.ts
+++ b/ui/src/features/Editor/hooks.ts
@@ -45,6 +45,8 @@ export default ({
     handleWorkflowUndo,
     handleWorkflowRedo,
     handleWorkflowRename,
+    canUndo,
+    canRedo,
   } = useYjsStore({
     workflowId: currentWorkflowId,
     yWorkflows,
@@ -196,5 +198,7 @@ export default ({
     handleWorkflowRedo,
     handleWorkflowUndo,
     handleWorkflowRename,
+    canUndo,
+    canRedo,
   };
 };

--- a/ui/src/features/Editor/index.tsx
+++ b/ui/src/features/Editor/index.tsx
@@ -32,6 +32,8 @@ export default function Editor({
     hoveredDetails,
     nodePickerOpen,
     openPanel,
+    canUndo,
+    canRedo,
     handleWorkflowAdd,
     handleWorkflowDeployment,
     handlePanelOpen,
@@ -63,6 +65,8 @@ export default function Editor({
             hoveredDetails={hoveredDetails}
             nodePickerOpen={nodePickerOpen}
             nodes={nodes}
+            canUndo={canUndo}
+            canRedo={canRedo}
             onWorkflowDeployment={handleWorkflowDeployment}
             onWorkflowUndo={handleWorkflowUndo}
             onWorkflowRedo={handleWorkflowRedo}

--- a/ui/src/lib/yjs/useYjsStore.ts
+++ b/ui/src/lib/yjs/useYjsStore.ts
@@ -37,17 +37,18 @@ export default ({
   const { createDeployment, useUpdateDeployment } = useDeployment();
 
   const handleWorkflowUndo = useCallback(() => {
-    if (undoManager?.undoStack && undoManager.undoStack.length > 0) {
+    const stackLength = undoManager?.undoStack?.length ?? 0;
+    if (stackLength > 0) {
       undoManager?.undo();
     }
   }, [undoManager]);
 
   const handleWorkflowRedo = useCallback(() => {
-    if (undoManager?.redoStack && undoManager.redoStack.length > 0) {
+    const stackLength = undoManager?.redoStack?.length ?? 0;
+    if (stackLength > 0) {
       undoManager?.redo();
     }
   }, [undoManager]);
-
   const canUndo = useMemo(() => {
     const stackLength = undoManager?.undoStack?.length ?? 0;
     return stackLength > 0;

--- a/ui/src/lib/yjs/useYjsStore.ts
+++ b/ui/src/lib/yjs/useYjsStore.ts
@@ -48,6 +48,16 @@ export default ({
     }
   }, [undoManager]);
 
+  const canUndo = useMemo(() => {
+    const stackLength = undoManager?.undoStack?.length ?? 0;
+    return stackLength > 0;
+  }, [undoManager?.undoStack?.length]);
+
+  const canRedo = useMemo(() => {
+    const stackLength = undoManager?.redoStack?.length ?? 0;
+    return stackLength > 0;
+  }, [undoManager?.redoStack?.length]);
+
   const rawWorkflows = useY(yWorkflows);
 
   const {
@@ -166,6 +176,8 @@ export default ({
     handleEdgesUpdate,
     handleWorkflowUndo,
     handleWorkflowRedo,
+    canUndo,
+    canRedo,
     handleWorkflowRename,
   };
 };


### PR DESCRIPTION
# Overview
Currently the buttons are forever clickable and no ui difference when there is, or isn’t, available undo or redo actions.
What we want is a UI indication that there are no actions available and have it so the user can’t click them either.
## What I've done
Track the length of the undoManagement stack to check if it has any history.
## What I haven't done

## How I tested
Manually
## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `canUndo` and `canRedo` properties to enhance the functionality of the Toolbox and OverlayUI components, allowing for better control of undo and redo actions.
  - Updated the Editor component to reflect the current state of undo and redo capabilities.
  - Enhanced state management in the application by integrating new properties into the hooks and components.

- **Bug Fixes**
  - Improved the interaction logic for the undo and redo buttons to ensure they accurately reflect the application's state.

- **Documentation**
  - Updated type definitions to include new properties, improving clarity for developers using these components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->