### PR TITLE
fix(ui): Added NodePickerDIalog drag and drop for batch node adding

### DIFF
--- a/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
@@ -37,7 +37,6 @@ const NodePickerDialog: React.FC<Props> = ({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
-  // Perhaps not the best way to do it, but it works. It feels unnecessary to do lots of prop drilling and useBatch is only used in useNodes.
   const { handleNodeDropInBatch } = useBatch();
   useEffect(() => {
     if (rawActions && openedActionType?.nodeType)

--- a/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
@@ -59,26 +59,6 @@ const NodePickerDialog: React.FC<Props> = ({
     }
   }, [selectedIndex, actions]);
 
-  const isPointInNode = (point: XYPosition, node: Node): boolean => {
-    if (!node.measured) return false;
-    return (
-      point.x >= node.position.x &&
-      point.x <= node.position.x + (node.measured.width ?? 0) &&
-      point.y >= node.position.y &&
-      point.y <= node.position.y + (node.measured.height ?? 0)
-    );
-  };
-
-  // Filter through the list of nodes to check for a batch node is present at the current position
-  const findBatchNodeAtPosition = (
-    position: XYPosition,
-    nodes: Node[],
-  ): Node | undefined => {
-    return nodes.find(
-      (node) => node.type === "batch" && isPointInNode(position, node),
-    );
-  };
-
   const [handleSingleClick, handleDoubleClick] = useDoubleClick(
     (name?: string) => {
       setSelected((prevName) => (prevName === name ? undefined : name));
@@ -107,17 +87,7 @@ const NodePickerDialog: React.FC<Props> = ({
         },
       };
       const newNodes = [...nodes, newNode];
-
-      const batchNode = findBatchNodeAtPosition(
-        openedActionType.position,
-        nodes,
-      );
-
-      if (batchNode) {
-        handleNodeDropInBatch(newNode, newNodes, onNodesChange);
-      } else {
-        onNodesChange(newNodes);
-      }
+      handleNodeDropInBatch(newNode, newNodes, onNodesChange);
       onClose();
     },
   );


### PR DESCRIPTION
# Overview
Added drag and drop from the Toolbox to allow nodes to be created and automatically added to batch nodes if they exist

## What I've done
Added the following:
- Added is a pointinnode and findbatchnodeatposition helper function to allow us to find the batch node to add to
- useBatch is used for the handleNodeDropInBatch

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly
I am currently using useBatch inside the NodePickerDialog. I am not sure this is the best way to do it but it certainly works. 
## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced node management in the NodePickerDialog component with new functionality for batch handling.
	- Updated logic for node creation to support batch processing upon double-click actions.
- **Bug Fixes**
	- Improved logic for node creation to ensure accurate node addition in batch context.
- **Documentation**
	- Added comments for clarity on node dimension measurements during creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->