### PR TITLE
fix(ui, api): entrygraphId & subgraph entry id should be same and no pub-sub for now

### DIFF
--- a/ui/src/utils/engineWorkflowYaml/consolidateWorkflows.test.ts
+++ b/ui/src/utils/engineWorkflowYaml/consolidateWorkflows.test.ts
@@ -32,9 +32,14 @@ describe("consolidateWorkflows", () => {
       { id: "sub1", name: "Sub Workflow 1", nodes: [], edges: [] },
     ];
 
-    const mockSubGraphs: EngineReadyGraph[] = [
+    // Generate predictable UUIDs
+    let uuidCounter = 0;
+    vi.mocked(generateUUID).mockImplementation(() => `uuid-${++uuidCounter}`);
+
+    // Create expected workflows with the new entry ID
+    const expectedConvertedWorkflows = [
       {
-        id: "random-id-1",
+        id: "uuid-1", // This replaces DEFAULT_ENTRY_GRAPH_ID
         name: "Main Workflow",
         nodes: [],
         edges: [],
@@ -42,67 +47,51 @@ describe("consolidateWorkflows", () => {
       { id: "sub1", name: "Sub Workflow 1", nodes: [], edges: [] },
     ];
 
-    let uuidCallCount = 0;
-    (createSubGraphs as any).mockReturnValue(mockSubGraphs);
-    (vi.mocked(generateUUID) as any).mockImplementation(
-      () => `random-id-${++uuidCallCount}`,
-    );
+    const mockSubGraphs: EngineReadyGraph[] = [
+      {
+        id: "uuid-1",
+        name: "Main Workflow",
+        nodes: [],
+        edges: [],
+      },
+      { id: "sub1", name: "Sub Workflow 1", nodes: [], edges: [] },
+    ];
+
+    vi.mocked(createSubGraphs).mockReturnValue(mockSubGraphs);
 
     const result = consolidateWorkflows("somename", mockWorkflows);
 
-    const expectedConvertedWorkflows = [
-      {
-        id: "random-id-1",
-        name: "Main Workflow",
-        nodes: [],
-        edges: [],
-      },
-      { id: "sub1", name: "Sub Workflow 1", nodes: [], edges: [] },
-    ];
-
     expect(result).toEqual({
-      id: "random-id-2",
+      id: "uuid-2",
       name: "somename",
-      entryGraphId: "random-id-3",
+      entryGraphId: "uuid-1",
       graphs: mockSubGraphs,
     });
 
     expect(createSubGraphs).toHaveBeenCalledWith(expectedConvertedWorkflows);
-    expect(generateUUID).toHaveBeenCalledTimes(3);
+    expect(generateUUID).toHaveBeenCalledTimes(2);
   });
 
-  it("should correctly consolidate workflows without a main workflow", () => {
+  it("should return undefined when no main workflow exists", () => {
     const mockWorkflows: Workflow[] = [
       { id: "sub1", name: "Sub Workflow 1", nodes: [], edges: [] },
       { id: "sub2", name: "Sub Workflow 2", nodes: [], edges: [] },
     ];
 
-    const mockSubGraphs: EngineReadyGraph[] = [
-      { id: "sub1", name: "Sub Workflow 1", nodes: [], edges: [] },
-      { id: "sub2", name: "Sub Workflow 2", nodes: [], edges: [] },
-    ];
-
-    (createSubGraphs as any).mockReturnValue(mockSubGraphs);
-    (vi.mocked(generateUUID) as any).mockReturnValue("random-id-456");
-
     const result = consolidateWorkflows("somename", mockWorkflows);
 
-    expect(result).toEqual(undefined);
-
-    expect(createSubGraphs).not.toHaveBeenCalledWith(mockWorkflows);
+    expect(result).toBeUndefined();
+    expect(createSubGraphs).not.toHaveBeenCalled();
     expect(generateUUID).not.toHaveBeenCalled();
   });
 
-  it("should return undefined when workflows array is empty (since there is no main/entry point)", () => {
+  it("should return undefined when workflows array is empty", () => {
     const mockWorkflows: Workflow[] = [];
-
-    (createSubGraphs as any).mockReturnValue([]);
-    (vi.mocked(generateUUID) as any).mockReturnValue("random-id-789");
 
     const result = consolidateWorkflows("somename", mockWorkflows);
 
-    expect(result).toEqual(undefined);
-    expect(createSubGraphs).not.toHaveBeenCalledWith(mockWorkflows);
+    expect(result).toBeUndefined();
+    expect(createSubGraphs).not.toHaveBeenCalled();
     expect(generateUUID).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/utils/engineWorkflowYaml/consolidateWorkflows.ts
+++ b/ui/src/utils/engineWorkflowYaml/consolidateWorkflows.ts
@@ -24,7 +24,7 @@ export const consolidateWorkflows = (
   const consolidatedWorkflow = {
     id: generateUUID(),
     name,
-    entryGraphId: generateUUID(),
+    entryGraphId: newEntryId,
     // with // TODO: conversion of data.params to with
     graphs: subGraphs,
   };


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the consistency of UUID generation for workflows, ensuring predictable results in tests.
	- Updated the logic for assigning `entryGraphId` to be derived from the default entry workflow's ID.

- **Tests**
	- Enhanced test clarity and reliability by revising test case descriptions and assertions to align with new UUID generation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->