### PR TITLE
feat(engine): enhance schema action command with language file support and i18n integration

### DIFF
--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -61,16 +61,38 @@ git ls-files |grep -E '.rs$' |(! xargs grep 'todo!')
 [tasks.doc-action]
 script = ['''
 #!/usr/bin/env bash -eux
-rm -rf ./schema/actions.json
-rm -rf ./docs/mdbook/src/action.md
+FILES=(
+  "./schema/actions.json"
+  "./schema/actions_en.json"
+  "./schema/actions_es.json"
+  "./schema/actions_fr.json"
+  "./schema/actions_ja.json"
+  "./schema/actions_zh.json"
+  "./docs/mdbook/src/action.md"
+)
+
+for f in "${FILES[@]}"; do
+  rm -rf "$f"
+done
+
 cargo run --package reearth-flow-cli -- schema-action > ./schema/actions.json
+
+LANGS=(en es fr ja zh)
+
+for lang in "${LANGS[@]}"; do
+  cargo run --package reearth-flow-cli \
+    -- schema-action \
+    --language-file-path "$PWD/schema/i18n/actions/${lang}.json" \
+    > "./schema/actions_${lang}.json"
+done
+
 cargo run --package reearth-flow-cli -- doc-action > ./docs/mdbook/src/action.md
 ''']
 
 [tasks.doc-workflow]
 script = ['''
 #!/usr/bin/env bash -eux
-rm -rf ../schema/workflow.json
+rm -rf ./schema/workflow.json
 cargo run --package reearth-flow-cli -- schema-workflow > ./schema/workflow.json
 ''']
 

--- a/engine/cli/src/cli.rs
+++ b/engine/cli/src/cli.rs
@@ -51,7 +51,9 @@ impl CliCommand {
         match subcommand.as_str() {
             "run" => RunCliCommand::parse_cli_args(submatches).map(CliCommand::Run),
             "dot" => DotCliCommand::parse_cli_args(submatches).map(CliCommand::Dot),
-            "schema-action" => Ok(CliCommand::SchemaAction(SchemaActionCliCommand)),
+            "schema-action" => Ok(CliCommand::SchemaAction(
+                SchemaActionCliCommand::parse_cli_args(submatches)?,
+            )),
             "schema-workflow" => Ok(CliCommand::SchemaWorkflow(SchemaWorkflowCliCommand)),
             "doc-action" => Ok(CliCommand::DocAction(DocActionCliCommand)),
             _ => Err(crate::errors::Error::unknown_command(subcommand)),

--- a/engine/cli/src/doc_action.rs
+++ b/engine/cli/src/doc_action.rs
@@ -21,6 +21,7 @@ pub struct DocActionCliCommand;
 impl DocActionCliCommand {
     pub fn execute(&self) -> crate::Result<()> {
         let mut builtin_action_factories = HashMap::new();
+        let i18n = HashMap::new();
         builtin_action_factories.extend(BUILTIN_ACTION_FACTORIES.clone());
         builtin_action_factories.insert(
             "Router".to_string(),
@@ -29,18 +30,18 @@ impl DocActionCliCommand {
         let mut actions = builtin_action_factories
             .clone()
             .values()
-            .map(|kind| create_action_schema(kind, true))
+            .map(|kind| create_action_schema(kind, true, &i18n))
             .collect::<Vec<_>>();
         let plateau_actions = PLATEAU_ACTION_FACTORIES
             .clone()
             .values()
-            .map(|kind| create_action_schema(kind, false))
+            .map(|kind| create_action_schema(kind, false, &i18n))
             .collect::<Vec<_>>();
         actions.extend(plateau_actions);
         let wasm_actions = WASM_ACTION_FACTORIES
             .clone()
             .values()
-            .map(|kind| create_action_schema(kind, false))
+            .map(|kind| create_action_schema(kind, false, &i18n))
             .collect::<Vec<_>>();
         actions.extend(wasm_actions);
         actions.sort_by(|a, b| a.name.cmp(&b.name));

--- a/engine/cli/src/schema_action.rs
+++ b/engine/cli/src/schema_action.rs
@@ -1,12 +1,12 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fs::File, io::BufReader};
 
-use clap::Command;
+use clap::{Arg, ArgMatches, Command};
 use reearth_flow_runtime::node::{NodeKind, RouterFactory};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     factory::{BUILTIN_ACTION_FACTORIES, PLATEAU_ACTION_FACTORIES, WASM_ACTION_FACTORIES},
-    utils::{create_action_schema, ActionSchema},
+    utils::{create_action_schema, ActionSchema, I18nSchema},
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -15,17 +15,54 @@ pub struct RootActionSchema {
     pub actions: Vec<ActionSchema>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RootI18nSchema {
+    pub actions: Vec<I18nSchema>,
+}
+
 pub fn build_schema_action_command() -> Command {
     Command::new("schema-action")
         .about("Show action schema.")
         .long_about("Show action schema.")
+        .arg(language_file_path_cli_arg())
+}
+
+fn language_file_path_cli_arg() -> Arg {
+    Arg::new("language_file_path")
+        .long("language-file-path")
+        .help("Language file path")
+        .required(false)
+        .display_order(1)
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct SchemaActionCliCommand;
+pub struct SchemaActionCliCommand {
+    pub language_file_path: Option<String>,
+}
 
 impl SchemaActionCliCommand {
+    pub fn parse_cli_args(mut matches: ArgMatches) -> crate::Result<Self> {
+        let language_file_path = matches
+            .try_remove_one::<String>("language_file_path")
+            .unwrap_or_default();
+        Ok(SchemaActionCliCommand { language_file_path })
+    }
+
     pub fn execute(&self) -> crate::Result<()> {
+        let i18n = if let Some(language_file_path) = &self.language_file_path {
+            let file = File::open(language_file_path)
+                .map_err(|e| crate::errors::Error::init(format!("{:?}", e)))?;
+            let reader = BufReader::new(file);
+            let i18n: RootI18nSchema = serde_json::from_reader(reader)
+                .map_err(|e| crate::errors::Error::init(format!("{:?}", e)))?;
+            i18n.actions
+                .into_iter()
+                .map(|action| (action.name.clone(), action.clone()))
+                .collect::<HashMap<_, _>>()
+        } else {
+            HashMap::new()
+        };
         let mut builtin_action_factories = HashMap::new();
         builtin_action_factories.extend(BUILTIN_ACTION_FACTORIES.clone());
         builtin_action_factories.insert(
@@ -35,18 +72,18 @@ impl SchemaActionCliCommand {
         let mut actions = builtin_action_factories
             .clone()
             .values()
-            .map(|kind| create_action_schema(kind, true))
+            .map(|kind| create_action_schema(kind, true, &i18n))
             .collect::<Vec<_>>();
         let plateau_actions = PLATEAU_ACTION_FACTORIES
             .clone()
             .values()
-            .map(|kind| create_action_schema(kind, false))
+            .map(|kind| create_action_schema(kind, false, &i18n))
             .collect::<Vec<_>>();
         actions.extend(plateau_actions);
         let wasm_actions = WASM_ACTION_FACTORIES
             .clone()
             .values()
-            .map(|kind| create_action_schema(kind, false))
+            .map(|kind| create_action_schema(kind, false, &i18n))
             .collect::<Vec<_>>();
         actions.extend(wasm_actions);
         actions.sort_by(|a, b| a.name.cmp(&b.name));

--- a/engine/cli/src/utils.rs
+++ b/engine/cli/src/utils.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use reearth_flow_runtime::node::NodeKind;
 use serde::{Deserialize, Serialize};
 
@@ -39,11 +41,24 @@ impl ActionSchema {
     }
 }
 
-pub(crate) fn create_action_schema(kind: &NodeKind, builtin: bool) -> ActionSchema {
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct I18nSchema {
+    pub name: String,
+    pub description: String,
+}
+
+pub(crate) fn create_action_schema(
+    kind: &NodeKind,
+    builtin: bool,
+    i18n: &HashMap<String, I18nSchema>,
+) -> ActionSchema {
     let (name, description, parameter, input_ports, output_ports, categories) = match kind {
         NodeKind::Source(factory) => (
             factory.name().to_string(),
-            factory.description().to_string(),
+            i18n.get(&factory.name().to_string())
+                .map(|schema| schema.description.clone())
+                .unwrap_or(factory.description().to_string()),
             factory
                 .parameter_schema()
                 .map_or(serde_json::Value::Null, |schema| {
@@ -59,7 +74,9 @@ pub(crate) fn create_action_schema(kind: &NodeKind, builtin: bool) -> ActionSche
         ),
         NodeKind::Processor(factory) => (
             factory.name().to_string(),
-            factory.description().to_string(),
+            i18n.get(&factory.name().to_string())
+                .map(|schema| schema.description.clone())
+                .unwrap_or(factory.description().to_string()),
             factory
                 .parameter_schema()
                 .map_or(serde_json::Value::Null, |schema| {
@@ -79,7 +96,9 @@ pub(crate) fn create_action_schema(kind: &NodeKind, builtin: bool) -> ActionSche
         ),
         NodeKind::Sink(factory) => (
             factory.name().to_string(),
-            factory.description().to_string(),
+            i18n.get(&factory.name().to_string())
+                .map(|schema| schema.description.clone())
+                .unwrap_or(factory.description().to_string()),
             factory
                 .parameter_schema()
                 .map_or(serde_json::Value::Null, |schema| {

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -1,0 +1,2944 @@
+{
+  "actions": [
+    {
+      "name": "AreaOnAreaOverlayer",
+      "type": "processor",
+      "description": "Overlays an area on another area",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AreaOnAreaOverlayerParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "remnants",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "AttributeAggregator",
+      "type": "processor",
+      "description": "Aggregates features by attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeAggregatorParam",
+        "type": "object",
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
+        "properties": {
+          "aggregateAttributes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AggregateAttribute"
+            }
+          },
+          "calculation": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calculationAttribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "calculationValue": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "method": {
+            "$ref": "#/definitions/Method"
+          }
+        },
+        "definitions": {
+          "AggregateAttribute": {
+            "type": "object",
+            "required": [
+              "newAttribute"
+            ],
+            "properties": {
+              "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "max",
+              "min",
+              "count"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeDuplicateFilter",
+      "type": "processor",
+      "description": "Filters features by duplicate attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeDuplicateFilterParam",
+        "type": "object",
+        "required": [
+          "filterBy"
+        ],
+        "properties": {
+          "filterBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeFilePathInfoExtractor",
+      "type": "processor",
+      "description": "Extracts file path information from attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeFilePathInfoExtractor",
+        "type": "object",
+        "required": [
+          "attribute"
+        ],
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeManager",
+      "type": "processor",
+      "description": "Manages attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeManagerParam",
+        "type": "object",
+        "required": [
+          "operations"
+        ],
+        "properties": {
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Operation"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "convert",
+              "create",
+              "rename",
+              "remove"
+            ]
+          },
+          "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/definitions/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeMapper",
+      "type": "processor",
+      "description": "Maps attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeMapperParam",
+        "type": "object",
+        "required": [
+          "mappers"
+        ],
+        "properties": {
+          "mappers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Mapper"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Mapper": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "childAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "multipleExpr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "parentAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "BoundsExtractor",
+      "type": "processor",
+      "description": "Bounds Extractor",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Bufferer",
+      "type": "processor",
+      "description": "Buffers a geometry",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Bufferer",
+        "type": "object",
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
+        "properties": {
+          "bufferType": {
+            "$ref": "#/definitions/BufferType"
+          },
+          "distance": {
+            "type": "number",
+            "format": "double"
+          },
+          "interpolationAngle": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "definitions": {
+          "BufferType": {
+            "type": "string",
+            "enum": [
+              "area2d"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "BulkAttributeRenamer",
+      "type": "processor",
+      "description": "Renames attributes by adding/removing prefixes or suffixes, or replacing text",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "BulkAttributeRenamerParam",
+        "type": "object",
+        "required": [
+          "renameAction",
+          "renameType",
+          "renameValue"
+        ],
+        "properties": {
+          "renameAction": {
+            "$ref": "#/definitions/RenameAction"
+          },
+          "renameType": {
+            "$ref": "#/definitions/RenameType"
+          },
+          "renameValue": {
+            "type": "string"
+          },
+          "selectedAttributes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "definitions": {
+          "RenameAction": {
+            "type": "string",
+            "enum": [
+              "AddPrefix",
+              "AddSuffix",
+              "RemovePrefix",
+              "RemoveSuffix",
+              "StringReplace"
+            ]
+          },
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "CenterPointReplacer",
+      "type": "processor",
+      "description": "Replaces the geometry of the feature with a point that is either in the center of the feature's bounding box, at the center of mass of the feature, or somewhere guaranteed to be inside the feature's area.",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "point",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Cesium3DTilesWriter",
+      "type": "sink",
+      "description": "Writes features to a file",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Cesium3DTilesWriterParam",
+        "type": "object",
+        "required": [
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
+        "properties": {
+          "attachTexture": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "Clipper",
+      "type": "processor",
+      "description": "Divides Candidate features using Clipper features, so that Candidates and parts of Candidates that are inside or outside of the Clipper features are output separately",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "clipper",
+        "candidate"
+      ],
+      "outputPorts": [
+        "inside",
+        "outside",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ClosedCurveFilter",
+      "type": "processor",
+      "description": "Checks if curves form closed loops",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "closed",
+        "open",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "CoordinateSystemSetter",
+      "type": "processor",
+      "description": "Sets the coordinate system of a feature",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "CoordinateSystemSetter",
+        "type": "object",
+        "required": [
+          "epsgCode"
+        ],
+        "properties": {
+          "epsgCode": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "DimensionFilter",
+      "type": "processor",
+      "description": "Filters the dimension of features",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "2d",
+        "3d",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "EchoProcessor",
+      "type": "processor",
+      "description": "Echo features",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "EchoSink",
+      "type": "sink",
+      "description": "Echo features",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "ElevationExtractor",
+      "type": "processor",
+      "description": "Extracts a feature’s first z coordinate value, storing it in an attribute.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ElevationExtractorParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Extruder",
+      "type": "processor",
+      "description": "Extrudes a polygon by a distance",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ExtruderParam",
+        "type": "object",
+        "required": [
+          "distance"
+        ],
+        "properties": {
+          "distance": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "FeatureCounter",
+      "type": "processor",
+      "description": "Counts features",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureCounterParam",
+        "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
+        "properties": {
+          "countStart": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "type": "string"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureCreator",
+      "type": "source",
+      "description": "Creates features from expressions",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureCreator",
+        "type": "object",
+        "required": [
+          "creator"
+        ],
+        "properties": {
+          "creator": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureFilter",
+      "type": "processor",
+      "description": "Filters features based on conditions",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureFilterParam",
+        "type": "object",
+        "required": [
+          "conditions"
+        ],
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Condition"
+            }
+          }
+        },
+        "definitions": {
+          "Condition": {
+            "type": "object",
+            "required": [
+              "expr",
+              "outputPort"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/definitions/Port"
+              }
+            }
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Port": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "unfiltered"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureMerger",
+      "type": "processor",
+      "description": "Merges features by attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureMergerParam",
+        "type": "object",
+        "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "requestorAttribute": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "requestorAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "supplierAttribute": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "requestor",
+        "supplier"
+      ],
+      "outputPorts": [
+        "merged",
+        "unmerged"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureReader",
+      "type": "processor",
+      "description": "Filters features based on conditions",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureReaderParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureSorter",
+      "type": "processor",
+      "description": "Sorts features by attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureSorterParam",
+        "type": "object",
+        "required": [
+          "sortBy"
+        ],
+        "properties": {
+          "sortBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SortBy"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Order": {
+            "type": "string",
+            "enum": [
+              "ascending",
+              "descending"
+            ]
+          },
+          "SortBy": {
+            "type": "object",
+            "required": [
+              "order"
+            ],
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/definitions/Order"
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureTransformer",
+      "type": "processor",
+      "description": "Transforms features by expressions",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureTransformerParam",
+        "type": "object",
+        "required": [
+          "transformers"
+        ],
+        "properties": {
+          "transformers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Transform"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureTypeFilter",
+      "type": "processor",
+      "description": "Filters features by feature type",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureTypeFilter",
+        "type": "object",
+        "required": [
+          "targetTypes"
+        ],
+        "properties": {
+          "targetTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "unfiltered"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FilePathExtractor",
+      "type": "source",
+      "description": "Extracts files from a directory or an archive",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FilePathExtractor",
+        "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
+        "properties": {
+          "extractArchive": {
+            "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FilePropertyExtractor",
+      "type": "processor",
+      "description": "Extracts properties from a file",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FilePropertyExtractor",
+        "type": "object",
+        "required": [
+          "filePathAttribute"
+        ],
+        "properties": {
+          "filePathAttribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FileReader",
+      "type": "source",
+      "description": "Reads features from a file",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FileReader",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FileWriter",
+      "type": "sink",
+      "description": "Writes features to a file",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FileWriterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "converter": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "excel"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              },
+              "sheetName": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "GeoJsonWriter",
+      "type": "sink",
+      "description": "Writes features to a geojson file",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeoJsonWriterParam",
+        "type": "object",
+        "required": [
+          "output"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "GeometryCoercer",
+      "type": "processor",
+      "description": "Coerces the geometry of a feature to a specific geometry",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryCoercer",
+        "type": "object",
+        "required": [
+          "coercerType"
+        ],
+        "properties": {
+          "coercerType": {
+            "$ref": "#/definitions/CoercerType"
+          }
+        },
+        "definitions": {
+          "CoercerType": {
+            "type": "string",
+            "enum": [
+              "lineString"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryDissolver",
+      "type": "processor",
+      "description": "Dissolve geometries",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryDissolverParam",
+        "type": "object",
+        "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryExtractor",
+      "type": "processor",
+      "description": "Extracts geometry from a feature and adds it as an attribute.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryExtractor",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryFilter",
+      "type": "processor",
+      "description": "Filter geometry by type",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryFilterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "none"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "multiple"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "geometryType"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "unfiltered",
+        "none",
+        "contains",
+        "point",
+        "line",
+        "lineString",
+        "polygon",
+        "multiPoint",
+        "multiLineString",
+        "multiPolygon",
+        "rect",
+        "triangle",
+        "solid",
+        "geometryCollection",
+        "solid",
+        "multiSurface",
+        "compositeSurface",
+        "surface",
+        "triangle",
+        "multiCurve",
+        "curve",
+        "multiPoint",
+        "point",
+        "tin"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryLodFilter",
+      "type": "processor",
+      "description": "Filter geometry by lod",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryLodFilterParam",
+        "type": "object",
+        "properties": {
+          "maxLod": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minLod": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "targetLods": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "unfiltered"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryReplacer",
+      "type": "processor",
+      "description": "Replaces the geometry of a feature with a new geometry.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryReplacer",
+        "type": "object",
+        "required": [
+          "sourceAttribute"
+        ],
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometrySplitter",
+      "type": "processor",
+      "description": "Split geometry by type",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryValidator",
+      "type": "processor",
+      "description": "Validates the geometry of a feature",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryValidator",
+        "type": "object",
+        "required": [
+          "validationTypes"
+        ],
+        "properties": {
+          "validationTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/ValidationType"
+            }
+          }
+        },
+        "definitions": {
+          "ValidationType": {
+            "type": "string",
+            "enum": [
+              "duplicatePoints",
+              "corruptGeometry",
+              "selfIntersection"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "success",
+        "failed",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryValueFilter",
+      "type": "processor",
+      "description": "Filter geometry by value",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "none",
+        "geometry2d",
+        "geometry3d",
+        "cityGml"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GltfWriter",
+      "type": "sink",
+      "description": "Writes features to a Gltf",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GltfWriterParam",
+        "type": "object",
+        "required": [
+          "output"
+        ],
+        "properties": {
+          "attachTexture": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "HoleCounter",
+      "type": "processor",
+      "description": "Counts the number of holes in a geometry and adds it as an attribute.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "HoleCounterParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "HoleExtractor",
+      "type": "processor",
+      "description": "Extracts holes in a geometry and adds it as an attribute.",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "outershell",
+        "hole",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "HorizontalReprojector",
+      "type": "processor",
+      "description": "Reprojects the geometry of a feature to a specified coordinate system",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "HorizontalReprojectorParam",
+        "type": "object",
+        "properties": {
+          "epsgCode": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "LineOnLineOverlayer",
+      "type": "processor",
+      "description": "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "LineOnLineOverlayerParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "point",
+        "line",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ListExploder",
+      "type": "processor",
+      "description": "Explodes list attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ListExploder",
+        "type": "object",
+        "required": [
+          "sourceAttribute"
+        ],
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "MVTWriter",
+      "type": "sink",
+      "description": "Writes features to a file",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "MVTWriterParam",
+        "type": "object",
+        "required": [
+          "layerName",
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
+        "properties": {
+          "layerName": {
+            "$ref": "#/definitions/Expr"
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "NoopProcessor",
+      "type": "processor",
+      "description": "Noop features",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Noop"
+      ]
+    },
+    {
+      "name": "NoopSink",
+      "type": "sink",
+      "description": "noop sink",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "Noop"
+      ]
+    },
+    {
+      "name": "Offsetter",
+      "type": "processor",
+      "description": "Adds offsets to the feature's coordinates.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "OffsetterParam",
+        "type": "object",
+        "properties": {
+          "offsetX": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "offsetY": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "offsetZ": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "OrientationExtractor",
+      "type": "processor",
+      "description": "Extracts the orientation of a geometry from a feature and adds it as an attribute.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "OrientationExtractorParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "PLATEAU.AttributeFlattener",
+      "type": "processor",
+      "description": "Flatten attributes for building feature",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.BuildingInstallationGeometryTypeExtractor",
+      "type": "processor",
+      "description": "Extracts BuildingInstallationGeometryType",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.BuildingUsageAttributeValidator",
+      "type": "processor",
+      "description": "This processor validates building usage attributes by checking for the presence of required attributes and ensuring the correctness of city codes. It outputs errors through the lBldgError and codeError ports if any issues are found.",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "lBldgError",
+        "codeError",
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.DictionariesInitiator",
+      "type": "processor",
+      "description": "Initializes dictionaries for PLATEAU",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.DomainOfDefinitionValidator",
+      "type": "processor",
+      "description": "Validates domain of definition of CityGML features",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.MaxLodExtractor",
+      "type": "processor",
+      "description": "Extracts maxLod",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.TranXLinkChecker",
+      "type": "processor",
+      "description": "Check Xlink for Tran",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.UDXFolderExtractor",
+      "type": "processor",
+      "description": "Extracts UDX folders from cityGML path",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.UnmatchedXlinkDetector",
+      "type": "processor",
+      "description": "Detect unmatched xlink for PLATEAU",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "summary",
+        "unMatchedXlinkFrom",
+        "unMatchedXlinkTo"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.XMLAttributeExtractor",
+      "type": "processor",
+      "description": "Extracts attributes from XML fragments based on a schema definition",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "attributeFeature",
+        "summary",
+        "filePath"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PlanarityFilter",
+      "type": "processor",
+      "description": "Filter geometry by type",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "planarity",
+        "notplanarity"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Refiner",
+      "type": "processor",
+      "description": "Geometry Refiner",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "remain"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "RhaiCaller",
+      "type": "processor",
+      "description": "Calls Rhai script",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "RhaiCallerParam",
+        "type": "object",
+        "required": [
+          "isTarget",
+          "process"
+        ],
+        "properties": {
+          "isTarget": {
+            "$ref": "#/definitions/Expr"
+          },
+          "process": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "Router",
+      "type": "processor",
+      "description": "Action for last port forwarding for sub-workflows.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Router",
+        "type": "object",
+        "required": [
+          "routingPort"
+        ],
+        "properties": {
+          "routingPort": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": []
+    },
+    {
+      "name": "StatisticsCalculator",
+      "type": "processor",
+      "description": "Calculates statistics of features",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "StatisticsCalculatorParam",
+        "type": "object",
+        "required": [
+          "calculations"
+        ],
+        "properties": {
+          "aggregateAttribute": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "aggregateName": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calculations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Calculation"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Calculation": {
+            "type": "object",
+            "required": [
+              "expr",
+              "newAttribute"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "complete"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "ThreeDimensionBoxReplacer",
+      "type": "processor",
+      "description": "Replaces a three Dimension box with a polygon.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreeDimensionBoxReplacer",
+        "type": "object",
+        "required": [
+          "maxX",
+          "maxY",
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
+        ],
+        "properties": {
+          "maxX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minZ": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ThreeDimensionRotator",
+      "type": "processor",
+      "description": "Replaces a three Dimension box with a polygon.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreeDimensionRotatorParam",
+        "type": "object",
+        "required": [
+          "angleDegree",
+          "directionX",
+          "directionY",
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
+        ],
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "TwoDimensionForcer",
+      "type": "processor",
+      "description": "Forces a geometry to be two dimensional.",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "VertexRemover",
+      "type": "processor",
+      "description": "Removes specific vertices from a feature’s geometry",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "VerticalReprojector",
+      "type": "processor",
+      "description": "Reprojects the geometry of a feature to a specified coordinate system",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "VerticalReprojectorParam",
+        "type": "object",
+        "required": [
+          "reprojectorType"
+        ],
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/definitions/VerticalReprojectorType"
+          }
+        },
+        "definitions": {
+          "VerticalReprojectorType": {
+            "type": "string",
+            "enum": [
+              "jgd2011ToWgs84"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "WasmRuntimeExecutor",
+      "type": "processor",
+      "description": "Compiles scripts into .wasm and runs at the wasm runtime",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "WasmRuntimeExecutorParam",
+        "type": "object",
+        "required": [
+          "processorType",
+          "programmingLanguage",
+          "sourceCodeFilePath"
+        ],
+        "properties": {
+          "processorType": {
+            "$ref": "#/definitions/ProcessorType"
+          },
+          "programmingLanguage": {
+            "$ref": "#/definitions/ProgrammingLanguage"
+          },
+          "sourceCodeFilePath": {
+            "type": "string"
+          }
+        },
+        "definitions": {
+          "ProcessorType": {
+            "type": "string",
+            "enum": [
+              "Attribute"
+            ]
+          },
+          "ProgrammingLanguage": {
+            "type": "string",
+            "enum": [
+              "Python"
+            ]
+          }
+        }
+      },
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Wasm"
+      ]
+    },
+    {
+      "name": "XMLFragmenter",
+      "type": "processor",
+      "description": "Fragment XML",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "XmlFragmenterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
+            "properties": {
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
+              },
+              "elementsToExclude": {
+                "$ref": "#/definitions/Expr"
+              },
+              "elementsToMatch": {
+                "$ref": "#/definitions/Expr"
+              },
+              "source": {
+                "type": "string",
+                "enum": [
+                  "url"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "XML"
+      ]
+    },
+    {
+      "name": "XMLValidator",
+      "type": "processor",
+      "description": "Validates XML content",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "XmlValidatorParam",
+        "type": "object",
+        "required": [
+          "attribute",
+          "inputType",
+          "validationType"
+        ],
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/definitions/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/definitions/ValidationType"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "ValidationType": {
+            "type": "string",
+            "enum": [
+              "syntax",
+              "syntaxAndNamespace",
+              "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "success",
+        "failed"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    }
+  ]
+}

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -1,0 +1,2944 @@
+{
+  "actions": [
+    {
+      "name": "AreaOnAreaOverlayer",
+      "type": "processor",
+      "description": "Superpone un área sobre otra área",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AreaOnAreaOverlayerParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "remnants",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "AttributeAggregator",
+      "type": "processor",
+      "description": "Agrupa las entidades según sus atributos",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeAggregatorParam",
+        "type": "object",
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
+        "properties": {
+          "aggregateAttributes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AggregateAttribute"
+            }
+          },
+          "calculation": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calculationAttribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "calculationValue": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "method": {
+            "$ref": "#/definitions/Method"
+          }
+        },
+        "definitions": {
+          "AggregateAttribute": {
+            "type": "object",
+            "required": [
+              "newAttribute"
+            ],
+            "properties": {
+              "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "max",
+              "min",
+              "count"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeDuplicateFilter",
+      "type": "processor",
+      "description": "Filtra las entidades con atributos duplicados",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeDuplicateFilterParam",
+        "type": "object",
+        "required": [
+          "filterBy"
+        ],
+        "properties": {
+          "filterBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeFilePathInfoExtractor",
+      "type": "processor",
+      "description": "Extrae información de rutas de archivo a partir de atributos",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeFilePathInfoExtractor",
+        "type": "object",
+        "required": [
+          "attribute"
+        ],
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeManager",
+      "type": "processor",
+      "description": "Gestiona atributos",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeManagerParam",
+        "type": "object",
+        "required": [
+          "operations"
+        ],
+        "properties": {
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Operation"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "convert",
+              "create",
+              "rename",
+              "remove"
+            ]
+          },
+          "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/definitions/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeMapper",
+      "type": "processor",
+      "description": "Asigna atributos",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeMapperParam",
+        "type": "object",
+        "required": [
+          "mappers"
+        ],
+        "properties": {
+          "mappers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Mapper"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Mapper": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "childAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "multipleExpr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "parentAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "BoundsExtractor",
+      "type": "processor",
+      "description": "Extrae los límites",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Bufferer",
+      "type": "processor",
+      "description": "Crea un búfer alrededor de una geometría",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Bufferer",
+        "type": "object",
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
+        "properties": {
+          "bufferType": {
+            "$ref": "#/definitions/BufferType"
+          },
+          "distance": {
+            "type": "number",
+            "format": "double"
+          },
+          "interpolationAngle": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "definitions": {
+          "BufferType": {
+            "type": "string",
+            "enum": [
+              "area2d"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "BulkAttributeRenamer",
+      "type": "processor",
+      "description": "Cambia el nombre de atributos añadiendo/eliminando prefijos o sufijos, o reemplazando texto",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "BulkAttributeRenamerParam",
+        "type": "object",
+        "required": [
+          "renameAction",
+          "renameType",
+          "renameValue"
+        ],
+        "properties": {
+          "renameAction": {
+            "$ref": "#/definitions/RenameAction"
+          },
+          "renameType": {
+            "$ref": "#/definitions/RenameType"
+          },
+          "renameValue": {
+            "type": "string"
+          },
+          "selectedAttributes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "definitions": {
+          "RenameAction": {
+            "type": "string",
+            "enum": [
+              "AddPrefix",
+              "AddSuffix",
+              "RemovePrefix",
+              "RemoveSuffix",
+              "StringReplace"
+            ]
+          },
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "CenterPointReplacer",
+      "type": "processor",
+      "description": "Reemplaza la geometría de la entidad con un punto que esté en el centro de su caja delimitadora, en su centro de masa o dentro de su área.",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "point",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Cesium3DTilesWriter",
+      "type": "sink",
+      "description": "Escribe las entidades en un archivo",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Cesium3DTilesWriterParam",
+        "type": "object",
+        "required": [
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
+        "properties": {
+          "attachTexture": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "Clipper",
+      "type": "processor",
+      "description": "Divide las entidades candidatas utilizando entidades recortadoras, de modo que las partes dentro o fuera de las recortadoras se produzcan por separado",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "clipper",
+        "candidate"
+      ],
+      "outputPorts": [
+        "inside",
+        "outside",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ClosedCurveFilter",
+      "type": "processor",
+      "description": "Comprueba si las curvas forman bucles cerrados",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "closed",
+        "open",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "CoordinateSystemSetter",
+      "type": "processor",
+      "description": "Establece el sistema de coordenadas de una entidad",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "CoordinateSystemSetter",
+        "type": "object",
+        "required": [
+          "epsgCode"
+        ],
+        "properties": {
+          "epsgCode": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "DimensionFilter",
+      "type": "processor",
+      "description": "Filtra las entidades según su dimensión",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "2d",
+        "3d",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "EchoProcessor",
+      "type": "processor",
+      "description": "Repite las entidades",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "EchoSink",
+      "type": "sink",
+      "description": "Repite las entidades",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "ElevationExtractor",
+      "type": "processor",
+      "description": "Extrae el primer valor de la coordenada z de una entidad y lo almacena en un atributo.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ElevationExtractorParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Extruder",
+      "type": "processor",
+      "description": "Extruye un polígono a una cierta distancia",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ExtruderParam",
+        "type": "object",
+        "required": [
+          "distance"
+        ],
+        "properties": {
+          "distance": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "FeatureCounter",
+      "type": "processor",
+      "description": "Cuenta entidades",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureCounterParam",
+        "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
+        "properties": {
+          "countStart": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "type": "string"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureCreator",
+      "type": "source",
+      "description": "Crea entidades a partir de expresiones",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureCreator",
+        "type": "object",
+        "required": [
+          "creator"
+        ],
+        "properties": {
+          "creator": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureFilter",
+      "type": "processor",
+      "description": "Filtra entidades según condiciones",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureFilterParam",
+        "type": "object",
+        "required": [
+          "conditions"
+        ],
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Condition"
+            }
+          }
+        },
+        "definitions": {
+          "Condition": {
+            "type": "object",
+            "required": [
+              "expr",
+              "outputPort"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/definitions/Port"
+              }
+            }
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Port": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "unfiltered"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureMerger",
+      "type": "processor",
+      "description": "Une entidades según sus atributos",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureMergerParam",
+        "type": "object",
+        "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "requestorAttribute": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "requestorAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "supplierAttribute": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "requestor",
+        "supplier"
+      ],
+      "outputPorts": [
+        "merged",
+        "unmerged"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureReader",
+      "type": "processor",
+      "description": "Filtra entidades según condiciones",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureReaderParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureSorter",
+      "type": "processor",
+      "description": "Ordena entidades por atributos",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureSorterParam",
+        "type": "object",
+        "required": [
+          "sortBy"
+        ],
+        "properties": {
+          "sortBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SortBy"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Order": {
+            "type": "string",
+            "enum": [
+              "ascending",
+              "descending"
+            ]
+          },
+          "SortBy": {
+            "type": "object",
+            "required": [
+              "order"
+            ],
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/definitions/Order"
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureTransformer",
+      "type": "processor",
+      "description": "Transforma entidades mediante expresiones",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureTransformerParam",
+        "type": "object",
+        "required": [
+          "transformers"
+        ],
+        "properties": {
+          "transformers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Transform"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureTypeFilter",
+      "type": "processor",
+      "description": "Filtra entidades por tipo de entidad",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureTypeFilter",
+        "type": "object",
+        "required": [
+          "targetTypes"
+        ],
+        "properties": {
+          "targetTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "unfiltered"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FilePathExtractor",
+      "type": "source",
+      "description": "Extrae archivos de un directorio o de un archivo comprimido",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FilePathExtractor",
+        "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
+        "properties": {
+          "extractArchive": {
+            "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FilePropertyExtractor",
+      "type": "processor",
+      "description": "Extrae propiedades de un archivo",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FilePropertyExtractor",
+        "type": "object",
+        "required": [
+          "filePathAttribute"
+        ],
+        "properties": {
+          "filePathAttribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FileReader",
+      "type": "source",
+      "description": "Lee entidades desde un archivo",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FileReader",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FileWriter",
+      "type": "sink",
+      "description": "Escribe entidades en un archivo",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FileWriterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "converter": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "excel"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              },
+              "sheetName": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "GeoJsonWriter",
+      "type": "sink",
+      "description": "Escribe entidades en un archivo GeoJSON",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeoJsonWriterParam",
+        "type": "object",
+        "required": [
+          "output"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "GeometryCoercer",
+      "type": "processor",
+      "description": "Fuerza la geometría de una entidad a una geometría específica",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryCoercer",
+        "type": "object",
+        "required": [
+          "coercerType"
+        ],
+        "properties": {
+          "coercerType": {
+            "$ref": "#/definitions/CoercerType"
+          }
+        },
+        "definitions": {
+          "CoercerType": {
+            "type": "string",
+            "enum": [
+              "lineString"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryDissolver",
+      "type": "processor",
+      "description": "Disuelve geometrías",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryDissolverParam",
+        "type": "object",
+        "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryExtractor",
+      "type": "processor",
+      "description": "Extrae la geometría de una entidad y la añade como un atributo.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryExtractor",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryFilter",
+      "type": "processor",
+      "description": "Filtra la geometría por tipo",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryFilterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "none"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "multiple"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "geometryType"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "unfiltered",
+        "none",
+        "contains",
+        "point",
+        "line",
+        "lineString",
+        "polygon",
+        "multiPoint",
+        "multiLineString",
+        "multiPolygon",
+        "rect",
+        "triangle",
+        "solid",
+        "geometryCollection",
+        "solid",
+        "multiSurface",
+        "compositeSurface",
+        "surface",
+        "triangle",
+        "multiCurve",
+        "curve",
+        "multiPoint",
+        "point",
+        "tin"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryLodFilter",
+      "type": "processor",
+      "description": "Filtra la geometría por nivel de detalle (lod)",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryLodFilterParam",
+        "type": "object",
+        "properties": {
+          "maxLod": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minLod": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "targetLods": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "unfiltered"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryReplacer",
+      "type": "processor",
+      "description": "Reemplaza la geometría de una entidad con una nueva geometría.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryReplacer",
+        "type": "object",
+        "required": [
+          "sourceAttribute"
+        ],
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometrySplitter",
+      "type": "processor",
+      "description": "Divide la geometría por tipo",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryValidator",
+      "type": "processor",
+      "description": "Valida la geometría de una entidad",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryValidator",
+        "type": "object",
+        "required": [
+          "validationTypes"
+        ],
+        "properties": {
+          "validationTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/ValidationType"
+            }
+          }
+        },
+        "definitions": {
+          "ValidationType": {
+            "type": "string",
+            "enum": [
+              "duplicatePoints",
+              "corruptGeometry",
+              "selfIntersection"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "success",
+        "failed",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryValueFilter",
+      "type": "processor",
+      "description": "Filtra la geometría por valor",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "none",
+        "geometry2d",
+        "geometry3d",
+        "cityGml"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GltfWriter",
+      "type": "sink",
+      "description": "Escribe entidades en un archivo Gltf",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GltfWriterParam",
+        "type": "object",
+        "required": [
+          "output"
+        ],
+        "properties": {
+          "attachTexture": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "HoleCounter",
+      "type": "processor",
+      "description": "Cuenta el número de huecos en una geometría y lo agrega como atributo.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "HoleCounterParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "HoleExtractor",
+      "type": "processor",
+      "description": "Extrae los huecos en una geometría y los agrega como atributo.",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "outershell",
+        "hole",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "HorizontalReprojector",
+      "type": "processor",
+      "description": "Reproyecta la geometría de una entidad a un sistema de coordenadas especificado",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "HorizontalReprojectorParam",
+        "type": "object",
+        "properties": {
+          "epsgCode": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "LineOnLineOverlayer",
+      "type": "processor",
+      "description": "Los puntos de intersección se convierten en entidades de puntos que pueden contener la lista combinada de atributos de las líneas originales intersectadas.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "LineOnLineOverlayerParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "point",
+        "line",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ListExploder",
+      "type": "processor",
+      "description": "Divide en varios elementos los atributos de tipo lista",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ListExploder",
+        "type": "object",
+        "required": [
+          "sourceAttribute"
+        ],
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "MVTWriter",
+      "type": "sink",
+      "description": "Escribe entidades en un archivo",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "MVTWriterParam",
+        "type": "object",
+        "required": [
+          "layerName",
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
+        "properties": {
+          "layerName": {
+            "$ref": "#/definitions/Expr"
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "NoopProcessor",
+      "type": "processor",
+      "description": "No realiza ninguna operación sobre las entidades",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Noop"
+      ]
+    },
+    {
+      "name": "NoopSink",
+      "type": "sink",
+      "description": "No realiza ninguna operación final",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "Noop"
+      ]
+    },
+    {
+      "name": "Offsetter",
+      "type": "processor",
+      "description": "Añade desplazamientos a las coordenadas de la entidad.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "OffsetterParam",
+        "type": "object",
+        "properties": {
+          "offsetX": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "offsetY": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "offsetZ": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "OrientationExtractor",
+      "type": "processor",
+      "description": "Extrae la orientación de una geometría de una entidad y la agrega como un atributo.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "OrientationExtractorParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "PLATEAU.AttributeFlattener",
+      "type": "processor",
+      "description": "Aplana los atributos para crear una entidad de edificio",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.BuildingInstallationGeometryTypeExtractor",
+      "type": "processor",
+      "description": "Extrae el tipo de geometría de la instalación de un edificio (BuildingInstallationGeometryType)",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.BuildingUsageAttributeValidator",
+      "type": "processor",
+      "description": "Este procesador valida los atributos de uso de edificios comprobando la presencia de atributos requeridos y garantizando la corrección de los códigos de ciudad. Si se encuentran problemas, produce errores a través de los puertos lBldgError y codeError.",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "lBldgError",
+        "codeError",
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.DictionariesInitiator",
+      "type": "processor",
+      "description": "Inicializa diccionarios para PLATEAU",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.DomainOfDefinitionValidator",
+      "type": "processor",
+      "description": "Valida el dominio de definición de las entidades CityGML",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.MaxLodExtractor",
+      "type": "processor",
+      "description": "Extrae maxLod",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.TranXLinkChecker",
+      "type": "processor",
+      "description": "Comprueba Xlink para Tran",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.UDXFolderExtractor",
+      "type": "processor",
+      "description": "Extrae carpetas UDX desde la ruta cityGML",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.UnmatchedXlinkDetector",
+      "type": "processor",
+      "description": "Detecta xlinks no coincidentes para PLATEAU",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "summary",
+        "unMatchedXlinkFrom",
+        "unMatchedXlinkTo"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.XMLAttributeExtractor",
+      "type": "processor",
+      "description": "Extrae atributos de fragmentos XML basándose en una definición de esquema",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "attributeFeature",
+        "summary",
+        "filePath"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PlanarityFilter",
+      "type": "processor",
+      "description": "Filtra la geometría por tipo",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "planarity",
+        "notplanarity"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Refiner",
+      "type": "processor",
+      "description": "Refina la geometría",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "remain"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "RhaiCaller",
+      "type": "processor",
+      "description": "Llama a un script Rhai",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "RhaiCallerParam",
+        "type": "object",
+        "required": [
+          "isTarget",
+          "process"
+        ],
+        "properties": {
+          "isTarget": {
+            "$ref": "#/definitions/Expr"
+          },
+          "process": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "Router",
+      "type": "processor",
+      "description": "Acción para el reenvío del último puerto en sub-flujos de trabajo.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Router",
+        "type": "object",
+        "required": [
+          "routingPort"
+        ],
+        "properties": {
+          "routingPort": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": []
+    },
+    {
+      "name": "StatisticsCalculator",
+      "type": "processor",
+      "description": "Calcula estadísticas de las entidades",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "StatisticsCalculatorParam",
+        "type": "object",
+        "required": [
+          "calculations"
+        ],
+        "properties": {
+          "aggregateAttribute": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "aggregateName": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calculations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Calculation"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Calculation": {
+            "type": "object",
+            "required": [
+              "expr",
+              "newAttribute"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "complete"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "ThreeDimensionBoxReplacer",
+      "type": "processor",
+      "description": "Reemplaza una caja tridimensional con un polígono.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreeDimensionBoxReplacer",
+        "type": "object",
+        "required": [
+          "maxX",
+          "maxY",
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
+        ],
+        "properties": {
+          "maxX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minZ": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ThreeDimensionRotator",
+      "type": "processor",
+      "description": "Reemplaza una caja tridimensional con un polígono.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreeDimensionRotatorParam",
+        "type": "object",
+        "required": [
+          "angleDegree",
+          "directionX",
+          "directionY",
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
+        ],
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "TwoDimensionForcer",
+      "type": "processor",
+      "description": "Fuerza una geometría a ser bidimensional.",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "VertexRemover",
+      "type": "processor",
+      "description": "Elimina vértices específicos de la geometría de una entidad",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "VerticalReprojector",
+      "type": "processor",
+      "description": "Reproyecta la geometría de una entidad a un sistema de coordenadas especificado",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "VerticalReprojectorParam",
+        "type": "object",
+        "required": [
+          "reprojectorType"
+        ],
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/definitions/VerticalReprojectorType"
+          }
+        },
+        "definitions": {
+          "VerticalReprojectorType": {
+            "type": "string",
+            "enum": [
+              "jgd2011ToWgs84"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "WasmRuntimeExecutor",
+      "type": "processor",
+      "description": "Compila scripts en .wasm y los ejecuta en tiempo de ejecución de wasm",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "WasmRuntimeExecutorParam",
+        "type": "object",
+        "required": [
+          "processorType",
+          "programmingLanguage",
+          "sourceCodeFilePath"
+        ],
+        "properties": {
+          "processorType": {
+            "$ref": "#/definitions/ProcessorType"
+          },
+          "programmingLanguage": {
+            "$ref": "#/definitions/ProgrammingLanguage"
+          },
+          "sourceCodeFilePath": {
+            "type": "string"
+          }
+        },
+        "definitions": {
+          "ProcessorType": {
+            "type": "string",
+            "enum": [
+              "Attribute"
+            ]
+          },
+          "ProgrammingLanguage": {
+            "type": "string",
+            "enum": [
+              "Python"
+            ]
+          }
+        }
+      },
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Wasm"
+      ]
+    },
+    {
+      "name": "XMLFragmenter",
+      "type": "processor",
+      "description": "Fragmenta XML",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "XmlFragmenterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
+            "properties": {
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
+              },
+              "elementsToExclude": {
+                "$ref": "#/definitions/Expr"
+              },
+              "elementsToMatch": {
+                "$ref": "#/definitions/Expr"
+              },
+              "source": {
+                "type": "string",
+                "enum": [
+                  "url"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "XML"
+      ]
+    },
+    {
+      "name": "XMLValidator",
+      "type": "processor",
+      "description": "Valida contenido XML",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "XmlValidatorParam",
+        "type": "object",
+        "required": [
+          "attribute",
+          "inputType",
+          "validationType"
+        ],
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/definitions/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/definitions/ValidationType"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "ValidationType": {
+            "type": "string",
+            "enum": [
+              "syntax",
+              "syntaxAndNamespace",
+              "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "success",
+        "failed"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    }
+  ]
+}

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -1,0 +1,2944 @@
+{
+  "actions": [
+    {
+      "name": "AreaOnAreaOverlayer",
+      "type": "processor",
+      "description": "Superpose une zone sur une autre zone",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AreaOnAreaOverlayerParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "remnants",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "AttributeAggregator",
+      "type": "processor",
+      "description": "Regroupe les entités selon leurs attributs",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeAggregatorParam",
+        "type": "object",
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
+        "properties": {
+          "aggregateAttributes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AggregateAttribute"
+            }
+          },
+          "calculation": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calculationAttribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "calculationValue": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "method": {
+            "$ref": "#/definitions/Method"
+          }
+        },
+        "definitions": {
+          "AggregateAttribute": {
+            "type": "object",
+            "required": [
+              "newAttribute"
+            ],
+            "properties": {
+              "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "max",
+              "min",
+              "count"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeDuplicateFilter",
+      "type": "processor",
+      "description": "Filtre les entités possédant des attributs dupliqués",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeDuplicateFilterParam",
+        "type": "object",
+        "required": [
+          "filterBy"
+        ],
+        "properties": {
+          "filterBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeFilePathInfoExtractor",
+      "type": "processor",
+      "description": "Extrait des informations de chemins de fichier à partir des attributs",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeFilePathInfoExtractor",
+        "type": "object",
+        "required": [
+          "attribute"
+        ],
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeManager",
+      "type": "processor",
+      "description": "Gère les attributs",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeManagerParam",
+        "type": "object",
+        "required": [
+          "operations"
+        ],
+        "properties": {
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Operation"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "convert",
+              "create",
+              "rename",
+              "remove"
+            ]
+          },
+          "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/definitions/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeMapper",
+      "type": "processor",
+      "description": "Assigne des attributs",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeMapperParam",
+        "type": "object",
+        "required": [
+          "mappers"
+        ],
+        "properties": {
+          "mappers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Mapper"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Mapper": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "childAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "multipleExpr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "parentAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "BoundsExtractor",
+      "type": "processor",
+      "description": "Extrait les limites",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Bufferer",
+      "type": "processor",
+      "description": "Crée un tampon autour d'une géométrie",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Bufferer",
+        "type": "object",
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
+        "properties": {
+          "bufferType": {
+            "$ref": "#/definitions/BufferType"
+          },
+          "distance": {
+            "type": "number",
+            "format": "double"
+          },
+          "interpolationAngle": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "definitions": {
+          "BufferType": {
+            "type": "string",
+            "enum": [
+              "area2d"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "BulkAttributeRenamer",
+      "type": "processor",
+      "description": "Renomme des attributs en ajoutant/supprimant des préfixes ou suffixes, ou en remplaçant du texte",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "BulkAttributeRenamerParam",
+        "type": "object",
+        "required": [
+          "renameAction",
+          "renameType",
+          "renameValue"
+        ],
+        "properties": {
+          "renameAction": {
+            "$ref": "#/definitions/RenameAction"
+          },
+          "renameType": {
+            "$ref": "#/definitions/RenameType"
+          },
+          "renameValue": {
+            "type": "string"
+          },
+          "selectedAttributes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "definitions": {
+          "RenameAction": {
+            "type": "string",
+            "enum": [
+              "AddPrefix",
+              "AddSuffix",
+              "RemovePrefix",
+              "RemoveSuffix",
+              "StringReplace"
+            ]
+          },
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "CenterPointReplacer",
+      "type": "processor",
+      "description": "Remplace la géométrie de l'entité par un point situé au centre de sa boîte englobante, à son centre de masse, ou à l'intérieur de son aire.",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "point",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Cesium3DTilesWriter",
+      "type": "sink",
+      "description": "Écrit les entités dans un fichier",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Cesium3DTilesWriterParam",
+        "type": "object",
+        "required": [
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
+        "properties": {
+          "attachTexture": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "Clipper",
+      "type": "processor",
+      "description": "Divise les entités candidates à l'aide d'entités de découpage, de sorte que les parties intérieures ou extérieures soient produites séparément",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "clipper",
+        "candidate"
+      ],
+      "outputPorts": [
+        "inside",
+        "outside",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ClosedCurveFilter",
+      "type": "processor",
+      "description": "Vérifie si les courbes forment des boucles fermées",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "closed",
+        "open",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "CoordinateSystemSetter",
+      "type": "processor",
+      "description": "Définit le système de coordonnées d'une entité",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "CoordinateSystemSetter",
+        "type": "object",
+        "required": [
+          "epsgCode"
+        ],
+        "properties": {
+          "epsgCode": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "DimensionFilter",
+      "type": "processor",
+      "description": "Filtre les entités en fonction de leur dimension",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "2d",
+        "3d",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "EchoProcessor",
+      "type": "processor",
+      "description": "Répète les entités",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "EchoSink",
+      "type": "sink",
+      "description": "Répète les entités",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "ElevationExtractor",
+      "type": "processor",
+      "description": "Extrait la première valeur de la coordonnée z d'une entité et la stocke dans un attribut.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ElevationExtractorParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Extruder",
+      "type": "processor",
+      "description": "Extrue un polygone sur une certaine distance",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ExtruderParam",
+        "type": "object",
+        "required": [
+          "distance"
+        ],
+        "properties": {
+          "distance": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "FeatureCounter",
+      "type": "processor",
+      "description": "Compte les entités",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureCounterParam",
+        "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
+        "properties": {
+          "countStart": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "type": "string"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureCreator",
+      "type": "source",
+      "description": "Crée des entités à partir d'expressions",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureCreator",
+        "type": "object",
+        "required": [
+          "creator"
+        ],
+        "properties": {
+          "creator": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureFilter",
+      "type": "processor",
+      "description": "Filtre les entités selon des conditions",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureFilterParam",
+        "type": "object",
+        "required": [
+          "conditions"
+        ],
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Condition"
+            }
+          }
+        },
+        "definitions": {
+          "Condition": {
+            "type": "object",
+            "required": [
+              "expr",
+              "outputPort"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/definitions/Port"
+              }
+            }
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Port": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "unfiltered"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureMerger",
+      "type": "processor",
+      "description": "Fusionne des entités selon leurs attributs",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureMergerParam",
+        "type": "object",
+        "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "requestorAttribute": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "requestorAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "supplierAttribute": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "requestor",
+        "supplier"
+      ],
+      "outputPorts": [
+        "merged",
+        "unmerged"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureReader",
+      "type": "processor",
+      "description": "Filtre les entités selon des conditions",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureReaderParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureSorter",
+      "type": "processor",
+      "description": "Trie les entités par attributs",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureSorterParam",
+        "type": "object",
+        "required": [
+          "sortBy"
+        ],
+        "properties": {
+          "sortBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SortBy"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Order": {
+            "type": "string",
+            "enum": [
+              "ascending",
+              "descending"
+            ]
+          },
+          "SortBy": {
+            "type": "object",
+            "required": [
+              "order"
+            ],
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/definitions/Order"
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureTransformer",
+      "type": "processor",
+      "description": "Transforme les entités à l'aide d'expressions",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureTransformerParam",
+        "type": "object",
+        "required": [
+          "transformers"
+        ],
+        "properties": {
+          "transformers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Transform"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureTypeFilter",
+      "type": "processor",
+      "description": "Filtre les entités par type",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureTypeFilter",
+        "type": "object",
+        "required": [
+          "targetTypes"
+        ],
+        "properties": {
+          "targetTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "unfiltered"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FilePathExtractor",
+      "type": "source",
+      "description": "Extrait des fichiers d'un répertoire ou d'une archive",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FilePathExtractor",
+        "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
+        "properties": {
+          "extractArchive": {
+            "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FilePropertyExtractor",
+      "type": "processor",
+      "description": "Extrait les propriétés d'un fichier",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FilePropertyExtractor",
+        "type": "object",
+        "required": [
+          "filePathAttribute"
+        ],
+        "properties": {
+          "filePathAttribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FileReader",
+      "type": "source",
+      "description": "Lit des entités depuis un fichier",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FileReader",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FileWriter",
+      "type": "sink",
+      "description": "Écrit des entités dans un fichier",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FileWriterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "converter": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "excel"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              },
+              "sheetName": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "GeoJsonWriter",
+      "type": "sink",
+      "description": "Écrit des entités dans un fichier GeoJSON",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeoJsonWriterParam",
+        "type": "object",
+        "required": [
+          "output"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "GeometryCoercer",
+      "type": "processor",
+      "description": "Force la géométrie d'une entité à une géométrie spécifique",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryCoercer",
+        "type": "object",
+        "required": [
+          "coercerType"
+        ],
+        "properties": {
+          "coercerType": {
+            "$ref": "#/definitions/CoercerType"
+          }
+        },
+        "definitions": {
+          "CoercerType": {
+            "type": "string",
+            "enum": [
+              "lineString"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryDissolver",
+      "type": "processor",
+      "description": "Dissout des géométries",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryDissolverParam",
+        "type": "object",
+        "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryExtractor",
+      "type": "processor",
+      "description": "Extrait la géométrie d'une entité et l'ajoute comme attribut.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryExtractor",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryFilter",
+      "type": "processor",
+      "description": "Filtre la géométrie par type",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryFilterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "none"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "multiple"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "geometryType"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "unfiltered",
+        "none",
+        "contains",
+        "point",
+        "line",
+        "lineString",
+        "polygon",
+        "multiPoint",
+        "multiLineString",
+        "multiPolygon",
+        "rect",
+        "triangle",
+        "solid",
+        "geometryCollection",
+        "solid",
+        "multiSurface",
+        "compositeSurface",
+        "surface",
+        "triangle",
+        "multiCurve",
+        "curve",
+        "multiPoint",
+        "point",
+        "tin"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryLodFilter",
+      "type": "processor",
+      "description": "Filtre la géométrie par niveau de détail (lod)",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryLodFilterParam",
+        "type": "object",
+        "properties": {
+          "maxLod": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minLod": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "targetLods": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "unfiltered"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryReplacer",
+      "type": "processor",
+      "description": "Remplace la géométrie d'une entité par une nouvelle géométrie.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryReplacer",
+        "type": "object",
+        "required": [
+          "sourceAttribute"
+        ],
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometrySplitter",
+      "type": "processor",
+      "description": "Divise la géométrie par type",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryValidator",
+      "type": "processor",
+      "description": "Valide la géométrie d'une entité",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryValidator",
+        "type": "object",
+        "required": [
+          "validationTypes"
+        ],
+        "properties": {
+          "validationTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/ValidationType"
+            }
+          }
+        },
+        "definitions": {
+          "ValidationType": {
+            "type": "string",
+            "enum": [
+              "duplicatePoints",
+              "corruptGeometry",
+              "selfIntersection"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "success",
+        "failed",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryValueFilter",
+      "type": "processor",
+      "description": "Filtre la géométrie par valeur",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "none",
+        "geometry2d",
+        "geometry3d",
+        "cityGml"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GltfWriter",
+      "type": "sink",
+      "description": "Écrit des entités dans un fichier Gltf",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GltfWriterParam",
+        "type": "object",
+        "required": [
+          "output"
+        ],
+        "properties": {
+          "attachTexture": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "HoleCounter",
+      "type": "processor",
+      "description": "Compte le nombre de trous dans une géométrie et l'ajoute comme attribut.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "HoleCounterParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "HoleExtractor",
+      "type": "processor",
+      "description": "Extrait les trous dans une géométrie et les ajoute comme attribut.",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "outershell",
+        "hole",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "HorizontalReprojector",
+      "type": "processor",
+      "description": "Reprojette la géométrie d'une entité dans un système de coordonnées spécifié",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "HorizontalReprojectorParam",
+        "type": "object",
+        "properties": {
+          "epsgCode": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "LineOnLineOverlayer",
+      "type": "processor",
+      "description": "Les points d'intersection deviennent des entités ponctuelles pouvant contenir la liste combinée des attributs des lignes d'origine intersectées.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "LineOnLineOverlayerParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "point",
+        "line",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ListExploder",
+      "type": "processor",
+      "description": "Explose les attributs de type liste en plusieurs éléments",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ListExploder",
+        "type": "object",
+        "required": [
+          "sourceAttribute"
+        ],
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "MVTWriter",
+      "type": "sink",
+      "description": "Écrit des entités dans un fichier",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "MVTWriterParam",
+        "type": "object",
+        "required": [
+          "layerName",
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
+        "properties": {
+          "layerName": {
+            "$ref": "#/definitions/Expr"
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "NoopProcessor",
+      "type": "processor",
+      "description": "N'effectue aucune opération sur les entités",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Noop"
+      ]
+    },
+    {
+      "name": "NoopSink",
+      "type": "sink",
+      "description": "N'effectue aucune opération finale",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "Noop"
+      ]
+    },
+    {
+      "name": "Offsetter",
+      "type": "processor",
+      "description": "Ajoute des décalages aux coordonnées de l'entité.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "OffsetterParam",
+        "type": "object",
+        "properties": {
+          "offsetX": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "offsetY": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "offsetZ": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "OrientationExtractor",
+      "type": "processor",
+      "description": "Extrait l'orientation de la géométrie d'une entité et l'ajoute comme attribut.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "OrientationExtractorParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "PLATEAU.AttributeFlattener",
+      "type": "processor",
+      "description": "Aplati les attributs pour créer une entité de bâtiment",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.BuildingInstallationGeometryTypeExtractor",
+      "type": "processor",
+      "description": "Extrait le type de géométrie de l'installation d'un bâtiment (BuildingInstallationGeometryType)",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.BuildingUsageAttributeValidator",
+      "type": "processor",
+      "description": "Ce processeur valide les attributs d'usage des bâtiments en vérifiant la présence d'attributs requis et la justesse des codes de ville. En cas de problème, il génère des erreurs via les ports lBldgError et codeError.",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "lBldgError",
+        "codeError",
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.DictionariesInitiator",
+      "type": "processor",
+      "description": "Initialise des dictionnaires pour PLATEAU",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.DomainOfDefinitionValidator",
+      "type": "processor",
+      "description": "Valide le domaine de définition des entités CityGML",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.MaxLodExtractor",
+      "type": "processor",
+      "description": "Extrait maxLod",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.TranXLinkChecker",
+      "type": "processor",
+      "description": "Vérifie Xlink pour Tran",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.UDXFolderExtractor",
+      "type": "processor",
+      "description": "Extrait les dossiers UDX du chemin cityGML",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.UnmatchedXlinkDetector",
+      "type": "processor",
+      "description": "Détecte les xlinks non correspondants pour PLATEAU",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "summary",
+        "unMatchedXlinkFrom",
+        "unMatchedXlinkTo"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.XMLAttributeExtractor",
+      "type": "processor",
+      "description": "Extrait les attributs de fragments XML en fonction d'une définition de schéma",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "attributeFeature",
+        "summary",
+        "filePath"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PlanarityFilter",
+      "type": "processor",
+      "description": "Filtre la géométrie par type",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "planarity",
+        "notplanarity"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Refiner",
+      "type": "processor",
+      "description": "Affine la géométrie",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "remain"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "RhaiCaller",
+      "type": "processor",
+      "description": "Appelle un script Rhai",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "RhaiCallerParam",
+        "type": "object",
+        "required": [
+          "isTarget",
+          "process"
+        ],
+        "properties": {
+          "isTarget": {
+            "$ref": "#/definitions/Expr"
+          },
+          "process": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "Router",
+      "type": "processor",
+      "description": "Action pour le renvoi du dernier port dans les sous-flux de travail.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Router",
+        "type": "object",
+        "required": [
+          "routingPort"
+        ],
+        "properties": {
+          "routingPort": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": []
+    },
+    {
+      "name": "StatisticsCalculator",
+      "type": "processor",
+      "description": "Calcule des statistiques sur les entités",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "StatisticsCalculatorParam",
+        "type": "object",
+        "required": [
+          "calculations"
+        ],
+        "properties": {
+          "aggregateAttribute": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "aggregateName": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calculations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Calculation"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Calculation": {
+            "type": "object",
+            "required": [
+              "expr",
+              "newAttribute"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "complete"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "ThreeDimensionBoxReplacer",
+      "type": "processor",
+      "description": "Remplace un boîtier tridimensionnel par un polygone.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreeDimensionBoxReplacer",
+        "type": "object",
+        "required": [
+          "maxX",
+          "maxY",
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
+        ],
+        "properties": {
+          "maxX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minZ": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ThreeDimensionRotator",
+      "type": "processor",
+      "description": "Remplace un boîtier tridimensionnel par un polygone.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreeDimensionRotatorParam",
+        "type": "object",
+        "required": [
+          "angleDegree",
+          "directionX",
+          "directionY",
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
+        ],
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "TwoDimensionForcer",
+      "type": "processor",
+      "description": "Force une géométrie à être bidimensionnelle.",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "VertexRemover",
+      "type": "processor",
+      "description": "Supprime des sommets spécifiques de la géométrie d'une entité",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "VerticalReprojector",
+      "type": "processor",
+      "description": "Reprojette la géométrie d'une entité dans un système de coordonnées spécifié",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "VerticalReprojectorParam",
+        "type": "object",
+        "required": [
+          "reprojectorType"
+        ],
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/definitions/VerticalReprojectorType"
+          }
+        },
+        "definitions": {
+          "VerticalReprojectorType": {
+            "type": "string",
+            "enum": [
+              "jgd2011ToWgs84"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "WasmRuntimeExecutor",
+      "type": "processor",
+      "description": "Compile des scripts en .wasm et les exécute dans un environnement d'exécution wasm",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "WasmRuntimeExecutorParam",
+        "type": "object",
+        "required": [
+          "processorType",
+          "programmingLanguage",
+          "sourceCodeFilePath"
+        ],
+        "properties": {
+          "processorType": {
+            "$ref": "#/definitions/ProcessorType"
+          },
+          "programmingLanguage": {
+            "$ref": "#/definitions/ProgrammingLanguage"
+          },
+          "sourceCodeFilePath": {
+            "type": "string"
+          }
+        },
+        "definitions": {
+          "ProcessorType": {
+            "type": "string",
+            "enum": [
+              "Attribute"
+            ]
+          },
+          "ProgrammingLanguage": {
+            "type": "string",
+            "enum": [
+              "Python"
+            ]
+          }
+        }
+      },
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Wasm"
+      ]
+    },
+    {
+      "name": "XMLFragmenter",
+      "type": "processor",
+      "description": "Fragmente du XML",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "XmlFragmenterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
+            "properties": {
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
+              },
+              "elementsToExclude": {
+                "$ref": "#/definitions/Expr"
+              },
+              "elementsToMatch": {
+                "$ref": "#/definitions/Expr"
+              },
+              "source": {
+                "type": "string",
+                "enum": [
+                  "url"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "XML"
+      ]
+    },
+    {
+      "name": "XMLValidator",
+      "type": "processor",
+      "description": "Valide le contenu XML",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "XmlValidatorParam",
+        "type": "object",
+        "required": [
+          "attribute",
+          "inputType",
+          "validationType"
+        ],
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/definitions/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/definitions/ValidationType"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "ValidationType": {
+            "type": "string",
+            "enum": [
+              "syntax",
+              "syntaxAndNamespace",
+              "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "success",
+        "failed"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    }
+  ]
+}

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -1,0 +1,2944 @@
+{
+  "actions": [
+    {
+      "name": "AreaOnAreaOverlayer",
+      "type": "processor",
+      "description": "あるエリアの上に別のエリアを重ね合わせる",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AreaOnAreaOverlayerParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "remnants",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "AttributeAggregator",
+      "type": "processor",
+      "description": "属性に基づいてフィーチャをグルーピングする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeAggregatorParam",
+        "type": "object",
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
+        "properties": {
+          "aggregateAttributes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AggregateAttribute"
+            }
+          },
+          "calculation": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calculationAttribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "calculationValue": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "method": {
+            "$ref": "#/definitions/Method"
+          }
+        },
+        "definitions": {
+          "AggregateAttribute": {
+            "type": "object",
+            "required": [
+              "newAttribute"
+            ],
+            "properties": {
+              "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "max",
+              "min",
+              "count"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeDuplicateFilter",
+      "type": "processor",
+      "description": "重複した属性を持つフィーチャをフィルタリングする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeDuplicateFilterParam",
+        "type": "object",
+        "required": [
+          "filterBy"
+        ],
+        "properties": {
+          "filterBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeFilePathInfoExtractor",
+      "type": "processor",
+      "description": "属性からファイルパス情報を抽出する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeFilePathInfoExtractor",
+        "type": "object",
+        "required": [
+          "attribute"
+        ],
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeManager",
+      "type": "processor",
+      "description": "属性を管理する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeManagerParam",
+        "type": "object",
+        "required": [
+          "operations"
+        ],
+        "properties": {
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Operation"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "convert",
+              "create",
+              "rename",
+              "remove"
+            ]
+          },
+          "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/definitions/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeMapper",
+      "type": "processor",
+      "description": "属性をマッピングする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeMapperParam",
+        "type": "object",
+        "required": [
+          "mappers"
+        ],
+        "properties": {
+          "mappers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Mapper"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Mapper": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "childAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "multipleExpr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "parentAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "BoundsExtractor",
+      "type": "processor",
+      "description": "境界を抽出する",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Bufferer",
+      "type": "processor",
+      "description": "ジオメトリの周囲にバッファを作成する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Bufferer",
+        "type": "object",
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
+        "properties": {
+          "bufferType": {
+            "$ref": "#/definitions/BufferType"
+          },
+          "distance": {
+            "type": "number",
+            "format": "double"
+          },
+          "interpolationAngle": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "definitions": {
+          "BufferType": {
+            "type": "string",
+            "enum": [
+              "area2d"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "BulkAttributeRenamer",
+      "type": "processor",
+      "description": "属性名にプレフィックス／サフィックスを追加・削除、またはテキスト置換して一括でリネームする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "BulkAttributeRenamerParam",
+        "type": "object",
+        "required": [
+          "renameAction",
+          "renameType",
+          "renameValue"
+        ],
+        "properties": {
+          "renameAction": {
+            "$ref": "#/definitions/RenameAction"
+          },
+          "renameType": {
+            "$ref": "#/definitions/RenameType"
+          },
+          "renameValue": {
+            "type": "string"
+          },
+          "selectedAttributes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "definitions": {
+          "RenameAction": {
+            "type": "string",
+            "enum": [
+              "AddPrefix",
+              "AddSuffix",
+              "RemovePrefix",
+              "RemoveSuffix",
+              "StringReplace"
+            ]
+          },
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "CenterPointReplacer",
+      "type": "processor",
+      "description": "フィーチャのジオメトリを、フィーチャのバウンディングボックス中央や質量中心、またはフィーチャ領域内に確実に収まる点で置き換える",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "point",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Cesium3DTilesWriter",
+      "type": "sink",
+      "description": "フィーチャをファイルに書き出す",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Cesium3DTilesWriterParam",
+        "type": "object",
+        "required": [
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
+        "properties": {
+          "attachTexture": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "Clipper",
+      "type": "processor",
+      "description": "クリッパーフィーチャを用いて候補フィーチャを分割し、内部または外部の部分を別々に出力する",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "clipper",
+        "candidate"
+      ],
+      "outputPorts": [
+        "inside",
+        "outside",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ClosedCurveFilter",
+      "type": "processor",
+      "description": "曲線が閉ループになっているか確認する",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "closed",
+        "open",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "CoordinateSystemSetter",
+      "type": "processor",
+      "description": "フィーチャの座標系を設定する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "CoordinateSystemSetter",
+        "type": "object",
+        "required": [
+          "epsgCode"
+        ],
+        "properties": {
+          "epsgCode": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "DimensionFilter",
+      "type": "processor",
+      "description": "フィーチャを次元に基づいてフィルタリングする",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "2d",
+        "3d",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "EchoProcessor",
+      "type": "processor",
+      "description": "フィーチャをエコー出力する",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "EchoSink",
+      "type": "sink",
+      "description": "フィーチャをエコー出力する",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "ElevationExtractor",
+      "type": "processor",
+      "description": "フィーチャの最初のZ座標値を抽出し、属性として格納する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ElevationExtractorParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Extruder",
+      "type": "processor",
+      "description": "ポリゴンを一定の距離で押し出す（エクストルード）",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ExtruderParam",
+        "type": "object",
+        "required": [
+          "distance"
+        ],
+        "properties": {
+          "distance": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "FeatureCounter",
+      "type": "processor",
+      "description": "フィーチャ数をカウントする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureCounterParam",
+        "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
+        "properties": {
+          "countStart": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "type": "string"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureCreator",
+      "type": "source",
+      "description": "式に基づいてフィーチャを作成する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureCreator",
+        "type": "object",
+        "required": [
+          "creator"
+        ],
+        "properties": {
+          "creator": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureFilter",
+      "type": "processor",
+      "description": "条件に基づいてフィーチャをフィルタリングする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureFilterParam",
+        "type": "object",
+        "required": [
+          "conditions"
+        ],
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Condition"
+            }
+          }
+        },
+        "definitions": {
+          "Condition": {
+            "type": "object",
+            "required": [
+              "expr",
+              "outputPort"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/definitions/Port"
+              }
+            }
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Port": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "unfiltered"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureMerger",
+      "type": "processor",
+      "description": "属性に基づいてフィーチャをマージする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureMergerParam",
+        "type": "object",
+        "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "requestorAttribute": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "requestorAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "supplierAttribute": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "requestor",
+        "supplier"
+      ],
+      "outputPorts": [
+        "merged",
+        "unmerged"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureReader",
+      "type": "processor",
+      "description": "条件に基づいてフィーチャをフィルタリングする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureReaderParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureSorter",
+      "type": "processor",
+      "description": "フィーチャを属性でソートする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureSorterParam",
+        "type": "object",
+        "required": [
+          "sortBy"
+        ],
+        "properties": {
+          "sortBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SortBy"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Order": {
+            "type": "string",
+            "enum": [
+              "ascending",
+              "descending"
+            ]
+          },
+          "SortBy": {
+            "type": "object",
+            "required": [
+              "order"
+            ],
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/definitions/Order"
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureTransformer",
+      "type": "processor",
+      "description": "式を用いてフィーチャを変換する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureTransformerParam",
+        "type": "object",
+        "required": [
+          "transformers"
+        ],
+        "properties": {
+          "transformers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Transform"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureTypeFilter",
+      "type": "processor",
+      "description": "フィーチャタイプに基づいてフィーチャをフィルタリングする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureTypeFilter",
+        "type": "object",
+        "required": [
+          "targetTypes"
+        ],
+        "properties": {
+          "targetTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "unfiltered"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FilePathExtractor",
+      "type": "source",
+      "description": "ディレクトリまたはアーカイブからファイルを抽出する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FilePathExtractor",
+        "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
+        "properties": {
+          "extractArchive": {
+            "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FilePropertyExtractor",
+      "type": "processor",
+      "description": "ファイルからプロパティを抽出する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FilePropertyExtractor",
+        "type": "object",
+        "required": [
+          "filePathAttribute"
+        ],
+        "properties": {
+          "filePathAttribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FileReader",
+      "type": "source",
+      "description": "ファイルからフィーチャを読み込む",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FileReader",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FileWriter",
+      "type": "sink",
+      "description": "フィーチャをファイルに書き出す",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FileWriterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "converter": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "excel"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              },
+              "sheetName": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "GeoJsonWriter",
+      "type": "sink",
+      "description": "フィーチャをGeoJSONファイルに書き出す",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeoJsonWriterParam",
+        "type": "object",
+        "required": [
+          "output"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "GeometryCoercer",
+      "type": "processor",
+      "description": "フィーチャのジオメトリを特定のジオメトリタイプに強制変換する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryCoercer",
+        "type": "object",
+        "required": [
+          "coercerType"
+        ],
+        "properties": {
+          "coercerType": {
+            "$ref": "#/definitions/CoercerType"
+          }
+        },
+        "definitions": {
+          "CoercerType": {
+            "type": "string",
+            "enum": [
+              "lineString"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryDissolver",
+      "type": "processor",
+      "description": "ジオメトリをディゾルブ（結合）する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryDissolverParam",
+        "type": "object",
+        "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryExtractor",
+      "type": "processor",
+      "description": "フィーチャからジオメトリを抽出し、属性として追加する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryExtractor",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryFilter",
+      "type": "processor",
+      "description": "ジオメトリをタイプに基づいてフィルタリングする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryFilterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "none"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "multiple"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "geometryType"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "unfiltered",
+        "none",
+        "contains",
+        "point",
+        "line",
+        "lineString",
+        "polygon",
+        "multiPoint",
+        "multiLineString",
+        "multiPolygon",
+        "rect",
+        "triangle",
+        "solid",
+        "geometryCollection",
+        "solid",
+        "multiSurface",
+        "compositeSurface",
+        "surface",
+        "triangle",
+        "multiCurve",
+        "curve",
+        "multiPoint",
+        "point",
+        "tin"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryLodFilter",
+      "type": "processor",
+      "description": "LOD（詳細レベル）に基づいてジオメトリをフィルタリングする",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryLodFilterParam",
+        "type": "object",
+        "properties": {
+          "maxLod": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minLod": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "targetLods": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "unfiltered"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryReplacer",
+      "type": "processor",
+      "description": "フィーチャのジオメトリを新しいジオメトリで置き換える",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryReplacer",
+        "type": "object",
+        "required": [
+          "sourceAttribute"
+        ],
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometrySplitter",
+      "type": "processor",
+      "description": "ジオメトリをタイプ別に分割する",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryValidator",
+      "type": "processor",
+      "description": "フィーチャのジオメトリを検証する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryValidator",
+        "type": "object",
+        "required": [
+          "validationTypes"
+        ],
+        "properties": {
+          "validationTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/ValidationType"
+            }
+          }
+        },
+        "definitions": {
+          "ValidationType": {
+            "type": "string",
+            "enum": [
+              "duplicatePoints",
+              "corruptGeometry",
+              "selfIntersection"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "success",
+        "failed",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryValueFilter",
+      "type": "processor",
+      "description": "値に基づいてジオメトリをフィルタリングする",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "none",
+        "geometry2d",
+        "geometry3d",
+        "cityGml"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GltfWriter",
+      "type": "sink",
+      "description": "フィーチャをGltfファイルに書き出す",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GltfWriterParam",
+        "type": "object",
+        "required": [
+          "output"
+        ],
+        "properties": {
+          "attachTexture": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "HoleCounter",
+      "type": "processor",
+      "description": "ジオメトリ内の穴の数をカウントし、属性として追加する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "HoleCounterParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "HoleExtractor",
+      "type": "processor",
+      "description": "ジオメトリ内の穴を抽出し、属性として追加する",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "outershell",
+        "hole",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "HorizontalReprojector",
+      "type": "processor",
+      "description": "フィーチャのジオメトリを指定された座標系に水平再投影する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "HorizontalReprojectorParam",
+        "type": "object",
+        "properties": {
+          "epsgCode": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "LineOnLineOverlayer",
+      "type": "processor",
+      "description": "交点を点フィーチャに変換し、元の交差したラインの属性リストを結合して含めることができる",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "LineOnLineOverlayerParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "point",
+        "line",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ListExploder",
+      "type": "processor",
+      "description": "リスト属性を複数の要素に分解する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ListExploder",
+        "type": "object",
+        "required": [
+          "sourceAttribute"
+        ],
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "MVTWriter",
+      "type": "sink",
+      "description": "フィーチャをファイルに書き出す",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "MVTWriterParam",
+        "type": "object",
+        "required": [
+          "layerName",
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
+        "properties": {
+          "layerName": {
+            "$ref": "#/definitions/Expr"
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "NoopProcessor",
+      "type": "processor",
+      "description": "フィーチャに対して何も処理しない",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Noop"
+      ]
+    },
+    {
+      "name": "NoopSink",
+      "type": "sink",
+      "description": "最終的な処理を行わない",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "Noop"
+      ]
+    },
+    {
+      "name": "Offsetter",
+      "type": "processor",
+      "description": "フィーチャの座標にオフセットを加える",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "OffsetterParam",
+        "type": "object",
+        "properties": {
+          "offsetX": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "offsetY": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "offsetZ": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "OrientationExtractor",
+      "type": "processor",
+      "description": "フィーチャのジオメトリの方向を抽出し、属性として追加する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "OrientationExtractorParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "PLATEAU.AttributeFlattener",
+      "type": "processor",
+      "description": "建物フィーチャを作成するために属性をフラット化する",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.BuildingInstallationGeometryTypeExtractor",
+      "type": "processor",
+      "description": "建物インスタレーションジオメトリタイプ（BuildingInstallationGeometryType）を抽出する",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.BuildingUsageAttributeValidator",
+      "type": "processor",
+      "description": "必要な属性の存在や都市コードの正しさを確認し、建物利用属性を検証する。問題があればlBldgErrorおよびcodeErrorポートを通じてエラーを出力する。",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "lBldgError",
+        "codeError",
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.DictionariesInitiator",
+      "type": "processor",
+      "description": "PLATEAU用の辞書を初期化する",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.DomainOfDefinitionValidator",
+      "type": "processor",
+      "description": "CityGMLフィーチャの定義域を検証する",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.MaxLodExtractor",
+      "type": "processor",
+      "description": "maxLodを抽出する",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.TranXLinkChecker",
+      "type": "processor",
+      "description": "TranのXlinkをチェックする",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.UDXFolderExtractor",
+      "type": "processor",
+      "description": "cityGMLパスからUDXフォルダを抽出する",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.UnmatchedXlinkDetector",
+      "type": "processor",
+      "description": "PLATEAUで一致しないxlinkを検出する",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "summary",
+        "unMatchedXlinkFrom",
+        "unMatchedXlinkTo"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.XMLAttributeExtractor",
+      "type": "processor",
+      "description": "スキーマ定義に基づいてXML断片から属性を抽出する",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "attributeFeature",
+        "summary",
+        "filePath"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PlanarityFilter",
+      "type": "processor",
+      "description": "タイプに基づいてジオメトリをフィルタリングする",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "planarity",
+        "notplanarity"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Refiner",
+      "type": "processor",
+      "description": "ジオメトリを精緻化する",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "remain"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "RhaiCaller",
+      "type": "processor",
+      "description": "Rhaiスクリプトを呼び出す",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "RhaiCallerParam",
+        "type": "object",
+        "required": [
+          "isTarget",
+          "process"
+        ],
+        "properties": {
+          "isTarget": {
+            "$ref": "#/definitions/Expr"
+          },
+          "process": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "Router",
+      "type": "processor",
+      "description": "サブワークフローで最後のポートを転送するアクション",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Router",
+        "type": "object",
+        "required": [
+          "routingPort"
+        ],
+        "properties": {
+          "routingPort": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": []
+    },
+    {
+      "name": "StatisticsCalculator",
+      "type": "processor",
+      "description": "フィーチャの統計情報を計算する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "StatisticsCalculatorParam",
+        "type": "object",
+        "required": [
+          "calculations"
+        ],
+        "properties": {
+          "aggregateAttribute": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "aggregateName": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calculations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Calculation"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Calculation": {
+            "type": "object",
+            "required": [
+              "expr",
+              "newAttribute"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "complete"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "ThreeDimensionBoxReplacer",
+      "type": "processor",
+      "description": "3次元ボックスをポリゴンで置き換える",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreeDimensionBoxReplacer",
+        "type": "object",
+        "required": [
+          "maxX",
+          "maxY",
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
+        ],
+        "properties": {
+          "maxX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minZ": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ThreeDimensionRotator",
+      "type": "processor",
+      "description": "3次元ボックスをポリゴンで置き換える",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreeDimensionRotatorParam",
+        "type": "object",
+        "required": [
+          "angleDegree",
+          "directionX",
+          "directionY",
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
+        ],
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "TwoDimensionForcer",
+      "type": "processor",
+      "description": "ジオメトリを2次元に強制する",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "VertexRemover",
+      "type": "processor",
+      "description": "フィーチャのジオメトリから特定の頂点を削除する",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "VerticalReprojector",
+      "type": "processor",
+      "description": "フィーチャのジオメトリを指定された座標系に垂直再投影する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "VerticalReprojectorParam",
+        "type": "object",
+        "required": [
+          "reprojectorType"
+        ],
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/definitions/VerticalReprojectorType"
+          }
+        },
+        "definitions": {
+          "VerticalReprojectorType": {
+            "type": "string",
+            "enum": [
+              "jgd2011ToWgs84"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "WasmRuntimeExecutor",
+      "type": "processor",
+      "description": "スクリプトを.wasmにコンパイルし、wasmランタイムで実行する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "WasmRuntimeExecutorParam",
+        "type": "object",
+        "required": [
+          "processorType",
+          "programmingLanguage",
+          "sourceCodeFilePath"
+        ],
+        "properties": {
+          "processorType": {
+            "$ref": "#/definitions/ProcessorType"
+          },
+          "programmingLanguage": {
+            "$ref": "#/definitions/ProgrammingLanguage"
+          },
+          "sourceCodeFilePath": {
+            "type": "string"
+          }
+        },
+        "definitions": {
+          "ProcessorType": {
+            "type": "string",
+            "enum": [
+              "Attribute"
+            ]
+          },
+          "ProgrammingLanguage": {
+            "type": "string",
+            "enum": [
+              "Python"
+            ]
+          }
+        }
+      },
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Wasm"
+      ]
+    },
+    {
+      "name": "XMLFragmenter",
+      "type": "processor",
+      "description": "XMLを分割する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "XmlFragmenterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
+            "properties": {
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
+              },
+              "elementsToExclude": {
+                "$ref": "#/definitions/Expr"
+              },
+              "elementsToMatch": {
+                "$ref": "#/definitions/Expr"
+              },
+              "source": {
+                "type": "string",
+                "enum": [
+                  "url"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "XML"
+      ]
+    },
+    {
+      "name": "XMLValidator",
+      "type": "processor",
+      "description": "XMLコンテンツを検証する",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "XmlValidatorParam",
+        "type": "object",
+        "required": [
+          "attribute",
+          "inputType",
+          "validationType"
+        ],
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/definitions/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/definitions/ValidationType"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "ValidationType": {
+            "type": "string",
+            "enum": [
+              "syntax",
+              "syntaxAndNamespace",
+              "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "success",
+        "failed"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    }
+  ]
+}

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -1,0 +1,2944 @@
+{
+  "actions": [
+    {
+      "name": "AreaOnAreaOverlayer",
+      "type": "processor",
+      "description": "在一个区域上叠加另一个区域",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AreaOnAreaOverlayerParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "remnants",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "AttributeAggregator",
+      "type": "processor",
+      "description": "根据属性对实体进行分组",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeAggregatorParam",
+        "type": "object",
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
+        "properties": {
+          "aggregateAttributes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AggregateAttribute"
+            }
+          },
+          "calculation": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calculationAttribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "calculationValue": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "method": {
+            "$ref": "#/definitions/Method"
+          }
+        },
+        "definitions": {
+          "AggregateAttribute": {
+            "type": "object",
+            "required": [
+              "newAttribute"
+            ],
+            "properties": {
+              "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "max",
+              "min",
+              "count"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeDuplicateFilter",
+      "type": "processor",
+      "description": "筛选具有重复属性的实体",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeDuplicateFilterParam",
+        "type": "object",
+        "required": [
+          "filterBy"
+        ],
+        "properties": {
+          "filterBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeFilePathInfoExtractor",
+      "type": "processor",
+      "description": "从属性中提取文件路径信息",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeFilePathInfoExtractor",
+        "type": "object",
+        "required": [
+          "attribute"
+        ],
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeManager",
+      "type": "processor",
+      "description": "管理属性",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeManagerParam",
+        "type": "object",
+        "required": [
+          "operations"
+        ],
+        "properties": {
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Operation"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "convert",
+              "create",
+              "rename",
+              "remove"
+            ]
+          },
+          "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/definitions/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "AttributeMapper",
+      "type": "processor",
+      "description": "分配属性",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "AttributeMapperParam",
+        "type": "object",
+        "required": [
+          "mappers"
+        ],
+        "properties": {
+          "mappers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Mapper"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Mapper": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "childAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "multipleExpr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "parentAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "BoundsExtractor",
+      "type": "processor",
+      "description": "提取边界",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Bufferer",
+      "type": "processor",
+      "description": "在几何图形周围创建缓冲区",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Bufferer",
+        "type": "object",
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
+        "properties": {
+          "bufferType": {
+            "$ref": "#/definitions/BufferType"
+          },
+          "distance": {
+            "type": "number",
+            "format": "double"
+          },
+          "interpolationAngle": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "definitions": {
+          "BufferType": {
+            "type": "string",
+            "enum": [
+              "area2d"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "BulkAttributeRenamer",
+      "type": "processor",
+      "description": "通过添加/删除前缀或后缀，或替换文本来重命名属性",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "BulkAttributeRenamerParam",
+        "type": "object",
+        "required": [
+          "renameAction",
+          "renameType",
+          "renameValue"
+        ],
+        "properties": {
+          "renameAction": {
+            "$ref": "#/definitions/RenameAction"
+          },
+          "renameType": {
+            "$ref": "#/definitions/RenameType"
+          },
+          "renameValue": {
+            "type": "string"
+          },
+          "selectedAttributes": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "definitions": {
+          "RenameAction": {
+            "type": "string",
+            "enum": [
+              "AddPrefix",
+              "AddSuffix",
+              "RemovePrefix",
+              "RemoveSuffix",
+              "StringReplace"
+            ]
+          },
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "CenterPointReplacer",
+      "type": "processor",
+      "description": "将实体的几何形状替换为位于其包围盒中心、质心或实体区域内部的点。",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "point",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Cesium3DTilesWriter",
+      "type": "sink",
+      "description": "将实体写入文件",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Cesium3DTilesWriterParam",
+        "type": "object",
+        "required": [
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
+        "properties": {
+          "attachTexture": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "Clipper",
+      "type": "processor",
+      "description": "使用裁剪实体来分割候选实体，使内部或外部部分分别输出",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "clipper",
+        "candidate"
+      ],
+      "outputPorts": [
+        "inside",
+        "outside",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ClosedCurveFilter",
+      "type": "processor",
+      "description": "检查曲线是否形成闭合回路",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "closed",
+        "open",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "CoordinateSystemSetter",
+      "type": "processor",
+      "description": "设置实体的坐标系",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "CoordinateSystemSetter",
+        "type": "object",
+        "required": [
+          "epsgCode"
+        ],
+        "properties": {
+          "epsgCode": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "DimensionFilter",
+      "type": "processor",
+      "description": "根据实体的维度进行筛选",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "2d",
+        "3d",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "EchoProcessor",
+      "type": "processor",
+      "description": "重复实体",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "EchoSink",
+      "type": "sink",
+      "description": "重复实体",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "Debug"
+      ]
+    },
+    {
+      "name": "ElevationExtractor",
+      "type": "processor",
+      "description": "提取实体的第一个z坐标值并存储为一个属性",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ElevationExtractorParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Extruder",
+      "type": "processor",
+      "description": "沿一定距离拉伸多边形",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ExtruderParam",
+        "type": "object",
+        "required": [
+          "distance"
+        ],
+        "properties": {
+          "distance": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "FeatureCounter",
+      "type": "processor",
+      "description": "统计实体数量",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureCounterParam",
+        "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
+        "properties": {
+          "countStart": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "type": "string"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureCreator",
+      "type": "source",
+      "description": "根据表达式创建实体",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureCreator",
+        "type": "object",
+        "required": [
+          "creator"
+        ],
+        "properties": {
+          "creator": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureFilter",
+      "type": "processor",
+      "description": "根据条件筛选实体",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureFilterParam",
+        "type": "object",
+        "required": [
+          "conditions"
+        ],
+        "properties": {
+          "conditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Condition"
+            }
+          }
+        },
+        "definitions": {
+          "Condition": {
+            "type": "object",
+            "required": [
+              "expr",
+              "outputPort"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/definitions/Port"
+              }
+            }
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Port": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "unfiltered"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureMerger",
+      "type": "processor",
+      "description": "根据属性合并实体",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureMergerParam",
+        "type": "object",
+        "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "requestorAttribute": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "requestorAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "supplierAttribute": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "requestor",
+        "supplier"
+      ],
+      "outputPorts": [
+        "merged",
+        "unmerged"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureReader",
+      "type": "processor",
+      "description": "根据条件筛选实体",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureReaderParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureSorter",
+      "type": "processor",
+      "description": "根据属性对实体排序",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureSorterParam",
+        "type": "object",
+        "required": [
+          "sortBy"
+        ],
+        "properties": {
+          "sortBy": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SortBy"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          },
+          "Order": {
+            "type": "string",
+            "enum": [
+              "ascending",
+              "descending"
+            ]
+          },
+          "SortBy": {
+            "type": "object",
+            "required": [
+              "order"
+            ],
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/definitions/Order"
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureTransformer",
+      "type": "processor",
+      "description": "通过表达式转换实体",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureTransformerParam",
+        "type": "object",
+        "required": [
+          "transformers"
+        ],
+        "properties": {
+          "transformers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Transform"
+            }
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
+          "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FeatureTypeFilter",
+      "type": "processor",
+      "description": "根据类型筛选实体",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FeatureTypeFilter",
+        "type": "object",
+        "required": [
+          "targetTypes"
+        ],
+        "properties": {
+          "targetTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "unfiltered"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "FilePathExtractor",
+      "type": "source",
+      "description": "从目录或归档文件中提取文件",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FilePathExtractor",
+        "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
+        "properties": {
+          "extractArchive": {
+            "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FilePropertyExtractor",
+      "type": "processor",
+      "description": "提取文件的属性",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FilePropertyExtractor",
+        "type": "object",
+        "required": [
+          "filePathAttribute"
+        ],
+        "properties": {
+          "filePathAttribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FileReader",
+      "type": "source",
+      "description": "从文件中读取实体",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FileReader",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "offset": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
+              "flatten": {
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "FileWriter",
+      "type": "sink",
+      "description": "将实体写入文件",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "FileWriterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "converter": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "excel"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
+              },
+              "sheetName": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "GeoJsonWriter",
+      "type": "sink",
+      "description": "将实体写入 GeoJSON 文件",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeoJsonWriterParam",
+        "type": "object",
+        "required": [
+          "output"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "GeometryCoercer",
+      "type": "processor",
+      "description": "强制将实体几何转换为特定几何类型",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryCoercer",
+        "type": "object",
+        "required": [
+          "coercerType"
+        ],
+        "properties": {
+          "coercerType": {
+            "$ref": "#/definitions/CoercerType"
+          }
+        },
+        "definitions": {
+          "CoercerType": {
+            "type": "string",
+            "enum": [
+              "lineString"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryDissolver",
+      "type": "processor",
+      "description": "溶解几何体",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryDissolverParam",
+        "type": "object",
+        "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryExtractor",
+      "type": "processor",
+      "description": "提取实体的几何并作为属性添加",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryExtractor",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryFilter",
+      "type": "processor",
+      "description": "根据类型筛选几何",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryFilterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "none"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "multiple"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "filterType"
+            ],
+            "properties": {
+              "filterType": {
+                "type": "string",
+                "enum": [
+                  "geometryType"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "unfiltered",
+        "none",
+        "contains",
+        "point",
+        "line",
+        "lineString",
+        "polygon",
+        "multiPoint",
+        "multiLineString",
+        "multiPolygon",
+        "rect",
+        "triangle",
+        "solid",
+        "geometryCollection",
+        "solid",
+        "multiSurface",
+        "compositeSurface",
+        "surface",
+        "triangle",
+        "multiCurve",
+        "curve",
+        "multiPoint",
+        "point",
+        "tin"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryLodFilter",
+      "type": "processor",
+      "description": "根据细节级别（LOD）筛选几何",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryLodFilterParam",
+        "type": "object",
+        "properties": {
+          "maxLod": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minLod": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "targetLods": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "unfiltered"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryReplacer",
+      "type": "processor",
+      "description": "用新几何替换实体的几何",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryReplacer",
+        "type": "object",
+        "required": [
+          "sourceAttribute"
+        ],
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometrySplitter",
+      "type": "processor",
+      "description": "根据类型分割几何",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryValidator",
+      "type": "processor",
+      "description": "验证实体的几何",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GeometryValidator",
+        "type": "object",
+        "required": [
+          "validationTypes"
+        ],
+        "properties": {
+          "validationTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/ValidationType"
+            }
+          }
+        },
+        "definitions": {
+          "ValidationType": {
+            "type": "string",
+            "enum": [
+              "duplicatePoints",
+              "corruptGeometry",
+              "selfIntersection"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "success",
+        "failed",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GeometryValueFilter",
+      "type": "processor",
+      "description": "根据值筛选几何",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "none",
+        "geometry2d",
+        "geometry3d",
+        "cityGml"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "GltfWriter",
+      "type": "sink",
+      "description": "将实体写入Gltf文件",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "GltfWriterParam",
+        "type": "object",
+        "required": [
+          "output"
+        ],
+        "properties": {
+          "attachTexture": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "HoleCounter",
+      "type": "processor",
+      "description": "统计几何中的孔数量并作为属性添加",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "HoleCounterParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "HoleExtractor",
+      "type": "processor",
+      "description": "提取几何中的孔并作为属性添加",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "outershell",
+        "hole",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "HorizontalReprojector",
+      "type": "processor",
+      "description": "将实体的几何重投影到指定坐标系",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "HorizontalReprojectorParam",
+        "type": "object",
+        "properties": {
+          "epsgCode": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "LineOnLineOverlayer",
+      "type": "processor",
+      "description": "交点转换为点实体，并可包含原始相交线段组合的属性列表",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "LineOnLineOverlayerParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "point",
+        "line",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ListExploder",
+      "type": "processor",
+      "description": "将列表类型的属性拆分为多个元素",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ListExploder",
+        "type": "object",
+        "required": [
+          "sourceAttribute"
+        ],
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "MVTWriter",
+      "type": "sink",
+      "description": "将实体写入文件",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "MVTWriterParam",
+        "type": "object",
+        "required": [
+          "layerName",
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
+        "properties": {
+          "layerName": {
+            "$ref": "#/definitions/Expr"
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "File"
+      ]
+    },
+    {
+      "name": "NoopProcessor",
+      "type": "processor",
+      "description": "对实体不执行任何操作",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Noop"
+      ]
+    },
+    {
+      "name": "NoopSink",
+      "type": "sink",
+      "description": "不执行任何最终操作",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": [
+        "Noop"
+      ]
+    },
+    {
+      "name": "Offsetter",
+      "type": "processor",
+      "description": "为实体的坐标添加偏移",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "OffsetterParam",
+        "type": "object",
+        "properties": {
+          "offsetX": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "offsetY": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "offsetZ": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "OrientationExtractor",
+      "type": "processor",
+      "description": "提取实体几何的方向并作为属性添加",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "OrientationExtractorParam",
+        "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "PLATEAU.AttributeFlattener",
+      "type": "processor",
+      "description": "扁平化属性以创建建筑实体",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.BuildingInstallationGeometryTypeExtractor",
+      "type": "processor",
+      "description": "提取建筑安装几何类型（BuildingInstallationGeometryType）",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.BuildingUsageAttributeValidator",
+      "type": "processor",
+      "description": "此处理器通过检查所需属性的存在和城市代码的正确性来验证建筑用途属性。如果发现问题，将通过lBldgError和codeError端口输出错误。",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "lBldgError",
+        "codeError",
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.DictionariesInitiator",
+      "type": "processor",
+      "description": "为PLATEAU初始化字典",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.DomainOfDefinitionValidator",
+      "type": "processor",
+      "description": "验证CityGML实体的定义域",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.MaxLodExtractor",
+      "type": "processor",
+      "description": "提取maxLod",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.TranXLinkChecker",
+      "type": "processor",
+      "description": "检查Tran的Xlink",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.UDXFolderExtractor",
+      "type": "processor",
+      "description": "从cityGML路径中提取UDX文件夹",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.UnmatchedXlinkDetector",
+      "type": "processor",
+      "description": "检测PLATEAU中不匹配的xlink",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "summary",
+        "unMatchedXlinkFrom",
+        "unMatchedXlinkTo"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PLATEAU.XMLAttributeExtractor",
+      "type": "processor",
+      "description": "根据模式定义从XML片段中提取属性",
+      "parameter": null,
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "attributeFeature",
+        "summary",
+        "filePath"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
+      "name": "PlanarityFilter",
+      "type": "processor",
+      "description": "根据类型筛选几何",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "planarity",
+        "notplanarity"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "Refiner",
+      "type": "processor",
+      "description": "优化几何",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "remain"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "RhaiCaller",
+      "type": "processor",
+      "description": "调用Rhai脚本",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "RhaiCallerParam",
+        "type": "object",
+        "required": [
+          "isTarget",
+          "process"
+        ],
+        "properties": {
+          "isTarget": {
+            "$ref": "#/definitions/Expr"
+          },
+          "process": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
+      "name": "Router",
+      "type": "processor",
+      "description": "用于子工作流中最后一个端口转发的操作",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Router",
+        "type": "object",
+        "required": [
+          "routingPort"
+        ],
+        "properties": {
+          "routingPort": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [],
+      "categories": []
+    },
+    {
+      "name": "StatisticsCalculator",
+      "type": "processor",
+      "description": "计算实体的统计信息",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "StatisticsCalculatorParam",
+        "type": "object",
+        "required": [
+          "calculations"
+        ],
+        "properties": {
+          "aggregateAttribute": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "aggregateName": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "calculations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Calculation"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Calculation": {
+            "type": "object",
+            "required": [
+              "expr",
+              "newAttribute"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "complete"
+      ],
+      "categories": [
+        "Attribute"
+      ]
+    },
+    {
+      "name": "ThreeDimensionBoxReplacer",
+      "type": "processor",
+      "description": "用多边形替换三维盒子",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreeDimensionBoxReplacer",
+        "type": "object",
+        "required": [
+          "maxX",
+          "maxY",
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
+        ],
+        "properties": {
+          "maxX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minZ": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "ThreeDimensionRotator",
+      "type": "processor",
+      "description": "用多边形替换三维盒子",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "ThreeDimensionRotatorParam",
+        "type": "object",
+        "required": [
+          "angleDegree",
+          "directionX",
+          "directionY",
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
+        ],
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "TwoDimensionForcer",
+      "type": "processor",
+      "description": "将几何强制为二维",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "VertexRemover",
+      "type": "processor",
+      "description": "从实体的几何中删除特定的顶点",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "VerticalReprojector",
+      "type": "processor",
+      "description": "将实体的几何重投影到指定坐标系",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "VerticalReprojectorParam",
+        "type": "object",
+        "required": [
+          "reprojectorType"
+        ],
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/definitions/VerticalReprojectorType"
+          }
+        },
+        "definitions": {
+          "VerticalReprojectorType": {
+            "type": "string",
+            "enum": [
+              "jgd2011ToWgs84"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
+      "name": "WasmRuntimeExecutor",
+      "type": "processor",
+      "description": "将脚本编译为.wasm并在wasm运行环境中执行",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "WasmRuntimeExecutorParam",
+        "type": "object",
+        "required": [
+          "processorType",
+          "programmingLanguage",
+          "sourceCodeFilePath"
+        ],
+        "properties": {
+          "processorType": {
+            "$ref": "#/definitions/ProcessorType"
+          },
+          "programmingLanguage": {
+            "$ref": "#/definitions/ProgrammingLanguage"
+          },
+          "sourceCodeFilePath": {
+            "type": "string"
+          }
+        },
+        "definitions": {
+          "ProcessorType": {
+            "type": "string",
+            "enum": [
+              "Attribute"
+            ]
+          },
+          "ProgrammingLanguage": {
+            "type": "string",
+            "enum": [
+              "Python"
+            ]
+          }
+        }
+      },
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Wasm"
+      ]
+    },
+    {
+      "name": "XMLFragmenter",
+      "type": "processor",
+      "description": "分割XML",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "XmlFragmenterParam",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
+            "properties": {
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
+              },
+              "elementsToExclude": {
+                "$ref": "#/definitions/Expr"
+              },
+              "elementsToMatch": {
+                "$ref": "#/definitions/Expr"
+              },
+              "source": {
+                "type": "string",
+                "enum": [
+                  "url"
+                ]
+              }
+            }
+          }
+        ],
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "XML"
+      ]
+    },
+    {
+      "name": "XMLValidator",
+      "type": "processor",
+      "description": "验证XML内容",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "XmlValidatorParam",
+        "type": "object",
+        "required": [
+          "attribute",
+          "inputType",
+          "validationType"
+        ],
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/definitions/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/definitions/ValidationType"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "ValidationType": {
+            "type": "string",
+            "enum": [
+              "syntax",
+              "syntaxAndNamespace",
+              "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "success",
+        "failed"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    }
+  ]
+}

--- a/engine/schema/i18n/actions/en.json
+++ b/engine/schema/i18n/actions/en.json
@@ -1,0 +1,304 @@
+{
+  "actions": [
+    {
+      "name": "AreaOnAreaOverlayer",
+      "description": "Overlays an area on another area"
+    },
+    {
+      "name": "AttributeAggregator",
+      "description": "Aggregates features by attributes"
+    },
+    {
+      "name": "AttributeDuplicateFilter",
+      "description": "Filters features by duplicate attributes"
+    },
+    {
+      "name": "AttributeFilePathInfoExtractor",
+      "description": "Extracts file path information from attributes"
+    },
+    {
+      "name": "AttributeManager",
+      "description": "Manages attributes"
+    },
+    {
+      "name": "AttributeMapper",
+      "description": "Maps attributes"
+    },
+    {
+      "name": "BoundsExtractor",
+      "description": "Bounds Extractor"
+    },
+    {
+      "name": "Bufferer",
+      "description": "Buffers a geometry"
+    },
+    {
+      "name": "BulkAttributeRenamer",
+      "description": "Renames attributes by adding/removing prefixes or suffixes, or replacing text"
+    },
+    {
+      "name": "CenterPointReplacer",
+      "description": "Replaces the geometry of the feature with a point that is either in the center of the feature's bounding box, at the center of mass of the feature, or somewhere guaranteed to be inside the feature's area."
+    },
+    {
+      "name": "Cesium3DTilesWriter",
+      "description": "Writes features to a file"
+    },
+    {
+      "name": "Clipper",
+      "description": "Divides Candidate features using Clipper features, so that Candidates and parts of Candidates that are inside or outside of the Clipper features are output separately"
+    },
+    {
+      "name": "ClosedCurveFilter",
+      "description": "Checks if curves form closed loops"
+    },
+    {
+      "name": "CoordinateSystemSetter",
+      "description": "Sets the coordinate system of a feature"
+    },
+    {
+      "name": "DimensionFilter",
+      "description": "Filters the dimension of features"
+    },
+    {
+      "name": "EchoProcessor",
+      "description": "Echo features"
+    },
+    {
+      "name": "EchoSink",
+      "description": "Echo features"
+    },
+    {
+      "name": "ElevationExtractor",
+      "description": "Extracts a feature’s first z coordinate value, storing it in an attribute."
+    },
+    {
+      "name": "Extruder",
+      "description": "Extrudes a polygon by a distance"
+    },
+    {
+      "name": "FeatureCounter",
+      "description": "Counts features"
+    },
+    {
+      "name": "FeatureCreator",
+      "description": "Creates features from expressions"
+    },
+    {
+      "name": "FeatureFilter",
+      "description": "Filters features based on conditions"
+    },
+    {
+      "name": "FeatureMerger",
+      "description": "Merges features by attributes"
+    },
+    {
+      "name": "FeatureReader",
+      "description": "Filters features based on conditions"
+    },
+    {
+      "name": "FeatureSorter",
+      "description": "Sorts features by attributes"
+    },
+    {
+      "name": "FeatureTransformer",
+      "description": "Transforms features by expressions"
+    },
+    {
+      "name": "FeatureTypeFilter",
+      "description": "Filters features by feature type"
+    },
+    {
+      "name": "FilePathExtractor",
+      "description": "Extracts files from a directory or an archive"
+    },
+    {
+      "name": "FilePropertyExtractor",
+      "description": "Extracts properties from a file"
+    },
+    {
+      "name": "FileReader",
+      "description": "Reads features from a file"
+    },
+    {
+      "name": "FileWriter",
+      "description": "Writes features to a file"
+    },
+    {
+      "name": "GeoJsonWriter",
+      "description": "Writes features to a geojson file"
+    },
+    {
+      "name": "GeometryCoercer",
+      "description": "Coerces the geometry of a feature to a specific geometry"
+    },
+    {
+      "name": "GeometryDissolver",
+      "description": "Dissolve geometries"
+    },
+    {
+      "name": "GeometryExtractor",
+      "description": "Extracts geometry from a feature and adds it as an attribute."
+    },
+    {
+      "name": "GeometryFilter",
+      "description": "Filter geometry by type"
+    },
+    {
+      "name": "GeometryLodFilter",
+      "description": "Filter geometry by lod"
+    },
+    {
+      "name": "GeometryReplacer",
+      "description": "Replaces the geometry of a feature with a new geometry."
+    },
+    {
+      "name": "GeometrySplitter",
+      "description": "Split geometry by type"
+    },
+    {
+      "name": "GeometryValidator",
+      "description": "Validates the geometry of a feature"
+    },
+    {
+      "name": "GeometryValueFilter",
+      "description": "Filter geometry by value"
+    },
+    {
+      "name": "GltfWriter",
+      "description": "Writes features to a Gltf"
+    },
+    {
+      "name": "HoleCounter",
+      "description": "Counts the number of holes in a geometry and adds it as an attribute."
+    },
+    {
+      "name": "HoleExtractor",
+      "description": "Extracts holes in a geometry and adds it as an attribute."
+    },
+    {
+      "name": "HorizontalReprojector",
+      "description": "Reprojects the geometry of a feature to a specified coordinate system"
+    },
+    {
+      "name": "LineOnLineOverlayer",
+      "description": "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines."
+    },
+    {
+      "name": "ListExploder",
+      "description": "Explodes list attributes"
+    },
+    {
+      "name": "MVTWriter",
+      "description": "Writes features to a file"
+    },
+    {
+      "name": "NoopProcessor",
+      "description": "Noop features"
+    },
+    {
+      "name": "NoopSink",
+      "description": "noop sink"
+    },
+    {
+      "name": "Offsetter",
+      "description": "Adds offsets to the feature's coordinates."
+    },
+    {
+      "name": "OrientationExtractor",
+      "description": "Extracts the orientation of a geometry from a feature and adds it as an attribute."
+    },
+    {
+      "name": "PLATEAU.AttributeFlattener",
+      "description": "Flatten attributes for building feature"
+    },
+    {
+      "name": "PLATEAU.BuildingInstallationGeometryTypeExtractor",
+      "description": "Extracts BuildingInstallationGeometryType"
+    },
+    {
+      "name": "PLATEAU.BuildingUsageAttributeValidator",
+      "description": "This processor validates building usage attributes by checking for the presence of required attributes and ensuring the correctness of city codes. It outputs errors through the lBldgError and codeError ports if any issues are found."
+    },
+    {
+      "name": "PLATEAU.DictionariesInitiator",
+      "description": "Initializes dictionaries for PLATEAU"
+    },
+    {
+      "name": "PLATEAU.DomainOfDefinitionValidator",
+      "description": "Validates domain of definition of CityGML features"
+    },
+    {
+      "name": "PLATEAU.MaxLodExtractor",
+      "description": "Extracts maxLod"
+    },
+    {
+      "name": "PLATEAU.TranXLinkChecker",
+      "description": "Check Xlink for Tran"
+    },
+    {
+      "name": "PLATEAU.UDXFolderExtractor",
+      "description": "Extracts UDX folders from cityGML path"
+    },
+    {
+      "name": "PLATEAU.UnmatchedXlinkDetector",
+      "description": "Detect unmatched xlink for PLATEAU"
+    },
+    {
+      "name": "PLATEAU.XMLAttributeExtractor",
+      "description": "Extracts attributes from XML fragments based on a schema definition"
+    },
+    {
+      "name": "PlanarityFilter",
+      "description": "Filter geometry by type"
+    },
+    {
+      "name": "Refiner",
+      "description": "Geometry Refiner"
+    },
+    {
+      "name": "RhaiCaller",
+      "description": "Calls Rhai script"
+    },
+    {
+      "name": "Router",
+      "description": "Action for last port forwarding for sub-workflows."
+    },
+    {
+      "name": "StatisticsCalculator",
+      "description": "Calculates statistics of features"
+    },
+    {
+      "name": "ThreeDimensionBoxReplacer",
+      "description": "Replaces a three Dimension box with a polygon."
+    },
+    {
+      "name": "ThreeDimensionRotator",
+      "description": "Replaces a three Dimension box with a polygon."
+    },
+    {
+      "name": "TwoDimensionForcer",
+      "description": "Forces a geometry to be two dimensional."
+    },
+    {
+      "name": "VertexRemover",
+      "description": "Removes specific vertices from a feature’s geometry"
+    },
+    {
+      "name": "VerticalReprojector",
+      "description": "Reprojects the geometry of a feature to a specified coordinate system"
+    },
+    {
+      "name": "WasmRuntimeExecutor",
+      "description": "Compiles scripts into .wasm and runs at the wasm runtime"
+    },
+    {
+      "name": "XMLFragmenter",
+      "description": "Fragment XML"
+    },
+    {
+      "name": "XMLValidator",
+      "description": "Validates XML content"
+    }
+  ]
+}

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -1,0 +1,304 @@
+{
+  "actions": [
+    {
+      "name": "AreaOnAreaOverlayer",
+      "description": "Superpone un área sobre otra área"
+    },
+    {
+      "name": "AttributeAggregator",
+      "description": "Agrupa las entidades según sus atributos"
+    },
+    {
+      "name": "AttributeDuplicateFilter",
+      "description": "Filtra las entidades con atributos duplicados"
+    },
+    {
+      "name": "AttributeFilePathInfoExtractor",
+      "description": "Extrae información de rutas de archivo a partir de atributos"
+    },
+    {
+      "name": "AttributeManager",
+      "description": "Gestiona atributos"
+    },
+    {
+      "name": "AttributeMapper",
+      "description": "Asigna atributos"
+    },
+    {
+      "name": "BoundsExtractor",
+      "description": "Extrae los límites"
+    },
+    {
+      "name": "Bufferer",
+      "description": "Crea un búfer alrededor de una geometría"
+    },
+    {
+      "name": "BulkAttributeRenamer",
+      "description": "Cambia el nombre de atributos añadiendo/eliminando prefijos o sufijos, o reemplazando texto"
+    },
+    {
+      "name": "CenterPointReplacer",
+      "description": "Reemplaza la geometría de la entidad con un punto que esté en el centro de su caja delimitadora, en su centro de masa o dentro de su área."
+    },
+    {
+      "name": "Cesium3DTilesWriter",
+      "description": "Escribe las entidades en un archivo"
+    },
+    {
+      "name": "Clipper",
+      "description": "Divide las entidades candidatas utilizando entidades recortadoras, de modo que las partes dentro o fuera de las recortadoras se produzcan por separado"
+    },
+    {
+      "name": "ClosedCurveFilter",
+      "description": "Comprueba si las curvas forman bucles cerrados"
+    },
+    {
+      "name": "CoordinateSystemSetter",
+      "description": "Establece el sistema de coordenadas de una entidad"
+    },
+    {
+      "name": "DimensionFilter",
+      "description": "Filtra las entidades según su dimensión"
+    },
+    {
+      "name": "EchoProcessor",
+      "description": "Repite las entidades"
+    },
+    {
+      "name": "EchoSink",
+      "description": "Repite las entidades"
+    },
+    {
+      "name": "ElevationExtractor",
+      "description": "Extrae el primer valor de la coordenada z de una entidad y lo almacena en un atributo."
+    },
+    {
+      "name": "Extruder",
+      "description": "Extruye un polígono a una cierta distancia"
+    },
+    {
+      "name": "FeatureCounter",
+      "description": "Cuenta entidades"
+    },
+    {
+      "name": "FeatureCreator",
+      "description": "Crea entidades a partir de expresiones"
+    },
+    {
+      "name": "FeatureFilter",
+      "description": "Filtra entidades según condiciones"
+    },
+    {
+      "name": "FeatureMerger",
+      "description": "Une entidades según sus atributos"
+    },
+    {
+      "name": "FeatureReader",
+      "description": "Filtra entidades según condiciones"
+    },
+    {
+      "name": "FeatureSorter",
+      "description": "Ordena entidades por atributos"
+    },
+    {
+      "name": "FeatureTransformer",
+      "description": "Transforma entidades mediante expresiones"
+    },
+    {
+      "name": "FeatureTypeFilter",
+      "description": "Filtra entidades por tipo de entidad"
+    },
+    {
+      "name": "FilePathExtractor",
+      "description": "Extrae archivos de un directorio o de un archivo comprimido"
+    },
+    {
+      "name": "FilePropertyExtractor",
+      "description": "Extrae propiedades de un archivo"
+    },
+    {
+      "name": "FileReader",
+      "description": "Lee entidades desde un archivo"
+    },
+    {
+      "name": "FileWriter",
+      "description": "Escribe entidades en un archivo"
+    },
+    {
+      "name": "GeoJsonWriter",
+      "description": "Escribe entidades en un archivo GeoJSON"
+    },
+    {
+      "name": "GeometryCoercer",
+      "description": "Fuerza la geometría de una entidad a una geometría específica"
+    },
+    {
+      "name": "GeometryDissolver",
+      "description": "Disuelve geometrías"
+    },
+    {
+      "name": "GeometryExtractor",
+      "description": "Extrae la geometría de una entidad y la añade como un atributo."
+    },
+    {
+      "name": "GeometryFilter",
+      "description": "Filtra la geometría por tipo"
+    },
+    {
+      "name": "GeometryLodFilter",
+      "description": "Filtra la geometría por nivel de detalle (lod)"
+    },
+    {
+      "name": "GeometryReplacer",
+      "description": "Reemplaza la geometría de una entidad con una nueva geometría."
+    },
+    {
+      "name": "GeometrySplitter",
+      "description": "Divide la geometría por tipo"
+    },
+    {
+      "name": "GeometryValidator",
+      "description": "Valida la geometría de una entidad"
+    },
+    {
+      "name": "GeometryValueFilter",
+      "description": "Filtra la geometría por valor"
+    },
+    {
+      "name": "GltfWriter",
+      "description": "Escribe entidades en un archivo Gltf"
+    },
+    {
+      "name": "HoleCounter",
+      "description": "Cuenta el número de huecos en una geometría y lo agrega como atributo."
+    },
+    {
+      "name": "HoleExtractor",
+      "description": "Extrae los huecos en una geometría y los agrega como atributo."
+    },
+    {
+      "name": "HorizontalReprojector",
+      "description": "Reproyecta la geometría de una entidad a un sistema de coordenadas especificado"
+    },
+    {
+      "name": "LineOnLineOverlayer",
+      "description": "Los puntos de intersección se convierten en entidades de puntos que pueden contener la lista combinada de atributos de las líneas originales intersectadas."
+    },
+    {
+      "name": "ListExploder",
+      "description": "Divide en varios elementos los atributos de tipo lista"
+    },
+    {
+      "name": "MVTWriter",
+      "description": "Escribe entidades en un archivo"
+    },
+    {
+      "name": "NoopProcessor",
+      "description": "No realiza ninguna operación sobre las entidades"
+    },
+    {
+      "name": "NoopSink",
+      "description": "No realiza ninguna operación final"
+    },
+    {
+      "name": "Offsetter",
+      "description": "Añade desplazamientos a las coordenadas de la entidad."
+    },
+    {
+      "name": "OrientationExtractor",
+      "description": "Extrae la orientación de una geometría de una entidad y la agrega como un atributo."
+    },
+    {
+      "name": "PLATEAU.AttributeFlattener",
+      "description": "Aplana los atributos para crear una entidad de edificio"
+    },
+    {
+      "name": "PLATEAU.BuildingInstallationGeometryTypeExtractor",
+      "description": "Extrae el tipo de geometría de la instalación de un edificio (BuildingInstallationGeometryType)"
+    },
+    {
+      "name": "PLATEAU.BuildingUsageAttributeValidator",
+      "description": "Este procesador valida los atributos de uso de edificios comprobando la presencia de atributos requeridos y garantizando la corrección de los códigos de ciudad. Si se encuentran problemas, produce errores a través de los puertos lBldgError y codeError."
+    },
+    {
+      "name": "PLATEAU.DictionariesInitiator",
+      "description": "Inicializa diccionarios para PLATEAU"
+    },
+    {
+      "name": "PLATEAU.DomainOfDefinitionValidator",
+      "description": "Valida el dominio de definición de las entidades CityGML"
+    },
+    {
+      "name": "PLATEAU.MaxLodExtractor",
+      "description": "Extrae maxLod"
+    },
+    {
+      "name": "PLATEAU.TranXLinkChecker",
+      "description": "Comprueba Xlink para Tran"
+    },
+    {
+      "name": "PLATEAU.UDXFolderExtractor",
+      "description": "Extrae carpetas UDX desde la ruta cityGML"
+    },
+    {
+      "name": "PLATEAU.UnmatchedXlinkDetector",
+      "description": "Detecta xlinks no coincidentes para PLATEAU"
+    },
+    {
+      "name": "PLATEAU.XMLAttributeExtractor",
+      "description": "Extrae atributos de fragmentos XML basándose en una definición de esquema"
+    },
+    {
+      "name": "PlanarityFilter",
+      "description": "Filtra la geometría por tipo"
+    },
+    {
+      "name": "Refiner",
+      "description": "Refina la geometría"
+    },
+    {
+      "name": "RhaiCaller",
+      "description": "Llama a un script Rhai"
+    },
+    {
+      "name": "Router",
+      "description": "Acción para el reenvío del último puerto en sub-flujos de trabajo."
+    },
+    {
+      "name": "StatisticsCalculator",
+      "description": "Calcula estadísticas de las entidades"
+    },
+    {
+      "name": "ThreeDimensionBoxReplacer",
+      "description": "Reemplaza una caja tridimensional con un polígono."
+    },
+    {
+      "name": "ThreeDimensionRotator",
+      "description": "Reemplaza una caja tridimensional con un polígono."
+    },
+    {
+      "name": "TwoDimensionForcer",
+      "description": "Fuerza una geometría a ser bidimensional."
+    },
+    {
+      "name": "VertexRemover",
+      "description": "Elimina vértices específicos de la geometría de una entidad"
+    },
+    {
+      "name": "VerticalReprojector",
+      "description": "Reproyecta la geometría de una entidad a un sistema de coordenadas especificado"
+    },
+    {
+      "name": "WasmRuntimeExecutor",
+      "description": "Compila scripts en .wasm y los ejecuta en tiempo de ejecución de wasm"
+    },
+    {
+      "name": "XMLFragmenter",
+      "description": "Fragmenta XML"
+    },
+    {
+      "name": "XMLValidator",
+      "description": "Valida contenido XML"
+    }
+  ]
+}

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -1,0 +1,304 @@
+{
+  "actions": [
+    {
+      "name": "AreaOnAreaOverlayer",
+      "description": "Superpose une zone sur une autre zone"
+    },
+    {
+      "name": "AttributeAggregator",
+      "description": "Regroupe les entités selon leurs attributs"
+    },
+    {
+      "name": "AttributeDuplicateFilter",
+      "description": "Filtre les entités possédant des attributs dupliqués"
+    },
+    {
+      "name": "AttributeFilePathInfoExtractor",
+      "description": "Extrait des informations de chemins de fichier à partir des attributs"
+    },
+    {
+      "name": "AttributeManager",
+      "description": "Gère les attributs"
+    },
+    {
+      "name": "AttributeMapper",
+      "description": "Assigne des attributs"
+    },
+    {
+      "name": "BoundsExtractor",
+      "description": "Extrait les limites"
+    },
+    {
+      "name": "Bufferer",
+      "description": "Crée un tampon autour d'une géométrie"
+    },
+    {
+      "name": "BulkAttributeRenamer",
+      "description": "Renomme des attributs en ajoutant/supprimant des préfixes ou suffixes, ou en remplaçant du texte"
+    },
+    {
+      "name": "CenterPointReplacer",
+      "description": "Remplace la géométrie de l'entité par un point situé au centre de sa boîte englobante, à son centre de masse, ou à l'intérieur de son aire."
+    },
+    {
+      "name": "Cesium3DTilesWriter",
+      "description": "Écrit les entités dans un fichier"
+    },
+    {
+      "name": "Clipper",
+      "description": "Divise les entités candidates à l'aide d'entités de découpage, de sorte que les parties intérieures ou extérieures soient produites séparément"
+    },
+    {
+      "name": "ClosedCurveFilter",
+      "description": "Vérifie si les courbes forment des boucles fermées"
+    },
+    {
+      "name": "CoordinateSystemSetter",
+      "description": "Définit le système de coordonnées d'une entité"
+    },
+    {
+      "name": "DimensionFilter",
+      "description": "Filtre les entités en fonction de leur dimension"
+    },
+    {
+      "name": "EchoProcessor",
+      "description": "Répète les entités"
+    },
+    {
+      "name": "EchoSink",
+      "description": "Répète les entités"
+    },
+    {
+      "name": "ElevationExtractor",
+      "description": "Extrait la première valeur de la coordonnée z d'une entité et la stocke dans un attribut."
+    },
+    {
+      "name": "Extruder",
+      "description": "Extrue un polygone sur une certaine distance"
+    },
+    {
+      "name": "FeatureCounter",
+      "description": "Compte les entités"
+    },
+    {
+      "name": "FeatureCreator",
+      "description": "Crée des entités à partir d'expressions"
+    },
+    {
+      "name": "FeatureFilter",
+      "description": "Filtre les entités selon des conditions"
+    },
+    {
+      "name": "FeatureMerger",
+      "description": "Fusionne des entités selon leurs attributs"
+    },
+    {
+      "name": "FeatureReader",
+      "description": "Filtre les entités selon des conditions"
+    },
+    {
+      "name": "FeatureSorter",
+      "description": "Trie les entités par attributs"
+    },
+    {
+      "name": "FeatureTransformer",
+      "description": "Transforme les entités à l'aide d'expressions"
+    },
+    {
+      "name": "FeatureTypeFilter",
+      "description": "Filtre les entités par type"
+    },
+    {
+      "name": "FilePathExtractor",
+      "description": "Extrait des fichiers d'un répertoire ou d'une archive"
+    },
+    {
+      "name": "FilePropertyExtractor",
+      "description": "Extrait les propriétés d'un fichier"
+    },
+    {
+      "name": "FileReader",
+      "description": "Lit des entités depuis un fichier"
+    },
+    {
+      "name": "FileWriter",
+      "description": "Écrit des entités dans un fichier"
+    },
+    {
+      "name": "GeoJsonWriter",
+      "description": "Écrit des entités dans un fichier GeoJSON"
+    },
+    {
+      "name": "GeometryCoercer",
+      "description": "Force la géométrie d'une entité à une géométrie spécifique"
+    },
+    {
+      "name": "GeometryDissolver",
+      "description": "Dissout des géométries"
+    },
+    {
+      "name": "GeometryExtractor",
+      "description": "Extrait la géométrie d'une entité et l'ajoute comme attribut."
+    },
+    {
+      "name": "GeometryFilter",
+      "description": "Filtre la géométrie par type"
+    },
+    {
+      "name": "GeometryLodFilter",
+      "description": "Filtre la géométrie par niveau de détail (lod)"
+    },
+    {
+      "name": "GeometryReplacer",
+      "description": "Remplace la géométrie d'une entité par une nouvelle géométrie."
+    },
+    {
+      "name": "GeometrySplitter",
+      "description": "Divise la géométrie par type"
+    },
+    {
+      "name": "GeometryValidator",
+      "description": "Valide la géométrie d'une entité"
+    },
+    {
+      "name": "GeometryValueFilter",
+      "description": "Filtre la géométrie par valeur"
+    },
+    {
+      "name": "GltfWriter",
+      "description": "Écrit des entités dans un fichier Gltf"
+    },
+    {
+      "name": "HoleCounter",
+      "description": "Compte le nombre de trous dans une géométrie et l'ajoute comme attribut."
+    },
+    {
+      "name": "HoleExtractor",
+      "description": "Extrait les trous dans une géométrie et les ajoute comme attribut."
+    },
+    {
+      "name": "HorizontalReprojector",
+      "description": "Reprojette la géométrie d'une entité dans un système de coordonnées spécifié"
+    },
+    {
+      "name": "LineOnLineOverlayer",
+      "description": "Les points d'intersection deviennent des entités ponctuelles pouvant contenir la liste combinée des attributs des lignes d'origine intersectées."
+    },
+    {
+      "name": "ListExploder",
+      "description": "Explose les attributs de type liste en plusieurs éléments"
+    },
+    {
+      "name": "MVTWriter",
+      "description": "Écrit des entités dans un fichier"
+    },
+    {
+      "name": "NoopProcessor",
+      "description": "N'effectue aucune opération sur les entités"
+    },
+    {
+      "name": "NoopSink",
+      "description": "N'effectue aucune opération finale"
+    },
+    {
+      "name": "Offsetter",
+      "description": "Ajoute des décalages aux coordonnées de l'entité."
+    },
+    {
+      "name": "OrientationExtractor",
+      "description": "Extrait l'orientation de la géométrie d'une entité et l'ajoute comme attribut."
+    },
+    {
+      "name": "PLATEAU.AttributeFlattener",
+      "description": "Aplati les attributs pour créer une entité de bâtiment"
+    },
+    {
+      "name": "PLATEAU.BuildingInstallationGeometryTypeExtractor",
+      "description": "Extrait le type de géométrie de l'installation d'un bâtiment (BuildingInstallationGeometryType)"
+    },
+    {
+      "name": "PLATEAU.BuildingUsageAttributeValidator",
+      "description": "Ce processeur valide les attributs d'usage des bâtiments en vérifiant la présence d'attributs requis et la justesse des codes de ville. En cas de problème, il génère des erreurs via les ports lBldgError et codeError."
+    },
+    {
+      "name": "PLATEAU.DictionariesInitiator",
+      "description": "Initialise des dictionnaires pour PLATEAU"
+    },
+    {
+      "name": "PLATEAU.DomainOfDefinitionValidator",
+      "description": "Valide le domaine de définition des entités CityGML"
+    },
+    {
+      "name": "PLATEAU.MaxLodExtractor",
+      "description": "Extrait maxLod"
+    },
+    {
+      "name": "PLATEAU.TranXLinkChecker",
+      "description": "Vérifie Xlink pour Tran"
+    },
+    {
+      "name": "PLATEAU.UDXFolderExtractor",
+      "description": "Extrait les dossiers UDX du chemin cityGML"
+    },
+    {
+      "name": "PLATEAU.UnmatchedXlinkDetector",
+      "description": "Détecte les xlinks non correspondants pour PLATEAU"
+    },
+    {
+      "name": "PLATEAU.XMLAttributeExtractor",
+      "description": "Extrait les attributs de fragments XML en fonction d'une définition de schéma"
+    },
+    {
+      "name": "PlanarityFilter",
+      "description": "Filtre la géométrie par type"
+    },
+    {
+      "name": "Refiner",
+      "description": "Affine la géométrie"
+    },
+    {
+      "name": "RhaiCaller",
+      "description": "Appelle un script Rhai"
+    },
+    {
+      "name": "Router",
+      "description": "Action pour le renvoi du dernier port dans les sous-flux de travail."
+    },
+    {
+      "name": "StatisticsCalculator",
+      "description": "Calcule des statistiques sur les entités"
+    },
+    {
+      "name": "ThreeDimensionBoxReplacer",
+      "description": "Remplace un boîtier tridimensionnel par un polygone."
+    },
+    {
+      "name": "ThreeDimensionRotator",
+      "description": "Remplace un boîtier tridimensionnel par un polygone."
+    },
+    {
+      "name": "TwoDimensionForcer",
+      "description": "Force une géométrie à être bidimensionnelle."
+    },
+    {
+      "name": "VertexRemover",
+      "description": "Supprime des sommets spécifiques de la géométrie d'une entité"
+    },
+    {
+      "name": "VerticalReprojector",
+      "description": "Reprojette la géométrie d'une entité dans un système de coordonnées spécifié"
+    },
+    {
+      "name": "WasmRuntimeExecutor",
+      "description": "Compile des scripts en .wasm et les exécute dans un environnement d'exécution wasm"
+    },
+    {
+      "name": "XMLFragmenter",
+      "description": "Fragmente du XML"
+    },
+    {
+      "name": "XMLValidator",
+      "description": "Valide le contenu XML"
+    }
+  ]
+}

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -1,0 +1,304 @@
+{
+  "actions": [
+    {
+      "name": "AreaOnAreaOverlayer",
+      "description": "あるエリアの上に別のエリアを重ね合わせる"
+    },
+    {
+      "name": "AttributeAggregator",
+      "description": "属性に基づいてフィーチャをグルーピングする"
+    },
+    {
+      "name": "AttributeDuplicateFilter",
+      "description": "重複した属性を持つフィーチャをフィルタリングする"
+    },
+    {
+      "name": "AttributeFilePathInfoExtractor",
+      "description": "属性からファイルパス情報を抽出する"
+    },
+    {
+      "name": "AttributeManager",
+      "description": "属性を管理する"
+    },
+    {
+      "name": "AttributeMapper",
+      "description": "属性をマッピングする"
+    },
+    {
+      "name": "BoundsExtractor",
+      "description": "境界を抽出する"
+    },
+    {
+      "name": "Bufferer",
+      "description": "ジオメトリの周囲にバッファを作成する"
+    },
+    {
+      "name": "BulkAttributeRenamer",
+      "description": "属性名にプレフィックス／サフィックスを追加・削除、またはテキスト置換して一括でリネームする"
+    },
+    {
+      "name": "CenterPointReplacer",
+      "description": "フィーチャのジオメトリを、フィーチャのバウンディングボックス中央や質量中心、またはフィーチャ領域内に確実に収まる点で置き換える"
+    },
+    {
+      "name": "Cesium3DTilesWriter",
+      "description": "フィーチャをファイルに書き出す"
+    },
+    {
+      "name": "Clipper",
+      "description": "クリッパーフィーチャを用いて候補フィーチャを分割し、内部または外部の部分を別々に出力する"
+    },
+    {
+      "name": "ClosedCurveFilter",
+      "description": "曲線が閉ループになっているか確認する"
+    },
+    {
+      "name": "CoordinateSystemSetter",
+      "description": "フィーチャの座標系を設定する"
+    },
+    {
+      "name": "DimensionFilter",
+      "description": "フィーチャを次元に基づいてフィルタリングする"
+    },
+    {
+      "name": "EchoProcessor",
+      "description": "フィーチャをエコー出力する"
+    },
+    {
+      "name": "EchoSink",
+      "description": "フィーチャをエコー出力する"
+    },
+    {
+      "name": "ElevationExtractor",
+      "description": "フィーチャの最初のZ座標値を抽出し、属性として格納する"
+    },
+    {
+      "name": "Extruder",
+      "description": "ポリゴンを一定の距離で押し出す（エクストルード）"
+    },
+    {
+      "name": "FeatureCounter",
+      "description": "フィーチャ数をカウントする"
+    },
+    {
+      "name": "FeatureCreator",
+      "description": "式に基づいてフィーチャを作成する"
+    },
+    {
+      "name": "FeatureFilter",
+      "description": "条件に基づいてフィーチャをフィルタリングする"
+    },
+    {
+      "name": "FeatureMerger",
+      "description": "属性に基づいてフィーチャをマージする"
+    },
+    {
+      "name": "FeatureReader",
+      "description": "条件に基づいてフィーチャをフィルタリングする"
+    },
+    {
+      "name": "FeatureSorter",
+      "description": "フィーチャを属性でソートする"
+    },
+    {
+      "name": "FeatureTransformer",
+      "description": "式を用いてフィーチャを変換する"
+    },
+    {
+      "name": "FeatureTypeFilter",
+      "description": "フィーチャタイプに基づいてフィーチャをフィルタリングする"
+    },
+    {
+      "name": "FilePathExtractor",
+      "description": "ディレクトリまたはアーカイブからファイルを抽出する"
+    },
+    {
+      "name": "FilePropertyExtractor",
+      "description": "ファイルからプロパティを抽出する"
+    },
+    {
+      "name": "FileReader",
+      "description": "ファイルからフィーチャを読み込む"
+    },
+    {
+      "name": "FileWriter",
+      "description": "フィーチャをファイルに書き出す"
+    },
+    {
+      "name": "GeoJsonWriter",
+      "description": "フィーチャをGeoJSONファイルに書き出す"
+    },
+    {
+      "name": "GeometryCoercer",
+      "description": "フィーチャのジオメトリを特定のジオメトリタイプに強制変換する"
+    },
+    {
+      "name": "GeometryDissolver",
+      "description": "ジオメトリをディゾルブ（結合）する"
+    },
+    {
+      "name": "GeometryExtractor",
+      "description": "フィーチャからジオメトリを抽出し、属性として追加する"
+    },
+    {
+      "name": "GeometryFilter",
+      "description": "ジオメトリをタイプに基づいてフィルタリングする"
+    },
+    {
+      "name": "GeometryLodFilter",
+      "description": "LOD（詳細レベル）に基づいてジオメトリをフィルタリングする"
+    },
+    {
+      "name": "GeometryReplacer",
+      "description": "フィーチャのジオメトリを新しいジオメトリで置き換える"
+    },
+    {
+      "name": "GeometrySplitter",
+      "description": "ジオメトリをタイプ別に分割する"
+    },
+    {
+      "name": "GeometryValidator",
+      "description": "フィーチャのジオメトリを検証する"
+    },
+    {
+      "name": "GeometryValueFilter",
+      "description": "値に基づいてジオメトリをフィルタリングする"
+    },
+    {
+      "name": "GltfWriter",
+      "description": "フィーチャをGltfファイルに書き出す"
+    },
+    {
+      "name": "HoleCounter",
+      "description": "ジオメトリ内の穴の数をカウントし、属性として追加する"
+    },
+    {
+      "name": "HoleExtractor",
+      "description": "ジオメトリ内の穴を抽出し、属性として追加する"
+    },
+    {
+      "name": "HorizontalReprojector",
+      "description": "フィーチャのジオメトリを指定された座標系に水平再投影する"
+    },
+    {
+      "name": "LineOnLineOverlayer",
+      "description": "交点を点フィーチャに変換し、元の交差したラインの属性リストを結合して含めることができる"
+    },
+    {
+      "name": "ListExploder",
+      "description": "リスト属性を複数の要素に分解する"
+    },
+    {
+      "name": "MVTWriter",
+      "description": "フィーチャをファイルに書き出す"
+    },
+    {
+      "name": "NoopProcessor",
+      "description": "フィーチャに対して何も処理しない"
+    },
+    {
+      "name": "NoopSink",
+      "description": "最終的な処理を行わない"
+    },
+    {
+      "name": "Offsetter",
+      "description": "フィーチャの座標にオフセットを加える"
+    },
+    {
+      "name": "OrientationExtractor",
+      "description": "フィーチャのジオメトリの方向を抽出し、属性として追加する"
+    },
+    {
+      "name": "PLATEAU.AttributeFlattener",
+      "description": "建物フィーチャを作成するために属性をフラット化する"
+    },
+    {
+      "name": "PLATEAU.BuildingInstallationGeometryTypeExtractor",
+      "description": "建物インスタレーションジオメトリタイプ（BuildingInstallationGeometryType）を抽出する"
+    },
+    {
+      "name": "PLATEAU.BuildingUsageAttributeValidator",
+      "description": "必要な属性の存在や都市コードの正しさを確認し、建物利用属性を検証する。問題があればlBldgErrorおよびcodeErrorポートを通じてエラーを出力する。"
+    },
+    {
+      "name": "PLATEAU.DictionariesInitiator",
+      "description": "PLATEAU用の辞書を初期化する"
+    },
+    {
+      "name": "PLATEAU.DomainOfDefinitionValidator",
+      "description": "CityGMLフィーチャの定義域を検証する"
+    },
+    {
+      "name": "PLATEAU.MaxLodExtractor",
+      "description": "maxLodを抽出する"
+    },
+    {
+      "name": "PLATEAU.TranXLinkChecker",
+      "description": "TranのXlinkをチェックする"
+    },
+    {
+      "name": "PLATEAU.UDXFolderExtractor",
+      "description": "cityGMLパスからUDXフォルダを抽出する"
+    },
+    {
+      "name": "PLATEAU.UnmatchedXlinkDetector",
+      "description": "PLATEAUで一致しないxlinkを検出する"
+    },
+    {
+      "name": "PLATEAU.XMLAttributeExtractor",
+      "description": "スキーマ定義に基づいてXML断片から属性を抽出する"
+    },
+    {
+      "name": "PlanarityFilter",
+      "description": "タイプに基づいてジオメトリをフィルタリングする"
+    },
+    {
+      "name": "Refiner",
+      "description": "ジオメトリを精緻化する"
+    },
+    {
+      "name": "RhaiCaller",
+      "description": "Rhaiスクリプトを呼び出す"
+    },
+    {
+      "name": "Router",
+      "description": "サブワークフローで最後のポートを転送するアクション"
+    },
+    {
+      "name": "StatisticsCalculator",
+      "description": "フィーチャの統計情報を計算する"
+    },
+    {
+      "name": "ThreeDimensionBoxReplacer",
+      "description": "3次元ボックスをポリゴンで置き換える"
+    },
+    {
+      "name": "ThreeDimensionRotator",
+      "description": "3次元ボックスをポリゴンで置き換える"
+    },
+    {
+      "name": "TwoDimensionForcer",
+      "description": "ジオメトリを2次元に強制する"
+    },
+    {
+      "name": "VertexRemover",
+      "description": "フィーチャのジオメトリから特定の頂点を削除する"
+    },
+    {
+      "name": "VerticalReprojector",
+      "description": "フィーチャのジオメトリを指定された座標系に垂直再投影する"
+    },
+    {
+      "name": "WasmRuntimeExecutor",
+      "description": "スクリプトを.wasmにコンパイルし、wasmランタイムで実行する"
+    },
+    {
+      "name": "XMLFragmenter",
+      "description": "XMLを分割する"
+    },
+    {
+      "name": "XMLValidator",
+      "description": "XMLコンテンツを検証する"
+    }
+  ]
+}

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -1,0 +1,304 @@
+{
+  "actions": [
+    {
+      "name": "AreaOnAreaOverlayer",
+      "description": "在一个区域上叠加另一个区域"
+    },
+    {
+      "name": "AttributeAggregator",
+      "description": "根据属性对实体进行分组"
+    },
+    {
+      "name": "AttributeDuplicateFilter",
+      "description": "筛选具有重复属性的实体"
+    },
+    {
+      "name": "AttributeFilePathInfoExtractor",
+      "description": "从属性中提取文件路径信息"
+    },
+    {
+      "name": "AttributeManager",
+      "description": "管理属性"
+    },
+    {
+      "name": "AttributeMapper",
+      "description": "分配属性"
+    },
+    {
+      "name": "BoundsExtractor",
+      "description": "提取边界"
+    },
+    {
+      "name": "Bufferer",
+      "description": "在几何图形周围创建缓冲区"
+    },
+    {
+      "name": "BulkAttributeRenamer",
+      "description": "通过添加/删除前缀或后缀，或替换文本来重命名属性"
+    },
+    {
+      "name": "CenterPointReplacer",
+      "description": "将实体的几何形状替换为位于其包围盒中心、质心或实体区域内部的点。"
+    },
+    {
+      "name": "Cesium3DTilesWriter",
+      "description": "将实体写入文件"
+    },
+    {
+      "name": "Clipper",
+      "description": "使用裁剪实体来分割候选实体，使内部或外部部分分别输出"
+    },
+    {
+      "name": "ClosedCurveFilter",
+      "description": "检查曲线是否形成闭合回路"
+    },
+    {
+      "name": "CoordinateSystemSetter",
+      "description": "设置实体的坐标系"
+    },
+    {
+      "name": "DimensionFilter",
+      "description": "根据实体的维度进行筛选"
+    },
+    {
+      "name": "EchoProcessor",
+      "description": "重复实体"
+    },
+    {
+      "name": "EchoSink",
+      "description": "重复实体"
+    },
+    {
+      "name": "ElevationExtractor",
+      "description": "提取实体的第一个z坐标值并存储为一个属性"
+    },
+    {
+      "name": "Extruder",
+      "description": "沿一定距离拉伸多边形"
+    },
+    {
+      "name": "FeatureCounter",
+      "description": "统计实体数量"
+    },
+    {
+      "name": "FeatureCreator",
+      "description": "根据表达式创建实体"
+    },
+    {
+      "name": "FeatureFilter",
+      "description": "根据条件筛选实体"
+    },
+    {
+      "name": "FeatureMerger",
+      "description": "根据属性合并实体"
+    },
+    {
+      "name": "FeatureReader",
+      "description": "根据条件筛选实体"
+    },
+    {
+      "name": "FeatureSorter",
+      "description": "根据属性对实体排序"
+    },
+    {
+      "name": "FeatureTransformer",
+      "description": "通过表达式转换实体"
+    },
+    {
+      "name": "FeatureTypeFilter",
+      "description": "根据类型筛选实体"
+    },
+    {
+      "name": "FilePathExtractor",
+      "description": "从目录或归档文件中提取文件"
+    },
+    {
+      "name": "FilePropertyExtractor",
+      "description": "提取文件的属性"
+    },
+    {
+      "name": "FileReader",
+      "description": "从文件中读取实体"
+    },
+    {
+      "name": "FileWriter",
+      "description": "将实体写入文件"
+    },
+    {
+      "name": "GeoJsonWriter",
+      "description": "将实体写入 GeoJSON 文件"
+    },
+    {
+      "name": "GeometryCoercer",
+      "description": "强制将实体几何转换为特定几何类型"
+    },
+    {
+      "name": "GeometryDissolver",
+      "description": "溶解几何体"
+    },
+    {
+      "name": "GeometryExtractor",
+      "description": "提取实体的几何并作为属性添加"
+    },
+    {
+      "name": "GeometryFilter",
+      "description": "根据类型筛选几何"
+    },
+    {
+      "name": "GeometryLodFilter",
+      "description": "根据细节级别（LOD）筛选几何"
+    },
+    {
+      "name": "GeometryReplacer",
+      "description": "用新几何替换实体的几何"
+    },
+    {
+      "name": "GeometrySplitter",
+      "description": "根据类型分割几何"
+    },
+    {
+      "name": "GeometryValidator",
+      "description": "验证实体的几何"
+    },
+    {
+      "name": "GeometryValueFilter",
+      "description": "根据值筛选几何"
+    },
+    {
+      "name": "GltfWriter",
+      "description": "将实体写入Gltf文件"
+    },
+    {
+      "name": "HoleCounter",
+      "description": "统计几何中的孔数量并作为属性添加"
+    },
+    {
+      "name": "HoleExtractor",
+      "description": "提取几何中的孔并作为属性添加"
+    },
+    {
+      "name": "HorizontalReprojector",
+      "description": "将实体的几何重投影到指定坐标系"
+    },
+    {
+      "name": "LineOnLineOverlayer",
+      "description": "交点转换为点实体，并可包含原始相交线段组合的属性列表"
+    },
+    {
+      "name": "ListExploder",
+      "description": "将列表类型的属性拆分为多个元素"
+    },
+    {
+      "name": "MVTWriter",
+      "description": "将实体写入文件"
+    },
+    {
+      "name": "NoopProcessor",
+      "description": "对实体不执行任何操作"
+    },
+    {
+      "name": "NoopSink",
+      "description": "不执行任何最终操作"
+    },
+    {
+      "name": "Offsetter",
+      "description": "为实体的坐标添加偏移"
+    },
+    {
+      "name": "OrientationExtractor",
+      "description": "提取实体几何的方向并作为属性添加"
+    },
+    {
+      "name": "PLATEAU.AttributeFlattener",
+      "description": "扁平化属性以创建建筑实体"
+    },
+    {
+      "name": "PLATEAU.BuildingInstallationGeometryTypeExtractor",
+      "description": "提取建筑安装几何类型（BuildingInstallationGeometryType）"
+    },
+    {
+      "name": "PLATEAU.BuildingUsageAttributeValidator",
+      "description": "此处理器通过检查所需属性的存在和城市代码的正确性来验证建筑用途属性。如果发现问题，将通过lBldgError和codeError端口输出错误。"
+    },
+    {
+      "name": "PLATEAU.DictionariesInitiator",
+      "description": "为PLATEAU初始化字典"
+    },
+    {
+      "name": "PLATEAU.DomainOfDefinitionValidator",
+      "description": "验证CityGML实体的定义域"
+    },
+    {
+      "name": "PLATEAU.MaxLodExtractor",
+      "description": "提取maxLod"
+    },
+    {
+      "name": "PLATEAU.TranXLinkChecker",
+      "description": "检查Tran的Xlink"
+    },
+    {
+      "name": "PLATEAU.UDXFolderExtractor",
+      "description": "从cityGML路径中提取UDX文件夹"
+    },
+    {
+      "name": "PLATEAU.UnmatchedXlinkDetector",
+      "description": "检测PLATEAU中不匹配的xlink"
+    },
+    {
+      "name": "PLATEAU.XMLAttributeExtractor",
+      "description": "根据模式定义从XML片段中提取属性"
+    },
+    {
+      "name": "PlanarityFilter",
+      "description": "根据类型筛选几何"
+    },
+    {
+      "name": "Refiner",
+      "description": "优化几何"
+    },
+    {
+      "name": "RhaiCaller",
+      "description": "调用Rhai脚本"
+    },
+    {
+      "name": "Router",
+      "description": "用于子工作流中最后一个端口转发的操作"
+    },
+    {
+      "name": "StatisticsCalculator",
+      "description": "计算实体的统计信息"
+    },
+    {
+      "name": "ThreeDimensionBoxReplacer",
+      "description": "用多边形替换三维盒子"
+    },
+    {
+      "name": "ThreeDimensionRotator",
+      "description": "用多边形替换三维盒子"
+    },
+    {
+      "name": "TwoDimensionForcer",
+      "description": "将几何强制为二维"
+    },
+    {
+      "name": "VertexRemover",
+      "description": "从实体的几何中删除特定的顶点"
+    },
+    {
+      "name": "VerticalReprojector",
+      "description": "将实体的几何重投影到指定坐标系"
+    },
+    {
+      "name": "WasmRuntimeExecutor",
+      "description": "将脚本编译为.wasm并在wasm运行环境中执行"
+    },
+    {
+      "name": "XMLFragmenter",
+      "description": "分割XML"
+    },
+    {
+      "name": "XMLValidator",
+      "description": "验证XML内容"
+    }
+  ]
+}


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced multiple new actions for geospatial processing, including `AreaOnAreaOverlayer`, `AttributeAggregator`, and `GeometryValidator`, across various language-specific JSON files.
  - Added support for internationalization (i18n) in action schemas, allowing for localized descriptions in English, Spanish, French, Japanese, and Chinese.

- **Bug Fixes**
  - Improved command-line argument parsing for the "schema-action" subcommand to enhance functionality.

- **Documentation**
  - Updated action definitions to include comprehensive descriptions and parameters for better user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->