### PR TITLE
ci(api): fix ci api mongo port

### DIFF
--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -29,7 +29,7 @@ jobs:
       mongo:
         image: mongo:6-focal
         ports:
-          - 12345:12345
+          - 27017:27017
     steps:
       - name: checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the MongoDB service configuration in the CI pipeline to use the default port.
	- Added caching for dependencies in the CI pipeline setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->