### PR TITLE
fix(ui): minwidth/height inherit added for textarea

### DIFF
--- a/ui/src/features/Editor/components/Canvas/components/Nodes/NoteNode/index.tsx
+++ b/ui/src/features/Editor/components/Canvas/components/Nodes/NoteNode/index.tsx
@@ -43,9 +43,9 @@ const NoteNode: React.FC<NoteNodeProps> = ({ data, ...props }) => {
           }}
           minWidth={minSize.width}
           minHeight={minSize.height}
-          onResize={(r) => {
-            console.log("ADS: ", r);
-          }}
+          // onResize={(r) => {
+          //   console.log("ADS: ", r);
+          // }}
         />
       )}
       <div
@@ -61,6 +61,10 @@ const NoteNode: React.FC<NoteNodeProps> = ({ data, ...props }) => {
         </div>
         <textarea
           defaultValue={data.content}
+          style={{
+            minWidth: "inherit",
+            minHeight: "inherit",
+          }}
           className="nowheel nodrag size-full resize-none bg-transparent text-xs focus-visible:outline-none"
         />
       </div>


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated resizing behavior for the NoteNode component's textarea to inherit dimensions from its parent.
- **Bug Fixes**
	- Removed logging functionality during the resize event for improved interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->