### PR TITLE
fix(ui): close for successful submission and no params message

### DIFF
--- a/ui/src/features/Editor/components/RightPanel/components/ParamEditor/index.tsx
+++ b/ui/src/features/Editor/components/RightPanel/components/ParamEditor/index.tsx
@@ -1,19 +1,7 @@
 import { ArrowLeft, ArrowRight } from "@phosphor-icons/react";
 import { memo } from "react";
 
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  IconButton,
-  Label,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-  SchemaForm,
-} from "@flow/components";
+import { IconButton, Tabs, TabsContent, SchemaForm } from "@flow/components";
 import { useAction } from "@flow/lib/fetch";
 import { useT } from "@flow/lib/i18n";
 import type { NodeData } from "@flow/types";
@@ -58,14 +46,13 @@ const ParamEditor: React.FC<Props> = ({
         </div>
       </div>
       <Tabs defaultValue="params" className="w-full">
-        <TabsList className="flex gap-2">
-          <TabsTrigger className="flex-1" value="params">
-            {t("Parameters")}
-          </TabsTrigger>
-          <TabsTrigger className="flex-1" value="data">
+        <div className="flex flex-col gap-2">
+          <p className="text-lg dark:font-thin">{t("Parameters")}</p>
+        </div>
+        {/* <TabsTrigger className="flex-1" value="data">
             {t("Node data")}
-          </TabsTrigger>
-        </TabsList>
+          </TabsTrigger> */}
+
         <TabsContent value="params">
           <div className="rounded border bg-card p-3">
             {!action?.parameter && <p>{t("No Parameters Available")}</p>}
@@ -78,7 +65,7 @@ const ParamEditor: React.FC<Props> = ({
             )}
           </div>
         </TabsContent>
-        <TabsContent value="data">
+        {/* <TabsContent value="data">
           <Card className="bg-transparent">
             <CardHeader>
               <CardTitle>Node data</CardTitle>
@@ -98,7 +85,7 @@ const ParamEditor: React.FC<Props> = ({
               </div>
             </CardContent>
           </Card>
-        </TabsContent>
+        </TabsContent> */}
       </Tabs>
     </div>
   );

--- a/ui/src/features/Editor/components/RightPanel/components/ParamEditor/index.tsx
+++ b/ui/src/features/Editor/components/RightPanel/components/ParamEditor/index.tsx
@@ -41,7 +41,6 @@ const ParamEditor: React.FC<Props> = ({
   const { action } = useGetActionById(nodeMeta.name);
 
   const handleSubmit = (data: any) => onSubmit(nodeId, data);
-
   return (
     <div>
       <div className="mb-3 flex justify-between gap-4">
@@ -69,6 +68,7 @@ const ParamEditor: React.FC<Props> = ({
         </TabsList>
         <TabsContent value="params">
           <div className="rounded border bg-card p-3">
+            {!action?.parameter && <p>{t("No Parameters Available")}</p>}
             {action && (
               <SchemaForm
                 schema={action.parameter}

--- a/ui/src/features/Editor/components/RightPanel/index.tsx
+++ b/ui/src/features/Editor/components/RightPanel/index.tsx
@@ -14,7 +14,7 @@ type Props = {
 const RightPanel: React.FC<Props> = ({ selected, onParamsSubmit }) => {
   // This is a little hacky, but it works. We need to dispatch a click event to the react-flow__pane
   // to unlock the node when user wants to close the right panel. - @KaWaite
-  const closePanel = useCallback(() => {
+  const handleClose = useCallback(() => {
     // react-flow__pane is the classname of the div inside react-flow that has the click event
     // https://github.com/xyflow/xyflow/blob/71db83761c245493d44e74311e10cc6465bf8387/packages/react/src/container/Pane/index.tsx#L249
     const paneElement = document.getElementsByClassName("react-flow__pane")[0];
@@ -26,9 +26,9 @@ const RightPanel: React.FC<Props> = ({ selected, onParamsSubmit }) => {
   const handleParamsSubmit = useCallback(
     async (nodeId: string, data: any) => {
       await Promise.resolve(onParamsSubmit(nodeId, data));
-      closePanel();
+      handleClose();
     },
-    [onParamsSubmit, closePanel],
+    [onParamsSubmit, handleClose],
   );
 
   return (
@@ -45,7 +45,7 @@ const RightPanel: React.FC<Props> = ({ selected, onParamsSubmit }) => {
           <IconButton
             className="relative before:absolute before:inset-y-0 before:right-0 before:z-[-1] before:bg-success before:content-['']"
             icon={<X className="size-[30px]" weight="thin" />}
-            onClick={closePanel}
+            onClick={handleClose}
           />
         </div>
       </div>

--- a/ui/src/features/Editor/components/RightPanel/index.tsx
+++ b/ui/src/features/Editor/components/RightPanel/index.tsx
@@ -1,5 +1,5 @@
 import { X } from "@phosphor-icons/react";
-import { memo, MouseEvent, useCallback } from "react";
+import { memo, useCallback } from "react";
 
 import { IconButton } from "@flow/components";
 import { Node } from "@flow/types";
@@ -14,9 +14,7 @@ type Props = {
 const RightPanel: React.FC<Props> = ({ selected, onParamsSubmit }) => {
   // This is a little hacky, but it works. We need to dispatch a click event to the react-flow__pane
   // to unlock the node when user wants to close the right panel. - @KaWaite
-  const handleClick = useCallback((e: MouseEvent) => {
-    e.stopPropagation();
-
+  const closePanel = useCallback(() => {
     // react-flow__pane is the classname of the div inside react-flow that has the click event
     // https://github.com/xyflow/xyflow/blob/71db83761c245493d44e74311e10cc6465bf8387/packages/react/src/container/Pane/index.tsx#L249
     const paneElement = document.getElementsByClassName("react-flow__pane")[0];
@@ -24,6 +22,17 @@ const RightPanel: React.FC<Props> = ({ selected, onParamsSubmit }) => {
     const clickEvent = new Event("click", { bubbles: true, cancelable: true });
     paneElement.dispatchEvent(clickEvent);
   }, []);
+
+  const handleParamsSubmit = useCallback(
+    (nodeId: string, data: any) => {
+      onParamsSubmit(nodeId, data);
+      // Ensures that the right panel closes after the submit button is clicked
+      setTimeout(() => {
+        closePanel();
+      }, 0);
+    },
+    [onParamsSubmit, closePanel],
+  );
 
   return (
     <>
@@ -39,7 +48,7 @@ const RightPanel: React.FC<Props> = ({ selected, onParamsSubmit }) => {
           <IconButton
             className="relative before:absolute before:inset-y-0 before:right-0 before:z-[-1] before:bg-success before:content-['']"
             icon={<X className="size-[30px]" weight="thin" />}
-            onClick={handleClick}
+            onClick={closePanel}
           />
         </div>
       </div>
@@ -58,7 +67,7 @@ const RightPanel: React.FC<Props> = ({ selected, onParamsSubmit }) => {
               nodeId={selected.id}
               nodeMeta={selected.data}
               nodeType={selected.type}
-              onSubmit={onParamsSubmit}
+              onSubmit={handleParamsSubmit}
             />
           )}
         </div>

--- a/ui/src/features/Editor/components/RightPanel/index.tsx
+++ b/ui/src/features/Editor/components/RightPanel/index.tsx
@@ -24,12 +24,9 @@ const RightPanel: React.FC<Props> = ({ selected, onParamsSubmit }) => {
   }, []);
 
   const handleParamsSubmit = useCallback(
-    (nodeId: string, data: any) => {
-      onParamsSubmit(nodeId, data);
-      // Ensures that the right panel closes after the submit button is clicked
-      setTimeout(() => {
-        closePanel();
-      }, 0);
+    async (nodeId: string, data: any) => {
+      await Promise.resolve(onParamsSubmit(nodeId, data));
+      closePanel();
     },
     [onParamsSubmit, closePanel],
   );

--- a/ui/src/lib/i18n/locales/en.json
+++ b/ui/src/lib/i18n/locales/en.json
@@ -51,7 +51,6 @@
   "Redo action": "",
   "Parameters": "",
   "No Parameters Available": "No Parameters Available",
-  "Node data": "",
   "Unable to rename workflow": "Unable to rename workflow",
   "Renaming workflow failed. Please try again later.": "Renaming workflow failed. Please try again later.",
   "Main Workflow": "",

--- a/ui/src/lib/i18n/locales/en.json
+++ b/ui/src/lib/i18n/locales/en.json
@@ -50,7 +50,7 @@
   "Undo last action": "",
   "Redo action": "",
   "Parameters": "",
-  "No Parameters Available": "",
+  "No Parameters Available": "No Parameters Available",
   "Node data": "",
   "Unable to rename workflow": "Unable to rename workflow",
   "Renaming workflow failed. Please try again later.": "Renaming workflow failed. Please try again later.",

--- a/ui/src/lib/i18n/locales/en.json
+++ b/ui/src/lib/i18n/locales/en.json
@@ -50,6 +50,7 @@
   "Undo last action": "",
   "Redo action": "",
   "Parameters": "",
+  "No Parameters Available": "",
   "Node data": "",
   "Unable to rename workflow": "Unable to rename workflow",
   "Renaming workflow failed. Please try again later.": "Renaming workflow failed. Please try again later.",

--- a/ui/src/lib/i18n/locales/es.json
+++ b/ui/src/lib/i18n/locales/es.json
@@ -50,6 +50,7 @@
   "Undo last action": "Deshacer última acción",
   "Redo action": "Rehacer acción",
   "Parameters": "Parámetros",
+  "No Parameters Available": "No hay parámetros disponibles",
   "Node data": "Datos del nodo",
   "Unable to rename workflow": "No se puede renombrar el flujo de trabajo",
   "Renaming workflow failed. Please try again later.": "Renombrar el flujo de trabajo falló. Por favor, inténtalo de nuevo más tarde.",

--- a/ui/src/lib/i18n/locales/es.json
+++ b/ui/src/lib/i18n/locales/es.json
@@ -51,7 +51,6 @@
   "Redo action": "Rehacer acción",
   "Parameters": "Parámetros",
   "No Parameters Available": "No hay parámetros disponibles",
-  "Node data": "Datos del nodo",
   "Unable to rename workflow": "No se puede renombrar el flujo de trabajo",
   "Renaming workflow failed. Please try again later.": "Renombrar el flujo de trabajo falló. Por favor, inténtalo de nuevo más tarde.",
   "Main Workflow": "Flujo de trabajo principal",

--- a/ui/src/lib/i18n/locales/fr.json
+++ b/ui/src/lib/i18n/locales/fr.json
@@ -51,7 +51,6 @@
   "Redo action": "Rétablir l'action",
   "Parameters": "Paramètres",
   "No Parameters Available": "Aucun paramètre disponible",
-  "Node data": "Données du nœud",
   "Unable to rename workflow": "Impossible de renommer le flux de travail",
   "Renaming workflow failed. Please try again later.": "Échec du renommage du flux de travail. Veuillez réessayer plus tard.",
   "Main Workflow": "Flux de travail principal",

--- a/ui/src/lib/i18n/locales/fr.json
+++ b/ui/src/lib/i18n/locales/fr.json
@@ -50,6 +50,7 @@
   "Undo last action": "Annuler la dernière action",
   "Redo action": "Rétablir l'action",
   "Parameters": "Paramètres",
+  "No Parameters Available": "Aucun paramètre disponible",
   "Node data": "Données du nœud",
   "Unable to rename workflow": "Impossible de renommer le flux de travail",
   "Renaming workflow failed. Please try again later.": "Échec du renommage du flux de travail. Veuillez réessayer plus tard.",

--- a/ui/src/lib/i18n/locales/ja.json
+++ b/ui/src/lib/i18n/locales/ja.json
@@ -51,7 +51,6 @@
   "Redo action": "アクションをやり直す",
   "Parameters": "パラメータ",
   "No Parameters Available": "利用可能なパラメータはありません",
-  "Node data": "ノードデータ",
   "Unable to rename workflow": "ワークフローの名前を変更できません",
   "Renaming workflow failed. Please try again later.": "ワークフローの名前変更に失敗しました。後でもう一度お試しください。",
   "Main Workflow": "メインワークフロー",

--- a/ui/src/lib/i18n/locales/ja.json
+++ b/ui/src/lib/i18n/locales/ja.json
@@ -50,6 +50,7 @@
   "Undo last action": "最後のアクションを元に戻す",
   "Redo action": "アクションをやり直す",
   "Parameters": "パラメータ",
+  "No Parameters Available": "利用可能なパラメータはありません",
   "Node data": "ノードデータ",
   "Unable to rename workflow": "ワークフローの名前を変更できません",
   "Renaming workflow failed. Please try again later.": "ワークフローの名前変更に失敗しました。後でもう一度お試しください。",

--- a/ui/src/lib/i18n/locales/zh.json
+++ b/ui/src/lib/i18n/locales/zh.json
@@ -51,7 +51,6 @@
   "Redo action": "重做操作",
   "Parameters": "参数",
   "No Parameters Available": "没有可用参数",
-  "Node data": "节点数据",
   "Unable to rename workflow": "无法重命名工作流",
   "Renaming workflow failed. Please try again later.": "重命名工作流失败。请稍后再试。",
   "Main Workflow": "主工作流",

--- a/ui/src/lib/i18n/locales/zh.json
+++ b/ui/src/lib/i18n/locales/zh.json
@@ -50,6 +50,7 @@
   "Undo last action": "撤销上一步操作",
   "Redo action": "重做操作",
   "Parameters": "参数",
+  "No Parameters Available": "没有可用参数",
   "Node data": "节点数据",
   "Unable to rename workflow": "无法重命名工作流",
   "Renaming workflow failed. Please try again later.": "重命名工作流失败。请稍后再试。",


### PR DESCRIPTION
# Overview
Small UI improves for the right panel node params. 
## What I've done
- Right Panel now closes after successful submission
- No parameter messages added if there are no parameters for a node e.g. echoSink. Note, etc
## What I haven't done

## How I tested
Manually
## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Simplified display in the ParamEditor component, now showing "No Parameters Available" when no parameters exist.

- **Bug Fixes**
  - Enhanced control flow for closing the RightPanel and submitting parameters.

- **Localization Updates**
  - Updated translations across English, Spanish, French, Japanese, and Chinese localization files, replacing "Node data" with "No Parameters Available" and adding new terms for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->