### PR TITLE
chore(engine): rename maxLod to upToLod and remove unused properties

### DIFF
--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -1794,32 +1794,13 @@ Filter geometry by lod
   "title": "GeometryLodFilterParam",
   "type": "object",
   "properties": {
-    "maxLod": {
+    "upToLod": {
       "type": [
         "integer",
         "null"
       ],
       "format": "uint8",
       "minimum": 0.0
-    },
-    "minLod": {
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "targetLods": {
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "integer",
-        "format": "uint8",
-        "minimum": 0.0
-      }
     }
   }
 }

--- a/engine/runtime/action-processor/src/geometry/lod_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/lod_filter.rs
@@ -71,7 +71,7 @@ impl ProcessorFactory for GeometryLodFilterFactory {
             .into());
         };
         let up_to_lod = params.up_to_lod.unwrap_or(4);
-        if !(1..4).contains(&up_to_lod) {
+        if !(1..=4).contains(&up_to_lod) {
             return Err(GeometryProcessorError::GeometryLodFilterFactory(
                 "Invalid up_to_lod parameter with 1..4".to_string(),
             )

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -1798,32 +1798,13 @@
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
-          "maxLod": {
+          "upToLod": {
             "type": [
               "integer",
               "null"
             ],
             "format": "uint8",
             "minimum": 0.0
-          },
-          "minLod": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "targetLods": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
           }
         }
       },

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -1798,32 +1798,13 @@
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
-          "maxLod": {
+          "upToLod": {
             "type": [
               "integer",
               "null"
             ],
             "format": "uint8",
             "minimum": 0.0
-          },
-          "minLod": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "targetLods": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
           }
         }
       },

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -1798,32 +1798,13 @@
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
-          "maxLod": {
+          "upToLod": {
             "type": [
               "integer",
               "null"
             ],
             "format": "uint8",
             "minimum": 0.0
-          },
-          "minLod": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "targetLods": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
           }
         }
       },

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -1798,32 +1798,13 @@
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
-          "maxLod": {
+          "upToLod": {
             "type": [
               "integer",
               "null"
             ],
             "format": "uint8",
             "minimum": 0.0
-          },
-          "minLod": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "targetLods": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
           }
         }
       },

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -1798,32 +1798,13 @@
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
-          "maxLod": {
+          "upToLod": {
             "type": [
               "integer",
               "null"
             ],
             "format": "uint8",
             "minimum": 0.0
-          },
-          "minLod": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "targetLods": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
           }
         }
       },

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -1798,32 +1798,13 @@
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
-          "maxLod": {
+          "upToLod": {
             "type": [
               "integer",
               "null"
             ],
             "format": "uint8",
             "minimum": 0.0
-          },
-          "minLod": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "targetLods": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
           }
         }
       },


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a simplified parameter structure for the Geometry Level of Detail (LOD) filter, focusing on a single `upToLod` parameter.

- **Bug Fixes**
  - Updated validation logic to ensure `upToLod` falls within the acceptable range.

- **Documentation**
  - Updated parameter definitions across multiple language schemas to reflect the new `upToLod` naming and removal of `minLod` and `targetLods`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->