### PR TITLE
feat(engine): update parameter_schema return type from RootSchema to Schema

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4244,7 +4244,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "url",
 ]
 
@@ -4293,28 +4293,29 @@ version = "0.1.0"
 source = "git+https://github.com/reearth/plateau-gis-converter?tag=v0.7.1#1eac33058ee2e45c46596a41119b3d3c9a33465b"
 dependencies = [
  "japan-geoid",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
 name = "nutype"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8789358e2d6cdffb0cb170c7802ee7548beb8067ed643f3122fa36c335f3c64"
+checksum = "0f1ea9dc0315b5f4a6bda53b4602f4c77f877ac37f427d640a7f647bfba8edb6"
 dependencies = [
  "nutype_macros",
 ]
 
 [[package]]
 name = "nutype_macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a3e222ba1f06a03552910fe89a232a1661dcf8ad4c837531fb199828d0916b"
+checksum = "23ebae17472b925d6a64837074e3f3ebe479f6bc4efaf673974a48adb90244d2"
 dependencies = [
  "cfg-if",
  "kinded",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn 2.0.90",
  "urlencoding",
 ]
@@ -4955,7 +4956,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "uuid",
 ]
 
@@ -5280,7 +5281,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "rustls",
  "socket2",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
 ]
@@ -5299,7 +5300,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5539,7 +5540,7 @@ dependencies = [
  "slog-async",
  "slog-term",
  "sloggers",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "time",
  "tokio",
  "tracing",
@@ -5573,10 +5574,10 @@ dependencies = [
  "reearth-flow-types",
  "regex",
  "rhai",
- "schemars",
+ "schemars 1.0.0-alpha.17",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
@@ -5614,10 +5615,10 @@ dependencies = [
  "regex",
  "rhai",
  "rstar 0.12.2",
- "schemars",
+ "schemars 1.0.0-alpha.17",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
@@ -5671,11 +5672,11 @@ dependencies = [
  "regex",
  "rhai",
  "rust_xlsxwriter",
- "schemars",
+ "schemars 1.0.0-alpha.17",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tinymvt",
  "tokio",
  "tracing",
@@ -5707,10 +5708,10 @@ dependencies = [
  "reearth-flow-types",
  "regex",
  "rhai",
- "schemars",
+ "schemars 1.0.0-alpha.17",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
@@ -5731,11 +5732,11 @@ dependencies = [
  "reearth-flow-storage",
  "reearth-flow-types",
  "regex",
- "schemars",
+ "schemars 1.0.0-alpha.17",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "wasmer",
@@ -5767,10 +5768,10 @@ dependencies = [
  "reearth-flow-storage",
  "reearth-flow-telemetry",
  "reearth-flow-types",
- "schemars",
+ "schemars 1.0.0-alpha.17",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "time",
  "tracing",
  "tracing-opentelemetry",
@@ -5803,7 +5804,7 @@ dependencies = [
  "sha2",
  "strum_macros",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "url",
  "uuid",
@@ -5820,7 +5821,7 @@ dependencies = [
  "rhai",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -5873,7 +5874,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum_macros",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -5895,11 +5896,11 @@ dependencies = [
  "reearth-flow-storage",
  "reearth-flow-types",
  "regex",
- "schemars",
+ "schemars 1.0.0-alpha.17",
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
 ]
@@ -5935,7 +5936,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "time",
  "tokio",
  "tracing",
@@ -5966,10 +5967,10 @@ dependencies = [
  "reearth-flow-types",
  "regex",
  "rmp-serde",
- "schemars",
+ "schemars 1.0.0-alpha.17",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "uuid",
@@ -6002,7 +6003,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
 ]
@@ -6018,7 +6019,7 @@ dependencies = [
  "opentelemetry-stdout",
  "opentelemetry_sdk",
  "serde",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -6075,11 +6076,11 @@ dependencies = [
  "reearth-flow-eval-expr",
  "reearth-flow-geometry",
  "rhai",
- "schemars",
+ "schemars 1.0.0-alpha.17",
  "serde",
  "serde_json",
  "strum_macros",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
  "url",
@@ -6113,10 +6114,10 @@ dependencies = [
  "reearth-flow-storage",
  "reearth-flow-telemetry",
  "reearth-flow-types",
- "schemars",
+ "schemars 1.0.0-alpha.17",
  "serde",
  "serde_json",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "time",
  "tokio",
  "tracing",
@@ -6124,6 +6125,26 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "walkdir",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6730,12 +6751,25 @@ version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
- "chrono",
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.21",
  "serde",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ef2a6523400a2228db974a8ddc9e1d3deaa04f51bddd7832ef8d7e531bafcc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.0.0-alpha.17",
+ "serde",
+ "serde_json",
  "uuid",
 ]
 
@@ -6744,6 +6778,18 @@ name = "schemars_derive"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.0-alpha.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6d4e1945a3c9e58edaa708449b026519f7f4197185e1b5dbc689615c1ad724d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6882,9 +6928,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
 dependencies = [
  "indexmap 2.7.0",
  "itoa 1.0.14",
@@ -7892,11 +7938,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.7"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.7",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -7912,9 +7958,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.7"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8980,7 +9026,7 @@ dependencies = [
  "derive_builder",
  "hex",
  "indexmap 2.7.0",
- "schemars",
+ "schemars 0.8.21",
  "semver",
  "serde",
  "serde_json",
@@ -9002,7 +9048,7 @@ dependencies = [
  "derive_builder",
  "hex",
  "indexmap 2.7.0",
- "schemars",
+ "schemars 0.8.21",
  "semver",
  "serde",
  "serde_json",
@@ -10169,7 +10215,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.8.5",
  "sha1",
- "thiserror 2.0.7",
+ "thiserror 2.0.9",
  "time",
  "zeroize",
  "zopfli",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -115,7 +115,7 @@ libxml = "0.3.3"
 nalgebra = "0.33.2"
 nalgebra-glm = "0.19.0"
 num-traits = "0.2.19"
-nutype = { version = "0.5.0", features = ["schemars08", "serde"] }
+nutype = { version = "0.5.1", features = ["schemars08", "serde"] }
 object_store = "0.11.1"
 once_cell = "1.20.2"
 opendal = { version = "0.50.2", features = ["layers-metrics", "services-fs", "services-gcs", "services-http"] }
@@ -139,10 +139,10 @@ robust = "1.1.0"
 rstar = "0.12.2"
 rstest = "0.23.0"
 rust_xlsxwriter = "0.80.0"
-schemars = { version = "0.8.21", features = ["chrono", "uuid1"] }
+schemars = { version = "1.0.0-alpha.17", features = ["chrono04", "uuid1"] }
 serde = { version = "1.0.216", features = ["derive"] }
 serde_derive = "1.0.216"
-serde_json = { version = "1.0.133", features = ["arbitrary_precision"] }
+serde_json = { version = "1.0.134", features = ["arbitrary_precision"] }
 serde_yaml = "0.9.34"
 sha2 = "0.10.8"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_trace"] }
@@ -152,7 +152,7 @@ sloggers = { version = "2.2.0", default-features = false }
 strum = "0.26.3"
 strum_macros = "0.26.4"
 tempfile = "3.14.0"
-thiserror = "2.0.7"
+thiserror = "2.0.9"
 time = { version = "0.3.37", features = ["formatting"] }
 tinymvt = { git = "https://github.com/MIERUNE/tinymvt.git" }
 tokio = { version = "1.42.0", features = ["full", "time"] }

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -8,12 +8,9 @@ Overlays an area on another area
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AreaOnAreaOverlayerParam",
   "type": "object",
-  "required": [
-    "outputAttribute"
-  ],
   "properties": {
     "groupBy": {
       "type": [
@@ -21,14 +18,17 @@ Overlays an area on another area
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/Attribute"
+        "$ref": "#/$defs/Attribute"
       }
     },
     "outputAttribute": {
-      "$ref": "#/definitions/Attribute"
+      "$ref": "#/$defs/Attribute"
     }
   },
-  "definitions": {
+  "required": [
+    "outputAttribute"
+  ],
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -52,33 +52,25 @@ Aggregates features by attributes
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AttributeAggregatorParam",
   "type": "object",
-  "required": [
-    "aggregateAttributes",
-    "calculationAttribute",
-    "method"
-  ],
   "properties": {
     "aggregateAttributes": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/AggregateAttribute"
+        "$ref": "#/$defs/AggregateAttribute"
       }
     },
     "calculation": {
       "anyOf": [
         {
-          "$ref": "#/definitions/Expr"
+          "$ref": "#/$defs/Expr"
         },
         {
           "type": "null"
         }
       ]
-    },
-    "calculationAttribute": {
-      "$ref": "#/definitions/Attribute"
     },
     "calculationValue": {
       "type": [
@@ -87,17 +79,25 @@ Aggregates features by attributes
       ],
       "format": "int64"
     },
+    "calculationAttribute": {
+      "$ref": "#/$defs/Attribute"
+    },
     "method": {
-      "$ref": "#/definitions/Method"
+      "$ref": "#/$defs/Method"
     }
   },
-  "definitions": {
+  "required": [
+    "aggregateAttributes",
+    "calculationAttribute",
+    "method"
+  ],
+  "$defs": {
     "AggregateAttribute": {
       "type": "object",
-      "required": [
-        "newAttribute"
-      ],
       "properties": {
+        "newAttribute": {
+          "$ref": "#/$defs/Attribute"
+        },
         "attribute": {
           "type": [
             "string",
@@ -107,17 +107,17 @@ Aggregates features by attributes
         "attributeValue": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Expr"
+              "$ref": "#/$defs/Expr"
             },
             {
               "type": "null"
             }
           ]
-        },
-        "newAttribute": {
-          "$ref": "#/definitions/Attribute"
         }
-      }
+      },
+      "required": [
+        "newAttribute"
+      ]
     },
     "Attribute": {
       "type": "string"
@@ -151,21 +151,21 @@ Filters features by duplicate attributes
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AttributeDuplicateFilterParam",
   "type": "object",
-  "required": [
-    "filterBy"
-  ],
   "properties": {
     "filterBy": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Attribute"
+        "$ref": "#/$defs/Attribute"
       }
     }
   },
-  "definitions": {
+  "required": [
+    "filterBy"
+  ],
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -187,18 +187,18 @@ Extracts file path information from attributes
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AttributeFilePathInfoExtractor",
   "type": "object",
+  "properties": {
+    "attribute": {
+      "$ref": "#/$defs/Attribute"
+    }
+  },
   "required": [
     "attribute"
   ],
-  "properties": {
-    "attribute": {
-      "$ref": "#/definitions/Attribute"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -221,23 +221,45 @@ Manages attributes
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AttributeManagerParam",
   "type": "object",
-  "required": [
-    "operations"
-  ],
   "properties": {
     "operations": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Operation"
+        "$ref": "#/$defs/Operation"
       }
     }
   },
-  "definitions": {
-    "Expr": {
-      "type": "string"
+  "required": [
+    "operations"
+  ],
+  "$defs": {
+    "Operation": {
+      "type": "object",
+      "properties": {
+        "attribute": {
+          "type": "string"
+        },
+        "method": {
+          "$ref": "#/$defs/Method"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Expr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "attribute",
+        "method"
+      ]
     },
     "Method": {
       "type": "string",
@@ -248,30 +270,8 @@ Manages attributes
         "remove"
       ]
     },
-    "Operation": {
-      "type": "object",
-      "required": [
-        "attribute",
-        "method"
-      ],
-      "properties": {
-        "attribute": {
-          "type": "string"
-        },
-        "method": {
-          "$ref": "#/definitions/Method"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Expr"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      }
+    "Expr": {
+      "type": "string"
     }
   }
 }
@@ -291,28 +291,47 @@ Maps attributes
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "AttributeMapperParam",
   "type": "object",
-  "required": [
-    "mappers"
-  ],
   "properties": {
     "mappers": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Mapper"
+        "$ref": "#/$defs/Mapper"
       }
     }
   },
-  "definitions": {
-    "Expr": {
-      "type": "string"
-    },
+  "required": [
+    "mappers"
+  ],
+  "$defs": {
     "Mapper": {
       "type": "object",
       "properties": {
         "attribute": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "expr": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Expr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "valueAttribute": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "parentAttribute": {
           "type": [
             "string",
             "null"
@@ -324,39 +343,20 @@ Maps attributes
             "null"
           ]
         },
-        "expr": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Expr"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "multipleExpr": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Expr"
+              "$ref": "#/$defs/Expr"
             },
             {
               "type": "null"
             }
           ]
-        },
-        "parentAttribute": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "valueAttribute": {
-          "type": [
-            "string",
-            "null"
-          ]
         }
       }
+    },
+    "Expr": {
+      "type": "string"
     }
   }
 }
@@ -391,17 +391,12 @@ Buffers a geometry
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Bufferer",
   "type": "object",
-  "required": [
-    "bufferType",
-    "distance",
-    "interpolationAngle"
-  ],
   "properties": {
     "bufferType": {
-      "$ref": "#/definitions/BufferType"
+      "$ref": "#/$defs/BufferType"
     },
     "distance": {
       "type": "number",
@@ -412,7 +407,12 @@ Buffers a geometry
       "format": "double"
     }
   },
-  "definitions": {
+  "required": [
+    "bufferType",
+    "distance",
+    "interpolationAngle"
+  ],
+  "$defs": {
     "BufferType": {
       "type": "string",
       "enum": [
@@ -438,20 +438,21 @@ Renames attributes by adding/removing prefixes or suffixes, or replacing text
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "BulkAttributeRenamerParam",
   "type": "object",
-  "required": [
-    "renameAction",
-    "renameType",
-    "renameValue"
-  ],
   "properties": {
-    "renameAction": {
-      "$ref": "#/definitions/RenameAction"
-    },
     "renameType": {
-      "$ref": "#/definitions/RenameType"
+      "$ref": "#/$defs/RenameType"
+    },
+    "renameAction": {
+      "$ref": "#/$defs/RenameAction"
+    },
+    "textToFind": {
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "renameValue": {
       "type": "string"
@@ -464,15 +465,21 @@ Renames attributes by adding/removing prefixes or suffixes, or replacing text
       "items": {
         "type": "string"
       }
-    },
-    "textToFind": {
-      "type": [
-        "string",
-        "null"
-      ]
     }
   },
-  "definitions": {
+  "required": [
+    "renameType",
+    "renameAction",
+    "renameValue"
+  ],
+  "$defs": {
+    "RenameType": {
+      "type": "string",
+      "enum": [
+        "All",
+        "Selected"
+      ]
+    },
     "RenameAction": {
       "type": "string",
       "enum": [
@@ -481,13 +488,6 @@ Renames attributes by adding/removing prefixes or suffixes, or replacing text
         "RemovePrefix",
         "RemoveSuffix",
         "StringReplace"
-      ]
-    },
-    "RenameType": {
-      "type": "string",
-      "enum": [
-        "All",
-        "Selected"
       ]
     }
   }
@@ -523,36 +523,36 @@ Writes features to a file
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Cesium3DTilesWriterParam",
   "type": "object",
-  "required": [
-    "maxZoom",
-    "minZoom",
-    "output"
-  ],
   "properties": {
+    "output": {
+      "$ref": "#/$defs/Expr"
+    },
+    "minZoom": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0
+    },
+    "maxZoom": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0
+    },
     "attachTexture": {
       "type": [
         "boolean",
         "null"
       ]
-    },
-    "maxZoom": {
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "minZoom": {
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "output": {
-      "$ref": "#/definitions/Expr"
     }
   },
-  "definitions": {
+  "required": [
+    "output",
+    "minZoom",
+    "maxZoom"
+  ],
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -606,19 +606,19 @@ Sets the coordinate system of a feature
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "CoordinateSystemSetter",
   "type": "object",
-  "required": [
-    "epsgCode"
-  ],
   "properties": {
     "epsgCode": {
       "type": "integer",
       "format": "uint16",
-      "minimum": 0.0
+      "minimum": 0
     }
-  }
+  },
+  "required": [
+    "epsgCode"
+  ]
 }
 ```
 ### Input Ports
@@ -679,18 +679,18 @@ Extracts a feature’s first z coordinate value, storing it in an attribute.
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ElevationExtractorParam",
   "type": "object",
+  "properties": {
+    "outputAttribute": {
+      "$ref": "#/$defs/Attribute"
+    }
+  },
   "required": [
     "outputAttribute"
   ],
-  "properties": {
-    "outputAttribute": {
-      "$ref": "#/definitions/Attribute"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -712,18 +712,18 @@ Extrudes a polygon by a distance
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ExtruderParam",
   "type": "object",
+  "properties": {
+    "distance": {
+      "$ref": "#/$defs/Expr"
+    }
+  },
   "required": [
     "distance"
   ],
-  "properties": {
-    "distance": {
-      "$ref": "#/definitions/Expr"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -745,13 +745,9 @@ Counts features
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FeatureCounterParam",
   "type": "object",
-  "required": [
-    "countStart",
-    "outputAttribute"
-  ],
   "properties": {
     "countStart": {
       "type": "integer",
@@ -763,14 +759,18 @@ Counts features
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/Attribute"
+        "$ref": "#/$defs/Attribute"
       }
     },
     "outputAttribute": {
       "type": "string"
     }
   },
-  "definitions": {
+  "required": [
+    "countStart",
+    "outputAttribute"
+  ],
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -793,18 +793,18 @@ Creates features from expressions
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FeatureCreator",
   "type": "object",
+  "properties": {
+    "creator": {
+      "$ref": "#/$defs/Expr"
+    }
+  },
   "required": [
     "creator"
   ],
-  "properties": {
-    "creator": {
-      "$ref": "#/definitions/Expr"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -825,22 +825,22 @@ Extracts features by file path
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FeatureFilePathExtractorParam",
   "type": "object",
-  "required": [
-    "extractArchive",
-    "sourceDataset"
-  ],
   "properties": {
+    "sourceDataset": {
+      "$ref": "#/$defs/Expr"
+    },
     "extractArchive": {
       "type": "boolean"
-    },
-    "sourceDataset": {
-      "$ref": "#/definitions/Expr"
     }
   },
-  "definitions": {
+  "required": [
+    "sourceDataset",
+    "extractArchive"
+  ],
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -863,35 +863,35 @@ Filters features based on conditions
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FeatureFilterParam",
   "type": "object",
-  "required": [
-    "conditions"
-  ],
   "properties": {
     "conditions": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Condition"
+        "$ref": "#/$defs/Condition"
       }
     }
   },
-  "definitions": {
+  "required": [
+    "conditions"
+  ],
+  "$defs": {
     "Condition": {
       "type": "object",
+      "properties": {
+        "expr": {
+          "$ref": "#/$defs/Expr"
+        },
+        "outputPort": {
+          "$ref": "#/$defs/Port"
+        }
+      },
       "required": [
         "expr",
         "outputPort"
-      ],
-      "properties": {
-        "expr": {
-          "$ref": "#/definitions/Expr"
-        },
-        "outputPort": {
-          "$ref": "#/definitions/Port"
-        }
-      }
+      ]
     },
     "Expr": {
       "type": "string"
@@ -917,34 +917,18 @@ Merges features by attributes
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FeatureMergerParam",
   "type": "object",
   "properties": {
-    "completeGrouped": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
     "requestorAttribute": {
       "type": [
         "array",
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/Attribute"
+        "$ref": "#/$defs/Attribute"
       }
-    },
-    "requestorAttributeValue": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Expr"
-        },
-        {
-          "type": "null"
-        }
-      ]
     },
     "supplierAttribute": {
       "type": [
@@ -952,21 +936,37 @@ Merges features by attributes
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/Attribute"
+        "$ref": "#/$defs/Attribute"
       }
     },
-    "supplierAttributeValue": {
+    "requestorAttributeValue": {
       "anyOf": [
         {
-          "$ref": "#/definitions/Expr"
+          "$ref": "#/$defs/Expr"
         },
         {
           "type": "null"
         }
       ]
+    },
+    "supplierAttributeValue": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Expr"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "completeGrouped": {
+      "type": [
+        "boolean",
+        "null"
+      ]
     }
   },
-  "definitions": {
+  "$defs": {
     "Attribute": {
       "type": "string"
     },
@@ -993,48 +993,40 @@ Filters features based on conditions
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FeatureReaderParam",
   "oneOf": [
     {
       "type": "object",
-      "required": [
-        "dataset",
-        "format"
-      ],
       "properties": {
+        "format": {
+          "type": "string",
+          "const": "citygml"
+        },
         "dataset": {
-          "$ref": "#/definitions/Expr"
+          "$ref": "#/$defs/Expr"
         },
         "flatten": {
           "type": [
             "boolean",
             "null"
           ]
-        },
-        "format": {
-          "type": "string",
-          "enum": [
-            "citygml"
-          ]
         }
-      }
+      },
+      "required": [
+        "format",
+        "dataset"
+      ]
     },
     {
       "type": "object",
-      "required": [
-        "dataset",
-        "format"
-      ],
       "properties": {
-        "dataset": {
-          "$ref": "#/definitions/Expr"
-        },
         "format": {
           "type": "string",
-          "enum": [
-            "csv"
-          ]
+          "const": "csv"
+        },
+        "dataset": {
+          "$ref": "#/$defs/Expr"
         },
         "offset": {
           "type": [
@@ -1042,25 +1034,23 @@ Filters features based on conditions
             "null"
           ],
           "format": "uint",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "format",
+        "dataset"
+      ]
     },
     {
       "type": "object",
-      "required": [
-        "dataset",
-        "format"
-      ],
       "properties": {
-        "dataset": {
-          "$ref": "#/definitions/Expr"
-        },
         "format": {
           "type": "string",
-          "enum": [
-            "tsv"
-          ]
+          "const": "tsv"
+        },
+        "dataset": {
+          "$ref": "#/$defs/Expr"
         },
         "offset": {
           "type": [
@@ -1068,12 +1058,16 @@ Filters features based on conditions
             "null"
           ],
           "format": "uint",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "format",
+        "dataset"
+      ]
     }
   ],
-  "definitions": {
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -1095,21 +1089,52 @@ Sorts features by attributes
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FeatureSorterParam",
   "type": "object",
-  "required": [
-    "sortBy"
-  ],
   "properties": {
     "sortBy": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/SortBy"
+        "$ref": "#/$defs/SortBy"
       }
     }
   },
-  "definitions": {
+  "required": [
+    "sortBy"
+  ],
+  "$defs": {
+    "SortBy": {
+      "type": "object",
+      "properties": {
+        "attribute": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Attribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "attributeValue": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Expr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "order": {
+          "$ref": "#/$defs/Order"
+        }
+      },
+      "required": [
+        "order"
+      ]
+    },
     "Attribute": {
       "type": "string"
     },
@@ -1122,37 +1147,6 @@ Sorts features by attributes
         "ascending",
         "descending"
       ]
-    },
-    "SortBy": {
-      "type": "object",
-      "required": [
-        "order"
-      ],
-      "properties": {
-        "attribute": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Attribute"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "attributeValue": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Expr"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "order": {
-          "$ref": "#/definitions/Order"
-        }
-      }
     }
   }
 }
@@ -1172,34 +1166,34 @@ Transforms features by expressions
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FeatureTransformerParam",
   "type": "object",
-  "required": [
-    "transformers"
-  ],
   "properties": {
     "transformers": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Transform"
+        "$ref": "#/$defs/Transform"
       }
     }
   },
-  "definitions": {
-    "Expr": {
-      "type": "string"
-    },
+  "required": [
+    "transformers"
+  ],
+  "$defs": {
     "Transform": {
       "type": "object",
-      "required": [
-        "expr"
-      ],
       "properties": {
         "expr": {
-          "$ref": "#/definitions/Expr"
+          "$ref": "#/$defs/Expr"
         }
-      }
+      },
+      "required": [
+        "expr"
+      ]
+    },
+    "Expr": {
+      "type": "string"
     }
   }
 }
@@ -1219,12 +1213,9 @@ Filters features by feature type
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FeatureTypeFilter",
   "type": "object",
-  "required": [
-    "targetTypes"
-  ],
   "properties": {
     "targetTypes": {
       "type": "array",
@@ -1232,7 +1223,10 @@ Filters features by feature type
         "type": "string"
       }
     }
-  }
+  },
+  "required": [
+    "targetTypes"
+  ]
 }
 ```
 ### Input Ports
@@ -1251,22 +1245,22 @@ Extracts files from a directory or an archive
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FilePathExtractor",
   "type": "object",
-  "required": [
-    "extractArchive",
-    "sourceDataset"
-  ],
   "properties": {
+    "sourceDataset": {
+      "$ref": "#/$defs/Expr"
+    },
     "extractArchive": {
       "type": "boolean"
-    },
-    "sourceDataset": {
-      "$ref": "#/definitions/Expr"
     }
   },
-  "definitions": {
+  "required": [
+    "sourceDataset",
+    "extractArchive"
+  ],
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -1287,17 +1281,17 @@ Extracts properties from a file
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FilePropertyExtractor",
   "type": "object",
-  "required": [
-    "filePathAttribute"
-  ],
   "properties": {
     "filePathAttribute": {
       "type": "string"
     }
-  }
+  },
+  "required": [
+    "filePathAttribute"
+  ]
 }
 ```
 ### Input Ports
@@ -1316,24 +1310,19 @@ Reads features from a file
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FileReader",
   "oneOf": [
     {
+      "title": "CSV",
       "type": "object",
-      "required": [
-        "dataset",
-        "format"
-      ],
       "properties": {
-        "dataset": {
-          "$ref": "#/definitions/Expr"
-        },
         "format": {
           "type": "string",
-          "enum": [
-            "csv"
-          ]
+          "const": "csv"
+        },
+        "dataset": {
+          "$ref": "#/$defs/Expr"
         },
         "offset": {
           "type": [
@@ -1341,25 +1330,24 @@ Reads features from a file
             "null"
           ],
           "format": "uint",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "format",
+        "dataset"
+      ]
     },
     {
+      "title": "TSV",
       "type": "object",
-      "required": [
-        "dataset",
-        "format"
-      ],
       "properties": {
-        "dataset": {
-          "$ref": "#/definitions/Expr"
-        },
         "format": {
           "type": "string",
-          "enum": [
-            "tsv"
-          ]
+          "const": "tsv"
+        },
+        "dataset": {
+          "$ref": "#/$defs/Expr"
         },
         "offset": {
           "type": [
@@ -1367,54 +1355,56 @@ Reads features from a file
             "null"
           ],
           "format": "uint",
-          "minimum": 0.0
+          "minimum": 0
         }
-      }
+      },
+      "required": [
+        "format",
+        "dataset"
+      ]
     },
     {
+      "title": "JSON",
       "type": "object",
-      "required": [
-        "dataset",
-        "format"
-      ],
       "properties": {
-        "dataset": {
-          "$ref": "#/definitions/Expr"
-        },
         "format": {
           "type": "string",
-          "enum": [
-            "json"
-          ]
+          "const": "json"
+        },
+        "dataset": {
+          "$ref": "#/$defs/Expr"
         }
-      }
+      },
+      "required": [
+        "format",
+        "dataset"
+      ]
     },
     {
+      "title": "CityGML",
       "type": "object",
-      "required": [
-        "dataset",
-        "format"
-      ],
       "properties": {
+        "format": {
+          "type": "string",
+          "const": "citygml"
+        },
         "dataset": {
-          "$ref": "#/definitions/Expr"
+          "$ref": "#/$defs/Expr"
         },
         "flatten": {
           "type": [
             "boolean",
             "null"
           ]
-        },
-        "format": {
-          "type": "string",
-          "enum": [
-            "citygml"
-          ]
         }
-      }
+      },
+      "required": [
+        "format",
+        "dataset"
+      ]
     }
   ],
-  "definitions": {
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -1435,88 +1425,76 @@ Writes features to a file
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FileWriterParam",
   "oneOf": [
     {
       "type": "object",
-      "required": [
-        "format",
-        "output"
-      ],
       "properties": {
         "format": {
           "type": "string",
-          "enum": [
-            "csv"
-          ]
+          "const": "csv"
         },
         "output": {
-          "$ref": "#/definitions/Expr"
+          "$ref": "#/$defs/Expr"
         }
-      }
-    },
-    {
-      "type": "object",
+      },
       "required": [
         "format",
         "output"
-      ],
+      ]
+    },
+    {
+      "type": "object",
       "properties": {
         "format": {
           "type": "string",
-          "enum": [
-            "tsv"
-          ]
+          "const": "tsv"
         },
         "output": {
-          "$ref": "#/definitions/Expr"
+          "$ref": "#/$defs/Expr"
         }
-      }
-    },
-    {
-      "type": "object",
+      },
       "required": [
         "format",
         "output"
-      ],
+      ]
+    },
+    {
+      "type": "object",
       "properties": {
+        "format": {
+          "type": "string",
+          "const": "json"
+        },
+        "output": {
+          "$ref": "#/$defs/Expr"
+        },
         "converter": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Expr"
+              "$ref": "#/$defs/Expr"
             },
             {
               "type": "null"
             }
           ]
-        },
-        "format": {
-          "type": "string",
-          "enum": [
-            "json"
-          ]
-        },
-        "output": {
-          "$ref": "#/definitions/Expr"
         }
-      }
-    },
-    {
-      "type": "object",
+      },
       "required": [
         "format",
         "output"
-      ],
+      ]
+    },
+    {
+      "type": "object",
       "properties": {
         "format": {
           "type": "string",
-          "enum": [
-            "excel"
-          ]
+          "const": "excel"
         },
         "output": {
-          "$ref": "#/definitions/Expr"
+          "$ref": "#/$defs/Expr"
         },
         "sheetName": {
           "type": [
@@ -1524,10 +1502,14 @@ Writes features to a file
             "null"
           ]
         }
-      }
+      },
+      "required": [
+        "format",
+        "output"
+      ]
     }
   ],
-  "definitions": {
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -1548,31 +1530,31 @@ Writes features to a geojson file
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GeoJsonWriterParam",
   "type": "object",
-  "required": [
-    "output"
-  ],
   "properties": {
+    "output": {
+      "$ref": "#/$defs/Expr"
+    },
     "groupBy": {
       "type": [
         "array",
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/Attribute"
+        "$ref": "#/$defs/Attribute"
       }
-    },
-    "output": {
-      "$ref": "#/definitions/Expr"
     }
   },
-  "definitions": {
-    "Attribute": {
+  "required": [
+    "output"
+  ],
+  "$defs": {
+    "Expr": {
       "type": "string"
     },
-    "Expr": {
+    "Attribute": {
       "type": "string"
     }
   }
@@ -1592,18 +1574,18 @@ Coerces the geometry of a feature to a specific geometry
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GeometryCoercer",
   "type": "object",
+  "properties": {
+    "coercerType": {
+      "$ref": "#/$defs/CoercerType"
+    }
+  },
   "required": [
     "coercerType"
   ],
-  "properties": {
-    "coercerType": {
-      "$ref": "#/definitions/CoercerType"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "CoercerType": {
       "type": "string",
       "enum": [
@@ -1628,27 +1610,27 @@ Dissolve geometries
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GeometryDissolverParam",
   "type": "object",
   "properties": {
-    "completeGrouped": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
     "groupBy": {
       "type": [
         "array",
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/Attribute"
+        "$ref": "#/$defs/Attribute"
       }
+    },
+    "completeGrouped": {
+      "type": [
+        "boolean",
+        "null"
+      ]
     }
   },
-  "definitions": {
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -1671,18 +1653,18 @@ Extracts geometry from a feature and adds it as an attribute.
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GeometryExtractor",
   "type": "object",
+  "properties": {
+    "outputAttribute": {
+      "$ref": "#/$defs/Attribute"
+    }
+  },
   "required": [
     "outputAttribute"
   ],
-  "properties": {
-    "outputAttribute": {
-      "$ref": "#/definitions/Attribute"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -1704,50 +1686,44 @@ Filter geometry by type
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GeometryFilterParam",
   "oneOf": [
     {
       "type": "object",
-      "required": [
-        "filterType"
-      ],
       "properties": {
         "filterType": {
           "type": "string",
-          "enum": [
-            "none"
-          ]
+          "const": "none"
         }
-      }
+      },
+      "required": [
+        "filterType"
+      ]
     },
     {
       "type": "object",
-      "required": [
-        "filterType"
-      ],
       "properties": {
         "filterType": {
           "type": "string",
-          "enum": [
-            "multiple"
-          ]
+          "const": "multiple"
         }
-      }
+      },
+      "required": [
+        "filterType"
+      ]
     },
     {
       "type": "object",
-      "required": [
-        "filterType"
-      ],
       "properties": {
         "filterType": {
           "type": "string",
-          "enum": [
-            "geometryType"
-          ]
+          "const": "geometryType"
         }
-      }
+      },
+      "required": [
+        "filterType"
+      ]
     }
   ]
 }
@@ -1790,7 +1766,7 @@ Filter geometry by lod
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GeometryLodFilterParam",
   "type": "object",
   "properties": {
@@ -1800,7 +1776,7 @@ Filter geometry by lod
         "null"
       ],
       "format": "uint8",
-      "minimum": 0.0
+      "minimum": 0
     }
   }
 }
@@ -1821,18 +1797,18 @@ Replaces the geometry of a feature with a new geometry.
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GeometryReplacer",
   "type": "object",
+  "properties": {
+    "sourceAttribute": {
+      "$ref": "#/$defs/Attribute"
+    }
+  },
   "required": [
     "sourceAttribute"
   ],
-  "properties": {
-    "sourceAttribute": {
-      "$ref": "#/definitions/Attribute"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -1868,21 +1844,21 @@ Validates the geometry of a feature
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GeometryValidator",
   "type": "object",
-  "required": [
-    "validationTypes"
-  ],
   "properties": {
     "validationTypes": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/ValidationType"
+        "$ref": "#/$defs/ValidationType"
       }
     }
   },
-  "definitions": {
+  "required": [
+    "validationTypes"
+  ],
+  "$defs": {
     "ValidationType": {
       "type": "string",
       "enum": [
@@ -1928,24 +1904,24 @@ Writes features to a Gltf
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GltfWriterParam",
   "type": "object",
-  "required": [
-    "output"
-  ],
   "properties": {
+    "output": {
+      "$ref": "#/$defs/Expr"
+    },
     "attachTexture": {
       "type": [
         "boolean",
         "null"
       ]
-    },
-    "output": {
-      "$ref": "#/definitions/Expr"
     }
   },
-  "definitions": {
+  "required": [
+    "output"
+  ],
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -1966,18 +1942,18 @@ Counts the number of holes in a geometry and adds it as an attribute.
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "HoleCounterParam",
   "type": "object",
+  "properties": {
+    "outputAttribute": {
+      "$ref": "#/$defs/Attribute"
+    }
+  },
   "required": [
     "outputAttribute"
   ],
-  "properties": {
-    "outputAttribute": {
-      "$ref": "#/definitions/Attribute"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -2015,7 +1991,7 @@ Reprojects the geometry of a feature to a specified coordinate system
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "HorizontalReprojectorParam",
   "type": "object",
   "properties": {
@@ -2025,7 +2001,7 @@ Reprojects the geometry of a feature to a specified coordinate system
         "null"
       ],
       "format": "uint16",
-      "minimum": 0.0
+      "minimum": 0
     }
   }
 }
@@ -2045,17 +2021,17 @@ Action for first port forwarding for sub-workflows.
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "InputRouter",
   "type": "object",
-  "required": [
-    "routingPort"
-  ],
   "properties": {
     "routingPort": {
       "type": "string"
     }
-  }
+  },
+  "required": [
+    "routingPort"
+  ]
 }
 ```
 ### Input Ports
@@ -2072,12 +2048,9 @@ Intersection points are turned into point features that can contain the merged l
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "LineOnLineOverlayerParam",
   "type": "object",
-  "required": [
-    "outputAttribute"
-  ],
   "properties": {
     "groupBy": {
       "type": [
@@ -2085,14 +2058,17 @@ Intersection points are turned into point features that can contain the merged l
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/Attribute"
+        "$ref": "#/$defs/Attribute"
       }
     },
     "outputAttribute": {
-      "$ref": "#/definitions/Attribute"
+      "$ref": "#/$defs/Attribute"
     }
   },
-  "definitions": {
+  "required": [
+    "outputAttribute"
+  ],
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -2116,18 +2092,18 @@ Explodes list attributes
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ListExploder",
   "type": "object",
+  "properties": {
+    "sourceAttribute": {
+      "$ref": "#/$defs/Attribute"
+    }
+  },
   "required": [
     "sourceAttribute"
   ],
-  "properties": {
-    "sourceAttribute": {
-      "$ref": "#/definitions/Attribute"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -2149,34 +2125,34 @@ Writes features to a file
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "MVTWriterParam",
   "type": "object",
-  "required": [
-    "layerName",
-    "maxZoom",
-    "minZoom",
-    "output"
-  ],
   "properties": {
-    "layerName": {
-      "$ref": "#/definitions/Expr"
+    "output": {
+      "$ref": "#/$defs/Expr"
     },
-    "maxZoom": {
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
+    "layerName": {
+      "$ref": "#/$defs/Expr"
     },
     "minZoom": {
       "type": "integer",
       "format": "uint8",
-      "minimum": 0.0
+      "minimum": 0
     },
-    "output": {
-      "$ref": "#/definitions/Expr"
+    "maxZoom": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0
     }
   },
-  "definitions": {
+  "required": [
+    "output",
+    "layerName",
+    "minZoom",
+    "maxZoom"
+  ],
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -2224,7 +2200,7 @@ Adds offsets to the feature's coordinates.
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "OffsetterParam",
   "type": "object",
   "properties": {
@@ -2267,18 +2243,18 @@ Extracts the orientation of a geometry from a feature and adds it as an attribut
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "OrientationExtractorParam",
   "type": "object",
+  "properties": {
+    "outputAttribute": {
+      "$ref": "#/$defs/Attribute"
+    }
+  },
   "required": [
     "outputAttribute"
   ],
-  "properties": {
-    "outputAttribute": {
-      "$ref": "#/definitions/Attribute"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -2300,17 +2276,17 @@ Action for last port forwarding for sub-workflows.
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "OutputRouter",
   "type": "object",
-  "required": [
-    "routingPort"
-  ],
   "properties": {
     "routingPort": {
       "type": "string"
     }
-  }
+  },
+  "required": [
+    "routingPort"
+  ]
 }
 ```
 ### Input Ports
@@ -2476,18 +2452,18 @@ Extracts UDX folders from cityGML path
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "UDXFolderExtractorParam",
   "type": "object",
+  "properties": {
+    "cityGmlPath": {
+      "$ref": "#/$defs/Expr"
+    }
+  },
   "required": [
     "cityGmlPath"
   ],
-  "properties": {
-    "cityGmlPath": {
-      "$ref": "#/definitions/Expr"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -2540,22 +2516,22 @@ Calls Rhai script
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "RhaiCallerParam",
   "type": "object",
+  "properties": {
+    "isTarget": {
+      "$ref": "#/$defs/Expr"
+    },
+    "process": {
+      "$ref": "#/$defs/Expr"
+    }
+  },
   "required": [
     "isTarget",
     "process"
   ],
-  "properties": {
-    "isTarget": {
-      "$ref": "#/definitions/Expr"
-    },
-    "process": {
-      "$ref": "#/definitions/Expr"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -2577,27 +2553,24 @@ Calculates statistics of features
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "StatisticsCalculatorParam",
   "type": "object",
-  "required": [
-    "calculations"
-  ],
   "properties": {
-    "aggregateAttribute": {
+    "aggregateName": {
       "anyOf": [
         {
-          "$ref": "#/definitions/Attribute"
+          "$ref": "#/$defs/Attribute"
         },
         {
           "type": "null"
         }
       ]
     },
-    "aggregateName": {
+    "aggregateAttribute": {
       "anyOf": [
         {
-          "$ref": "#/definitions/Attribute"
+          "$ref": "#/$defs/Attribute"
         },
         {
           "type": "null"
@@ -2607,28 +2580,31 @@ Calculates statistics of features
     "calculations": {
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Calculation"
+        "$ref": "#/$defs/Calculation"
       }
     }
   },
-  "definitions": {
+  "required": [
+    "calculations"
+  ],
+  "$defs": {
     "Attribute": {
       "type": "string"
     },
     "Calculation": {
       "type": "object",
-      "required": [
-        "expr",
-        "newAttribute"
-      ],
       "properties": {
-        "expr": {
-          "$ref": "#/definitions/Expr"
-        },
         "newAttribute": {
-          "$ref": "#/definitions/Attribute"
+          "$ref": "#/$defs/Attribute"
+        },
+        "expr": {
+          "$ref": "#/$defs/Expr"
         }
-      }
+      },
+      "required": [
+        "newAttribute",
+        "expr"
+      ]
     },
     "Expr": {
       "type": "string"
@@ -2652,38 +2628,38 @@ Replaces a three Dimension box with a polygon.
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ThreeDimensionBoxReplacer",
   "type": "object",
-  "required": [
-    "maxX",
-    "maxY",
-    "maxZ",
-    "minX",
-    "minY",
-    "minZ"
-  ],
   "properties": {
-    "maxX": {
-      "$ref": "#/definitions/Attribute"
-    },
-    "maxY": {
-      "$ref": "#/definitions/Attribute"
-    },
-    "maxZ": {
-      "$ref": "#/definitions/Attribute"
-    },
     "minX": {
-      "$ref": "#/definitions/Attribute"
+      "$ref": "#/$defs/Attribute"
     },
     "minY": {
-      "$ref": "#/definitions/Attribute"
+      "$ref": "#/$defs/Attribute"
     },
     "minZ": {
-      "$ref": "#/definitions/Attribute"
+      "$ref": "#/$defs/Attribute"
+    },
+    "maxX": {
+      "$ref": "#/$defs/Attribute"
+    },
+    "maxY": {
+      "$ref": "#/$defs/Attribute"
+    },
+    "maxZ": {
+      "$ref": "#/$defs/Attribute"
     }
   },
-  "definitions": {
+  "required": [
+    "minX",
+    "minY",
+    "minZ",
+    "maxX",
+    "maxY",
+    "maxZ"
+  ],
+  "$defs": {
     "Attribute": {
       "type": "string"
     }
@@ -2705,42 +2681,42 @@ Replaces a three Dimension box with a polygon.
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ThreeDimensionRotatorParam",
   "type": "object",
-  "required": [
-    "angleDegree",
-    "directionX",
-    "directionY",
-    "directionZ",
-    "originX",
-    "originY",
-    "originZ"
-  ],
   "properties": {
     "angleDegree": {
-      "$ref": "#/definitions/Expr"
-    },
-    "directionX": {
-      "$ref": "#/definitions/Expr"
-    },
-    "directionY": {
-      "$ref": "#/definitions/Expr"
-    },
-    "directionZ": {
-      "$ref": "#/definitions/Expr"
+      "$ref": "#/$defs/Expr"
     },
     "originX": {
-      "$ref": "#/definitions/Expr"
+      "$ref": "#/$defs/Expr"
     },
     "originY": {
-      "$ref": "#/definitions/Expr"
+      "$ref": "#/$defs/Expr"
     },
     "originZ": {
-      "$ref": "#/definitions/Expr"
+      "$ref": "#/$defs/Expr"
+    },
+    "directionX": {
+      "$ref": "#/$defs/Expr"
+    },
+    "directionY": {
+      "$ref": "#/$defs/Expr"
+    },
+    "directionZ": {
+      "$ref": "#/$defs/Expr"
     }
   },
-  "definitions": {
+  "required": [
+    "angleDegree",
+    "originX",
+    "originY",
+    "originZ",
+    "directionX",
+    "directionY",
+    "directionZ"
+  ],
+  "$defs": {
     "Expr": {
       "type": "string"
     }
@@ -2791,18 +2767,18 @@ Reprojects the geometry of a feature to a specified coordinate system
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "VerticalReprojectorParam",
   "type": "object",
+  "properties": {
+    "reprojectorType": {
+      "$ref": "#/$defs/VerticalReprojectorType"
+    }
+  },
   "required": [
     "reprojectorType"
   ],
-  "properties": {
-    "reprojectorType": {
-      "$ref": "#/definitions/VerticalReprojectorType"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "VerticalReprojectorType": {
       "type": "string",
       "enum": [
@@ -2827,26 +2803,26 @@ Compiles scripts into .wasm and runs at the wasm runtime
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "WasmRuntimeExecutorParam",
   "type": "object",
-  "required": [
-    "processorType",
-    "programmingLanguage",
-    "sourceCodeFilePath"
-  ],
   "properties": {
-    "processorType": {
-      "$ref": "#/definitions/ProcessorType"
-    },
-    "programmingLanguage": {
-      "$ref": "#/definitions/ProgrammingLanguage"
-    },
     "sourceCodeFilePath": {
       "type": "string"
+    },
+    "processorType": {
+      "$ref": "#/$defs/ProcessorType"
+    },
+    "programmingLanguage": {
+      "$ref": "#/$defs/ProgrammingLanguage"
     }
   },
-  "definitions": {
+  "required": [
+    "sourceCodeFilePath",
+    "processorType",
+    "programmingLanguage"
+  ],
+  "$defs": {
     "ProcessorType": {
       "type": "string",
       "enum": [
@@ -2877,41 +2853,39 @@ Fragment XML
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "XmlFragmenterParam",
   "oneOf": [
     {
       "type": "object",
-      "required": [
-        "attribute",
-        "elementsToExclude",
-        "elementsToMatch",
-        "source"
-      ],
       "properties": {
-        "attribute": {
-          "$ref": "#/definitions/Attribute"
+        "elementsToMatch": {
+          "$ref": "#/$defs/Expr"
         },
         "elementsToExclude": {
-          "$ref": "#/definitions/Expr"
+          "$ref": "#/$defs/Expr"
         },
-        "elementsToMatch": {
-          "$ref": "#/definitions/Expr"
+        "attribute": {
+          "$ref": "#/$defs/Attribute"
         },
         "source": {
           "type": "string",
-          "enum": [
-            "url"
-          ]
+          "const": "url"
         }
-      }
+      },
+      "required": [
+        "source",
+        "elementsToMatch",
+        "elementsToExclude",
+        "attribute"
+      ]
     }
   ],
-  "definitions": {
-    "Attribute": {
+  "$defs": {
+    "Expr": {
       "type": "string"
     },
-    "Expr": {
+    "Attribute": {
       "type": "string"
     }
   }
@@ -2932,28 +2906,35 @@ Validates XML content
 ### Parameters
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "XmlValidatorParam",
   "type": "object",
+  "properties": {
+    "attribute": {
+      "$ref": "#/$defs/Attribute"
+    },
+    "inputType": {
+      "$ref": "#/$defs/XmlInputType"
+    },
+    "validationType": {
+      "$ref": "#/$defs/ValidationType"
+    }
+  },
   "required": [
     "attribute",
     "inputType",
     "validationType"
   ],
-  "properties": {
-    "attribute": {
-      "$ref": "#/definitions/Attribute"
-    },
-    "inputType": {
-      "$ref": "#/definitions/XmlInputType"
-    },
-    "validationType": {
-      "$ref": "#/definitions/ValidationType"
-    }
-  },
-  "definitions": {
+  "$defs": {
     "Attribute": {
       "type": "string"
+    },
+    "XmlInputType": {
+      "type": "string",
+      "enum": [
+        "file",
+        "text"
+      ]
     },
     "ValidationType": {
       "type": "string",
@@ -2961,13 +2942,6 @@ Validates XML content
         "syntax",
         "syntaxAndNamespace",
         "syntaxAndSchema"
-      ]
-    },
-    "XmlInputType": {
-      "type": "string",
-      "enum": [
-        "file",
-        "text"
       ]
     }
   }

--- a/engine/runtime/action-plateau-processor/src/plateau3/attribute_flattener.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/attribute_flattener.rs
@@ -400,7 +400,7 @@ impl ProcessorFactory for AttributeFlattenerFactory {
         "Flatten attributes for building feature"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/building_installation_geometry_type_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/building_installation_geometry_type_extractor.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for BuildingInstallationGeometryTypeExtractorFactory {
         "Extracts BuildingInstallationGeometryType"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/building_usage_attribute_validator.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/building_usage_attribute_validator.rs
@@ -50,7 +50,7 @@ impl ProcessorFactory for BuildingUsageAttributeValidatorFactory {
         "This processor validates building usage attributes by checking for the presence of required attributes and ensuring the correctness of city codes. It outputs errors through the lBldgError and codeError ports if any issues are found."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/dictionaries_initiator.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/dictionaries_initiator.rs
@@ -39,7 +39,7 @@ impl ProcessorFactory for DictionariesInitiatorFactory {
         "Initializes dictionaries for PLATEAU"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/domain_of_definition_validator.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/domain_of_definition_validator.rs
@@ -286,7 +286,7 @@ impl ProcessorFactory for DomainOfDefinitionValidatorFactory {
         "Validates domain of definition of CityGML features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/max_lod_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/max_lod_extractor.rs
@@ -28,7 +28,7 @@ impl ProcessorFactory for MaxLodExtractorFactory {
         "Extracts maxLod"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/tran_xlink_checker.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/tran_xlink_checker.rs
@@ -31,7 +31,7 @@ impl ProcessorFactory for TranXLinkCheckerFactory {
         "Check Xlink for Tran"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/udx_folder_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/udx_folder_extractor.rs
@@ -65,7 +65,7 @@ impl ProcessorFactory for UdxFolderExtractorFactory {
         "Extracts UDX folders from cityGML path"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/unmatched_xlink_detector.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/unmatched_xlink_detector.rs
@@ -115,7 +115,7 @@ impl ProcessorFactory for UnmatchedXlinkDetectorFactory {
         "Detect unmatched xlink for PLATEAU"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/xml_attribute_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/xml_attribute_extractor.rs
@@ -412,7 +412,7 @@ impl ProcessorFactory for XmlAttributeExtractorFactory {
         "Extracts attributes from XML fragments based on a schema definition"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau4/udx_folder_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/udx_folder_extractor.rs
@@ -67,7 +67,7 @@ impl ProcessorFactory for UDXFolderExtractorFactory {
         "Extracts UDX folders from cityGML path"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(UDXFolderExtractorParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/aggregator.rs
+++ b/engine/runtime/action-processor/src/attribute/aggregator.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for AttributeAggregatorFactory {
         "Aggregates features by attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(AttributeAggregatorParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/bulk_renamer.rs
+++ b/engine/runtime/action-processor/src/attribute/bulk_renamer.rs
@@ -24,7 +24,7 @@ impl ProcessorFactory for BulkAttributeRenamerFactory {
         "Renames attributes by adding/removing prefixes or suffixes, or replacing text"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(BulkAttributeRenamerParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/duplicate_filter.rs
+++ b/engine/runtime/action-processor/src/attribute/duplicate_filter.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for AttributeDuplicateFilterFactory {
         "Filters features by duplicate attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(AttributeDuplicateFilterParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/file_path_info_extractor.rs
+++ b/engine/runtime/action-processor/src/attribute/file_path_info_extractor.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for AttributeFilePathInfoExtractorFactory {
         "Extracts file path information from attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(AttributeFilePathInfoExtractor))
     }
 

--- a/engine/runtime/action-processor/src/attribute/manager.rs
+++ b/engine/runtime/action-processor/src/attribute/manager.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for AttributeManagerFactory {
         "Manages attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(AttributeManagerParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/mapper.rs
+++ b/engine/runtime/action-processor/src/attribute/mapper.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for AttributeMapperFactory {
         "Maps attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(AttributeMapperParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/statistics_calculator.rs
+++ b/engine/runtime/action-processor/src/attribute/statistics_calculator.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for StatisticsCalculatorFactory {
         "Calculates statistics of features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(StatisticsCalculatorParam))
     }
 

--- a/engine/runtime/action-processor/src/echo.rs
+++ b/engine/runtime/action-processor/src/echo.rs
@@ -21,7 +21,7 @@ impl ProcessorFactory for EchoProcessorFactory {
         "Echo features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/feature/counter.rs
+++ b/engine/runtime/action-processor/src/feature/counter.rs
@@ -68,7 +68,7 @@ impl ProcessorFactory for FeatureCounterFactory {
         "Counts features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FeatureCounterParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/file_path_extractor.rs
+++ b/engine/runtime/action-processor/src/feature/file_path_extractor.rs
@@ -31,7 +31,7 @@ impl ProcessorFactory for FeatureFilePathExtractorFactory {
         "Extracts features by file path"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FeatureFilePathExtractorParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/filter.rs
+++ b/engine/runtime/action-processor/src/feature/filter.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for FeatureFilterFactory {
         "Filters features based on conditions"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FeatureFilterParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/list_exploder.rs
+++ b/engine/runtime/action-processor/src/feature/list_exploder.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for ListExploderFactory {
         "Explodes list attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(ListExploder))
     }
 

--- a/engine/runtime/action-processor/src/feature/merger.rs
+++ b/engine/runtime/action-processor/src/feature/merger.rs
@@ -35,7 +35,7 @@ impl ProcessorFactory for FeatureMergerFactory {
         "Merges features by attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FeatureMergerParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/reader.rs
+++ b/engine/runtime/action-processor/src/feature/reader.rs
@@ -30,7 +30,7 @@ impl ProcessorFactory for FeatureReaderFactory {
         "Filters features based on conditions"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FeatureReaderParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/rhai.rs
+++ b/engine/runtime/action-processor/src/feature/rhai.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for RhaiCallerFactory {
         "Calls Rhai script"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(RhaiCallerParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/sorter.rs
+++ b/engine/runtime/action-processor/src/feature/sorter.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for FeatureSorterFactory {
         "Sorts features by attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FeatureSorterParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/transformer.rs
+++ b/engine/runtime/action-processor/src/feature/transformer.rs
@@ -28,7 +28,7 @@ impl ProcessorFactory for FeatureTransformerFactory {
         "Transforms features by expressions"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FeatureTransformerParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/type_filter.rs
+++ b/engine/runtime/action-processor/src/feature/type_filter.rs
@@ -28,7 +28,7 @@ impl ProcessorFactory for FeatureTypeFilterFactory {
         "Filters features by feature type"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FeatureTypeFilter))
     }
 

--- a/engine/runtime/action-processor/src/file/property_extractor.rs
+++ b/engine/runtime/action-processor/src/file/property_extractor.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for FilePropertyExtractorFactory {
         "Extracts properties from a file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FilePropertyExtractor))
     }
 

--- a/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
@@ -43,7 +43,7 @@ impl ProcessorFactory for AreaOnAreaOverlayerFactory {
         "Overlays an area on another area"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(AreaOnAreaOverlayerParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
@@ -60,7 +60,7 @@ impl ProcessorFactory for BoundsExtractorFactory {
         "Bounds Extractor"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/bufferer.rs
+++ b/engine/runtime/action-processor/src/geometry/bufferer.rs
@@ -32,7 +32,7 @@ impl ProcessorFactory for BuffererFactory {
         "Buffers a geometry"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(Bufferer))
     }
 

--- a/engine/runtime/action-processor/src/geometry/center_point_replacer.rs
+++ b/engine/runtime/action-processor/src/geometry/center_point_replacer.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for CenterPointReplacerFactory {
         "Replaces the geometry of the feature with a point that is either in the center of the feature's bounding box, at the center of mass of the feature, or somewhere guaranteed to be inside the feature's area."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/clipper.rs
+++ b/engine/runtime/action-processor/src/geometry/clipper.rs
@@ -35,7 +35,7 @@ impl ProcessorFactory for ClipperFactory {
         "Divides Candidate features using Clipper features, so that Candidates and parts of Candidates that are inside or outside of the Clipper features are output separately"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/closed_curve_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/closed_curve_filter.rs
@@ -30,7 +30,7 @@ impl ProcessorFactory for ClosedCurveFilterFactory {
         "Checks if curves form closed loops"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/coercer.rs
+++ b/engine/runtime/action-processor/src/geometry/coercer.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for GeometryCoercerFactory {
         "Coerces the geometry of a feature to a specific geometry"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(GeometryCoercer))
     }
 

--- a/engine/runtime/action-processor/src/geometry/coordinate_system_setter.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_system_setter.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for CoordinateSystemSetterFactory {
         "Sets the coordinate system of a feature"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(CoordinateSystemSetter))
     }
 

--- a/engine/runtime/action-processor/src/geometry/dimension_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/dimension_filter.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for DimensionFilterFactory {
         "Filters the dimension of features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/dissolver.rs
+++ b/engine/runtime/action-processor/src/geometry/dissolver.rs
@@ -37,7 +37,7 @@ impl ProcessorFactory for GeometryDissolverFactory {
         "Dissolve geometries"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(GeometryDissolverParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/elevation_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/elevation_extractor.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for ElevationExtractorFactory {
         "Extracts a feature’s first z coordinate value, storing it in an attribute."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(ElevationExtractorParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/extractor.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for GeometryExtractorFactory {
         "Extracts geometry from a feature and adds it as an attribute."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(GeometryExtractor))
     }
 

--- a/engine/runtime/action-processor/src/geometry/extruder.rs
+++ b/engine/runtime/action-processor/src/geometry/extruder.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for ExtruderFactory {
         "Extrudes a polygon by a distance"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(ExtruderParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/filter.rs
+++ b/engine/runtime/action-processor/src/geometry/filter.rs
@@ -31,7 +31,7 @@ impl ProcessorFactory for GeometryFilterFactory {
         "Filter geometry by type"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(GeometryFilterParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/hole_counter.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_counter.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for HoleCounterFactory {
         "Counts the number of holes in a geometry and adds it as an attribute."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(HoleCounterParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/hole_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_extractor.rs
@@ -30,7 +30,7 @@ impl ProcessorFactory for HoleExtractorFactory {
         "Extracts holes in a geometry and adds it as an attribute."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/horizontal_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/horizontal_reprojector.rs
@@ -34,7 +34,7 @@ impl ProcessorFactory for HorizontalReprojectorFactory {
         "Reprojects the geometry of a feature to a specified coordinate system"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(HorizontalReprojectorParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -41,7 +41,7 @@ impl ProcessorFactory for LineOnLineOverlayerFactory {
         "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(LineOnLineOverlayerParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/lod_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/lod_filter.rs
@@ -28,7 +28,7 @@ impl ProcessorFactory for GeometryLodFilterFactory {
         "Filter geometry by lod"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(GeometryLodFilterParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/offsetter.rs
+++ b/engine/runtime/action-processor/src/geometry/offsetter.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for OffsetterFactory {
         "Adds offsets to the feature's coordinates."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(OffsetterParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/orientation_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/orientation_extractor.rs
@@ -36,7 +36,7 @@ impl ProcessorFactory for OrientationExtractorFactory {
         "Extracts the orientation of a geometry from a feature and adds it as an attribute."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(OrientationExtractorParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/planarity_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/planarity_filter.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for PlanarityFilterFactory {
         "Filter geometry by type"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/refiner.rs
+++ b/engine/runtime/action-processor/src/geometry/refiner.rs
@@ -33,7 +33,7 @@ impl ProcessorFactory for RefinerFactory {
         "Geometry Refiner"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/replacer.rs
+++ b/engine/runtime/action-processor/src/geometry/replacer.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for GeometryReplacerFactory {
         "Replaces the geometry of a feature with a new geometry."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(GeometryReplacer))
     }
 

--- a/engine/runtime/action-processor/src/geometry/splitter.rs
+++ b/engine/runtime/action-processor/src/geometry/splitter.rs
@@ -22,7 +22,7 @@ impl ProcessorFactory for GeometrySplitterFactory {
         "Split geometry by type"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/three_dimension_box_replacer.rs
+++ b/engine/runtime/action-processor/src/geometry/three_dimension_box_replacer.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for ThreeDimensionBoxReplacerFactory {
         "Replaces a three Dimension box with a polygon."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(ThreeDimensionBoxReplacer))
     }
 

--- a/engine/runtime/action-processor/src/geometry/three_dimension_rotator.rs
+++ b/engine/runtime/action-processor/src/geometry/three_dimension_rotator.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for ThreeDimensionRotatorFactory {
         "Replaces a three Dimension box with a polygon."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(ThreeDimensionRotatorParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
+++ b/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
@@ -23,7 +23,7 @@ impl ProcessorFactory for TwoDimensionForcerFactory {
         "Forces a geometry to be two dimensional."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/validator.rs
+++ b/engine/runtime/action-processor/src/geometry/validator.rs
@@ -37,7 +37,7 @@ impl ProcessorFactory for GeometryValidatorFactory {
         "Validates the geometry of a feature"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(GeometryValidator))
     }
 

--- a/engine/runtime/action-processor/src/geometry/value_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/value_filter.rs
@@ -28,7 +28,7 @@ impl ProcessorFactory for GeometryValueFilterFactory {
         "Filter geometry by value"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/vertex_remover.rs
+++ b/engine/runtime/action-processor/src/geometry/vertex_remover.rs
@@ -30,7 +30,7 @@ impl ProcessorFactory for VertexRemoverFactory {
         "Removes specific vertices from a feature’s geometry"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/vertical_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/vertical_reprojector.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for VerticalReprojectorFactory {
         "Reprojects the geometry of a feature to a specified coordinate system"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(VerticalReprojectorParam))
     }
 

--- a/engine/runtime/action-processor/src/noop.rs
+++ b/engine/runtime/action-processor/src/noop.rs
@@ -21,7 +21,7 @@ impl ProcessorFactory for NoopProcessorFactory {
         "Noop features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/xml/fragmenter.rs
+++ b/engine/runtime/action-processor/src/xml/fragmenter.rs
@@ -30,7 +30,7 @@ impl ProcessorFactory for XmlFragmenterFactory {
         "Fragment XML"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(XmlFragmenterParam))
     }
 

--- a/engine/runtime/action-processor/src/xml/validator.rs
+++ b/engine/runtime/action-processor/src/xml/validator.rs
@@ -98,7 +98,7 @@ impl ProcessorFactory for XmlValidatorFactory {
         "Validates XML content"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(XmlValidatorParam))
     }
 

--- a/engine/runtime/action-sink/src/echo.rs
+++ b/engine/runtime/action-sink/src/echo.rs
@@ -18,7 +18,7 @@ impl SinkFactory for EchoSinkFactory {
         "Echo features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
@@ -64,7 +64,7 @@ impl SinkFactory for Cesium3DTilesSinkFactory {
         "Writes features to a file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(Cesium3DTilesWriterParam))
     }
 

--- a/engine/runtime/action-sink/src/file/geojson.rs
+++ b/engine/runtime/action-sink/src/file/geojson.rs
@@ -29,7 +29,7 @@ impl SinkFactory for GeoJsonWriterFactory {
         "Writes features to a geojson file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(GeoJsonWriterParam))
     }
 

--- a/engine/runtime/action-sink/src/file/gltf.rs
+++ b/engine/runtime/action-sink/src/file/gltf.rs
@@ -47,7 +47,7 @@ impl SinkFactory for GltfWriterSinkFactory {
         "Writes features to a Gltf"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(GltfWriterParam))
     }
 

--- a/engine/runtime/action-sink/src/file/mvt/sink.rs
+++ b/engine/runtime/action-sink/src/file/mvt/sink.rs
@@ -49,7 +49,7 @@ impl SinkFactory for MVTSinkFactory {
         "Writes features to a file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(MVTWriterParam))
     }
 

--- a/engine/runtime/action-sink/src/file/writer.rs
+++ b/engine/runtime/action-sink/src/file/writer.rs
@@ -35,7 +35,7 @@ impl SinkFactory for FileWriterSinkFactory {
         "Writes features to a file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FileWriterParam))
     }
 

--- a/engine/runtime/action-sink/src/noop.rs
+++ b/engine/runtime/action-sink/src/noop.rs
@@ -18,7 +18,7 @@ impl SinkFactory for NoopSinkFactory {
         "noop sink"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         None
     }
 

--- a/engine/runtime/action-source/src/feature_creator.rs
+++ b/engine/runtime/action-source/src/feature_creator.rs
@@ -27,7 +27,7 @@ impl SourceFactory for FeatureCreatorFactory {
         "Creates features from expressions"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FeatureCreator))
     }
 

--- a/engine/runtime/action-source/src/file/path_extractor.rs
+++ b/engine/runtime/action-source/src/file/path_extractor.rs
@@ -36,7 +36,7 @@ impl SourceFactory for FilePathExtractorFactory {
         "Extracts files from a directory or an archive"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FilePathExtractor))
     }
 

--- a/engine/runtime/action-source/src/file/reader.rs
+++ b/engine/runtime/action-source/src/file/reader.rs
@@ -29,7 +29,7 @@ impl SourceFactory for FileReaderFactory {
         "Reads features from a file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(FileReader))
     }
 

--- a/engine/runtime/action-source/src/file/reader/runner.rs
+++ b/engine/runtime/action-source/src/file/reader/runner.rs
@@ -22,22 +22,26 @@ pub struct FileReaderCommonParam {
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase", tag = "format")]
 pub enum FileReader {
+    /// # CSV
     Csv {
         #[serde(flatten)]
         common_property: FileReaderCommonParam,
         #[serde(flatten)]
         property: csv::CsvReaderParam,
     },
+    /// # TSV
     Tsv {
         #[serde(flatten)]
         common_property: FileReaderCommonParam,
         #[serde(flatten)]
         property: csv::CsvReaderParam,
     },
+    /// # JSON
     Json {
         #[serde(flatten)]
         common_property: FileReaderCommonParam,
     },
+    /// # CityGML
     Citygml {
         #[serde(flatten)]
         common_property: FileReaderCommonParam,

--- a/engine/runtime/action-wasm-processor/src/runtime_executor.rs
+++ b/engine/runtime/action-wasm-processor/src/runtime_executor.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for WasmRuntimeExecutorFactory {
         "Compiles scripts into .wasm and runs at the wasm runtime"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(WasmRuntimeExecutorParam))
     }
 

--- a/engine/runtime/runtime/src/node.rs
+++ b/engine/runtime/runtime/src/node.rs
@@ -211,7 +211,7 @@ pub trait SourceFactory: Send + Sync + Debug + SourceFactoryClone {
     fn description(&self) -> &str {
         ""
     }
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema>;
+    fn parameter_schema(&self) -> Option<schemars::Schema>;
 
     fn categories(&self) -> &[&'static str] {
         &[]
@@ -275,7 +275,7 @@ pub trait ProcessorFactory: Send + Sync + Debug + ProcessorFactoryClone {
     fn description(&self) -> &str {
         ""
     }
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema>;
+    fn parameter_schema(&self) -> Option<schemars::Schema>;
 
     fn categories(&self) -> &[&'static str] {
         &[]
@@ -337,7 +337,7 @@ pub trait SinkFactory: Send + Sync + Debug + SinkFactoryClone {
     fn description(&self) -> &str {
         ""
     }
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema>;
+    fn parameter_schema(&self) -> Option<schemars::Schema>;
 
     fn categories(&self) -> &[&'static str] {
         &[]
@@ -402,7 +402,7 @@ impl ProcessorFactory for InputRouterFactory {
         "Action for first port forwarding for sub-workflows."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(InputRouter))
     }
 
@@ -484,7 +484,7 @@ impl ProcessorFactory for OutputRouterFactory {
         "Action for last port forwarding for sub-workflows."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+    fn parameter_schema(&self) -> Option<schemars::Schema> {
         Some(schemars::schema_for!(OutputRouter))
     }
 

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -5,12 +5,9 @@
       "type": "processor",
       "description": "Overlays an area on another area",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -18,14 +15,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -49,33 +49,25 @@
       "type": "processor",
       "description": "Aggregates features by attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeAggregatorParam",
         "type": "object",
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/AggregateAttribute"
+              "$ref": "#/$defs/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "calculationAttribute": {
-            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -84,17 +76,25 @@
             ],
             "format": "int64"
           },
+          "calculationAttribute": {
+            "$ref": "#/$defs/Attribute"
+          },
           "method": {
-            "$ref": "#/definitions/Method"
+            "$ref": "#/$defs/Method"
           }
         },
-        "definitions": {
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
+        "$defs": {
           "AggregateAttribute": {
             "type": "object",
-            "required": [
-              "newAttribute"
-            ],
             "properties": {
+              "newAttribute": {
+                "$ref": "#/$defs/Attribute"
+              },
               "attribute": {
                 "type": [
                   "string",
@@ -104,17 +104,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "newAttribute": {
-                "$ref": "#/definitions/Attribute"
               }
-            }
+            },
+            "required": [
+              "newAttribute"
+            ]
           },
           "Attribute": {
             "type": "string"
@@ -148,21 +148,21 @@
       "type": "processor",
       "description": "Filters features by duplicate attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
-        "required": [
-          "filterBy"
-        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "filterBy"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -184,18 +184,18 @@
       "type": "processor",
       "description": "Extracts file path information from attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "attribute"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -218,23 +218,45 @@
       "type": "processor",
       "description": "Manages attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeManagerParam",
         "type": "object",
-        "required": [
-          "operations"
-        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Operation"
+              "$ref": "#/$defs/Operation"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
+        "required": [
+          "operations"
+        ],
+        "$defs": {
+          "Operation": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/$defs/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "attribute",
+              "method"
+            ]
           },
           "Method": {
             "type": "string",
@@ -245,30 +267,8 @@
               "remove"
             ]
           },
-          "Operation": {
-            "type": "object",
-            "required": [
-              "attribute",
-              "method"
-            ],
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/definitions/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            }
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -288,28 +288,47 @@
       "type": "processor",
       "description": "Maps attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeMapperParam",
         "type": "object",
-        "required": [
-          "mappers"
-        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Mapper"
+              "$ref": "#/$defs/Mapper"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "mappers"
+        ],
+        "$defs": {
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -321,39 +340,20 @@
                   "null"
                 ]
               },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
               "multipleExpr": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "parentAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -390,17 +390,12 @@
       "type": "processor",
       "description": "Buffers a geometry",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Bufferer",
         "type": "object",
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/definitions/BufferType"
+            "$ref": "#/$defs/BufferType"
           },
           "distance": {
             "type": "number",
@@ -411,7 +406,12 @@
             "format": "double"
           }
         },
-        "definitions": {
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
+        "$defs": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -437,20 +437,21 @@
       "type": "processor",
       "description": "Renames attributes by adding/removing prefixes or suffixes, or replacing text",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
-        "required": [
-          "renameAction",
-          "renameType",
-          "renameValue"
-        ],
         "properties": {
-          "renameAction": {
-            "$ref": "#/definitions/RenameAction"
-          },
           "renameType": {
-            "$ref": "#/definitions/RenameType"
+            "$ref": "#/$defs/RenameType"
+          },
+          "renameAction": {
+            "$ref": "#/$defs/RenameAction"
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "renameValue": {
             "type": "string"
@@ -463,15 +464,21 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
-        "definitions": {
+        "required": [
+          "renameType",
+          "renameAction",
+          "renameValue"
+        ],
+        "$defs": {
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
+            ]
+          },
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -480,13 +487,6 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
-            ]
-          },
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
             ]
           }
         }
@@ -524,36 +524,36 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
-        "required": [
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -610,19 +610,19 @@
       "type": "processor",
       "description": "Sets the coordinate system of a feature",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "CoordinateSystemSetter",
         "type": "object",
-        "required": [
-          "epsgCode"
-        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
-        }
+        },
+        "required": [
+          "epsgCode"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -688,18 +688,18 @@
       "type": "processor",
       "description": "Extracts a feature’s first z coordinate value, storing it in an attribute.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ElevationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -721,18 +721,18 @@
       "type": "processor",
       "description": "Extrudes a polygon by a distance",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ExtruderParam",
         "type": "object",
+        "properties": {
+          "distance": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "distance"
         ],
-        "properties": {
-          "distance": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -754,13 +754,9 @@
       "type": "processor",
       "description": "Counts features",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCounterParam",
         "type": "object",
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,14 +768,18 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "definitions": {
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -802,18 +802,18 @@
       "type": "source",
       "description": "Creates features from expressions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCreator",
         "type": "object",
+        "properties": {
+          "creator": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "creator"
         ],
-        "properties": {
-          "creator": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -833,22 +833,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -871,35 +871,35 @@
       "type": "processor",
       "description": "Filters features based on conditions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilterParam",
         "type": "object",
-        "required": [
-          "conditions"
-        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Condition"
+              "$ref": "#/$defs/Condition"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "conditions"
+        ],
+        "$defs": {
           "Condition": {
             "type": "object",
+            "properties": {
+              "expr": {
+                "$ref": "#/$defs/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/$defs/Port"
+              }
+            },
             "required": [
               "expr",
               "outputPort"
-            ],
-            "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/definitions/Port"
-              }
-            }
+            ]
           },
           "Expr": {
             "type": "string"
@@ -925,34 +925,18 @@
       "type": "processor",
       "description": "Merges features by attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttribute": {
             "type": [
@@ -960,21 +944,37 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
-          "supplierAttributeValue": {
+          "requestorAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "supplierAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
@@ -1001,48 +1001,40 @@
       "type": "processor",
       "description": "Filters features based on conditions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1050,25 +1042,23 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1076,12 +1066,16 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1103,21 +1097,52 @@
       "type": "processor",
       "description": "Sorts features by attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureSorterParam",
         "type": "object",
-        "required": [
-          "sortBy"
-        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/SortBy"
+              "$ref": "#/$defs/SortBy"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "sortBy"
+        ],
+        "$defs": {
+          "SortBy": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/$defs/Order"
+              }
+            },
+            "required": [
+              "order"
+            ]
+          },
           "Attribute": {
             "type": "string"
           },
@@ -1130,37 +1155,6 @@
               "ascending",
               "descending"
             ]
-          },
-          "SortBy": {
-            "type": "object",
-            "required": [
-              "order"
-            ],
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/definitions/Order"
-              }
-            }
           }
         }
       },
@@ -1180,34 +1174,34 @@
       "type": "processor",
       "description": "Transforms features by expressions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTransformerParam",
         "type": "object",
-        "required": [
-          "transformers"
-        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Transform"
+              "$ref": "#/$defs/Transform"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "transformers"
+        ],
+        "$defs": {
           "Transform": {
             "type": "object",
-            "required": [
-              "expr"
-            ],
             "properties": {
               "expr": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "expr"
+            ]
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -1227,12 +1221,9 @@
       "type": "processor",
       "description": "Filters features by feature type",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTypeFilter",
         "type": "object",
-        "required": [
-          "targetTypes"
-        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1240,7 +1231,10 @@
               "type": "string"
             }
           }
-        }
+        },
+        "required": [
+          "targetTypes"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1259,22 +1253,22 @@
       "type": "source",
       "description": "Extracts files from a directory or an archive",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePathExtractor",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1294,17 +1288,17 @@
       "type": "processor",
       "description": "Extracts properties from a file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePropertyExtractor",
         "type": "object",
-        "required": [
-          "filePathAttribute"
-        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "filePathAttribute"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1323,24 +1317,19 @@
       "type": "source",
       "description": "Reads features from a file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileReader",
         "oneOf": [
           {
+            "title": "CSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1348,25 +1337,24 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "TSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1374,54 +1362,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "JSON",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "json"
-                ]
+                "const": "json"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "CityGML",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1441,88 +1431,76 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "format",
-              "output"
-            ],
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "json"
+              },
+              "output": {
+                "$ref": "#/$defs/Expr"
+              },
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "json"
-                ]
-              },
-              "output": {
-                "$ref": "#/definitions/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "excel"
-                ]
+                "const": "excel"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1530,10 +1508,14 @@
                   "null"
                 ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "output"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1553,31 +1535,31 @@
       "type": "sink",
       "description": "Writes features to a geojson file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeoJsonWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
-          "Attribute": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -1596,18 +1578,18 @@
       "type": "processor",
       "description": "Coerces the geometry of a feature to a specific geometry",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryCoercer",
         "type": "object",
+        "properties": {
+          "coercerType": {
+            "$ref": "#/$defs/CoercerType"
+          }
+        },
         "required": [
           "coercerType"
         ],
-        "properties": {
-          "coercerType": {
-            "$ref": "#/definitions/CoercerType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1632,27 +1614,27 @@
       "type": "processor",
       "description": "Dissolve geometries",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1675,18 +1657,18 @@
       "type": "processor",
       "description": "Extracts geometry from a feature and adds it as an attribute.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryExtractor",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1708,50 +1690,44 @@
       "type": "processor",
       "description": "Filter geometry by type",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "none"
-                ]
+                "const": "none"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "multiple"
-                ]
+                "const": "multiple"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "geometryType"
-                ]
+                "const": "geometryType"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           }
         ]
       },
@@ -1794,7 +1770,7 @@
       "type": "processor",
       "description": "Filter geometry by lod",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
@@ -1804,7 +1780,7 @@
               "null"
             ],
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -1825,18 +1801,18 @@
       "type": "processor",
       "description": "Replaces the geometry of a feature with a new geometry.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryReplacer",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1874,21 +1850,21 @@
       "type": "processor",
       "description": "Validates the geometry of a feature",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryValidator",
         "type": "object",
-        "required": [
-          "validationTypes"
-        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/ValidationType"
+              "$ref": "#/$defs/ValidationType"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "validationTypes"
+        ],
+        "$defs": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1936,24 +1912,24 @@
       "type": "sink",
       "description": "Writes features to a Gltf",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GltfWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1973,18 +1949,18 @@
       "type": "processor",
       "description": "Counts the number of holes in a geometry and adds it as an attribute.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HoleCounterParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2024,7 +2000,7 @@
       "type": "processor",
       "description": "Reprojects the geometry of a feature to a specified coordinate system",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2034,7 +2010,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -2054,17 +2030,17 @@
       "type": "processor",
       "description": "Action for first port forwarding for sub-workflows.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "InputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [],
@@ -2080,12 +2056,9 @@
       "type": "processor",
       "description": "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2093,14 +2066,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2124,18 +2100,18 @@
       "type": "processor",
       "description": "Explodes list attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ListExploder",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2157,34 +2133,34 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "MVTWriterParam",
         "type": "object",
-        "required": [
-          "layerName",
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
-          "layerName": {
-            "$ref": "#/definitions/Expr"
+          "output": {
+            "$ref": "#/$defs/Expr"
           },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
+          "layerName": {
+            "$ref": "#/$defs/Expr"
           },
           "minZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           },
-          "output": {
-            "$ref": "#/definitions/Expr"
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "layerName",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2234,7 +2210,7 @@
       "type": "processor",
       "description": "Adds offsets to the feature's coordinates.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2277,18 +2253,18 @@
       "type": "processor",
       "description": "Extracts the orientation of a geometry from a feature and adds it as an attribute.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OrientationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2310,17 +2286,17 @@
       "type": "processor",
       "description": "Action for last port forwarding for sub-workflows.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OutputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -2505,18 +2481,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "UDXFolderExtractorParam",
         "type": "object",
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "cityGmlPath"
         ],
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2573,22 +2549,22 @@
       "type": "processor",
       "description": "Calls Rhai script",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "RhaiCallerParam",
         "type": "object",
+        "properties": {
+          "isTarget": {
+            "$ref": "#/$defs/Expr"
+          },
+          "process": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "isTarget",
           "process"
         ],
-        "properties": {
-          "isTarget": {
-            "$ref": "#/definitions/Expr"
-          },
-          "process": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2610,27 +2586,24 @@
       "type": "processor",
       "description": "Calculates statistics of features",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "StatisticsCalculatorParam",
         "type": "object",
-        "required": [
-          "calculations"
-        ],
         "properties": {
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
@@ -2640,28 +2613,31 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Calculation"
+              "$ref": "#/$defs/Calculation"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "calculations"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "required": [
-              "expr",
-              "newAttribute"
-            ],
             "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
               "newAttribute": {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
+              },
+              "expr": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "newAttribute",
+              "expr"
+            ]
           },
           "Expr": {
             "type": "string"
@@ -2685,38 +2661,38 @@
       "type": "processor",
       "description": "Replaces a three Dimension box with a polygon.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "required": [
-          "maxX",
-          "maxY",
-          "maxZ",
-          "minX",
-          "minY",
-          "minZ"
-        ],
         "properties": {
-          "maxX": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/definitions/Attribute"
-          },
           "minX": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minY": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minZ": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxX": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "minX",
+          "minY",
+          "minZ",
+          "maxX",
+          "maxY",
+          "maxZ"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2738,42 +2714,42 @@
       "type": "processor",
       "description": "Replaces a three Dimension box with a polygon.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "required": [
-          "angleDegree",
-          "directionX",
-          "directionY",
-          "directionZ",
-          "originX",
-          "originY",
-          "originZ"
-        ],
         "properties": {
           "angleDegree": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionX": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionY": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originX": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originY": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
+          },
+          "directionX": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionY": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/$defs/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "angleDegree",
+          "originX",
+          "originY",
+          "originZ",
+          "directionX",
+          "directionY",
+          "directionZ"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2828,18 +2804,18 @@
       "type": "processor",
       "description": "Reprojects the geometry of a feature to a specified coordinate system",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "VerticalReprojectorParam",
         "type": "object",
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/$defs/VerticalReprojectorType"
+          }
+        },
         "required": [
           "reprojectorType"
         ],
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/definitions/VerticalReprojectorType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2864,26 +2840,26 @@
       "type": "processor",
       "description": "Compiles scripts into .wasm and runs at the wasm runtime",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
-        "required": [
-          "processorType",
-          "programmingLanguage",
-          "sourceCodeFilePath"
-        ],
         "properties": {
-          "processorType": {
-            "$ref": "#/definitions/ProcessorType"
-          },
-          "programmingLanguage": {
-            "$ref": "#/definitions/ProgrammingLanguage"
-          },
           "sourceCodeFilePath": {
             "type": "string"
+          },
+          "processorType": {
+            "$ref": "#/$defs/ProcessorType"
+          },
+          "programmingLanguage": {
+            "$ref": "#/$defs/ProgrammingLanguage"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceCodeFilePath",
+          "processorType",
+          "programmingLanguage"
+        ],
+        "$defs": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2914,41 +2890,39 @@
       "type": "processor",
       "description": "Fragment XML",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "attribute",
-              "elementsToExclude",
-              "elementsToMatch",
-              "source"
-            ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/$defs/Expr"
               },
               "elementsToExclude": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
-              "elementsToMatch": {
-                "$ref": "#/definitions/Expr"
+              "attribute": {
+                "$ref": "#/$defs/Attribute"
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "url"
-                ]
+                "const": "url"
               }
-            }
+            },
+            "required": [
+              "source",
+              "elementsToMatch",
+              "elementsToExclude",
+              "attribute"
+            ]
           }
         ],
-        "definitions": {
-          "Attribute": {
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -2969,28 +2943,35 @@
       "type": "processor",
       "description": "Validates XML content",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlValidatorParam",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/$defs/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/$defs/ValidationType"
+          }
+        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/definitions/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/definitions/ValidationType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
           },
           "ValidationType": {
             "type": "string",
@@ -2998,13 +2979,6 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -5,12 +5,9 @@
       "type": "processor",
       "description": "Overlays an area on another area",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -18,14 +15,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -49,33 +49,25 @@
       "type": "processor",
       "description": "Aggregates features by attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeAggregatorParam",
         "type": "object",
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/AggregateAttribute"
+              "$ref": "#/$defs/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "calculationAttribute": {
-            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -84,17 +76,25 @@
             ],
             "format": "int64"
           },
+          "calculationAttribute": {
+            "$ref": "#/$defs/Attribute"
+          },
           "method": {
-            "$ref": "#/definitions/Method"
+            "$ref": "#/$defs/Method"
           }
         },
-        "definitions": {
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
+        "$defs": {
           "AggregateAttribute": {
             "type": "object",
-            "required": [
-              "newAttribute"
-            ],
             "properties": {
+              "newAttribute": {
+                "$ref": "#/$defs/Attribute"
+              },
               "attribute": {
                 "type": [
                   "string",
@@ -104,17 +104,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "newAttribute": {
-                "$ref": "#/definitions/Attribute"
               }
-            }
+            },
+            "required": [
+              "newAttribute"
+            ]
           },
           "Attribute": {
             "type": "string"
@@ -148,21 +148,21 @@
       "type": "processor",
       "description": "Filters features by duplicate attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
-        "required": [
-          "filterBy"
-        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "filterBy"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -184,18 +184,18 @@
       "type": "processor",
       "description": "Extracts file path information from attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "attribute"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -218,23 +218,45 @@
       "type": "processor",
       "description": "Manages attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeManagerParam",
         "type": "object",
-        "required": [
-          "operations"
-        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Operation"
+              "$ref": "#/$defs/Operation"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
+        "required": [
+          "operations"
+        ],
+        "$defs": {
+          "Operation": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/$defs/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "attribute",
+              "method"
+            ]
           },
           "Method": {
             "type": "string",
@@ -245,30 +267,8 @@
               "remove"
             ]
           },
-          "Operation": {
-            "type": "object",
-            "required": [
-              "attribute",
-              "method"
-            ],
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/definitions/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            }
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -288,28 +288,47 @@
       "type": "processor",
       "description": "Maps attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeMapperParam",
         "type": "object",
-        "required": [
-          "mappers"
-        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Mapper"
+              "$ref": "#/$defs/Mapper"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "mappers"
+        ],
+        "$defs": {
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -321,39 +340,20 @@
                   "null"
                 ]
               },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
               "multipleExpr": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "parentAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -390,17 +390,12 @@
       "type": "processor",
       "description": "Buffers a geometry",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Bufferer",
         "type": "object",
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/definitions/BufferType"
+            "$ref": "#/$defs/BufferType"
           },
           "distance": {
             "type": "number",
@@ -411,7 +406,12 @@
             "format": "double"
           }
         },
-        "definitions": {
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
+        "$defs": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -437,20 +437,21 @@
       "type": "processor",
       "description": "Renames attributes by adding/removing prefixes or suffixes, or replacing text",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
-        "required": [
-          "renameAction",
-          "renameType",
-          "renameValue"
-        ],
         "properties": {
-          "renameAction": {
-            "$ref": "#/definitions/RenameAction"
-          },
           "renameType": {
-            "$ref": "#/definitions/RenameType"
+            "$ref": "#/$defs/RenameType"
+          },
+          "renameAction": {
+            "$ref": "#/$defs/RenameAction"
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "renameValue": {
             "type": "string"
@@ -463,15 +464,21 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
-        "definitions": {
+        "required": [
+          "renameType",
+          "renameAction",
+          "renameValue"
+        ],
+        "$defs": {
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
+            ]
+          },
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -480,13 +487,6 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
-            ]
-          },
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
             ]
           }
         }
@@ -524,36 +524,36 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
-        "required": [
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -610,19 +610,19 @@
       "type": "processor",
       "description": "Sets the coordinate system of a feature",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "CoordinateSystemSetter",
         "type": "object",
-        "required": [
-          "epsgCode"
-        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
-        }
+        },
+        "required": [
+          "epsgCode"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -688,18 +688,18 @@
       "type": "processor",
       "description": "Extracts a feature’s first z coordinate value, storing it in an attribute.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ElevationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -721,18 +721,18 @@
       "type": "processor",
       "description": "Extrudes a polygon by a distance",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ExtruderParam",
         "type": "object",
+        "properties": {
+          "distance": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "distance"
         ],
-        "properties": {
-          "distance": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -754,13 +754,9 @@
       "type": "processor",
       "description": "Counts features",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCounterParam",
         "type": "object",
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,14 +768,18 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "definitions": {
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -802,18 +802,18 @@
       "type": "source",
       "description": "Creates features from expressions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCreator",
         "type": "object",
+        "properties": {
+          "creator": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "creator"
         ],
-        "properties": {
-          "creator": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -833,22 +833,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -871,35 +871,35 @@
       "type": "processor",
       "description": "Filters features based on conditions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilterParam",
         "type": "object",
-        "required": [
-          "conditions"
-        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Condition"
+              "$ref": "#/$defs/Condition"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "conditions"
+        ],
+        "$defs": {
           "Condition": {
             "type": "object",
+            "properties": {
+              "expr": {
+                "$ref": "#/$defs/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/$defs/Port"
+              }
+            },
             "required": [
               "expr",
               "outputPort"
-            ],
-            "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/definitions/Port"
-              }
-            }
+            ]
           },
           "Expr": {
             "type": "string"
@@ -925,34 +925,18 @@
       "type": "processor",
       "description": "Merges features by attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttribute": {
             "type": [
@@ -960,21 +944,37 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
-          "supplierAttributeValue": {
+          "requestorAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "supplierAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
@@ -1001,48 +1001,40 @@
       "type": "processor",
       "description": "Filters features based on conditions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1050,25 +1042,23 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1076,12 +1066,16 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1103,21 +1097,52 @@
       "type": "processor",
       "description": "Sorts features by attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureSorterParam",
         "type": "object",
-        "required": [
-          "sortBy"
-        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/SortBy"
+              "$ref": "#/$defs/SortBy"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "sortBy"
+        ],
+        "$defs": {
+          "SortBy": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/$defs/Order"
+              }
+            },
+            "required": [
+              "order"
+            ]
+          },
           "Attribute": {
             "type": "string"
           },
@@ -1130,37 +1155,6 @@
               "ascending",
               "descending"
             ]
-          },
-          "SortBy": {
-            "type": "object",
-            "required": [
-              "order"
-            ],
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/definitions/Order"
-              }
-            }
           }
         }
       },
@@ -1180,34 +1174,34 @@
       "type": "processor",
       "description": "Transforms features by expressions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTransformerParam",
         "type": "object",
-        "required": [
-          "transformers"
-        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Transform"
+              "$ref": "#/$defs/Transform"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "transformers"
+        ],
+        "$defs": {
           "Transform": {
             "type": "object",
-            "required": [
-              "expr"
-            ],
             "properties": {
               "expr": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "expr"
+            ]
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -1227,12 +1221,9 @@
       "type": "processor",
       "description": "Filters features by feature type",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTypeFilter",
         "type": "object",
-        "required": [
-          "targetTypes"
-        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1240,7 +1231,10 @@
               "type": "string"
             }
           }
-        }
+        },
+        "required": [
+          "targetTypes"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1259,22 +1253,22 @@
       "type": "source",
       "description": "Extracts files from a directory or an archive",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePathExtractor",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1294,17 +1288,17 @@
       "type": "processor",
       "description": "Extracts properties from a file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePropertyExtractor",
         "type": "object",
-        "required": [
-          "filePathAttribute"
-        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "filePathAttribute"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1323,24 +1317,19 @@
       "type": "source",
       "description": "Reads features from a file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileReader",
         "oneOf": [
           {
+            "title": "CSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1348,25 +1337,24 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "TSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1374,54 +1362,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "JSON",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "json"
-                ]
+                "const": "json"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "CityGML",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1441,88 +1431,76 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "format",
-              "output"
-            ],
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "json"
+              },
+              "output": {
+                "$ref": "#/$defs/Expr"
+              },
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "json"
-                ]
-              },
-              "output": {
-                "$ref": "#/definitions/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "excel"
-                ]
+                "const": "excel"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1530,10 +1508,14 @@
                   "null"
                 ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "output"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1553,31 +1535,31 @@
       "type": "sink",
       "description": "Writes features to a geojson file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeoJsonWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
-          "Attribute": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -1596,18 +1578,18 @@
       "type": "processor",
       "description": "Coerces the geometry of a feature to a specific geometry",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryCoercer",
         "type": "object",
+        "properties": {
+          "coercerType": {
+            "$ref": "#/$defs/CoercerType"
+          }
+        },
         "required": [
           "coercerType"
         ],
-        "properties": {
-          "coercerType": {
-            "$ref": "#/definitions/CoercerType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1632,27 +1614,27 @@
       "type": "processor",
       "description": "Dissolve geometries",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1675,18 +1657,18 @@
       "type": "processor",
       "description": "Extracts geometry from a feature and adds it as an attribute.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryExtractor",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1708,50 +1690,44 @@
       "type": "processor",
       "description": "Filter geometry by type",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "none"
-                ]
+                "const": "none"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "multiple"
-                ]
+                "const": "multiple"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "geometryType"
-                ]
+                "const": "geometryType"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           }
         ]
       },
@@ -1794,7 +1770,7 @@
       "type": "processor",
       "description": "Filter geometry by lod",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
@@ -1804,7 +1780,7 @@
               "null"
             ],
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -1825,18 +1801,18 @@
       "type": "processor",
       "description": "Replaces the geometry of a feature with a new geometry.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryReplacer",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1874,21 +1850,21 @@
       "type": "processor",
       "description": "Validates the geometry of a feature",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryValidator",
         "type": "object",
-        "required": [
-          "validationTypes"
-        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/ValidationType"
+              "$ref": "#/$defs/ValidationType"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "validationTypes"
+        ],
+        "$defs": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1936,24 +1912,24 @@
       "type": "sink",
       "description": "Writes features to a Gltf",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GltfWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1973,18 +1949,18 @@
       "type": "processor",
       "description": "Counts the number of holes in a geometry and adds it as an attribute.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HoleCounterParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2024,7 +2000,7 @@
       "type": "processor",
       "description": "Reprojects the geometry of a feature to a specified coordinate system",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2034,7 +2010,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -2054,17 +2030,17 @@
       "type": "processor",
       "description": "Action for first port forwarding for sub-workflows.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "InputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [],
@@ -2080,12 +2056,9 @@
       "type": "processor",
       "description": "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2093,14 +2066,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2124,18 +2100,18 @@
       "type": "processor",
       "description": "Explodes list attributes",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ListExploder",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2157,34 +2133,34 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "MVTWriterParam",
         "type": "object",
-        "required": [
-          "layerName",
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
-          "layerName": {
-            "$ref": "#/definitions/Expr"
+          "output": {
+            "$ref": "#/$defs/Expr"
           },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
+          "layerName": {
+            "$ref": "#/$defs/Expr"
           },
           "minZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           },
-          "output": {
-            "$ref": "#/definitions/Expr"
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "layerName",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2234,7 +2210,7 @@
       "type": "processor",
       "description": "Adds offsets to the feature's coordinates.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2277,18 +2253,18 @@
       "type": "processor",
       "description": "Extracts the orientation of a geometry from a feature and adds it as an attribute.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OrientationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2310,17 +2286,17 @@
       "type": "processor",
       "description": "Action for last port forwarding for sub-workflows.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OutputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -2505,18 +2481,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "UDXFolderExtractorParam",
         "type": "object",
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "cityGmlPath"
         ],
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2573,22 +2549,22 @@
       "type": "processor",
       "description": "Calls Rhai script",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "RhaiCallerParam",
         "type": "object",
+        "properties": {
+          "isTarget": {
+            "$ref": "#/$defs/Expr"
+          },
+          "process": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "isTarget",
           "process"
         ],
-        "properties": {
-          "isTarget": {
-            "$ref": "#/definitions/Expr"
-          },
-          "process": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2610,27 +2586,24 @@
       "type": "processor",
       "description": "Calculates statistics of features",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "StatisticsCalculatorParam",
         "type": "object",
-        "required": [
-          "calculations"
-        ],
         "properties": {
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
@@ -2640,28 +2613,31 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Calculation"
+              "$ref": "#/$defs/Calculation"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "calculations"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "required": [
-              "expr",
-              "newAttribute"
-            ],
             "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
               "newAttribute": {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
+              },
+              "expr": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "newAttribute",
+              "expr"
+            ]
           },
           "Expr": {
             "type": "string"
@@ -2685,38 +2661,38 @@
       "type": "processor",
       "description": "Replaces a three Dimension box with a polygon.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "required": [
-          "maxX",
-          "maxY",
-          "maxZ",
-          "minX",
-          "minY",
-          "minZ"
-        ],
         "properties": {
-          "maxX": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/definitions/Attribute"
-          },
           "minX": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minY": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minZ": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxX": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "minX",
+          "minY",
+          "minZ",
+          "maxX",
+          "maxY",
+          "maxZ"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2738,42 +2714,42 @@
       "type": "processor",
       "description": "Replaces a three Dimension box with a polygon.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "required": [
-          "angleDegree",
-          "directionX",
-          "directionY",
-          "directionZ",
-          "originX",
-          "originY",
-          "originZ"
-        ],
         "properties": {
           "angleDegree": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionX": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionY": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originX": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originY": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
+          },
+          "directionX": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionY": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/$defs/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "angleDegree",
+          "originX",
+          "originY",
+          "originZ",
+          "directionX",
+          "directionY",
+          "directionZ"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2828,18 +2804,18 @@
       "type": "processor",
       "description": "Reprojects the geometry of a feature to a specified coordinate system",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "VerticalReprojectorParam",
         "type": "object",
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/$defs/VerticalReprojectorType"
+          }
+        },
         "required": [
           "reprojectorType"
         ],
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/definitions/VerticalReprojectorType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2864,26 +2840,26 @@
       "type": "processor",
       "description": "Compiles scripts into .wasm and runs at the wasm runtime",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
-        "required": [
-          "processorType",
-          "programmingLanguage",
-          "sourceCodeFilePath"
-        ],
         "properties": {
-          "processorType": {
-            "$ref": "#/definitions/ProcessorType"
-          },
-          "programmingLanguage": {
-            "$ref": "#/definitions/ProgrammingLanguage"
-          },
           "sourceCodeFilePath": {
             "type": "string"
+          },
+          "processorType": {
+            "$ref": "#/$defs/ProcessorType"
+          },
+          "programmingLanguage": {
+            "$ref": "#/$defs/ProgrammingLanguage"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceCodeFilePath",
+          "processorType",
+          "programmingLanguage"
+        ],
+        "$defs": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2914,41 +2890,39 @@
       "type": "processor",
       "description": "Fragment XML",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "attribute",
-              "elementsToExclude",
-              "elementsToMatch",
-              "source"
-            ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/$defs/Expr"
               },
               "elementsToExclude": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
-              "elementsToMatch": {
-                "$ref": "#/definitions/Expr"
+              "attribute": {
+                "$ref": "#/$defs/Attribute"
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "url"
-                ]
+                "const": "url"
               }
-            }
+            },
+            "required": [
+              "source",
+              "elementsToMatch",
+              "elementsToExclude",
+              "attribute"
+            ]
           }
         ],
-        "definitions": {
-          "Attribute": {
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -2969,28 +2943,35 @@
       "type": "processor",
       "description": "Validates XML content",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlValidatorParam",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/$defs/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/$defs/ValidationType"
+          }
+        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/definitions/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/definitions/ValidationType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
           },
           "ValidationType": {
             "type": "string",
@@ -2998,13 +2979,6 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -5,12 +5,9 @@
       "type": "processor",
       "description": "Superpone un área sobre otra área",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -18,14 +15,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -49,33 +49,25 @@
       "type": "processor",
       "description": "Agrupa las entidades según sus atributos",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeAggregatorParam",
         "type": "object",
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/AggregateAttribute"
+              "$ref": "#/$defs/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "calculationAttribute": {
-            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -84,17 +76,25 @@
             ],
             "format": "int64"
           },
+          "calculationAttribute": {
+            "$ref": "#/$defs/Attribute"
+          },
           "method": {
-            "$ref": "#/definitions/Method"
+            "$ref": "#/$defs/Method"
           }
         },
-        "definitions": {
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
+        "$defs": {
           "AggregateAttribute": {
             "type": "object",
-            "required": [
-              "newAttribute"
-            ],
             "properties": {
+              "newAttribute": {
+                "$ref": "#/$defs/Attribute"
+              },
               "attribute": {
                 "type": [
                   "string",
@@ -104,17 +104,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "newAttribute": {
-                "$ref": "#/definitions/Attribute"
               }
-            }
+            },
+            "required": [
+              "newAttribute"
+            ]
           },
           "Attribute": {
             "type": "string"
@@ -148,21 +148,21 @@
       "type": "processor",
       "description": "Filtra las entidades con atributos duplicados",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
-        "required": [
-          "filterBy"
-        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "filterBy"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -184,18 +184,18 @@
       "type": "processor",
       "description": "Extrae información de rutas de archivo a partir de atributos",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "attribute"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -218,23 +218,45 @@
       "type": "processor",
       "description": "Gestiona atributos",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeManagerParam",
         "type": "object",
-        "required": [
-          "operations"
-        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Operation"
+              "$ref": "#/$defs/Operation"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
+        "required": [
+          "operations"
+        ],
+        "$defs": {
+          "Operation": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/$defs/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "attribute",
+              "method"
+            ]
           },
           "Method": {
             "type": "string",
@@ -245,30 +267,8 @@
               "remove"
             ]
           },
-          "Operation": {
-            "type": "object",
-            "required": [
-              "attribute",
-              "method"
-            ],
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/definitions/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            }
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -288,28 +288,47 @@
       "type": "processor",
       "description": "Asigna atributos",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeMapperParam",
         "type": "object",
-        "required": [
-          "mappers"
-        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Mapper"
+              "$ref": "#/$defs/Mapper"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "mappers"
+        ],
+        "$defs": {
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -321,39 +340,20 @@
                   "null"
                 ]
               },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
               "multipleExpr": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "parentAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -390,17 +390,12 @@
       "type": "processor",
       "description": "Crea un búfer alrededor de una geometría",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Bufferer",
         "type": "object",
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/definitions/BufferType"
+            "$ref": "#/$defs/BufferType"
           },
           "distance": {
             "type": "number",
@@ -411,7 +406,12 @@
             "format": "double"
           }
         },
-        "definitions": {
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
+        "$defs": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -437,20 +437,21 @@
       "type": "processor",
       "description": "Cambia el nombre de atributos añadiendo/eliminando prefijos o sufijos, o reemplazando texto",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
-        "required": [
-          "renameAction",
-          "renameType",
-          "renameValue"
-        ],
         "properties": {
-          "renameAction": {
-            "$ref": "#/definitions/RenameAction"
-          },
           "renameType": {
-            "$ref": "#/definitions/RenameType"
+            "$ref": "#/$defs/RenameType"
+          },
+          "renameAction": {
+            "$ref": "#/$defs/RenameAction"
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "renameValue": {
             "type": "string"
@@ -463,15 +464,21 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
-        "definitions": {
+        "required": [
+          "renameType",
+          "renameAction",
+          "renameValue"
+        ],
+        "$defs": {
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
+            ]
+          },
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -480,13 +487,6 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
-            ]
-          },
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
             ]
           }
         }
@@ -524,36 +524,36 @@
       "type": "sink",
       "description": "Escribe las entidades en un archivo",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
-        "required": [
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -610,19 +610,19 @@
       "type": "processor",
       "description": "Establece el sistema de coordenadas de una entidad",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "CoordinateSystemSetter",
         "type": "object",
-        "required": [
-          "epsgCode"
-        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
-        }
+        },
+        "required": [
+          "epsgCode"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -688,18 +688,18 @@
       "type": "processor",
       "description": "Extrae el primer valor de la coordenada z de una entidad y lo almacena en un atributo.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ElevationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -721,18 +721,18 @@
       "type": "processor",
       "description": "Extruye un polígono a una cierta distancia",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ExtruderParam",
         "type": "object",
+        "properties": {
+          "distance": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "distance"
         ],
-        "properties": {
-          "distance": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -754,13 +754,9 @@
       "type": "processor",
       "description": "Cuenta entidades",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCounterParam",
         "type": "object",
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,14 +768,18 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "definitions": {
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -802,18 +802,18 @@
       "type": "source",
       "description": "Crea entidades a partir de expresiones",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCreator",
         "type": "object",
+        "properties": {
+          "creator": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "creator"
         ],
-        "properties": {
-          "creator": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -833,22 +833,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -871,35 +871,35 @@
       "type": "processor",
       "description": "Filtra entidades según condiciones",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilterParam",
         "type": "object",
-        "required": [
-          "conditions"
-        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Condition"
+              "$ref": "#/$defs/Condition"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "conditions"
+        ],
+        "$defs": {
           "Condition": {
             "type": "object",
+            "properties": {
+              "expr": {
+                "$ref": "#/$defs/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/$defs/Port"
+              }
+            },
             "required": [
               "expr",
               "outputPort"
-            ],
-            "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/definitions/Port"
-              }
-            }
+            ]
           },
           "Expr": {
             "type": "string"
@@ -925,34 +925,18 @@
       "type": "processor",
       "description": "Une entidades según sus atributos",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttribute": {
             "type": [
@@ -960,21 +944,37 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
-          "supplierAttributeValue": {
+          "requestorAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "supplierAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
@@ -1001,48 +1001,40 @@
       "type": "processor",
       "description": "Filtra entidades según condiciones",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1050,25 +1042,23 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1076,12 +1066,16 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1103,21 +1097,52 @@
       "type": "processor",
       "description": "Ordena entidades por atributos",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureSorterParam",
         "type": "object",
-        "required": [
-          "sortBy"
-        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/SortBy"
+              "$ref": "#/$defs/SortBy"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "sortBy"
+        ],
+        "$defs": {
+          "SortBy": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/$defs/Order"
+              }
+            },
+            "required": [
+              "order"
+            ]
+          },
           "Attribute": {
             "type": "string"
           },
@@ -1130,37 +1155,6 @@
               "ascending",
               "descending"
             ]
-          },
-          "SortBy": {
-            "type": "object",
-            "required": [
-              "order"
-            ],
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/definitions/Order"
-              }
-            }
           }
         }
       },
@@ -1180,34 +1174,34 @@
       "type": "processor",
       "description": "Transforma entidades mediante expresiones",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTransformerParam",
         "type": "object",
-        "required": [
-          "transformers"
-        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Transform"
+              "$ref": "#/$defs/Transform"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "transformers"
+        ],
+        "$defs": {
           "Transform": {
             "type": "object",
-            "required": [
-              "expr"
-            ],
             "properties": {
               "expr": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "expr"
+            ]
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -1227,12 +1221,9 @@
       "type": "processor",
       "description": "Filtra entidades por tipo de entidad",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTypeFilter",
         "type": "object",
-        "required": [
-          "targetTypes"
-        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1240,7 +1231,10 @@
               "type": "string"
             }
           }
-        }
+        },
+        "required": [
+          "targetTypes"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1259,22 +1253,22 @@
       "type": "source",
       "description": "Extrae archivos de un directorio o de un archivo comprimido",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePathExtractor",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1294,17 +1288,17 @@
       "type": "processor",
       "description": "Extrae propiedades de un archivo",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePropertyExtractor",
         "type": "object",
-        "required": [
-          "filePathAttribute"
-        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "filePathAttribute"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1323,24 +1317,19 @@
       "type": "source",
       "description": "Lee entidades desde un archivo",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileReader",
         "oneOf": [
           {
+            "title": "CSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1348,25 +1337,24 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "TSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1374,54 +1362,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "JSON",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "json"
-                ]
+                "const": "json"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "CityGML",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1441,88 +1431,76 @@
       "type": "sink",
       "description": "Escribe entidades en un archivo",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "format",
-              "output"
-            ],
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "json"
+              },
+              "output": {
+                "$ref": "#/$defs/Expr"
+              },
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "json"
-                ]
-              },
-              "output": {
-                "$ref": "#/definitions/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "excel"
-                ]
+                "const": "excel"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1530,10 +1508,14 @@
                   "null"
                 ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "output"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1553,31 +1535,31 @@
       "type": "sink",
       "description": "Escribe entidades en un archivo GeoJSON",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeoJsonWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
-          "Attribute": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -1596,18 +1578,18 @@
       "type": "processor",
       "description": "Fuerza la geometría de una entidad a una geometría específica",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryCoercer",
         "type": "object",
+        "properties": {
+          "coercerType": {
+            "$ref": "#/$defs/CoercerType"
+          }
+        },
         "required": [
           "coercerType"
         ],
-        "properties": {
-          "coercerType": {
-            "$ref": "#/definitions/CoercerType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1632,27 +1614,27 @@
       "type": "processor",
       "description": "Disuelve geometrías",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1675,18 +1657,18 @@
       "type": "processor",
       "description": "Extrae la geometría de una entidad y la añade como un atributo.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryExtractor",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1708,50 +1690,44 @@
       "type": "processor",
       "description": "Filtra la geometría por tipo",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "none"
-                ]
+                "const": "none"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "multiple"
-                ]
+                "const": "multiple"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "geometryType"
-                ]
+                "const": "geometryType"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           }
         ]
       },
@@ -1794,7 +1770,7 @@
       "type": "processor",
       "description": "Filtra la geometría por nivel de detalle (lod)",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
@@ -1804,7 +1780,7 @@
               "null"
             ],
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -1825,18 +1801,18 @@
       "type": "processor",
       "description": "Reemplaza la geometría de una entidad con una nueva geometría.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryReplacer",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1874,21 +1850,21 @@
       "type": "processor",
       "description": "Valida la geometría de una entidad",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryValidator",
         "type": "object",
-        "required": [
-          "validationTypes"
-        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/ValidationType"
+              "$ref": "#/$defs/ValidationType"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "validationTypes"
+        ],
+        "$defs": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1936,24 +1912,24 @@
       "type": "sink",
       "description": "Escribe entidades en un archivo Gltf",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GltfWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1973,18 +1949,18 @@
       "type": "processor",
       "description": "Cuenta el número de huecos en una geometría y lo agrega como atributo.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HoleCounterParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2024,7 +2000,7 @@
       "type": "processor",
       "description": "Reproyecta la geometría de una entidad a un sistema de coordenadas especificado",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2034,7 +2010,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -2054,17 +2030,17 @@
       "type": "processor",
       "description": "Acción para el reenvío del primer puerto en sub-flujos de trabajo.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "InputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [],
@@ -2080,12 +2056,9 @@
       "type": "processor",
       "description": "Los puntos de intersección se convierten en entidades de puntos que pueden contener la lista combinada de atributos de las líneas originales intersectadas.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2093,14 +2066,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2124,18 +2100,18 @@
       "type": "processor",
       "description": "Divide en varios elementos los atributos de tipo lista",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ListExploder",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2157,34 +2133,34 @@
       "type": "sink",
       "description": "Escribe entidades en un archivo",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "MVTWriterParam",
         "type": "object",
-        "required": [
-          "layerName",
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
-          "layerName": {
-            "$ref": "#/definitions/Expr"
+          "output": {
+            "$ref": "#/$defs/Expr"
           },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
+          "layerName": {
+            "$ref": "#/$defs/Expr"
           },
           "minZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           },
-          "output": {
-            "$ref": "#/definitions/Expr"
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "layerName",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2234,7 +2210,7 @@
       "type": "processor",
       "description": "Añade desplazamientos a las coordenadas de la entidad.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2277,18 +2253,18 @@
       "type": "processor",
       "description": "Extrae la orientación de una geometría de una entidad y la agrega como un atributo.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OrientationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2310,17 +2286,17 @@
       "type": "processor",
       "description": "Acción para el reenvío del último puerto en sub-flujos de trabajo.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OutputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -2505,18 +2481,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "UDXFolderExtractorParam",
         "type": "object",
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "cityGmlPath"
         ],
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2573,22 +2549,22 @@
       "type": "processor",
       "description": "Llama a un script Rhai",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "RhaiCallerParam",
         "type": "object",
+        "properties": {
+          "isTarget": {
+            "$ref": "#/$defs/Expr"
+          },
+          "process": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "isTarget",
           "process"
         ],
-        "properties": {
-          "isTarget": {
-            "$ref": "#/definitions/Expr"
-          },
-          "process": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2610,27 +2586,24 @@
       "type": "processor",
       "description": "Calcula estadísticas de las entidades",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "StatisticsCalculatorParam",
         "type": "object",
-        "required": [
-          "calculations"
-        ],
         "properties": {
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
@@ -2640,28 +2613,31 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Calculation"
+              "$ref": "#/$defs/Calculation"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "calculations"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "required": [
-              "expr",
-              "newAttribute"
-            ],
             "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
               "newAttribute": {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
+              },
+              "expr": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "newAttribute",
+              "expr"
+            ]
           },
           "Expr": {
             "type": "string"
@@ -2685,38 +2661,38 @@
       "type": "processor",
       "description": "Reemplaza una caja tridimensional con un polígono.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "required": [
-          "maxX",
-          "maxY",
-          "maxZ",
-          "minX",
-          "minY",
-          "minZ"
-        ],
         "properties": {
-          "maxX": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/definitions/Attribute"
-          },
           "minX": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minY": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minZ": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxX": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "minX",
+          "minY",
+          "minZ",
+          "maxX",
+          "maxY",
+          "maxZ"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2738,42 +2714,42 @@
       "type": "processor",
       "description": "Reemplaza una caja tridimensional con un polígono.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "required": [
-          "angleDegree",
-          "directionX",
-          "directionY",
-          "directionZ",
-          "originX",
-          "originY",
-          "originZ"
-        ],
         "properties": {
           "angleDegree": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionX": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionY": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originX": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originY": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
+          },
+          "directionX": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionY": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/$defs/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "angleDegree",
+          "originX",
+          "originY",
+          "originZ",
+          "directionX",
+          "directionY",
+          "directionZ"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2828,18 +2804,18 @@
       "type": "processor",
       "description": "Reproyecta la geometría de una entidad a un sistema de coordenadas especificado",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "VerticalReprojectorParam",
         "type": "object",
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/$defs/VerticalReprojectorType"
+          }
+        },
         "required": [
           "reprojectorType"
         ],
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/definitions/VerticalReprojectorType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2864,26 +2840,26 @@
       "type": "processor",
       "description": "Compila scripts en .wasm y los ejecuta en tiempo de ejecución de wasm",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
-        "required": [
-          "processorType",
-          "programmingLanguage",
-          "sourceCodeFilePath"
-        ],
         "properties": {
-          "processorType": {
-            "$ref": "#/definitions/ProcessorType"
-          },
-          "programmingLanguage": {
-            "$ref": "#/definitions/ProgrammingLanguage"
-          },
           "sourceCodeFilePath": {
             "type": "string"
+          },
+          "processorType": {
+            "$ref": "#/$defs/ProcessorType"
+          },
+          "programmingLanguage": {
+            "$ref": "#/$defs/ProgrammingLanguage"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceCodeFilePath",
+          "processorType",
+          "programmingLanguage"
+        ],
+        "$defs": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2914,41 +2890,39 @@
       "type": "processor",
       "description": "Fragmenta XML",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "attribute",
-              "elementsToExclude",
-              "elementsToMatch",
-              "source"
-            ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/$defs/Expr"
               },
               "elementsToExclude": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
-              "elementsToMatch": {
-                "$ref": "#/definitions/Expr"
+              "attribute": {
+                "$ref": "#/$defs/Attribute"
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "url"
-                ]
+                "const": "url"
               }
-            }
+            },
+            "required": [
+              "source",
+              "elementsToMatch",
+              "elementsToExclude",
+              "attribute"
+            ]
           }
         ],
-        "definitions": {
-          "Attribute": {
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -2969,28 +2943,35 @@
       "type": "processor",
       "description": "Valida contenido XML",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlValidatorParam",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/$defs/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/$defs/ValidationType"
+          }
+        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/definitions/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/definitions/ValidationType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
           },
           "ValidationType": {
             "type": "string",
@@ -2998,13 +2979,6 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -5,12 +5,9 @@
       "type": "processor",
       "description": "Superpose une zone sur une autre zone",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -18,14 +15,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -49,33 +49,25 @@
       "type": "processor",
       "description": "Regroupe les entités selon leurs attributs",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeAggregatorParam",
         "type": "object",
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/AggregateAttribute"
+              "$ref": "#/$defs/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "calculationAttribute": {
-            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -84,17 +76,25 @@
             ],
             "format": "int64"
           },
+          "calculationAttribute": {
+            "$ref": "#/$defs/Attribute"
+          },
           "method": {
-            "$ref": "#/definitions/Method"
+            "$ref": "#/$defs/Method"
           }
         },
-        "definitions": {
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
+        "$defs": {
           "AggregateAttribute": {
             "type": "object",
-            "required": [
-              "newAttribute"
-            ],
             "properties": {
+              "newAttribute": {
+                "$ref": "#/$defs/Attribute"
+              },
               "attribute": {
                 "type": [
                   "string",
@@ -104,17 +104,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "newAttribute": {
-                "$ref": "#/definitions/Attribute"
               }
-            }
+            },
+            "required": [
+              "newAttribute"
+            ]
           },
           "Attribute": {
             "type": "string"
@@ -148,21 +148,21 @@
       "type": "processor",
       "description": "Filtre les entités possédant des attributs dupliqués",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
-        "required": [
-          "filterBy"
-        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "filterBy"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -184,18 +184,18 @@
       "type": "processor",
       "description": "Extrait des informations de chemins de fichier à partir des attributs",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "attribute"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -218,23 +218,45 @@
       "type": "processor",
       "description": "Gère les attributs",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeManagerParam",
         "type": "object",
-        "required": [
-          "operations"
-        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Operation"
+              "$ref": "#/$defs/Operation"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
+        "required": [
+          "operations"
+        ],
+        "$defs": {
+          "Operation": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/$defs/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "attribute",
+              "method"
+            ]
           },
           "Method": {
             "type": "string",
@@ -245,30 +267,8 @@
               "remove"
             ]
           },
-          "Operation": {
-            "type": "object",
-            "required": [
-              "attribute",
-              "method"
-            ],
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/definitions/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            }
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -288,28 +288,47 @@
       "type": "processor",
       "description": "Assigne des attributs",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeMapperParam",
         "type": "object",
-        "required": [
-          "mappers"
-        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Mapper"
+              "$ref": "#/$defs/Mapper"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "mappers"
+        ],
+        "$defs": {
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -321,39 +340,20 @@
                   "null"
                 ]
               },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
               "multipleExpr": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "parentAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -390,17 +390,12 @@
       "type": "processor",
       "description": "Crée un tampon autour d'une géométrie",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Bufferer",
         "type": "object",
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/definitions/BufferType"
+            "$ref": "#/$defs/BufferType"
           },
           "distance": {
             "type": "number",
@@ -411,7 +406,12 @@
             "format": "double"
           }
         },
-        "definitions": {
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
+        "$defs": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -437,20 +437,21 @@
       "type": "processor",
       "description": "Renomme des attributs en ajoutant/supprimant des préfixes ou suffixes, ou en remplaçant du texte",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
-        "required": [
-          "renameAction",
-          "renameType",
-          "renameValue"
-        ],
         "properties": {
-          "renameAction": {
-            "$ref": "#/definitions/RenameAction"
-          },
           "renameType": {
-            "$ref": "#/definitions/RenameType"
+            "$ref": "#/$defs/RenameType"
+          },
+          "renameAction": {
+            "$ref": "#/$defs/RenameAction"
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "renameValue": {
             "type": "string"
@@ -463,15 +464,21 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
-        "definitions": {
+        "required": [
+          "renameType",
+          "renameAction",
+          "renameValue"
+        ],
+        "$defs": {
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
+            ]
+          },
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -480,13 +487,6 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
-            ]
-          },
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
             ]
           }
         }
@@ -524,36 +524,36 @@
       "type": "sink",
       "description": "Écrit les entités dans un fichier",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
-        "required": [
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -610,19 +610,19 @@
       "type": "processor",
       "description": "Définit le système de coordonnées d'une entité",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "CoordinateSystemSetter",
         "type": "object",
-        "required": [
-          "epsgCode"
-        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
-        }
+        },
+        "required": [
+          "epsgCode"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -688,18 +688,18 @@
       "type": "processor",
       "description": "Extrait la première valeur de la coordonnée z d'une entité et la stocke dans un attribut.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ElevationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -721,18 +721,18 @@
       "type": "processor",
       "description": "Extrue un polygone sur une certaine distance",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ExtruderParam",
         "type": "object",
+        "properties": {
+          "distance": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "distance"
         ],
-        "properties": {
-          "distance": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -754,13 +754,9 @@
       "type": "processor",
       "description": "Compte les entités",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCounterParam",
         "type": "object",
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,14 +768,18 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "definitions": {
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -802,18 +802,18 @@
       "type": "source",
       "description": "Crée des entités à partir d'expressions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCreator",
         "type": "object",
+        "properties": {
+          "creator": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "creator"
         ],
-        "properties": {
-          "creator": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -833,22 +833,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -871,35 +871,35 @@
       "type": "processor",
       "description": "Filtre les entités selon des conditions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilterParam",
         "type": "object",
-        "required": [
-          "conditions"
-        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Condition"
+              "$ref": "#/$defs/Condition"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "conditions"
+        ],
+        "$defs": {
           "Condition": {
             "type": "object",
+            "properties": {
+              "expr": {
+                "$ref": "#/$defs/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/$defs/Port"
+              }
+            },
             "required": [
               "expr",
               "outputPort"
-            ],
-            "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/definitions/Port"
-              }
-            }
+            ]
           },
           "Expr": {
             "type": "string"
@@ -925,34 +925,18 @@
       "type": "processor",
       "description": "Fusionne des entités selon leurs attributs",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttribute": {
             "type": [
@@ -960,21 +944,37 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
-          "supplierAttributeValue": {
+          "requestorAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "supplierAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
@@ -1001,48 +1001,40 @@
       "type": "processor",
       "description": "Filtre les entités selon des conditions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1050,25 +1042,23 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1076,12 +1066,16 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1103,21 +1097,52 @@
       "type": "processor",
       "description": "Trie les entités par attributs",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureSorterParam",
         "type": "object",
-        "required": [
-          "sortBy"
-        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/SortBy"
+              "$ref": "#/$defs/SortBy"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "sortBy"
+        ],
+        "$defs": {
+          "SortBy": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/$defs/Order"
+              }
+            },
+            "required": [
+              "order"
+            ]
+          },
           "Attribute": {
             "type": "string"
           },
@@ -1130,37 +1155,6 @@
               "ascending",
               "descending"
             ]
-          },
-          "SortBy": {
-            "type": "object",
-            "required": [
-              "order"
-            ],
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/definitions/Order"
-              }
-            }
           }
         }
       },
@@ -1180,34 +1174,34 @@
       "type": "processor",
       "description": "Transforme les entités à l'aide d'expressions",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTransformerParam",
         "type": "object",
-        "required": [
-          "transformers"
-        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Transform"
+              "$ref": "#/$defs/Transform"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "transformers"
+        ],
+        "$defs": {
           "Transform": {
             "type": "object",
-            "required": [
-              "expr"
-            ],
             "properties": {
               "expr": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "expr"
+            ]
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -1227,12 +1221,9 @@
       "type": "processor",
       "description": "Filtre les entités par type",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTypeFilter",
         "type": "object",
-        "required": [
-          "targetTypes"
-        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1240,7 +1231,10 @@
               "type": "string"
             }
           }
-        }
+        },
+        "required": [
+          "targetTypes"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1259,22 +1253,22 @@
       "type": "source",
       "description": "Extrait des fichiers d'un répertoire ou d'une archive",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePathExtractor",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1294,17 +1288,17 @@
       "type": "processor",
       "description": "Extrait les propriétés d'un fichier",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePropertyExtractor",
         "type": "object",
-        "required": [
-          "filePathAttribute"
-        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "filePathAttribute"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1323,24 +1317,19 @@
       "type": "source",
       "description": "Lit des entités depuis un fichier",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileReader",
         "oneOf": [
           {
+            "title": "CSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1348,25 +1337,24 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "TSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1374,54 +1362,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "JSON",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "json"
-                ]
+                "const": "json"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "CityGML",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1441,88 +1431,76 @@
       "type": "sink",
       "description": "Écrit des entités dans un fichier",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "format",
-              "output"
-            ],
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "json"
+              },
+              "output": {
+                "$ref": "#/$defs/Expr"
+              },
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "json"
-                ]
-              },
-              "output": {
-                "$ref": "#/definitions/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "excel"
-                ]
+                "const": "excel"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1530,10 +1508,14 @@
                   "null"
                 ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "output"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1553,31 +1535,31 @@
       "type": "sink",
       "description": "Écrit des entités dans un fichier GeoJSON",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeoJsonWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
-          "Attribute": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -1596,18 +1578,18 @@
       "type": "processor",
       "description": "Force la géométrie d'une entité à une géométrie spécifique",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryCoercer",
         "type": "object",
+        "properties": {
+          "coercerType": {
+            "$ref": "#/$defs/CoercerType"
+          }
+        },
         "required": [
           "coercerType"
         ],
-        "properties": {
-          "coercerType": {
-            "$ref": "#/definitions/CoercerType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1632,27 +1614,27 @@
       "type": "processor",
       "description": "Dissout des géométries",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1675,18 +1657,18 @@
       "type": "processor",
       "description": "Extrait la géométrie d'une entité et l'ajoute comme attribut.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryExtractor",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1708,50 +1690,44 @@
       "type": "processor",
       "description": "Filtre la géométrie par type",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "none"
-                ]
+                "const": "none"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "multiple"
-                ]
+                "const": "multiple"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "geometryType"
-                ]
+                "const": "geometryType"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           }
         ]
       },
@@ -1794,7 +1770,7 @@
       "type": "processor",
       "description": "Filtre la géométrie par niveau de détail (lod)",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
@@ -1804,7 +1780,7 @@
               "null"
             ],
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -1825,18 +1801,18 @@
       "type": "processor",
       "description": "Remplace la géométrie d'une entité par une nouvelle géométrie.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryReplacer",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1874,21 +1850,21 @@
       "type": "processor",
       "description": "Valide la géométrie d'une entité",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryValidator",
         "type": "object",
-        "required": [
-          "validationTypes"
-        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/ValidationType"
+              "$ref": "#/$defs/ValidationType"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "validationTypes"
+        ],
+        "$defs": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1936,24 +1912,24 @@
       "type": "sink",
       "description": "Écrit des entités dans un fichier Gltf",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GltfWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1973,18 +1949,18 @@
       "type": "processor",
       "description": "Compte le nombre de trous dans une géométrie et l'ajoute comme attribut.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HoleCounterParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2024,7 +2000,7 @@
       "type": "processor",
       "description": "Reprojette la géométrie d'une entité dans un système de coordonnées spécifié",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2034,7 +2010,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -2054,17 +2030,17 @@
       "type": "processor",
       "description": "Action pour le renvoi du premier port dans les sous-flux de travail.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "InputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [],
@@ -2080,12 +2056,9 @@
       "type": "processor",
       "description": "Les points d'intersection deviennent des entités ponctuelles pouvant contenir la liste combinée des attributs des lignes d'origine intersectées.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2093,14 +2066,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2124,18 +2100,18 @@
       "type": "processor",
       "description": "Explose les attributs de type liste en plusieurs éléments",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ListExploder",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2157,34 +2133,34 @@
       "type": "sink",
       "description": "Écrit des entités dans un fichier",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "MVTWriterParam",
         "type": "object",
-        "required": [
-          "layerName",
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
-          "layerName": {
-            "$ref": "#/definitions/Expr"
+          "output": {
+            "$ref": "#/$defs/Expr"
           },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
+          "layerName": {
+            "$ref": "#/$defs/Expr"
           },
           "minZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           },
-          "output": {
-            "$ref": "#/definitions/Expr"
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "layerName",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2234,7 +2210,7 @@
       "type": "processor",
       "description": "Ajoute des décalages aux coordonnées de l'entité.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2277,18 +2253,18 @@
       "type": "processor",
       "description": "Extrait l'orientation de la géométrie d'une entité et l'ajoute comme attribut.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OrientationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2310,17 +2286,17 @@
       "type": "processor",
       "description": "Action pour le renvoi du dernier port dans les sous-flux de travail.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OutputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -2505,18 +2481,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "UDXFolderExtractorParam",
         "type": "object",
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "cityGmlPath"
         ],
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2573,22 +2549,22 @@
       "type": "processor",
       "description": "Appelle un script Rhai",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "RhaiCallerParam",
         "type": "object",
+        "properties": {
+          "isTarget": {
+            "$ref": "#/$defs/Expr"
+          },
+          "process": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "isTarget",
           "process"
         ],
-        "properties": {
-          "isTarget": {
-            "$ref": "#/definitions/Expr"
-          },
-          "process": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2610,27 +2586,24 @@
       "type": "processor",
       "description": "Calcule des statistiques sur les entités",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "StatisticsCalculatorParam",
         "type": "object",
-        "required": [
-          "calculations"
-        ],
         "properties": {
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
@@ -2640,28 +2613,31 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Calculation"
+              "$ref": "#/$defs/Calculation"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "calculations"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "required": [
-              "expr",
-              "newAttribute"
-            ],
             "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
               "newAttribute": {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
+              },
+              "expr": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "newAttribute",
+              "expr"
+            ]
           },
           "Expr": {
             "type": "string"
@@ -2685,38 +2661,38 @@
       "type": "processor",
       "description": "Remplace un boîtier tridimensionnel par un polygone.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "required": [
-          "maxX",
-          "maxY",
-          "maxZ",
-          "minX",
-          "minY",
-          "minZ"
-        ],
         "properties": {
-          "maxX": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/definitions/Attribute"
-          },
           "minX": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minY": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minZ": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxX": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "minX",
+          "minY",
+          "minZ",
+          "maxX",
+          "maxY",
+          "maxZ"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2738,42 +2714,42 @@
       "type": "processor",
       "description": "Remplace un boîtier tridimensionnel par un polygone.",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "required": [
-          "angleDegree",
-          "directionX",
-          "directionY",
-          "directionZ",
-          "originX",
-          "originY",
-          "originZ"
-        ],
         "properties": {
           "angleDegree": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionX": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionY": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originX": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originY": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
+          },
+          "directionX": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionY": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/$defs/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "angleDegree",
+          "originX",
+          "originY",
+          "originZ",
+          "directionX",
+          "directionY",
+          "directionZ"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2828,18 +2804,18 @@
       "type": "processor",
       "description": "Reprojette la géométrie d'une entité dans un système de coordonnées spécifié",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "VerticalReprojectorParam",
         "type": "object",
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/$defs/VerticalReprojectorType"
+          }
+        },
         "required": [
           "reprojectorType"
         ],
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/definitions/VerticalReprojectorType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2864,26 +2840,26 @@
       "type": "processor",
       "description": "Compile des scripts en .wasm et les exécute dans un environnement d'exécution wasm",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
-        "required": [
-          "processorType",
-          "programmingLanguage",
-          "sourceCodeFilePath"
-        ],
         "properties": {
-          "processorType": {
-            "$ref": "#/definitions/ProcessorType"
-          },
-          "programmingLanguage": {
-            "$ref": "#/definitions/ProgrammingLanguage"
-          },
           "sourceCodeFilePath": {
             "type": "string"
+          },
+          "processorType": {
+            "$ref": "#/$defs/ProcessorType"
+          },
+          "programmingLanguage": {
+            "$ref": "#/$defs/ProgrammingLanguage"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceCodeFilePath",
+          "processorType",
+          "programmingLanguage"
+        ],
+        "$defs": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2914,41 +2890,39 @@
       "type": "processor",
       "description": "Fragmente du XML",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "attribute",
-              "elementsToExclude",
-              "elementsToMatch",
-              "source"
-            ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/$defs/Expr"
               },
               "elementsToExclude": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
-              "elementsToMatch": {
-                "$ref": "#/definitions/Expr"
+              "attribute": {
+                "$ref": "#/$defs/Attribute"
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "url"
-                ]
+                "const": "url"
               }
-            }
+            },
+            "required": [
+              "source",
+              "elementsToMatch",
+              "elementsToExclude",
+              "attribute"
+            ]
           }
         ],
-        "definitions": {
-          "Attribute": {
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -2969,28 +2943,35 @@
       "type": "processor",
       "description": "Valide le contenu XML",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlValidatorParam",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/$defs/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/$defs/ValidationType"
+          }
+        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/definitions/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/definitions/ValidationType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
           },
           "ValidationType": {
             "type": "string",
@@ -2998,13 +2979,6 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -5,12 +5,9 @@
       "type": "processor",
       "description": "あるエリアの上に別のエリアを重ね合わせる",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -18,14 +15,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -49,33 +49,25 @@
       "type": "processor",
       "description": "属性に基づいてフィーチャをグルーピングする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeAggregatorParam",
         "type": "object",
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/AggregateAttribute"
+              "$ref": "#/$defs/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "calculationAttribute": {
-            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -84,17 +76,25 @@
             ],
             "format": "int64"
           },
+          "calculationAttribute": {
+            "$ref": "#/$defs/Attribute"
+          },
           "method": {
-            "$ref": "#/definitions/Method"
+            "$ref": "#/$defs/Method"
           }
         },
-        "definitions": {
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
+        "$defs": {
           "AggregateAttribute": {
             "type": "object",
-            "required": [
-              "newAttribute"
-            ],
             "properties": {
+              "newAttribute": {
+                "$ref": "#/$defs/Attribute"
+              },
               "attribute": {
                 "type": [
                   "string",
@@ -104,17 +104,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "newAttribute": {
-                "$ref": "#/definitions/Attribute"
               }
-            }
+            },
+            "required": [
+              "newAttribute"
+            ]
           },
           "Attribute": {
             "type": "string"
@@ -148,21 +148,21 @@
       "type": "processor",
       "description": "重複した属性を持つフィーチャをフィルタリングする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
-        "required": [
-          "filterBy"
-        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "filterBy"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -184,18 +184,18 @@
       "type": "processor",
       "description": "属性からファイルパス情報を抽出する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "attribute"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -218,23 +218,45 @@
       "type": "processor",
       "description": "属性を管理する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeManagerParam",
         "type": "object",
-        "required": [
-          "operations"
-        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Operation"
+              "$ref": "#/$defs/Operation"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
+        "required": [
+          "operations"
+        ],
+        "$defs": {
+          "Operation": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/$defs/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "attribute",
+              "method"
+            ]
           },
           "Method": {
             "type": "string",
@@ -245,30 +267,8 @@
               "remove"
             ]
           },
-          "Operation": {
-            "type": "object",
-            "required": [
-              "attribute",
-              "method"
-            ],
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/definitions/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            }
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -288,28 +288,47 @@
       "type": "processor",
       "description": "属性をマッピングする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeMapperParam",
         "type": "object",
-        "required": [
-          "mappers"
-        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Mapper"
+              "$ref": "#/$defs/Mapper"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "mappers"
+        ],
+        "$defs": {
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -321,39 +340,20 @@
                   "null"
                 ]
               },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
               "multipleExpr": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "parentAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -390,17 +390,12 @@
       "type": "processor",
       "description": "ジオメトリの周囲にバッファを作成する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Bufferer",
         "type": "object",
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/definitions/BufferType"
+            "$ref": "#/$defs/BufferType"
           },
           "distance": {
             "type": "number",
@@ -411,7 +406,12 @@
             "format": "double"
           }
         },
-        "definitions": {
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
+        "$defs": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -437,20 +437,21 @@
       "type": "processor",
       "description": "属性名にプレフィックス／サフィックスを追加・削除、またはテキスト置換して一括でリネームする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
-        "required": [
-          "renameAction",
-          "renameType",
-          "renameValue"
-        ],
         "properties": {
-          "renameAction": {
-            "$ref": "#/definitions/RenameAction"
-          },
           "renameType": {
-            "$ref": "#/definitions/RenameType"
+            "$ref": "#/$defs/RenameType"
+          },
+          "renameAction": {
+            "$ref": "#/$defs/RenameAction"
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "renameValue": {
             "type": "string"
@@ -463,15 +464,21 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
-        "definitions": {
+        "required": [
+          "renameType",
+          "renameAction",
+          "renameValue"
+        ],
+        "$defs": {
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
+            ]
+          },
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -480,13 +487,6 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
-            ]
-          },
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
             ]
           }
         }
@@ -524,36 +524,36 @@
       "type": "sink",
       "description": "フィーチャをファイルに書き出す",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
-        "required": [
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -610,19 +610,19 @@
       "type": "processor",
       "description": "フィーチャの座標系を設定する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "CoordinateSystemSetter",
         "type": "object",
-        "required": [
-          "epsgCode"
-        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
-        }
+        },
+        "required": [
+          "epsgCode"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -688,18 +688,18 @@
       "type": "processor",
       "description": "フィーチャの最初のZ座標値を抽出し、属性として格納する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ElevationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -721,18 +721,18 @@
       "type": "processor",
       "description": "ポリゴンを一定の距離で押し出す（エクストルード）",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ExtruderParam",
         "type": "object",
+        "properties": {
+          "distance": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "distance"
         ],
-        "properties": {
-          "distance": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -754,13 +754,9 @@
       "type": "processor",
       "description": "フィーチャ数をカウントする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCounterParam",
         "type": "object",
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,14 +768,18 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "definitions": {
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -802,18 +802,18 @@
       "type": "source",
       "description": "式に基づいてフィーチャを作成する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCreator",
         "type": "object",
+        "properties": {
+          "creator": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "creator"
         ],
-        "properties": {
-          "creator": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -833,22 +833,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -871,35 +871,35 @@
       "type": "processor",
       "description": "条件に基づいてフィーチャをフィルタリングする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilterParam",
         "type": "object",
-        "required": [
-          "conditions"
-        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Condition"
+              "$ref": "#/$defs/Condition"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "conditions"
+        ],
+        "$defs": {
           "Condition": {
             "type": "object",
+            "properties": {
+              "expr": {
+                "$ref": "#/$defs/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/$defs/Port"
+              }
+            },
             "required": [
               "expr",
               "outputPort"
-            ],
-            "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/definitions/Port"
-              }
-            }
+            ]
           },
           "Expr": {
             "type": "string"
@@ -925,34 +925,18 @@
       "type": "processor",
       "description": "属性に基づいてフィーチャをマージする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttribute": {
             "type": [
@@ -960,21 +944,37 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
-          "supplierAttributeValue": {
+          "requestorAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "supplierAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
@@ -1001,48 +1001,40 @@
       "type": "processor",
       "description": "条件に基づいてフィーチャをフィルタリングする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1050,25 +1042,23 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1076,12 +1066,16 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1103,21 +1097,52 @@
       "type": "processor",
       "description": "フィーチャを属性でソートする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureSorterParam",
         "type": "object",
-        "required": [
-          "sortBy"
-        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/SortBy"
+              "$ref": "#/$defs/SortBy"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "sortBy"
+        ],
+        "$defs": {
+          "SortBy": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/$defs/Order"
+              }
+            },
+            "required": [
+              "order"
+            ]
+          },
           "Attribute": {
             "type": "string"
           },
@@ -1130,37 +1155,6 @@
               "ascending",
               "descending"
             ]
-          },
-          "SortBy": {
-            "type": "object",
-            "required": [
-              "order"
-            ],
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/definitions/Order"
-              }
-            }
           }
         }
       },
@@ -1180,34 +1174,34 @@
       "type": "processor",
       "description": "式を用いてフィーチャを変換する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTransformerParam",
         "type": "object",
-        "required": [
-          "transformers"
-        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Transform"
+              "$ref": "#/$defs/Transform"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "transformers"
+        ],
+        "$defs": {
           "Transform": {
             "type": "object",
-            "required": [
-              "expr"
-            ],
             "properties": {
               "expr": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "expr"
+            ]
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -1227,12 +1221,9 @@
       "type": "processor",
       "description": "フィーチャタイプに基づいてフィーチャをフィルタリングする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTypeFilter",
         "type": "object",
-        "required": [
-          "targetTypes"
-        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1240,7 +1231,10 @@
               "type": "string"
             }
           }
-        }
+        },
+        "required": [
+          "targetTypes"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1259,22 +1253,22 @@
       "type": "source",
       "description": "ディレクトリまたはアーカイブからファイルを抽出する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePathExtractor",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1294,17 +1288,17 @@
       "type": "processor",
       "description": "ファイルからプロパティを抽出する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePropertyExtractor",
         "type": "object",
-        "required": [
-          "filePathAttribute"
-        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "filePathAttribute"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1323,24 +1317,19 @@
       "type": "source",
       "description": "ファイルからフィーチャを読み込む",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileReader",
         "oneOf": [
           {
+            "title": "CSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1348,25 +1337,24 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "TSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1374,54 +1362,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "JSON",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "json"
-                ]
+                "const": "json"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "CityGML",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1441,88 +1431,76 @@
       "type": "sink",
       "description": "フィーチャをファイルに書き出す",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "format",
-              "output"
-            ],
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "json"
+              },
+              "output": {
+                "$ref": "#/$defs/Expr"
+              },
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "json"
-                ]
-              },
-              "output": {
-                "$ref": "#/definitions/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "excel"
-                ]
+                "const": "excel"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1530,10 +1508,14 @@
                   "null"
                 ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "output"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1553,31 +1535,31 @@
       "type": "sink",
       "description": "フィーチャをGeoJSONファイルに書き出す",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeoJsonWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
-          "Attribute": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -1596,18 +1578,18 @@
       "type": "processor",
       "description": "フィーチャのジオメトリを特定のジオメトリタイプに強制変換する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryCoercer",
         "type": "object",
+        "properties": {
+          "coercerType": {
+            "$ref": "#/$defs/CoercerType"
+          }
+        },
         "required": [
           "coercerType"
         ],
-        "properties": {
-          "coercerType": {
-            "$ref": "#/definitions/CoercerType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1632,27 +1614,27 @@
       "type": "processor",
       "description": "ジオメトリをディゾルブ（結合）する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1675,18 +1657,18 @@
       "type": "processor",
       "description": "フィーチャからジオメトリを抽出し、属性として追加する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryExtractor",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1708,50 +1690,44 @@
       "type": "processor",
       "description": "ジオメトリをタイプに基づいてフィルタリングする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "none"
-                ]
+                "const": "none"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "multiple"
-                ]
+                "const": "multiple"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "geometryType"
-                ]
+                "const": "geometryType"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           }
         ]
       },
@@ -1794,7 +1770,7 @@
       "type": "processor",
       "description": "LOD（詳細レベル）に基づいてジオメトリをフィルタリングする",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
@@ -1804,7 +1780,7 @@
               "null"
             ],
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -1825,18 +1801,18 @@
       "type": "processor",
       "description": "フィーチャのジオメトリを新しいジオメトリで置き換える",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryReplacer",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1874,21 +1850,21 @@
       "type": "processor",
       "description": "フィーチャのジオメトリを検証する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryValidator",
         "type": "object",
-        "required": [
-          "validationTypes"
-        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/ValidationType"
+              "$ref": "#/$defs/ValidationType"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "validationTypes"
+        ],
+        "$defs": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1936,24 +1912,24 @@
       "type": "sink",
       "description": "フィーチャをGltfファイルに書き出す",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GltfWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1973,18 +1949,18 @@
       "type": "processor",
       "description": "ジオメトリ内の穴の数をカウントし、属性として追加する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HoleCounterParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2024,7 +2000,7 @@
       "type": "processor",
       "description": "フィーチャのジオメトリを指定された座標系に水平再投影する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2034,7 +2010,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -2054,17 +2030,17 @@
       "type": "processor",
       "description": "サブワークフローで最初のポートを転送するアクション",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "InputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [],
@@ -2080,12 +2056,9 @@
       "type": "processor",
       "description": "交点を点フィーチャに変換し、元の交差したラインの属性リストを結合して含めることができる",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2093,14 +2066,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2124,18 +2100,18 @@
       "type": "processor",
       "description": "リスト属性を複数の要素に分解する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ListExploder",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2157,34 +2133,34 @@
       "type": "sink",
       "description": "フィーチャをファイルに書き出す",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "MVTWriterParam",
         "type": "object",
-        "required": [
-          "layerName",
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
-          "layerName": {
-            "$ref": "#/definitions/Expr"
+          "output": {
+            "$ref": "#/$defs/Expr"
           },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
+          "layerName": {
+            "$ref": "#/$defs/Expr"
           },
           "minZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           },
-          "output": {
-            "$ref": "#/definitions/Expr"
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "layerName",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2234,7 +2210,7 @@
       "type": "processor",
       "description": "フィーチャの座標にオフセットを加える",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2277,18 +2253,18 @@
       "type": "processor",
       "description": "フィーチャのジオメトリの方向を抽出し、属性として追加する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OrientationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2310,17 +2286,17 @@
       "type": "processor",
       "description": "サブワークフローで最後のポートを転送するアクション",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OutputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -2505,18 +2481,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "UDXFolderExtractorParam",
         "type": "object",
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "cityGmlPath"
         ],
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2573,22 +2549,22 @@
       "type": "processor",
       "description": "Rhaiスクリプトを呼び出す",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "RhaiCallerParam",
         "type": "object",
+        "properties": {
+          "isTarget": {
+            "$ref": "#/$defs/Expr"
+          },
+          "process": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "isTarget",
           "process"
         ],
-        "properties": {
-          "isTarget": {
-            "$ref": "#/definitions/Expr"
-          },
-          "process": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2610,27 +2586,24 @@
       "type": "processor",
       "description": "フィーチャの統計情報を計算する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "StatisticsCalculatorParam",
         "type": "object",
-        "required": [
-          "calculations"
-        ],
         "properties": {
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
@@ -2640,28 +2613,31 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Calculation"
+              "$ref": "#/$defs/Calculation"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "calculations"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "required": [
-              "expr",
-              "newAttribute"
-            ],
             "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
               "newAttribute": {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
+              },
+              "expr": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "newAttribute",
+              "expr"
+            ]
           },
           "Expr": {
             "type": "string"
@@ -2685,38 +2661,38 @@
       "type": "processor",
       "description": "3次元ボックスをポリゴンで置き換える",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "required": [
-          "maxX",
-          "maxY",
-          "maxZ",
-          "minX",
-          "minY",
-          "minZ"
-        ],
         "properties": {
-          "maxX": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/definitions/Attribute"
-          },
           "minX": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minY": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minZ": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxX": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "minX",
+          "minY",
+          "minZ",
+          "maxX",
+          "maxY",
+          "maxZ"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2738,42 +2714,42 @@
       "type": "processor",
       "description": "3次元ボックスをポリゴンで置き換える",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "required": [
-          "angleDegree",
-          "directionX",
-          "directionY",
-          "directionZ",
-          "originX",
-          "originY",
-          "originZ"
-        ],
         "properties": {
           "angleDegree": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionX": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionY": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originX": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originY": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
+          },
+          "directionX": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionY": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/$defs/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "angleDegree",
+          "originX",
+          "originY",
+          "originZ",
+          "directionX",
+          "directionY",
+          "directionZ"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2828,18 +2804,18 @@
       "type": "processor",
       "description": "フィーチャのジオメトリを指定された座標系に垂直再投影する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "VerticalReprojectorParam",
         "type": "object",
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/$defs/VerticalReprojectorType"
+          }
+        },
         "required": [
           "reprojectorType"
         ],
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/definitions/VerticalReprojectorType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2864,26 +2840,26 @@
       "type": "processor",
       "description": "スクリプトを.wasmにコンパイルし、wasmランタイムで実行する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
-        "required": [
-          "processorType",
-          "programmingLanguage",
-          "sourceCodeFilePath"
-        ],
         "properties": {
-          "processorType": {
-            "$ref": "#/definitions/ProcessorType"
-          },
-          "programmingLanguage": {
-            "$ref": "#/definitions/ProgrammingLanguage"
-          },
           "sourceCodeFilePath": {
             "type": "string"
+          },
+          "processorType": {
+            "$ref": "#/$defs/ProcessorType"
+          },
+          "programmingLanguage": {
+            "$ref": "#/$defs/ProgrammingLanguage"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceCodeFilePath",
+          "processorType",
+          "programmingLanguage"
+        ],
+        "$defs": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2914,41 +2890,39 @@
       "type": "processor",
       "description": "XMLを分割する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "attribute",
-              "elementsToExclude",
-              "elementsToMatch",
-              "source"
-            ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/$defs/Expr"
               },
               "elementsToExclude": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
-              "elementsToMatch": {
-                "$ref": "#/definitions/Expr"
+              "attribute": {
+                "$ref": "#/$defs/Attribute"
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "url"
-                ]
+                "const": "url"
               }
-            }
+            },
+            "required": [
+              "source",
+              "elementsToMatch",
+              "elementsToExclude",
+              "attribute"
+            ]
           }
         ],
-        "definitions": {
-          "Attribute": {
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -2969,28 +2943,35 @@
       "type": "processor",
       "description": "XMLコンテンツを検証する",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlValidatorParam",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/$defs/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/$defs/ValidationType"
+          }
+        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/definitions/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/definitions/ValidationType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
           },
           "ValidationType": {
             "type": "string",
@@ -2998,13 +2979,6 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -5,12 +5,9 @@
       "type": "processor",
       "description": "在一个区域上叠加另一个区域",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -18,14 +15,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -49,33 +49,25 @@
       "type": "processor",
       "description": "根据属性对实体进行分组",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeAggregatorParam",
         "type": "object",
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/AggregateAttribute"
+              "$ref": "#/$defs/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "calculationAttribute": {
-            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -84,17 +76,25 @@
             ],
             "format": "int64"
           },
+          "calculationAttribute": {
+            "$ref": "#/$defs/Attribute"
+          },
           "method": {
-            "$ref": "#/definitions/Method"
+            "$ref": "#/$defs/Method"
           }
         },
-        "definitions": {
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
+        "$defs": {
           "AggregateAttribute": {
             "type": "object",
-            "required": [
-              "newAttribute"
-            ],
             "properties": {
+              "newAttribute": {
+                "$ref": "#/$defs/Attribute"
+              },
               "attribute": {
                 "type": [
                   "string",
@@ -104,17 +104,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "newAttribute": {
-                "$ref": "#/definitions/Attribute"
               }
-            }
+            },
+            "required": [
+              "newAttribute"
+            ]
           },
           "Attribute": {
             "type": "string"
@@ -148,21 +148,21 @@
       "type": "processor",
       "description": "筛选具有重复属性的实体",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
-        "required": [
-          "filterBy"
-        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "filterBy"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -184,18 +184,18 @@
       "type": "processor",
       "description": "从属性中提取文件路径信息",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "attribute"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -218,23 +218,45 @@
       "type": "processor",
       "description": "管理属性",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeManagerParam",
         "type": "object",
-        "required": [
-          "operations"
-        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Operation"
+              "$ref": "#/$defs/Operation"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
+        "required": [
+          "operations"
+        ],
+        "$defs": {
+          "Operation": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/$defs/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "attribute",
+              "method"
+            ]
           },
           "Method": {
             "type": "string",
@@ -245,30 +267,8 @@
               "remove"
             ]
           },
-          "Operation": {
-            "type": "object",
-            "required": [
-              "attribute",
-              "method"
-            ],
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/definitions/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            }
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -288,28 +288,47 @@
       "type": "processor",
       "description": "分配属性",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "AttributeMapperParam",
         "type": "object",
-        "required": [
-          "mappers"
-        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Mapper"
+              "$ref": "#/$defs/Mapper"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "mappers"
+        ],
+        "$defs": {
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "expr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -321,39 +340,20 @@
                   "null"
                 ]
               },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
               "multipleExpr": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "parentAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -390,17 +390,12 @@
       "type": "processor",
       "description": "在几何图形周围创建缓冲区",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Bufferer",
         "type": "object",
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/definitions/BufferType"
+            "$ref": "#/$defs/BufferType"
           },
           "distance": {
             "type": "number",
@@ -411,7 +406,12 @@
             "format": "double"
           }
         },
-        "definitions": {
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
+        "$defs": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -437,20 +437,21 @@
       "type": "processor",
       "description": "通过添加/删除前缀或后缀，或替换文本来重命名属性",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
-        "required": [
-          "renameAction",
-          "renameType",
-          "renameValue"
-        ],
         "properties": {
-          "renameAction": {
-            "$ref": "#/definitions/RenameAction"
-          },
           "renameType": {
-            "$ref": "#/definitions/RenameType"
+            "$ref": "#/$defs/RenameType"
+          },
+          "renameAction": {
+            "$ref": "#/$defs/RenameAction"
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "renameValue": {
             "type": "string"
@@ -463,15 +464,21 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
-        "definitions": {
+        "required": [
+          "renameType",
+          "renameAction",
+          "renameValue"
+        ],
+        "$defs": {
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
+            ]
+          },
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -480,13 +487,6 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
-            ]
-          },
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
             ]
           }
         }
@@ -524,36 +524,36 @@
       "type": "sink",
       "description": "将实体写入文件",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
-        "required": [
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -610,19 +610,19 @@
       "type": "processor",
       "description": "设置实体的坐标系",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "CoordinateSystemSetter",
         "type": "object",
-        "required": [
-          "epsgCode"
-        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
-        }
+        },
+        "required": [
+          "epsgCode"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -688,18 +688,18 @@
       "type": "processor",
       "description": "提取实体的第一个z坐标值并存储为一个属性",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ElevationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -721,18 +721,18 @@
       "type": "processor",
       "description": "沿一定距离拉伸多边形",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ExtruderParam",
         "type": "object",
+        "properties": {
+          "distance": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "distance"
         ],
-        "properties": {
-          "distance": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -754,13 +754,9 @@
       "type": "processor",
       "description": "统计实体数量",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCounterParam",
         "type": "object",
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,14 +768,18 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "definitions": {
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -802,18 +802,18 @@
       "type": "source",
       "description": "根据表达式创建实体",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureCreator",
         "type": "object",
+        "properties": {
+          "creator": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "creator"
         ],
-        "properties": {
-          "creator": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -833,22 +833,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -871,35 +871,35 @@
       "type": "processor",
       "description": "根据条件筛选实体",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureFilterParam",
         "type": "object",
-        "required": [
-          "conditions"
-        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Condition"
+              "$ref": "#/$defs/Condition"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "conditions"
+        ],
+        "$defs": {
           "Condition": {
             "type": "object",
+            "properties": {
+              "expr": {
+                "$ref": "#/$defs/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/$defs/Port"
+              }
+            },
             "required": [
               "expr",
               "outputPort"
-            ],
-            "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/definitions/Port"
-              }
-            }
+            ]
           },
           "Expr": {
             "type": "string"
@@ -925,34 +925,18 @@
       "type": "processor",
       "description": "根据属性合并实体",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttribute": {
             "type": [
@@ -960,21 +944,37 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
-          "supplierAttributeValue": {
+          "requestorAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "supplierAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
@@ -1001,48 +1001,40 @@
       "type": "processor",
       "description": "根据条件筛选实体",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1050,25 +1042,23 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1076,12 +1066,16 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1103,21 +1097,52 @@
       "type": "processor",
       "description": "根据属性对实体排序",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureSorterParam",
         "type": "object",
-        "required": [
-          "sortBy"
-        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/SortBy"
+              "$ref": "#/$defs/SortBy"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "sortBy"
+        ],
+        "$defs": {
+          "SortBy": {
+            "type": "object",
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/$defs/Order"
+              }
+            },
+            "required": [
+              "order"
+            ]
+          },
           "Attribute": {
             "type": "string"
           },
@@ -1130,37 +1155,6 @@
               "ascending",
               "descending"
             ]
-          },
-          "SortBy": {
-            "type": "object",
-            "required": [
-              "order"
-            ],
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/definitions/Order"
-              }
-            }
           }
         }
       },
@@ -1180,34 +1174,34 @@
       "type": "processor",
       "description": "通过表达式转换实体",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTransformerParam",
         "type": "object",
-        "required": [
-          "transformers"
-        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Transform"
+              "$ref": "#/$defs/Transform"
             }
           }
         },
-        "definitions": {
-          "Expr": {
-            "type": "string"
-          },
+        "required": [
+          "transformers"
+        ],
+        "$defs": {
           "Transform": {
             "type": "object",
-            "required": [
-              "expr"
-            ],
             "properties": {
               "expr": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "expr"
+            ]
+          },
+          "Expr": {
+            "type": "string"
           }
         }
       },
@@ -1227,12 +1221,9 @@
       "type": "processor",
       "description": "根据类型筛选实体",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FeatureTypeFilter",
         "type": "object",
-        "required": [
-          "targetTypes"
-        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1240,7 +1231,10 @@
               "type": "string"
             }
           }
-        }
+        },
+        "required": [
+          "targetTypes"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1259,22 +1253,22 @@
       "type": "source",
       "description": "从目录或归档文件中提取文件",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePathExtractor",
         "type": "object",
-        "required": [
-          "extractArchive",
-          "sourceDataset"
-        ],
         "properties": {
+          "sourceDataset": {
+            "$ref": "#/$defs/Expr"
+          },
           "extractArchive": {
             "type": "boolean"
-          },
-          "sourceDataset": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceDataset",
+          "extractArchive"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1294,17 +1288,17 @@
       "type": "processor",
       "description": "提取文件的属性",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FilePropertyExtractor",
         "type": "object",
-        "required": [
-          "filePathAttribute"
-        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "filePathAttribute"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -1323,24 +1317,19 @@
       "type": "source",
       "description": "从文件中读取实体",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileReader",
         "oneOf": [
           {
+            "title": "CSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1348,25 +1337,24 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "TSV",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               },
               "offset": {
                 "type": [
@@ -1374,54 +1362,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0.0
+                "minimum": 0
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "JSON",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
-              "dataset": {
-                "$ref": "#/definitions/Expr"
-              },
               "format": {
                 "type": "string",
-                "enum": [
-                  "json"
-                ]
+                "const": "json"
+              },
+              "dataset": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           },
           {
+            "title": "CityGML",
             "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "citygml"
+              },
               "dataset": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "citygml"
-                ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "dataset"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1441,88 +1431,76 @@
       "type": "sink",
       "description": "将实体写入文件",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "format",
-              "output"
-            ],
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "csv"
-                ]
+                "const": "csv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "tsv"
-                ]
+                "const": "tsv"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
+              "format": {
+                "type": "string",
+                "const": "json"
+              },
+              "output": {
+                "$ref": "#/$defs/Expr"
+              },
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/$defs/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
-              },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "json"
-                ]
-              },
-              "output": {
-                "$ref": "#/definitions/Expr"
               }
-            }
-          },
-          {
-            "type": "object",
+            },
             "required": [
               "format",
               "output"
-            ],
+            ]
+          },
+          {
+            "type": "object",
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "excel"
-                ]
+                "const": "excel"
               },
               "output": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1530,10 +1508,14 @@
                   "null"
                 ]
               }
-            }
+            },
+            "required": [
+              "format",
+              "output"
+            ]
           }
         ],
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1553,31 +1535,31 @@
       "type": "sink",
       "description": "将实体写入 GeoJSON 文件",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeoJsonWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
-          "Attribute": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -1596,18 +1578,18 @@
       "type": "processor",
       "description": "强制将实体几何转换为特定几何类型",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryCoercer",
         "type": "object",
+        "properties": {
+          "coercerType": {
+            "$ref": "#/$defs/CoercerType"
+          }
+        },
         "required": [
           "coercerType"
         ],
-        "properties": {
-          "coercerType": {
-            "$ref": "#/definitions/CoercerType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1632,27 +1614,27 @@
       "type": "processor",
       "description": "溶解几何体",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
+          },
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1675,18 +1657,18 @@
       "type": "processor",
       "description": "提取实体的几何并作为属性添加",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryExtractor",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1708,50 +1690,44 @@
       "type": "processor",
       "description": "根据类型筛选几何",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "none"
-                ]
+                "const": "none"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "multiple"
-                ]
+                "const": "multiple"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           },
           {
             "type": "object",
-            "required": [
-              "filterType"
-            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "enum": [
-                  "geometryType"
-                ]
+                "const": "geometryType"
               }
-            }
+            },
+            "required": [
+              "filterType"
+            ]
           }
         ]
       },
@@ -1794,7 +1770,7 @@
       "type": "processor",
       "description": "根据细节级别（LOD）筛选几何",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryLodFilterParam",
         "type": "object",
         "properties": {
@@ -1804,7 +1780,7 @@
               "null"
             ],
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -1825,18 +1801,18 @@
       "type": "processor",
       "description": "用新几何替换实体的几何",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryReplacer",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -1874,21 +1850,21 @@
       "type": "processor",
       "description": "验证实体的几何",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GeometryValidator",
         "type": "object",
-        "required": [
-          "validationTypes"
-        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/ValidationType"
+              "$ref": "#/$defs/ValidationType"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "validationTypes"
+        ],
+        "$defs": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1936,24 +1912,24 @@
       "type": "sink",
       "description": "将实体写入Gltf文件",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "GltfWriterParam",
         "type": "object",
-        "required": [
-          "output"
-        ],
         "properties": {
+          "output": {
+            "$ref": "#/$defs/Expr"
+          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
-          },
-          "output": {
-            "$ref": "#/definitions/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "output"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -1973,18 +1949,18 @@
       "type": "processor",
       "description": "统计几何中的孔数量并作为属性添加",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HoleCounterParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2024,7 +2000,7 @@
       "type": "processor",
       "description": "将实体的几何重投影到指定坐标系",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2034,7 +2010,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0.0
+            "minimum": 0
           }
         }
       },
@@ -2054,17 +2030,17 @@
       "type": "processor",
       "description": "用于子工作流中最初一个端口转发的操作",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "InputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [],
@@ -2080,12 +2056,9 @@
       "type": "processor",
       "description": "交点转换为点实体，并可包含原始相交线段组合的属性列表",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
-        "required": [
-          "outputAttribute"
-        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2093,14 +2066,17 @@
               "null"
             ],
             "items": {
-              "$ref": "#/definitions/Attribute"
+              "$ref": "#/$defs/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "outputAttribute"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2124,18 +2100,18 @@
       "type": "processor",
       "description": "将列表类型的属性拆分为多个元素",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ListExploder",
         "type": "object",
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "sourceAttribute"
         ],
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2157,34 +2133,34 @@
       "type": "sink",
       "description": "将实体写入文件",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "MVTWriterParam",
         "type": "object",
-        "required": [
-          "layerName",
-          "maxZoom",
-          "minZoom",
-          "output"
-        ],
         "properties": {
-          "layerName": {
-            "$ref": "#/definitions/Expr"
+          "output": {
+            "$ref": "#/$defs/Expr"
           },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
+          "layerName": {
+            "$ref": "#/$defs/Expr"
           },
           "minZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0.0
+            "minimum": 0
           },
-          "output": {
-            "$ref": "#/definitions/Expr"
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
           }
         },
-        "definitions": {
+        "required": [
+          "output",
+          "layerName",
+          "minZoom",
+          "maxZoom"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2234,7 +2210,7 @@
       "type": "processor",
       "description": "为实体的坐标添加偏移",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2277,18 +2253,18 @@
       "type": "processor",
       "description": "提取实体几何的方向并作为属性添加",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OrientationExtractorParam",
         "type": "object",
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/$defs/Attribute"
+          }
+        },
         "required": [
           "outputAttribute"
         ],
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/definitions/Attribute"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2310,17 +2286,17 @@
       "type": "processor",
       "description": "用于子工作流中最后一个端口转发的操作",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "OutputRouter",
         "type": "object",
-        "required": [
-          "routingPort"
-        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "routingPort"
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -2505,18 +2481,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "UDXFolderExtractorParam",
         "type": "object",
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "cityGmlPath"
         ],
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2573,22 +2549,22 @@
       "type": "processor",
       "description": "调用Rhai脚本",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "RhaiCallerParam",
         "type": "object",
+        "properties": {
+          "isTarget": {
+            "$ref": "#/$defs/Expr"
+          },
+          "process": {
+            "$ref": "#/$defs/Expr"
+          }
+        },
         "required": [
           "isTarget",
           "process"
         ],
-        "properties": {
-          "isTarget": {
-            "$ref": "#/definitions/Expr"
-          },
-          "process": {
-            "$ref": "#/definitions/Expr"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2610,27 +2586,24 @@
       "type": "processor",
       "description": "计算实体的统计信息",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "StatisticsCalculatorParam",
         "type": "object",
-        "required": [
-          "calculations"
-        ],
         "properties": {
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
               },
               {
                 "type": "null"
@@ -2640,28 +2613,31 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/Calculation"
+              "$ref": "#/$defs/Calculation"
             }
           }
         },
-        "definitions": {
+        "required": [
+          "calculations"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "required": [
-              "expr",
-              "newAttribute"
-            ],
             "properties": {
-              "expr": {
-                "$ref": "#/definitions/Expr"
-              },
               "newAttribute": {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/$defs/Attribute"
+              },
+              "expr": {
+                "$ref": "#/$defs/Expr"
               }
-            }
+            },
+            "required": [
+              "newAttribute",
+              "expr"
+            ]
           },
           "Expr": {
             "type": "string"
@@ -2685,38 +2661,38 @@
       "type": "processor",
       "description": "用多边形替换三维盒子",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "required": [
-          "maxX",
-          "maxY",
-          "maxZ",
-          "minX",
-          "minY",
-          "minZ"
-        ],
         "properties": {
-          "maxX": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/definitions/Attribute"
-          },
           "minX": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minY": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
           },
           "minZ": {
-            "$ref": "#/definitions/Attribute"
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxX": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/$defs/Attribute"
           }
         },
-        "definitions": {
+        "required": [
+          "minX",
+          "minY",
+          "minZ",
+          "maxX",
+          "maxY",
+          "maxZ"
+        ],
+        "$defs": {
           "Attribute": {
             "type": "string"
           }
@@ -2738,42 +2714,42 @@
       "type": "processor",
       "description": "用多边形替换三维盒子",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "required": [
-          "angleDegree",
-          "directionX",
-          "directionY",
-          "directionZ",
-          "originX",
-          "originY",
-          "originZ"
-        ],
         "properties": {
           "angleDegree": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionX": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionY": {
-            "$ref": "#/definitions/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originX": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originY": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
           },
           "originZ": {
-            "$ref": "#/definitions/Expr"
+            "$ref": "#/$defs/Expr"
+          },
+          "directionX": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionY": {
+            "$ref": "#/$defs/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/$defs/Expr"
           }
         },
-        "definitions": {
+        "required": [
+          "angleDegree",
+          "originX",
+          "originY",
+          "originZ",
+          "directionX",
+          "directionY",
+          "directionZ"
+        ],
+        "$defs": {
           "Expr": {
             "type": "string"
           }
@@ -2828,18 +2804,18 @@
       "type": "processor",
       "description": "将实体的几何重投影到指定坐标系",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "VerticalReprojectorParam",
         "type": "object",
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/$defs/VerticalReprojectorType"
+          }
+        },
         "required": [
           "reprojectorType"
         ],
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/definitions/VerticalReprojectorType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2864,26 +2840,26 @@
       "type": "processor",
       "description": "将脚本编译为.wasm并在wasm运行环境中执行",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
-        "required": [
-          "processorType",
-          "programmingLanguage",
-          "sourceCodeFilePath"
-        ],
         "properties": {
-          "processorType": {
-            "$ref": "#/definitions/ProcessorType"
-          },
-          "programmingLanguage": {
-            "$ref": "#/definitions/ProgrammingLanguage"
-          },
           "sourceCodeFilePath": {
             "type": "string"
+          },
+          "processorType": {
+            "$ref": "#/$defs/ProcessorType"
+          },
+          "programmingLanguage": {
+            "$ref": "#/$defs/ProgrammingLanguage"
           }
         },
-        "definitions": {
+        "required": [
+          "sourceCodeFilePath",
+          "processorType",
+          "programmingLanguage"
+        ],
+        "$defs": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2914,41 +2890,39 @@
       "type": "processor",
       "description": "分割XML",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "attribute",
-              "elementsToExclude",
-              "elementsToMatch",
-              "source"
-            ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/$defs/Expr"
               },
               "elementsToExclude": {
-                "$ref": "#/definitions/Expr"
+                "$ref": "#/$defs/Expr"
               },
-              "elementsToMatch": {
-                "$ref": "#/definitions/Expr"
+              "attribute": {
+                "$ref": "#/$defs/Attribute"
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "url"
-                ]
+                "const": "url"
               }
-            }
+            },
+            "required": [
+              "source",
+              "elementsToMatch",
+              "elementsToExclude",
+              "attribute"
+            ]
           }
         ],
-        "definitions": {
-          "Attribute": {
+        "$defs": {
+          "Expr": {
             "type": "string"
           },
-          "Expr": {
+          "Attribute": {
             "type": "string"
           }
         }
@@ -2969,28 +2943,35 @@
       "type": "processor",
       "description": "验证XML内容",
       "parameter": {
-        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "XmlValidatorParam",
         "type": "object",
+        "properties": {
+          "attribute": {
+            "$ref": "#/$defs/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/$defs/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/$defs/ValidationType"
+          }
+        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "properties": {
-          "attribute": {
-            "$ref": "#/definitions/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/definitions/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/definitions/ValidationType"
-          }
-        },
-        "definitions": {
+        "$defs": {
           "Attribute": {
             "type": "string"
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
           },
           "ValidationType": {
             "type": "string",
@@ -2998,13 +2979,6 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new variants in the `FileReader` enum to support additional file formats: `Tsv`, `Json`, and `Citygml`.
	- Enhanced JSON schema definitions for various processor and sink actions, including new required fields and updated references.
  
- **Bug Fixes**
	- Updated return types for the `parameter_schema` method in multiple factories and processors to align with new schema handling.

- **Documentation**
	- Comprehensive updates to JSON schema files to reflect the latest standards and structural changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->