### PR TITLE
fix(ui): entryGraphId should be a UUID

### DIFF
--- a/ui/src/utils/engineWorkflowYaml/consolidateWorkflows.test.ts
+++ b/ui/src/utils/engineWorkflowYaml/consolidateWorkflows.test.ts
@@ -42,20 +42,23 @@ describe("consolidateWorkflows", () => {
       { id: "sub1", name: "Sub Workflow 1", nodes: [], edges: [] },
     ];
 
+    let uuidCallCount = 0;
     (createSubGraphs as any).mockReturnValue(mockSubGraphs);
-    (vi.mocked(generateUUID) as any).mockReturnValue("random-id-123");
+    (vi.mocked(generateUUID) as any).mockImplementation(
+      () => `random-id-${++uuidCallCount}`,
+    );
 
     const result = consolidateWorkflows("somename", mockWorkflows);
 
     expect(result).toEqual({
-      id: "random-id-123",
+      id: "random-id-1",
       name: "somename",
-      entryGraphId: DEFAULT_ENTRY_GRAPH_ID,
+      entryGraphId: "random-id-2",
       graphs: mockSubGraphs,
     });
 
     expect(createSubGraphs).toHaveBeenCalledWith(mockWorkflows);
-    expect(generateUUID).toHaveBeenCalled();
+    expect(generateUUID).toHaveBeenCalledTimes(2);
   });
 
   it("should correctly consolidate workflows without a main workflow", () => {

--- a/ui/src/utils/engineWorkflowYaml/consolidateWorkflows.ts
+++ b/ui/src/utils/engineWorkflowYaml/consolidateWorkflows.ts
@@ -19,7 +19,7 @@ export const consolidateWorkflows = (
   const consolidatedWorkflow = {
     id: generateUUID(),
     name,
-    entryGraphId,
+    entryGraphId: generateUUID(),
     // with // TODO: conversion of data.params to with
     graphs: subGraphs,
   };


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced workflow consolidation by generating unique entry graph IDs.
  
- **Bug Fixes**
	- Resolved issues related to the assignment of entry graph IDs in consolidated workflows.
  
- **Tests**
	- Updated test suite to reflect changes in UUID generation logic for workflow consolidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->