### PR TITLE
fix(ui): removed dnd edge nodes without inputs & outputs

### DIFF
--- a/ui/src/features/Editor/components/Canvas/useNodes.ts
+++ b/ui/src/features/Editor/components/Canvas/useNodes.ts
@@ -79,40 +79,10 @@ export default ({
     [edges, nodes, onEdgesChange],
   );
 
-  // Smart handle selection for node drop on edge
-  const getMatchingHandle = (
-    sourceHandles: string[],
-    targetHandles: string[],
-    currentHandle: string | null,
-  ): string => {
-    // If there's a current handle and it exists in both arrays, use it
-    if (
-      currentHandle &&
-      sourceHandles.includes(currentHandle) &&
-      targetHandles.includes(currentHandle)
-    ) {
-      return currentHandle;
-    }
-
-    // Look for matching handles between source and target
-    const matchingHandle = sourceHandles.find((h) => targetHandles.includes(h));
-    if (matchingHandle) {
-      return matchingHandle;
-    }
-
-    // Default to first available or 'default'
-    return sourceHandles[0] || "default";
-  };
-
   const handleNodeDropOnEdge = useCallback(
     (droppedNode: Node) => {
-      // Validate node has both inputs and outputs
-      if (
-        !droppedNode.data.inputs?.length ||
-        !droppedNode.data.outputs?.length
-      ) {
+      if (!droppedNode.data.outputs?.length || !droppedNode.data.inputs?.length)
         return;
-      }
 
       let edgeCreationComplete = false;
 
@@ -132,14 +102,6 @@ export default ({
         const sourceNode = nodes.find((n) => n.id === e.source);
         const targetNode = nodes.find((n) => n.id === e.target);
         if (!sourceNode || !targetNode) return;
-
-        // Validate nodes have required inputs/outputs
-        if (
-          !sourceNode.data.outputs?.length ||
-          !targetNode.data.inputs?.length
-        ) {
-          return;
-        }
 
         let sourceNodeXYPosition: XYPosition = sourceNode.position;
         let targetNodeXYPosition: XYPosition = targetNode.position;
@@ -184,33 +146,23 @@ export default ({
         ) {
           // remove previous edge
           let newEdges = edges.filter((ed) => ed.id !== e.id);
-
-          // Select best matching handles
-          const targetHandle = getMatchingHandle(
-            droppedNode.data.inputs,
-            sourceNode.data.outputs,
-            e.sourceHandle ?? null,
-          );
-
-          const sourceHandle = getMatchingHandle(
-            droppedNode.data.outputs,
-            targetNode.data.inputs,
-            e.targetHandle ?? null,
-          );
-
           // create new connection between original source node and dragged node
           const newConnectionA: Connection = {
             source: e.source,
             sourceHandle: e.sourceHandle ?? null,
             target: droppedNode.id,
-            targetHandle,
+            targetHandle:
+              droppedNode.handles?.find((h) => h.type === "target")?.type ??
+              null,
           };
           newEdges = addEdge(newConnectionA, newEdges);
 
           // create new connection between dragged node and original target node
           const newConnectionB: Connection = {
             source: droppedNode.id,
-            sourceHandle,
+            sourceHandle:
+              droppedNode.handles?.find((h) => h.type === "source")?.type ??
+              null,
             target: e.target,
             targetHandle: e.targetHandle ?? null,
           };


### PR DESCRIPTION
# Overview
Before we had this issue below:
1. Have a reader node (only output) and add a transformer (input and output)
2. Drag another transformer node into the connector
3. Then add another reader or writer (only output) into the connector of the transformer node
4. Error should occur [React Flow]: Couldn't create edge for target handle id: "null", edge id: edge-id.

Therefore, decided to allow nodes with only input and outputs to be dnd into edges.

## What I've done
- Add smart handle selection to maintain connection type compatibility
- Preserve existing handle types when possible
- Add fallback to default handles only when no match found

## What I haven't done

## How I tested
- Manually
## Screenshot

## Which point I want you to review particularly
- Possible refactors 
- Code Quality
## Memo
- Important to note that this new change may not work on existing projects. Therefore, test on a new project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logic for edge creation when nodes are dropped, ensuring valid connections are established.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->