### PR TITLE
refactor(ui): synchronized and cleaned node creation

### DIFF
--- a/ui/src/features/Editor/components/Canvas/useCreateNode.ts
+++ b/ui/src/features/Editor/components/Canvas/useCreateNode.ts
@@ -1,0 +1,103 @@
+import { XYPosition } from "@xyflow/react";
+
+import { config } from "@flow/config";
+import { fetcher } from "@flow/lib/fetch/transformers/useFetch";
+import { nodeTypes, type Action, type Node, type NodeType } from "@flow/types";
+import { randomID } from "@flow/utils";
+
+import { baseBatchNode } from "./components/Nodes/BatchNode";
+import { baseNoteNode } from "./components/Nodes/NoteNode";
+
+type CreateNodeOptions = {
+  position: XYPosition;
+  type: string;
+  action?: Action;
+};
+
+export const useCreateNode = () => {
+  const { api } = config();
+
+  const createBaseNode = ({ position, type }: CreateNodeOptions): Node => ({
+    id: randomID(),
+    position,
+    type,
+    data: {
+      name: type,
+      status: "idle",
+      locked: false,
+    },
+  });
+
+  const createActionNode = async (
+    name: string,
+    position: XYPosition,
+  ): Promise<Node | null> => {
+    const action = await fetcher<Action>(`${api}/actions/${name}`);
+    if (!action) return null;
+
+    return {
+      ...createBaseNode({ position, type: action.type }),
+      // Needs measured, but at time of creation we don't know size yet.
+      // 150x25 is base-size of GeneralNode.
+      measured: {
+        width: 150,
+        height: 25,
+      },
+      data: {
+        name: action.name,
+        inputs: [...action.inputPorts],
+        outputs: [...action.outputPorts],
+        status: "idle",
+        locked: false,
+      },
+    };
+  };
+  // for Batch or Note Nodes
+  const createSpecializedNode = ({
+    position,
+    type,
+  }: CreateNodeOptions): Node | null => {
+    const node = createBaseNode({ position, type });
+
+    switch (type) {
+      case "batch":
+        return { ...node, ...baseBatchNode };
+      case "note":
+        return {
+          ...node,
+          data: { ...node.data, ...baseNoteNode },
+        };
+      default:
+        return null;
+    }
+  };
+
+  const createNode = async ({
+    position,
+    type,
+    action,
+  }: CreateNodeOptions): Promise<Node | null> => {
+    if (action) {
+      return {
+        ...createBaseNode({ position, type: action.type }),
+        data: {
+          name: action.name,
+          inputs: [...action.inputPorts],
+          outputs: [...action.outputPorts],
+          status: "idle",
+          locked: false,
+        },
+      };
+    }
+    if (nodeTypes.includes(type as NodeType)) {
+      return createSpecializedNode({ position, type });
+    }
+
+    return createActionNode(type, position);
+  };
+
+  return {
+    createNode,
+    createActionNode,
+  };
+};

--- a/ui/src/features/Editor/components/Canvas/useDnd.ts
+++ b/ui/src/features/Editor/components/Canvas/useDnd.ts
@@ -1,19 +1,14 @@
 import { useReactFlow, XYPosition } from "@xyflow/react";
 import { DragEvent, useCallback } from "react";
 
-import { config } from "@flow/config";
-import { fetcher } from "@flow/lib/fetch/transformers/useFetch";
 import {
   nodeTypes,
   type ActionNodeType,
-  type Action,
   type Node,
   type NodeType,
 } from "@flow/types";
-import { randomID } from "@flow/utils";
 
-import { baseBatchNode } from "./components/Nodes/BatchNode";
-import { baseNoteNode } from "./components/Nodes/NoteNode";
+import { useCreateNode } from "./useCreateNode";
 
 type Props = {
   nodes: Node[];
@@ -33,7 +28,7 @@ export default ({
   handleNodeDropInBatch,
 }: Props) => {
   const { screenToFlowPosition } = useReactFlow();
-  const { api } = config();
+  const { createNode } = useCreateNode();
 
   const handleNodeDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -49,72 +44,29 @@ export default ({
         y: event.clientY,
       });
 
-      const d = event.dataTransfer.getData("application/reactflow");
+      const type = event.dataTransfer.getData("application/reactflow");
+      if (!type) return;
 
-      // check if the dropped element is valid
-      if (typeof d === "undefined" || !d) return;
-
-      if (d === "subworkflow") {
+      if (type === "subworkflow") {
         onWorkflowAdd(position);
         return;
       }
 
-      let newNode: Node = {
-        id: randomID(),
-        position,
-        type: d,
-        data: {
-          name: d,
-          status: "idle",
-          locked: false,
-        },
-      };
-
-      if (nodeTypes.includes(d as NodeType)) {
-        newNode = {
-          ...newNode,
-          type: d,
-          data: {
-            ...newNode.data,
-          },
-        };
-
-        if (d === "batch") {
-          newNode = { ...newNode, ...baseBatchNode };
-        } else if (d === "note") {
-          newNode = {
-            ...newNode,
-            data: { ...newNode.data, ...baseNoteNode },
-          };
-        } else {
-          onNodePickerOpen(position, d as ActionNodeType);
-          return;
-        }
-      } else {
-        const action = await fetcher<Action>(`${api}/actions/${d}`);
-        if (!action) return;
-
-        newNode = {
-          ...newNode,
-          type: action.type,
-          // Needs measured, but at time of creation we don't know size yet.
-          // 150x25 is base-size of GeneralNode.
-          measured: {
-            width: 150,
-            height: 25,
-          },
-          data: {
-            ...newNode.data,
-            name: action.name,
-            inputs: [...action.inputPorts],
-            outputs: [...action.outputPorts],
-          },
-        };
+      if (
+        nodeTypes.includes(type as NodeType) &&
+        type !== "batch" &&
+        type !== "note"
+      ) {
+        onNodePickerOpen(position, type as ActionNodeType);
+        return;
       }
+
+      const newNode = await createNode({ position, type });
+      if (!newNode) return;
 
       const newNodes = [...nodes, newNode];
 
-      if (d !== "batch") {
+      if (type !== "batch") {
         onNodesChange(handleNodeDropInBatch(newNode, newNodes));
       } else {
         onNodesChange(newNodes);
@@ -122,12 +74,12 @@ export default ({
     },
     [
       nodes,
-      api,
       screenToFlowPosition,
       handleNodeDropInBatch,
       onWorkflowAdd,
       onNodesChange,
       onNodePickerOpen,
+      createNode,
     ],
   );
 


### PR DESCRIPTION
# Overview
Essentially useDnd and nodepickerdialog had the same creation methods for nodes. This has been moved into a useCreateNode hook instead for DRY purposes. 

## What I've done
Moved creation logic which was repetitive from useDnd and nodepickerdialog component into a separate hook called useCreateNode. This makes it easier to maintain in the future for new possible node types.

## What I haven't done

## How I tested
Manually
## Screenshot

## Which point I want you to review particularly
- Quality and purpose
- Any further improvements that can be made
## Memo
