### PR TITLE
feat(ui): Hide Reader and Writer options in toolbox if subworkflow

### DIFF
--- a/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
@@ -14,6 +14,7 @@ import { createRoot } from "react-dom/client";
 import { IconButton } from "@flow/components";
 import { useT } from "@flow/lib/i18n";
 import { type NodeType } from "@flow/types";
+import { useCurrentWorkflowId } from "@flow/stores";
 
 type ToolboxItem<T> = {
   id: T;
@@ -36,7 +37,9 @@ type Props = {
 const Toolbox: React.FC<Props> = ({ canUndo, canRedo, onRedo, onUndo }) => {
   const t = useT();
 
-  const availableTools: Tool[] = [
+  const [workflowId] = useCurrentWorkflowId();
+  
+  const allTools: Tool[] = [
     {
       id: "reader",
       name: t("Reader Node"),
@@ -68,6 +71,11 @@ const Toolbox: React.FC<Props> = ({ canUndo, canRedo, onRedo, onUndo }) => {
       icon: <Graph weight="thin" />,
     },
   ];
+
+  const availableTools =
+    workflowId === "main"
+      ? allTools
+      : allTools.filter((tool) => tool.id !== "reader" && tool.id !== "writer");
 
   const availableActions: Action[] = [
     {

--- a/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
@@ -15,6 +15,7 @@ import { IconButton } from "@flow/components";
 import { useT } from "@flow/lib/i18n";
 import { type NodeType } from "@flow/types";
 import { useCurrentWorkflowId } from "@flow/stores";
+import { DEFAULT_ENTRY_GRAPH_ID } from "@flow/global-constants";
 
 type ToolboxItem<T> = {
   id: T;
@@ -73,7 +74,7 @@ const Toolbox: React.FC<Props> = ({ canUndo, canRedo, onRedo, onUndo }) => {
   ];
 
   const availableTools =
-    workflowId === "main"
+    workflowId === DEFAULT_ENTRY_GRAPH_ID
       ? allTools
       : allTools.filter((tool) => tool.id !== "reader" && tool.id !== "writer");
 

--- a/ui/src/stores/index.ts
+++ b/ui/src/stores/index.ts
@@ -2,6 +2,9 @@ import { atom, useAtom } from "jotai";
 
 import { Workspace, Project } from "@flow/types";
 
+const currentWorkflowId = atom<string | undefined>("main");
+export const useCurrentWorkflowId = () => useAtom(currentWorkflowId);
+
 const currentProject = atom<Project | undefined>(undefined);
 export const useCurrentProject = () => useAtom(currentProject);
 


### PR DESCRIPTION
# Overview
I made if the current tab is subworkflow, reader and writer node in the toolbox are not visible.
## What I've done

- Get current tab name
- If current tab in not main, make reader and writer node in the toolbox are not visible.

## What I haven't done

## How I tested
Manually
## Screenshot
![image](https://github.com/user-attachments/assets/53090ca1-3903-46e4-bf54-430f19f478a2)
![image](https://github.com/user-attachments/assets/750c1be0-9bfc-430c-b23a-cf25e2aeeddd)

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Toolbox component to display tools based on the current workflow context.
	- Introduced a new hook to access the current workflow ID.
- **Bug Fixes**
	- Adjusted available tools based on workflow ID, ensuring the correct tools are shown for different workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->