### PR TITLE
fix(engine): update parameter_schema return type to RootSchema for consistency

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5583,7 +5583,7 @@ dependencies = [
  "reearth-flow-types",
  "regex",
  "rhai",
- "schemars 1.0.0-alpha.17",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.9",
@@ -5624,7 +5624,7 @@ dependencies = [
  "regex",
  "rhai",
  "rstar 0.12.2",
- "schemars 1.0.0-alpha.17",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.9",
@@ -5681,7 +5681,7 @@ dependencies = [
  "regex",
  "rhai",
  "rust_xlsxwriter",
- "schemars 1.0.0-alpha.17",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -5717,7 +5717,7 @@ dependencies = [
  "reearth-flow-types",
  "regex",
  "rhai",
- "schemars 1.0.0-alpha.17",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.9",
@@ -5741,7 +5741,7 @@ dependencies = [
  "reearth-flow-storage",
  "reearth-flow-types",
  "regex",
- "schemars 1.0.0-alpha.17",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -5777,7 +5777,7 @@ dependencies = [
  "reearth-flow-storage",
  "reearth-flow-telemetry",
  "reearth-flow-types",
- "schemars 1.0.0-alpha.17",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.9",
@@ -5905,7 +5905,7 @@ dependencies = [
  "reearth-flow-storage",
  "reearth-flow-types",
  "regex",
- "schemars 1.0.0-alpha.17",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -5976,7 +5976,7 @@ dependencies = [
  "reearth-flow-types",
  "regex",
  "rmp-serde",
- "schemars 1.0.0-alpha.17",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.9",
@@ -6085,7 +6085,7 @@ dependencies = [
  "reearth-flow-eval-expr",
  "reearth-flow-geometry",
  "rhai",
- "schemars 1.0.0-alpha.17",
+ "schemars",
  "serde",
  "serde_json",
  "strum_macros",
@@ -6123,7 +6123,7 @@ dependencies = [
  "reearth-flow-storage",
  "reearth-flow-telemetry",
  "reearth-flow-types",
- "schemars 1.0.0-alpha.17",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.9",
@@ -6134,26 +6134,6 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "walkdir",
-]
-
-[[package]]
-name = "ref-cast"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.95",
 ]
 
 [[package]]
@@ -6761,25 +6741,12 @@ version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
+ "chrono",
  "dyn-clone",
- "schemars_derive 0.8.21",
+ "schemars_derive",
  "serde",
  "serde_json",
  "url",
-]
-
-[[package]]
-name = "schemars"
-version = "1.0.0-alpha.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ef2a6523400a2228db974a8ddc9e1d3deaa04f51bddd7832ef8d7e531bafcc"
-dependencies = [
- "chrono",
- "dyn-clone",
- "ref-cast",
- "schemars_derive 1.0.0-alpha.17",
- "serde",
- "serde_json",
  "uuid",
 ]
 
@@ -6788,18 +6755,6 @@ name = "schemars_derive"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.95",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "1.0.0-alpha.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d4e1945a3c9e58edaa708449b026519f7f4197185e1b5dbc689615c1ad724d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9038,7 +8993,7 @@ dependencies = [
  "derive_builder",
  "hex",
  "indexmap 2.7.0",
- "schemars 0.8.21",
+ "schemars",
  "semver",
  "serde",
  "serde_json",
@@ -9060,7 +9015,7 @@ dependencies = [
  "derive_builder",
  "hex",
  "indexmap 2.7.0",
- "schemars 0.8.21",
+ "schemars",
  "semver",
  "serde",
  "serde_json",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -139,7 +139,7 @@ robust = "1.1.0"
 rstar = "0.12.2"
 rstest = "0.24.0"
 rust_xlsxwriter = "0.80.0"
-schemars = { version = "1.0.0-alpha.17", features = ["chrono04", "uuid1"] }
+schemars = { version = "0.8.21", features = ["chrono", "uuid1"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_derive = "1.0.217"
 serde_json = { version = "1.0.134", features = ["arbitrary_precision"] }

--- a/engine/cli/src/schema_workflow.rs
+++ b/engine/cli/src/schema_workflow.rs
@@ -1,6 +1,5 @@
 use clap::Command;
 use reearth_flow_types::Workflow;
-use schemars::schema_for;
 
 pub fn build_schema_workflow_command() -> Command {
     Command::new("schema-workflow")
@@ -13,7 +12,7 @@ pub struct SchemaWorkflowCliCommand;
 
 impl SchemaWorkflowCliCommand {
     pub fn execute(&self) -> crate::Result<()> {
-        let schema = schema_for!(Workflow);
+        let schema = schemars::schema_for!(Workflow);
         println!("{}", serde_json::to_string_pretty(&schema).unwrap());
         Ok(())
     }

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -8,9 +8,12 @@ Overlays an area on another area
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AreaOnAreaOverlayerParam",
   "type": "object",
+  "required": [
+    "outputAttribute"
+  ],
   "properties": {
     "groupBy": {
       "type": [
@@ -18,17 +21,14 @@ Overlays an area on another area
         "null"
       ],
       "items": {
-        "$ref": "#/$defs/Attribute"
+        "$ref": "#/definitions/Attribute"
       }
     },
     "outputAttribute": {
-      "$ref": "#/$defs/Attribute"
+      "$ref": "#/definitions/Attribute"
     }
   },
-  "required": [
-    "outputAttribute"
-  ],
-  "$defs": {
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -52,25 +52,33 @@ Aggregates features by attributes
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AttributeAggregatorParam",
   "type": "object",
+  "required": [
+    "aggregateAttributes",
+    "calculationAttribute",
+    "method"
+  ],
   "properties": {
     "aggregateAttributes": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/AggregateAttribute"
+        "$ref": "#/definitions/AggregateAttribute"
       }
     },
     "calculation": {
       "anyOf": [
         {
-          "$ref": "#/$defs/Expr"
+          "$ref": "#/definitions/Expr"
         },
         {
           "type": "null"
         }
       ]
+    },
+    "calculationAttribute": {
+      "$ref": "#/definitions/Attribute"
     },
     "calculationValue": {
       "type": [
@@ -79,29 +87,21 @@ Aggregates features by attributes
       ],
       "format": "int64"
     },
-    "calculationAttribute": {
-      "$ref": "#/$defs/Attribute"
-    },
     "method": {
-      "$ref": "#/$defs/Method"
+      "$ref": "#/definitions/Method"
     }
   },
-  "required": [
-    "aggregateAttributes",
-    "calculationAttribute",
-    "method"
-  ],
-  "$defs": {
+  "definitions": {
     "AggregateAttribute": {
       "type": "object",
+      "required": [
+        "newAttribute"
+      ],
       "properties": {
-        "newAttribute": {
-          "$ref": "#/$defs/Attribute"
-        },
         "attribute": {
           "anyOf": [
             {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             },
             {
               "type": "null"
@@ -111,17 +111,17 @@ Aggregates features by attributes
         "attributeValue": {
           "anyOf": [
             {
-              "$ref": "#/$defs/Expr"
+              "$ref": "#/definitions/Expr"
             },
             {
               "type": "null"
             }
           ]
+        },
+        "newAttribute": {
+          "$ref": "#/definitions/Attribute"
         }
-      },
-      "required": [
-        "newAttribute"
-      ]
+      }
     },
     "Attribute": {
       "type": "string"
@@ -155,21 +155,21 @@ Filters features by duplicate attributes
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AttributeDuplicateFilterParam",
   "type": "object",
+  "required": [
+    "filterBy"
+  ],
   "properties": {
     "filterBy": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/Attribute"
+        "$ref": "#/definitions/Attribute"
       }
     }
   },
-  "required": [
-    "filterBy"
-  ],
-  "$defs": {
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -191,18 +191,18 @@ Extracts file path information from attributes
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AttributeFilePathInfoExtractor",
   "type": "object",
-  "properties": {
-    "attribute": {
-      "$ref": "#/$defs/Attribute"
-    }
-  },
   "required": [
     "attribute"
   ],
-  "$defs": {
+  "properties": {
+    "attribute": {
+      "$ref": "#/definitions/Attribute"
+    }
+  },
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -225,45 +225,23 @@ Manages attributes
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AttributeManagerParam",
   "type": "object",
+  "required": [
+    "operations"
+  ],
   "properties": {
     "operations": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/Operation"
+        "$ref": "#/definitions/Operation"
       }
     }
   },
-  "required": [
-    "operations"
-  ],
-  "$defs": {
-    "Operation": {
-      "type": "object",
-      "properties": {
-        "attribute": {
-          "type": "string"
-        },
-        "method": {
-          "$ref": "#/$defs/Method"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Expr"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        }
-      },
-      "required": [
-        "attribute",
-        "method"
-      ]
+  "definitions": {
+    "Expr": {
+      "type": "string"
     },
     "Method": {
       "type": "string",
@@ -274,8 +252,30 @@ Manages attributes
         "remove"
       ]
     },
-    "Expr": {
-      "type": "string"
+    "Operation": {
+      "type": "object",
+      "required": [
+        "attribute",
+        "method"
+      ],
+      "properties": {
+        "attribute": {
+          "type": "string"
+        },
+        "method": {
+          "$ref": "#/definitions/Method"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
     }
   }
 }
@@ -295,47 +295,28 @@ Maps attributes
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AttributeMapperParam",
   "type": "object",
+  "required": [
+    "mappers"
+  ],
   "properties": {
     "mappers": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/Mapper"
+        "$ref": "#/definitions/Mapper"
       }
     }
   },
-  "required": [
-    "mappers"
-  ],
-  "$defs": {
+  "definitions": {
+    "Expr": {
+      "type": "string"
+    },
     "Mapper": {
       "type": "object",
       "properties": {
         "attribute": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "expr": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Expr"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "valueAttribute": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "parentAttribute": {
           "type": [
             "string",
             "null"
@@ -347,20 +328,39 @@ Maps attributes
             "null"
           ]
         },
-        "multipleExpr": {
+        "expr": {
           "anyOf": [
             {
-              "$ref": "#/$defs/Expr"
+              "$ref": "#/definitions/Expr"
             },
             {
               "type": "null"
             }
           ]
+        },
+        "multipleExpr": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "parentAttribute": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "valueAttribute": {
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
-    },
-    "Expr": {
-      "type": "string"
     }
   }
 }
@@ -395,12 +395,17 @@ Buffers a geometry
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Bufferer",
   "type": "object",
+  "required": [
+    "bufferType",
+    "distance",
+    "interpolationAngle"
+  ],
   "properties": {
     "bufferType": {
-      "$ref": "#/$defs/BufferType"
+      "$ref": "#/definitions/BufferType"
     },
     "distance": {
       "type": "number",
@@ -411,12 +416,7 @@ Buffers a geometry
       "format": "double"
     }
   },
-  "required": [
-    "bufferType",
-    "distance",
-    "interpolationAngle"
-  ],
-  "$defs": {
+  "definitions": {
     "BufferType": {
       "type": "string",
       "enum": [
@@ -442,21 +442,20 @@ Renames attributes by adding/removing prefixes or suffixes, or replacing text
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "BulkAttributeRenamerParam",
   "type": "object",
+  "required": [
+    "renameAction",
+    "renameType",
+    "renameValue"
+  ],
   "properties": {
-    "renameType": {
-      "$ref": "#/$defs/RenameType"
-    },
     "renameAction": {
-      "$ref": "#/$defs/RenameAction"
+      "$ref": "#/definitions/RenameAction"
     },
-    "textToFind": {
-      "type": [
-        "string",
-        "null"
-      ]
+    "renameType": {
+      "$ref": "#/definitions/RenameType"
     },
     "renameValue": {
       "type": "string"
@@ -469,21 +468,15 @@ Renames attributes by adding/removing prefixes or suffixes, or replacing text
       "items": {
         "type": "string"
       }
+    },
+    "textToFind": {
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
-  "required": [
-    "renameType",
-    "renameAction",
-    "renameValue"
-  ],
-  "$defs": {
-    "RenameType": {
-      "type": "string",
-      "enum": [
-        "All",
-        "Selected"
-      ]
-    },
+  "definitions": {
     "RenameAction": {
       "type": "string",
       "enum": [
@@ -492,6 +485,13 @@ Renames attributes by adding/removing prefixes or suffixes, or replacing text
         "RemovePrefix",
         "RemoveSuffix",
         "StringReplace"
+      ]
+    },
+    "RenameType": {
+      "type": "string",
+      "enum": [
+        "All",
+        "Selected"
       ]
     }
   }
@@ -527,36 +527,36 @@ Writes features to a file
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Cesium3DTilesWriterParam",
   "type": "object",
+  "required": [
+    "maxZoom",
+    "minZoom",
+    "output"
+  ],
   "properties": {
-    "output": {
-      "$ref": "#/$defs/Expr"
-    },
-    "minZoom": {
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0
-    },
-    "maxZoom": {
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0
-    },
     "attachTexture": {
       "type": [
         "boolean",
         "null"
       ]
+    },
+    "maxZoom": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "minZoom": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "output": {
+      "$ref": "#/definitions/Expr"
     }
   },
-  "required": [
-    "output",
-    "minZoom",
-    "maxZoom"
-  ],
-  "$defs": {
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -610,19 +610,19 @@ Sets the coordinate system of a feature
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "CoordinateSystemSetter",
   "type": "object",
+  "required": [
+    "epsgCode"
+  ],
   "properties": {
     "epsgCode": {
       "type": "integer",
       "format": "uint16",
-      "minimum": 0
+      "minimum": 0.0
     }
-  },
-  "required": [
-    "epsgCode"
-  ]
+  }
 }
 ```
 ### Input Ports
@@ -683,18 +683,18 @@ Extracts a feature’s first z coordinate value, storing it in an attribute.
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ElevationExtractorParam",
   "type": "object",
-  "properties": {
-    "outputAttribute": {
-      "$ref": "#/$defs/Attribute"
-    }
-  },
   "required": [
     "outputAttribute"
   ],
-  "$defs": {
+  "properties": {
+    "outputAttribute": {
+      "$ref": "#/definitions/Attribute"
+    }
+  },
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -716,18 +716,18 @@ Extrudes a polygon by a distance
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExtruderParam",
   "type": "object",
-  "properties": {
-    "distance": {
-      "$ref": "#/$defs/Expr"
-    }
-  },
   "required": [
     "distance"
   ],
-  "$defs": {
+  "properties": {
+    "distance": {
+      "$ref": "#/definitions/Expr"
+    }
+  },
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -749,9 +749,13 @@ Counts features
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FeatureCounterParam",
   "type": "object",
+  "required": [
+    "countStart",
+    "outputAttribute"
+  ],
   "properties": {
     "countStart": {
       "type": "integer",
@@ -763,18 +767,14 @@ Counts features
         "null"
       ],
       "items": {
-        "$ref": "#/$defs/Attribute"
+        "$ref": "#/definitions/Attribute"
       }
     },
     "outputAttribute": {
       "type": "string"
     }
   },
-  "required": [
-    "countStart",
-    "outputAttribute"
-  ],
-  "$defs": {
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -797,18 +797,18 @@ Creates features from expressions
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FeatureCreator",
   "type": "object",
-  "properties": {
-    "creator": {
-      "$ref": "#/$defs/Expr"
-    }
-  },
   "required": [
     "creator"
   ],
-  "$defs": {
+  "properties": {
+    "creator": {
+      "$ref": "#/definitions/Expr"
+    }
+  },
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -829,22 +829,22 @@ Extracts features by file path
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FeatureFilePathExtractorParam",
   "type": "object",
+  "required": [
+    "extractArchive",
+    "sourceDataset"
+  ],
   "properties": {
-    "sourceDataset": {
-      "$ref": "#/$defs/Expr"
-    },
     "extractArchive": {
       "type": "boolean"
+    },
+    "sourceDataset": {
+      "$ref": "#/definitions/Expr"
     }
   },
-  "required": [
-    "sourceDataset",
-    "extractArchive"
-  ],
-  "$defs": {
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -867,35 +867,35 @@ Filters features based on conditions
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FeatureFilterParam",
   "type": "object",
+  "required": [
+    "conditions"
+  ],
   "properties": {
     "conditions": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/Condition"
+        "$ref": "#/definitions/Condition"
       }
     }
   },
-  "required": [
-    "conditions"
-  ],
-  "$defs": {
+  "definitions": {
     "Condition": {
       "type": "object",
-      "properties": {
-        "expr": {
-          "$ref": "#/$defs/Expr"
-        },
-        "outputPort": {
-          "$ref": "#/$defs/Port"
-        }
-      },
       "required": [
         "expr",
         "outputPort"
-      ]
+      ],
+      "properties": {
+        "expr": {
+          "$ref": "#/definitions/Expr"
+        },
+        "outputPort": {
+          "$ref": "#/definitions/Port"
+        }
+      }
     },
     "Expr": {
       "type": "string"
@@ -921,18 +921,18 @@ Filter Geometry by lod
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FeatureLodFilterParam",
   "type": "object",
-  "properties": {
-    "filterKey": {
-      "$ref": "#/$defs/Attribute"
-    }
-  },
   "required": [
     "filterKey"
   ],
-  "$defs": {
+  "properties": {
+    "filterKey": {
+      "$ref": "#/definitions/Attribute"
+    }
+  },
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -958,18 +958,34 @@ Merges features by attributes
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FeatureMergerParam",
   "type": "object",
   "properties": {
+    "completeGrouped": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "requestorAttribute": {
       "type": [
         "array",
         "null"
       ],
       "items": {
-        "$ref": "#/$defs/Attribute"
+        "$ref": "#/definitions/Attribute"
       }
+    },
+    "requestorAttributeValue": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Expr"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "supplierAttribute": {
       "type": [
@@ -977,37 +993,21 @@ Merges features by attributes
         "null"
       ],
       "items": {
-        "$ref": "#/$defs/Attribute"
+        "$ref": "#/definitions/Attribute"
       }
-    },
-    "requestorAttributeValue": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/Expr"
-        },
-        {
-          "type": "null"
-        }
-      ]
     },
     "supplierAttributeValue": {
       "anyOf": [
         {
-          "$ref": "#/$defs/Expr"
+          "$ref": "#/definitions/Expr"
         },
         {
           "type": "null"
         }
       ]
-    },
-    "completeGrouped": {
-      "type": [
-        "boolean",
-        "null"
-      ]
     }
   },
-  "$defs": {
+  "definitions": {
     "Attribute": {
       "type": "string"
     },
@@ -1034,40 +1034,48 @@ Filters features based on conditions
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FeatureReaderParam",
   "oneOf": [
     {
       "type": "object",
+      "required": [
+        "dataset",
+        "format"
+      ],
       "properties": {
-        "format": {
-          "type": "string",
-          "const": "citygml"
-        },
         "dataset": {
-          "$ref": "#/$defs/Expr"
+          "$ref": "#/definitions/Expr"
         },
         "flatten": {
           "type": [
             "boolean",
             "null"
           ]
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "citygml"
+          ]
         }
-      },
-      "required": [
-        "format",
-        "dataset"
-      ]
+      }
     },
     {
       "type": "object",
+      "required": [
+        "dataset",
+        "format"
+      ],
       "properties": {
+        "dataset": {
+          "$ref": "#/definitions/Expr"
+        },
         "format": {
           "type": "string",
-          "const": "csv"
-        },
-        "dataset": {
-          "$ref": "#/$defs/Expr"
+          "enum": [
+            "csv"
+          ]
         },
         "offset": {
           "type": [
@@ -1075,23 +1083,25 @@ Filters features based on conditions
             "null"
           ],
           "format": "uint",
-          "minimum": 0
+          "minimum": 0.0
         }
-      },
-      "required": [
-        "format",
-        "dataset"
-      ]
+      }
     },
     {
       "type": "object",
+      "required": [
+        "dataset",
+        "format"
+      ],
       "properties": {
+        "dataset": {
+          "$ref": "#/definitions/Expr"
+        },
         "format": {
           "type": "string",
-          "const": "tsv"
-        },
-        "dataset": {
-          "$ref": "#/$defs/Expr"
+          "enum": [
+            "tsv"
+          ]
         },
         "offset": {
           "type": [
@@ -1099,16 +1109,12 @@ Filters features based on conditions
             "null"
           ],
           "format": "uint",
-          "minimum": 0
+          "minimum": 0.0
         }
-      },
-      "required": [
-        "format",
-        "dataset"
-      ]
+      }
     }
   ],
-  "$defs": {
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -1130,52 +1136,21 @@ Sorts features by attributes
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FeatureSorterParam",
   "type": "object",
+  "required": [
+    "sortBy"
+  ],
   "properties": {
     "sortBy": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/SortBy"
+        "$ref": "#/definitions/SortBy"
       }
     }
   },
-  "required": [
-    "sortBy"
-  ],
-  "$defs": {
-    "SortBy": {
-      "type": "object",
-      "properties": {
-        "attribute": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Attribute"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "attributeValue": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/Expr"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "order": {
-          "$ref": "#/$defs/Order"
-        }
-      },
-      "required": [
-        "order"
-      ]
-    },
+  "definitions": {
     "Attribute": {
       "type": "string"
     },
@@ -1188,6 +1163,37 @@ Sorts features by attributes
         "ascending",
         "descending"
       ]
+    },
+    "SortBy": {
+      "type": "object",
+      "required": [
+        "order"
+      ],
+      "properties": {
+        "attribute": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Attribute"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "attributeValue": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "order": {
+          "$ref": "#/definitions/Order"
+        }
+      }
     }
   }
 }
@@ -1207,34 +1213,34 @@ Transforms features by expressions
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FeatureTransformerParam",
   "type": "object",
+  "required": [
+    "transformers"
+  ],
   "properties": {
     "transformers": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/Transform"
+        "$ref": "#/definitions/Transform"
       }
     }
   },
-  "required": [
-    "transformers"
-  ],
-  "$defs": {
-    "Transform": {
-      "type": "object",
-      "properties": {
-        "expr": {
-          "$ref": "#/$defs/Expr"
-        }
-      },
-      "required": [
-        "expr"
-      ]
-    },
+  "definitions": {
     "Expr": {
       "type": "string"
+    },
+    "Transform": {
+      "type": "object",
+      "required": [
+        "expr"
+      ],
+      "properties": {
+        "expr": {
+          "$ref": "#/definitions/Expr"
+        }
+      }
     }
   }
 }
@@ -1254,9 +1260,12 @@ Filters features by feature type
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FeatureTypeFilter",
   "type": "object",
+  "required": [
+    "targetTypes"
+  ],
   "properties": {
     "targetTypes": {
       "type": "array",
@@ -1264,10 +1273,7 @@ Filters features by feature type
         "type": "string"
       }
     }
-  },
-  "required": [
-    "targetTypes"
-  ]
+  }
 }
 ```
 ### Input Ports
@@ -1286,22 +1292,22 @@ Extracts files from a directory or an archive
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FilePathExtractor",
   "type": "object",
+  "required": [
+    "extractArchive",
+    "sourceDataset"
+  ],
   "properties": {
-    "sourceDataset": {
-      "$ref": "#/$defs/Expr"
-    },
     "extractArchive": {
       "type": "boolean"
+    },
+    "sourceDataset": {
+      "$ref": "#/definitions/Expr"
     }
   },
-  "required": [
-    "sourceDataset",
-    "extractArchive"
-  ],
-  "$defs": {
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -1322,17 +1328,17 @@ Extracts properties from a file
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FilePropertyExtractor",
   "type": "object",
+  "required": [
+    "filePathAttribute"
+  ],
   "properties": {
     "filePathAttribute": {
       "type": "string"
     }
-  },
-  "required": [
-    "filePathAttribute"
-  ]
+  }
 }
 ```
 ### Input Ports
@@ -1351,19 +1357,25 @@ Reads features from a file
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FileReader",
   "oneOf": [
     {
       "title": "CSV",
       "type": "object",
+      "required": [
+        "dataset",
+        "format"
+      ],
       "properties": {
+        "dataset": {
+          "$ref": "#/definitions/Expr"
+        },
         "format": {
           "type": "string",
-          "const": "csv"
-        },
-        "dataset": {
-          "$ref": "#/$defs/Expr"
+          "enum": [
+            "csv"
+          ]
         },
         "offset": {
           "type": [
@@ -1371,24 +1383,26 @@ Reads features from a file
             "null"
           ],
           "format": "uint",
-          "minimum": 0
+          "minimum": 0.0
         }
-      },
-      "required": [
-        "format",
-        "dataset"
-      ]
+      }
     },
     {
       "title": "TSV",
       "type": "object",
+      "required": [
+        "dataset",
+        "format"
+      ],
       "properties": {
+        "dataset": {
+          "$ref": "#/definitions/Expr"
+        },
         "format": {
           "type": "string",
-          "const": "tsv"
-        },
-        "dataset": {
-          "$ref": "#/$defs/Expr"
+          "enum": [
+            "tsv"
+          ]
         },
         "offset": {
           "type": [
@@ -1396,56 +1410,56 @@ Reads features from a file
             "null"
           ],
           "format": "uint",
-          "minimum": 0
+          "minimum": 0.0
         }
-      },
-      "required": [
-        "format",
-        "dataset"
-      ]
+      }
     },
     {
       "title": "JSON",
       "type": "object",
+      "required": [
+        "dataset",
+        "format"
+      ],
       "properties": {
+        "dataset": {
+          "$ref": "#/definitions/Expr"
+        },
         "format": {
           "type": "string",
-          "const": "json"
-        },
-        "dataset": {
-          "$ref": "#/$defs/Expr"
+          "enum": [
+            "json"
+          ]
         }
-      },
-      "required": [
-        "format",
-        "dataset"
-      ]
+      }
     },
     {
       "title": "CityGML",
       "type": "object",
+      "required": [
+        "dataset",
+        "format"
+      ],
       "properties": {
-        "format": {
-          "type": "string",
-          "const": "citygml"
-        },
         "dataset": {
-          "$ref": "#/$defs/Expr"
+          "$ref": "#/definitions/Expr"
         },
         "flatten": {
           "type": [
             "boolean",
             "null"
           ]
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "citygml"
+          ]
         }
-      },
-      "required": [
-        "format",
-        "dataset"
-      ]
+      }
     }
   ],
-  "$defs": {
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -1466,76 +1480,88 @@ Writes features to a file
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "FileWriterParam",
   "oneOf": [
     {
       "type": "object",
-      "properties": {
-        "format": {
-          "type": "string",
-          "const": "csv"
-        },
-        "output": {
-          "$ref": "#/$defs/Expr"
-        }
-      },
       "required": [
         "format",
         "output"
-      ]
-    },
-    {
-      "type": "object",
+      ],
       "properties": {
         "format": {
           "type": "string",
-          "const": "tsv"
+          "enum": [
+            "csv"
+          ]
         },
         "output": {
-          "$ref": "#/$defs/Expr"
+          "$ref": "#/definitions/Expr"
         }
-      },
+      }
+    },
+    {
+      "type": "object",
       "required": [
         "format",
         "output"
-      ]
-    },
-    {
-      "type": "object",
+      ],
       "properties": {
         "format": {
           "type": "string",
-          "const": "json"
+          "enum": [
+            "tsv"
+          ]
         },
         "output": {
-          "$ref": "#/$defs/Expr"
-        },
+          "$ref": "#/definitions/Expr"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "format",
+        "output"
+      ],
+      "properties": {
         "converter": {
           "anyOf": [
             {
-              "$ref": "#/$defs/Expr"
+              "$ref": "#/definitions/Expr"
             },
             {
               "type": "null"
             }
           ]
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "json"
+          ]
+        },
+        "output": {
+          "$ref": "#/definitions/Expr"
         }
-      },
-      "required": [
-        "format",
-        "output"
-      ]
+      }
     },
     {
       "type": "object",
+      "required": [
+        "format",
+        "output"
+      ],
       "properties": {
         "format": {
           "type": "string",
-          "const": "excel"
+          "enum": [
+            "excel"
+          ]
         },
         "output": {
-          "$ref": "#/$defs/Expr"
+          "$ref": "#/definitions/Expr"
         },
         "sheetName": {
           "type": [
@@ -1543,14 +1569,10 @@ Writes features to a file
             "null"
           ]
         }
-      },
-      "required": [
-        "format",
-        "output"
-      ]
+      }
     }
   ],
-  "$defs": {
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -1571,31 +1593,31 @@ Writes features to a geojson file
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "GeoJsonWriterParam",
   "type": "object",
+  "required": [
+    "output"
+  ],
   "properties": {
-    "output": {
-      "$ref": "#/$defs/Expr"
-    },
     "groupBy": {
       "type": [
         "array",
         "null"
       ],
       "items": {
-        "$ref": "#/$defs/Attribute"
+        "$ref": "#/definitions/Attribute"
       }
+    },
+    "output": {
+      "$ref": "#/definitions/Expr"
     }
   },
-  "required": [
-    "output"
-  ],
-  "$defs": {
-    "Expr": {
+  "definitions": {
+    "Attribute": {
       "type": "string"
     },
-    "Attribute": {
+    "Expr": {
       "type": "string"
     }
   }
@@ -1615,18 +1637,18 @@ Coerces the geometry of a feature to a specific geometry
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "GeometryCoercer",
   "type": "object",
-  "properties": {
-    "coercerType": {
-      "$ref": "#/$defs/CoercerType"
-    }
-  },
   "required": [
     "coercerType"
   ],
-  "$defs": {
+  "properties": {
+    "coercerType": {
+      "$ref": "#/definitions/CoercerType"
+    }
+  },
+  "definitions": {
     "CoercerType": {
       "type": "string",
       "enum": [
@@ -1651,27 +1673,27 @@ Dissolve geometries
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "GeometryDissolverParam",
   "type": "object",
   "properties": {
+    "completeGrouped": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "groupBy": {
       "type": [
         "array",
         "null"
       ],
       "items": {
-        "$ref": "#/$defs/Attribute"
+        "$ref": "#/definitions/Attribute"
       }
-    },
-    "completeGrouped": {
-      "type": [
-        "boolean",
-        "null"
-      ]
     }
   },
-  "$defs": {
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -1694,18 +1716,18 @@ Extracts geometry from a feature and adds it as an attribute.
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "GeometryExtractor",
   "type": "object",
-  "properties": {
-    "outputAttribute": {
-      "$ref": "#/$defs/Attribute"
-    }
-  },
   "required": [
     "outputAttribute"
   ],
-  "$defs": {
+  "properties": {
+    "outputAttribute": {
+      "$ref": "#/definitions/Attribute"
+    }
+  },
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -1727,44 +1749,50 @@ Filter geometry by type
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "GeometryFilterParam",
   "oneOf": [
     {
       "type": "object",
+      "required": [
+        "filterType"
+      ],
       "properties": {
         "filterType": {
           "type": "string",
-          "const": "none"
+          "enum": [
+            "none"
+          ]
         }
-      },
-      "required": [
-        "filterType"
-      ]
+      }
     },
     {
       "type": "object",
+      "required": [
+        "filterType"
+      ],
       "properties": {
         "filterType": {
           "type": "string",
-          "const": "multiple"
+          "enum": [
+            "multiple"
+          ]
         }
-      },
-      "required": [
-        "filterType"
-      ]
+      }
     },
     {
       "type": "object",
+      "required": [
+        "filterType"
+      ],
       "properties": {
         "filterType": {
           "type": "string",
-          "const": "geometryType"
+          "enum": [
+            "geometryType"
+          ]
         }
-      },
-      "required": [
-        "filterType"
-      ]
+      }
     }
   ]
 }
@@ -1807,18 +1835,18 @@ Replaces the geometry of a feature with a new geometry.
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "GeometryReplacer",
   "type": "object",
-  "properties": {
-    "sourceAttribute": {
-      "$ref": "#/$defs/Attribute"
-    }
-  },
   "required": [
     "sourceAttribute"
   ],
-  "$defs": {
+  "properties": {
+    "sourceAttribute": {
+      "$ref": "#/definitions/Attribute"
+    }
+  },
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -1854,21 +1882,21 @@ Validates the geometry of a feature
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "GeometryValidator",
   "type": "object",
+  "required": [
+    "validationTypes"
+  ],
   "properties": {
     "validationTypes": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/ValidationType"
+        "$ref": "#/definitions/ValidationType"
       }
     }
   },
-  "required": [
-    "validationTypes"
-  ],
-  "$defs": {
+  "definitions": {
     "ValidationType": {
       "type": "string",
       "enum": [
@@ -1914,24 +1942,24 @@ Writes features to a Gltf
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "GltfWriterParam",
   "type": "object",
+  "required": [
+    "output"
+  ],
   "properties": {
-    "output": {
-      "$ref": "#/$defs/Expr"
-    },
     "attachTexture": {
       "type": [
         "boolean",
         "null"
       ]
+    },
+    "output": {
+      "$ref": "#/definitions/Expr"
     }
   },
-  "required": [
-    "output"
-  ],
-  "$defs": {
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -1952,18 +1980,18 @@ Counts the number of holes in a geometry and adds it as an attribute.
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "HoleCounterParam",
   "type": "object",
-  "properties": {
-    "outputAttribute": {
-      "$ref": "#/$defs/Attribute"
-    }
-  },
   "required": [
     "outputAttribute"
   ],
-  "$defs": {
+  "properties": {
+    "outputAttribute": {
+      "$ref": "#/definitions/Attribute"
+    }
+  },
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -2001,7 +2029,7 @@ Reprojects the geometry of a feature to a specified coordinate system
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "HorizontalReprojectorParam",
   "type": "object",
   "properties": {
@@ -2011,7 +2039,7 @@ Reprojects the geometry of a feature to a specified coordinate system
         "null"
       ],
       "format": "uint16",
-      "minimum": 0
+      "minimum": 0.0
     }
   }
 }
@@ -2031,17 +2059,17 @@ Action for first port forwarding for sub-workflows.
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "InputRouter",
   "type": "object",
+  "required": [
+    "routingPort"
+  ],
   "properties": {
     "routingPort": {
       "type": "string"
     }
-  },
-  "required": [
-    "routingPort"
-  ]
+  }
 }
 ```
 ### Input Ports
@@ -2058,9 +2086,12 @@ Intersection points are turned into point features that can contain the merged l
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "LineOnLineOverlayerParam",
   "type": "object",
+  "required": [
+    "outputAttribute"
+  ],
   "properties": {
     "groupBy": {
       "type": [
@@ -2068,17 +2099,14 @@ Intersection points are turned into point features that can contain the merged l
         "null"
       ],
       "items": {
-        "$ref": "#/$defs/Attribute"
+        "$ref": "#/definitions/Attribute"
       }
     },
     "outputAttribute": {
-      "$ref": "#/$defs/Attribute"
+      "$ref": "#/definitions/Attribute"
     }
   },
-  "required": [
-    "outputAttribute"
-  ],
-  "$defs": {
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -2102,18 +2130,18 @@ Explodes list attributes
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ListExploder",
   "type": "object",
-  "properties": {
-    "sourceAttribute": {
-      "$ref": "#/$defs/Attribute"
-    }
-  },
   "required": [
     "sourceAttribute"
   ],
-  "$defs": {
+  "properties": {
+    "sourceAttribute": {
+      "$ref": "#/definitions/Attribute"
+    }
+  },
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -2135,34 +2163,34 @@ Writes features to a file
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MVTWriterParam",
   "type": "object",
+  "required": [
+    "layerName",
+    "maxZoom",
+    "minZoom",
+    "output"
+  ],
   "properties": {
-    "output": {
-      "$ref": "#/$defs/Expr"
-    },
     "layerName": {
-      "$ref": "#/$defs/Expr"
-    },
-    "minZoom": {
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0
+      "$ref": "#/definitions/Expr"
     },
     "maxZoom": {
       "type": "integer",
       "format": "uint8",
-      "minimum": 0
+      "minimum": 0.0
+    },
+    "minZoom": {
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "output": {
+      "$ref": "#/definitions/Expr"
     }
   },
-  "required": [
-    "output",
-    "layerName",
-    "minZoom",
-    "maxZoom"
-  ],
-  "$defs": {
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -2210,7 +2238,7 @@ Adds offsets to the feature's coordinates.
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "OffsetterParam",
   "type": "object",
   "properties": {
@@ -2253,18 +2281,18 @@ Extracts the orientation of a geometry from a feature and adds it as an attribut
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "OrientationExtractorParam",
   "type": "object",
-  "properties": {
-    "outputAttribute": {
-      "$ref": "#/$defs/Attribute"
-    }
-  },
   "required": [
     "outputAttribute"
   ],
-  "$defs": {
+  "properties": {
+    "outputAttribute": {
+      "$ref": "#/definitions/Attribute"
+    }
+  },
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -2286,17 +2314,17 @@ Action for last port forwarding for sub-workflows.
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "OutputRouter",
   "type": "object",
+  "required": [
+    "routingPort"
+  ],
   "properties": {
     "routingPort": {
       "type": "string"
     }
-  },
-  "required": [
-    "routingPort"
-  ]
+  }
 }
 ```
 ### Input Ports
@@ -2476,22 +2504,22 @@ Extracts maxLod
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MaxLodExtractorParam",
   "type": "object",
-  "properties": {
-    "cityGmlPathAttribute": {
-      "$ref": "#/$defs/Attribute"
-    },
-    "maxLodAttribute": {
-      "$ref": "#/$defs/Attribute"
-    }
-  },
   "required": [
     "cityGmlPathAttribute",
     "maxLodAttribute"
   ],
-  "$defs": {
+  "properties": {
+    "cityGmlPathAttribute": {
+      "$ref": "#/definitions/Attribute"
+    },
+    "maxLodAttribute": {
+      "$ref": "#/definitions/Attribute"
+    }
+  },
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -2513,18 +2541,18 @@ Extracts UDX folders from cityGML path
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "UDXFolderExtractorParam",
   "type": "object",
-  "properties": {
-    "cityGmlPath": {
-      "$ref": "#/$defs/Expr"
-    }
-  },
   "required": [
     "cityGmlPath"
   ],
-  "$defs": {
+  "properties": {
+    "cityGmlPath": {
+      "$ref": "#/definitions/Expr"
+    }
+  },
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -2577,22 +2605,22 @@ Calls Rhai script
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "RhaiCallerParam",
   "type": "object",
-  "properties": {
-    "isTarget": {
-      "$ref": "#/$defs/Expr"
-    },
-    "process": {
-      "$ref": "#/$defs/Expr"
-    }
-  },
   "required": [
     "isTarget",
     "process"
   ],
-  "$defs": {
+  "properties": {
+    "isTarget": {
+      "$ref": "#/definitions/Expr"
+    },
+    "process": {
+      "$ref": "#/definitions/Expr"
+    }
+  },
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -2614,24 +2642,27 @@ Calculates statistics of features
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "StatisticsCalculatorParam",
   "type": "object",
+  "required": [
+    "calculations"
+  ],
   "properties": {
-    "aggregateName": {
+    "aggregateAttribute": {
       "anyOf": [
         {
-          "$ref": "#/$defs/Attribute"
+          "$ref": "#/definitions/Attribute"
         },
         {
           "type": "null"
         }
       ]
     },
-    "aggregateAttribute": {
+    "aggregateName": {
       "anyOf": [
         {
-          "$ref": "#/$defs/Attribute"
+          "$ref": "#/definitions/Attribute"
         },
         {
           "type": "null"
@@ -2641,31 +2672,28 @@ Calculates statistics of features
     "calculations": {
       "type": "array",
       "items": {
-        "$ref": "#/$defs/Calculation"
+        "$ref": "#/definitions/Calculation"
       }
     }
   },
-  "required": [
-    "calculations"
-  ],
-  "$defs": {
+  "definitions": {
     "Attribute": {
       "type": "string"
     },
     "Calculation": {
       "type": "object",
-      "properties": {
-        "newAttribute": {
-          "$ref": "#/$defs/Attribute"
-        },
-        "expr": {
-          "$ref": "#/$defs/Expr"
-        }
-      },
       "required": [
-        "newAttribute",
-        "expr"
-      ]
+        "expr",
+        "newAttribute"
+      ],
+      "properties": {
+        "expr": {
+          "$ref": "#/definitions/Expr"
+        },
+        "newAttribute": {
+          "$ref": "#/definitions/Attribute"
+        }
+      }
     },
     "Expr": {
       "type": "string"
@@ -2689,38 +2717,38 @@ Replaces a three Dimension box with a polygon.
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ThreeDimensionBoxReplacer",
   "type": "object",
-  "properties": {
-    "minX": {
-      "$ref": "#/$defs/Attribute"
-    },
-    "minY": {
-      "$ref": "#/$defs/Attribute"
-    },
-    "minZ": {
-      "$ref": "#/$defs/Attribute"
-    },
-    "maxX": {
-      "$ref": "#/$defs/Attribute"
-    },
-    "maxY": {
-      "$ref": "#/$defs/Attribute"
-    },
-    "maxZ": {
-      "$ref": "#/$defs/Attribute"
-    }
-  },
   "required": [
-    "minX",
-    "minY",
-    "minZ",
     "maxX",
     "maxY",
-    "maxZ"
+    "maxZ",
+    "minX",
+    "minY",
+    "minZ"
   ],
-  "$defs": {
+  "properties": {
+    "maxX": {
+      "$ref": "#/definitions/Attribute"
+    },
+    "maxY": {
+      "$ref": "#/definitions/Attribute"
+    },
+    "maxZ": {
+      "$ref": "#/definitions/Attribute"
+    },
+    "minX": {
+      "$ref": "#/definitions/Attribute"
+    },
+    "minY": {
+      "$ref": "#/definitions/Attribute"
+    },
+    "minZ": {
+      "$ref": "#/definitions/Attribute"
+    }
+  },
+  "definitions": {
     "Attribute": {
       "type": "string"
     }
@@ -2742,42 +2770,42 @@ Replaces a three Dimension box with a polygon.
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ThreeDimensionRotatorParam",
   "type": "object",
-  "properties": {
-    "angleDegree": {
-      "$ref": "#/$defs/Expr"
-    },
-    "originX": {
-      "$ref": "#/$defs/Expr"
-    },
-    "originY": {
-      "$ref": "#/$defs/Expr"
-    },
-    "originZ": {
-      "$ref": "#/$defs/Expr"
-    },
-    "directionX": {
-      "$ref": "#/$defs/Expr"
-    },
-    "directionY": {
-      "$ref": "#/$defs/Expr"
-    },
-    "directionZ": {
-      "$ref": "#/$defs/Expr"
-    }
-  },
   "required": [
     "angleDegree",
-    "originX",
-    "originY",
-    "originZ",
     "directionX",
     "directionY",
-    "directionZ"
+    "directionZ",
+    "originX",
+    "originY",
+    "originZ"
   ],
-  "$defs": {
+  "properties": {
+    "angleDegree": {
+      "$ref": "#/definitions/Expr"
+    },
+    "directionX": {
+      "$ref": "#/definitions/Expr"
+    },
+    "directionY": {
+      "$ref": "#/definitions/Expr"
+    },
+    "directionZ": {
+      "$ref": "#/definitions/Expr"
+    },
+    "originX": {
+      "$ref": "#/definitions/Expr"
+    },
+    "originY": {
+      "$ref": "#/definitions/Expr"
+    },
+    "originZ": {
+      "$ref": "#/definitions/Expr"
+    }
+  },
+  "definitions": {
     "Expr": {
       "type": "string"
     }
@@ -2828,18 +2856,18 @@ Reprojects the geometry of a feature to a specified coordinate system
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "VerticalReprojectorParam",
   "type": "object",
-  "properties": {
-    "reprojectorType": {
-      "$ref": "#/$defs/VerticalReprojectorType"
-    }
-  },
   "required": [
     "reprojectorType"
   ],
-  "$defs": {
+  "properties": {
+    "reprojectorType": {
+      "$ref": "#/definitions/VerticalReprojectorType"
+    }
+  },
+  "definitions": {
     "VerticalReprojectorType": {
       "type": "string",
       "enum": [
@@ -2864,26 +2892,26 @@ Compiles scripts into .wasm and runs at the wasm runtime
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "WasmRuntimeExecutorParam",
   "type": "object",
+  "required": [
+    "processorType",
+    "programmingLanguage",
+    "sourceCodeFilePath"
+  ],
   "properties": {
-    "sourceCodeFilePath": {
-      "type": "string"
-    },
     "processorType": {
-      "$ref": "#/$defs/ProcessorType"
+      "$ref": "#/definitions/ProcessorType"
     },
     "programmingLanguage": {
-      "$ref": "#/$defs/ProgrammingLanguage"
+      "$ref": "#/definitions/ProgrammingLanguage"
+    },
+    "sourceCodeFilePath": {
+      "type": "string"
     }
   },
-  "required": [
-    "sourceCodeFilePath",
-    "processorType",
-    "programmingLanguage"
-  ],
-  "$defs": {
+  "definitions": {
     "ProcessorType": {
       "type": "string",
       "enum": [
@@ -2914,39 +2942,41 @@ Fragment XML
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "XmlFragmenterParam",
   "oneOf": [
     {
       "type": "object",
+      "required": [
+        "attribute",
+        "elementsToExclude",
+        "elementsToMatch",
+        "source"
+      ],
       "properties": {
-        "elementsToMatch": {
-          "$ref": "#/$defs/Expr"
+        "attribute": {
+          "$ref": "#/definitions/Attribute"
         },
         "elementsToExclude": {
-          "$ref": "#/$defs/Expr"
+          "$ref": "#/definitions/Expr"
         },
-        "attribute": {
-          "$ref": "#/$defs/Attribute"
+        "elementsToMatch": {
+          "$ref": "#/definitions/Expr"
         },
         "source": {
           "type": "string",
-          "const": "url"
+          "enum": [
+            "url"
+          ]
         }
-      },
-      "required": [
-        "source",
-        "elementsToMatch",
-        "elementsToExclude",
-        "attribute"
-      ]
+      }
     }
   ],
-  "$defs": {
-    "Expr": {
+  "definitions": {
+    "Attribute": {
       "type": "string"
     },
-    "Attribute": {
+    "Expr": {
       "type": "string"
     }
   }
@@ -2967,35 +2997,28 @@ Validates XML content
 ### Parameters
 ```json
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "XmlValidatorParam",
   "type": "object",
-  "properties": {
-    "attribute": {
-      "$ref": "#/$defs/Attribute"
-    },
-    "inputType": {
-      "$ref": "#/$defs/XmlInputType"
-    },
-    "validationType": {
-      "$ref": "#/$defs/ValidationType"
-    }
-  },
   "required": [
     "attribute",
     "inputType",
     "validationType"
   ],
-  "$defs": {
+  "properties": {
+    "attribute": {
+      "$ref": "#/definitions/Attribute"
+    },
+    "inputType": {
+      "$ref": "#/definitions/XmlInputType"
+    },
+    "validationType": {
+      "$ref": "#/definitions/ValidationType"
+    }
+  },
+  "definitions": {
     "Attribute": {
       "type": "string"
-    },
-    "XmlInputType": {
-      "type": "string",
-      "enum": [
-        "file",
-        "text"
-      ]
     },
     "ValidationType": {
       "type": "string",
@@ -3003,6 +3026,13 @@ Validates XML content
         "syntax",
         "syntaxAndNamespace",
         "syntaxAndSchema"
+      ]
+    },
+    "XmlInputType": {
+      "type": "string",
+      "enum": [
+        "file",
+        "text"
       ]
     }
   }

--- a/engine/runtime/action-plateau-processor/src/plateau3/attribute_flattener.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/attribute_flattener.rs
@@ -400,7 +400,7 @@ impl ProcessorFactory for AttributeFlattenerFactory {
         "Flatten attributes for building feature"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/building_installation_geometry_type_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/building_installation_geometry_type_extractor.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for BuildingInstallationGeometryTypeExtractorFactory {
         "Extracts BuildingInstallationGeometryType"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/building_usage_attribute_validator.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/building_usage_attribute_validator.rs
@@ -50,7 +50,7 @@ impl ProcessorFactory for BuildingUsageAttributeValidatorFactory {
         "This processor validates building usage attributes by checking for the presence of required attributes and ensuring the correctness of city codes. It outputs errors through the lBldgError and codeError ports if any issues are found."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/dictionaries_initiator.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/dictionaries_initiator.rs
@@ -39,7 +39,7 @@ impl ProcessorFactory for DictionariesInitiatorFactory {
         "Initializes dictionaries for PLATEAU"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/domain_of_definition_validator.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/domain_of_definition_validator.rs
@@ -286,7 +286,7 @@ impl ProcessorFactory for DomainOfDefinitionValidatorFactory {
         "Validates domain of definition of CityGML features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/max_lod_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/max_lod_extractor.rs
@@ -28,7 +28,7 @@ impl ProcessorFactory for MaxLodExtractorFactory {
         "Extracts maxLod"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/tran_xlink_checker.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/tran_xlink_checker.rs
@@ -31,7 +31,7 @@ impl ProcessorFactory for TranXLinkCheckerFactory {
         "Check Xlink for Tran"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/udx_folder_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/udx_folder_extractor.rs
@@ -65,7 +65,7 @@ impl ProcessorFactory for UdxFolderExtractorFactory {
         "Extracts UDX folders from cityGML path"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/unmatched_xlink_detector.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/unmatched_xlink_detector.rs
@@ -115,7 +115,7 @@ impl ProcessorFactory for UnmatchedXlinkDetectorFactory {
         "Detect unmatched xlink for PLATEAU"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau3/xml_attribute_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/xml_attribute_extractor.rs
@@ -412,7 +412,7 @@ impl ProcessorFactory for XmlAttributeExtractorFactory {
         "Extracts attributes from XML fragments based on a schema definition"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau4/attribute_flattener.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/attribute_flattener.rs
@@ -400,7 +400,7 @@ impl ProcessorFactory for AttributeFlattenerFactory {
         "Flatten attributes for building feature"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau4/max_lod_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/max_lod_extractor.rs
@@ -24,7 +24,7 @@ impl ProcessorFactory for MaxLodExtractorFactory {
         "Extracts maxLod"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(MaxLodExtractorParam))
     }
 

--- a/engine/runtime/action-plateau-processor/src/plateau4/udx_folder_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/udx_folder_extractor.rs
@@ -67,7 +67,7 @@ impl ProcessorFactory for UDXFolderExtractorFactory {
         "Extracts UDX folders from cityGML path"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(UDXFolderExtractorParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/aggregator.rs
+++ b/engine/runtime/action-processor/src/attribute/aggregator.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for AttributeAggregatorFactory {
         "Aggregates features by attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(AttributeAggregatorParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/bulk_renamer.rs
+++ b/engine/runtime/action-processor/src/attribute/bulk_renamer.rs
@@ -24,7 +24,7 @@ impl ProcessorFactory for BulkAttributeRenamerFactory {
         "Renames attributes by adding/removing prefixes or suffixes, or replacing text"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(BulkAttributeRenamerParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/duplicate_filter.rs
+++ b/engine/runtime/action-processor/src/attribute/duplicate_filter.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for AttributeDuplicateFilterFactory {
         "Filters features by duplicate attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(AttributeDuplicateFilterParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/file_path_info_extractor.rs
+++ b/engine/runtime/action-processor/src/attribute/file_path_info_extractor.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for AttributeFilePathInfoExtractorFactory {
         "Extracts file path information from attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(AttributeFilePathInfoExtractor))
     }
 

--- a/engine/runtime/action-processor/src/attribute/manager.rs
+++ b/engine/runtime/action-processor/src/attribute/manager.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for AttributeManagerFactory {
         "Manages attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(AttributeManagerParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/mapper.rs
+++ b/engine/runtime/action-processor/src/attribute/mapper.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for AttributeMapperFactory {
         "Maps attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(AttributeMapperParam))
     }
 

--- a/engine/runtime/action-processor/src/attribute/statistics_calculator.rs
+++ b/engine/runtime/action-processor/src/attribute/statistics_calculator.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for StatisticsCalculatorFactory {
         "Calculates statistics of features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(StatisticsCalculatorParam))
     }
 

--- a/engine/runtime/action-processor/src/echo.rs
+++ b/engine/runtime/action-processor/src/echo.rs
@@ -21,7 +21,7 @@ impl ProcessorFactory for EchoProcessorFactory {
         "Echo features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/feature/counter.rs
+++ b/engine/runtime/action-processor/src/feature/counter.rs
@@ -68,7 +68,7 @@ impl ProcessorFactory for FeatureCounterFactory {
         "Counts features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FeatureCounterParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/file_path_extractor.rs
+++ b/engine/runtime/action-processor/src/feature/file_path_extractor.rs
@@ -31,7 +31,7 @@ impl ProcessorFactory for FeatureFilePathExtractorFactory {
         "Extracts features by file path"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FeatureFilePathExtractorParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/filter.rs
+++ b/engine/runtime/action-processor/src/feature/filter.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for FeatureFilterFactory {
         "Filters features based on conditions"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FeatureFilterParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/list_exploder.rs
+++ b/engine/runtime/action-processor/src/feature/list_exploder.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for ListExploderFactory {
         "Explodes list attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(ListExploder))
     }
 

--- a/engine/runtime/action-processor/src/feature/lod_filter.rs
+++ b/engine/runtime/action-processor/src/feature/lod_filter.rs
@@ -33,7 +33,7 @@ impl ProcessorFactory for FeatureLodFilterFactory {
         "Filter Geometry by lod"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FeatureLodFilterParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/merger.rs
+++ b/engine/runtime/action-processor/src/feature/merger.rs
@@ -35,7 +35,7 @@ impl ProcessorFactory for FeatureMergerFactory {
         "Merges features by attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FeatureMergerParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/reader.rs
+++ b/engine/runtime/action-processor/src/feature/reader.rs
@@ -30,7 +30,7 @@ impl ProcessorFactory for FeatureReaderFactory {
         "Filters features based on conditions"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FeatureReaderParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/rhai.rs
+++ b/engine/runtime/action-processor/src/feature/rhai.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for RhaiCallerFactory {
         "Calls Rhai script"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(RhaiCallerParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/sorter.rs
+++ b/engine/runtime/action-processor/src/feature/sorter.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for FeatureSorterFactory {
         "Sorts features by attributes"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FeatureSorterParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/transformer.rs
+++ b/engine/runtime/action-processor/src/feature/transformer.rs
@@ -28,7 +28,7 @@ impl ProcessorFactory for FeatureTransformerFactory {
         "Transforms features by expressions"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FeatureTransformerParam))
     }
 

--- a/engine/runtime/action-processor/src/feature/type_filter.rs
+++ b/engine/runtime/action-processor/src/feature/type_filter.rs
@@ -28,7 +28,7 @@ impl ProcessorFactory for FeatureTypeFilterFactory {
         "Filters features by feature type"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FeatureTypeFilter))
     }
 

--- a/engine/runtime/action-processor/src/file/property_extractor.rs
+++ b/engine/runtime/action-processor/src/file/property_extractor.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for FilePropertyExtractorFactory {
         "Extracts properties from a file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FilePropertyExtractor))
     }
 

--- a/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
@@ -43,7 +43,7 @@ impl ProcessorFactory for AreaOnAreaOverlayerFactory {
         "Overlays an area on another area"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(AreaOnAreaOverlayerParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
@@ -60,7 +60,7 @@ impl ProcessorFactory for BoundsExtractorFactory {
         "Bounds Extractor"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/bufferer.rs
+++ b/engine/runtime/action-processor/src/geometry/bufferer.rs
@@ -32,7 +32,7 @@ impl ProcessorFactory for BuffererFactory {
         "Buffers a geometry"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(Bufferer))
     }
 

--- a/engine/runtime/action-processor/src/geometry/center_point_replacer.rs
+++ b/engine/runtime/action-processor/src/geometry/center_point_replacer.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for CenterPointReplacerFactory {
         "Replaces the geometry of the feature with a point that is either in the center of the feature's bounding box, at the center of mass of the feature, or somewhere guaranteed to be inside the feature's area."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/clipper.rs
+++ b/engine/runtime/action-processor/src/geometry/clipper.rs
@@ -35,7 +35,7 @@ impl ProcessorFactory for ClipperFactory {
         "Divides Candidate features using Clipper features, so that Candidates and parts of Candidates that are inside or outside of the Clipper features are output separately"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/closed_curve_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/closed_curve_filter.rs
@@ -30,7 +30,7 @@ impl ProcessorFactory for ClosedCurveFilterFactory {
         "Checks if curves form closed loops"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/coercer.rs
+++ b/engine/runtime/action-processor/src/geometry/coercer.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for GeometryCoercerFactory {
         "Coerces the geometry of a feature to a specific geometry"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(GeometryCoercer))
     }
 

--- a/engine/runtime/action-processor/src/geometry/coordinate_system_setter.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_system_setter.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for CoordinateSystemSetterFactory {
         "Sets the coordinate system of a feature"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(CoordinateSystemSetter))
     }
 

--- a/engine/runtime/action-processor/src/geometry/dimension_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/dimension_filter.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for DimensionFilterFactory {
         "Filters the dimension of features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/dissolver.rs
+++ b/engine/runtime/action-processor/src/geometry/dissolver.rs
@@ -37,7 +37,7 @@ impl ProcessorFactory for GeometryDissolverFactory {
         "Dissolve geometries"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(GeometryDissolverParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/elevation_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/elevation_extractor.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for ElevationExtractorFactory {
         "Extracts a feature’s first z coordinate value, storing it in an attribute."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(ElevationExtractorParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/extractor.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for GeometryExtractorFactory {
         "Extracts geometry from a feature and adds it as an attribute."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(GeometryExtractor))
     }
 

--- a/engine/runtime/action-processor/src/geometry/extruder.rs
+++ b/engine/runtime/action-processor/src/geometry/extruder.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for ExtruderFactory {
         "Extrudes a polygon by a distance"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(ExtruderParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/filter.rs
+++ b/engine/runtime/action-processor/src/geometry/filter.rs
@@ -31,7 +31,7 @@ impl ProcessorFactory for GeometryFilterFactory {
         "Filter geometry by type"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(GeometryFilterParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/hole_counter.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_counter.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for HoleCounterFactory {
         "Counts the number of holes in a geometry and adds it as an attribute."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(HoleCounterParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/hole_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_extractor.rs
@@ -30,7 +30,7 @@ impl ProcessorFactory for HoleExtractorFactory {
         "Extracts holes in a geometry and adds it as an attribute."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/horizontal_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/horizontal_reprojector.rs
@@ -34,7 +34,7 @@ impl ProcessorFactory for HorizontalReprojectorFactory {
         "Reprojects the geometry of a feature to a specified coordinate system"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(HorizontalReprojectorParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -41,7 +41,7 @@ impl ProcessorFactory for LineOnLineOverlayerFactory {
         "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(LineOnLineOverlayerParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/offsetter.rs
+++ b/engine/runtime/action-processor/src/geometry/offsetter.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for OffsetterFactory {
         "Adds offsets to the feature's coordinates."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(OffsetterParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/orientation_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/orientation_extractor.rs
@@ -36,7 +36,7 @@ impl ProcessorFactory for OrientationExtractorFactory {
         "Extracts the orientation of a geometry from a feature and adds it as an attribute."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(OrientationExtractorParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/planarity_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/planarity_filter.rs
@@ -26,7 +26,7 @@ impl ProcessorFactory for PlanarityFilterFactory {
         "Filter geometry by type"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/refiner.rs
+++ b/engine/runtime/action-processor/src/geometry/refiner.rs
@@ -33,7 +33,7 @@ impl ProcessorFactory for RefinerFactory {
         "Geometry Refiner"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/replacer.rs
+++ b/engine/runtime/action-processor/src/geometry/replacer.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for GeometryReplacerFactory {
         "Replaces the geometry of a feature with a new geometry."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(GeometryReplacer))
     }
 

--- a/engine/runtime/action-processor/src/geometry/splitter.rs
+++ b/engine/runtime/action-processor/src/geometry/splitter.rs
@@ -22,7 +22,7 @@ impl ProcessorFactory for GeometrySplitterFactory {
         "Split geometry by type"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/three_dimension_box_replacer.rs
+++ b/engine/runtime/action-processor/src/geometry/three_dimension_box_replacer.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for ThreeDimensionBoxReplacerFactory {
         "Replaces a three Dimension box with a polygon."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(ThreeDimensionBoxReplacer))
     }
 

--- a/engine/runtime/action-processor/src/geometry/three_dimension_rotator.rs
+++ b/engine/runtime/action-processor/src/geometry/three_dimension_rotator.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for ThreeDimensionRotatorFactory {
         "Replaces a three Dimension box with a polygon."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(ThreeDimensionRotatorParam))
     }
 

--- a/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
+++ b/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
@@ -23,7 +23,7 @@ impl ProcessorFactory for TwoDimensionForcerFactory {
         "Forces a geometry to be two dimensional."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/validator.rs
+++ b/engine/runtime/action-processor/src/geometry/validator.rs
@@ -37,7 +37,7 @@ impl ProcessorFactory for GeometryValidatorFactory {
         "Validates the geometry of a feature"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(GeometryValidator))
     }
 

--- a/engine/runtime/action-processor/src/geometry/value_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/value_filter.rs
@@ -28,7 +28,7 @@ impl ProcessorFactory for GeometryValueFilterFactory {
         "Filter geometry by value"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/vertex_remover.rs
+++ b/engine/runtime/action-processor/src/geometry/vertex_remover.rs
@@ -30,7 +30,7 @@ impl ProcessorFactory for VertexRemoverFactory {
         "Removes specific vertices from a feature’s geometry"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/geometry/vertical_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/vertical_reprojector.rs
@@ -27,7 +27,7 @@ impl ProcessorFactory for VerticalReprojectorFactory {
         "Reprojects the geometry of a feature to a specified coordinate system"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(VerticalReprojectorParam))
     }
 

--- a/engine/runtime/action-processor/src/noop.rs
+++ b/engine/runtime/action-processor/src/noop.rs
@@ -21,7 +21,7 @@ impl ProcessorFactory for NoopProcessorFactory {
         "Noop features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-processor/src/xml/fragmenter.rs
+++ b/engine/runtime/action-processor/src/xml/fragmenter.rs
@@ -30,7 +30,7 @@ impl ProcessorFactory for XmlFragmenterFactory {
         "Fragment XML"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(XmlFragmenterParam))
     }
 

--- a/engine/runtime/action-processor/src/xml/validator.rs
+++ b/engine/runtime/action-processor/src/xml/validator.rs
@@ -98,7 +98,7 @@ impl ProcessorFactory for XmlValidatorFactory {
         "Validates XML content"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(XmlValidatorParam))
     }
 

--- a/engine/runtime/action-sink/src/echo.rs
+++ b/engine/runtime/action-sink/src/echo.rs
@@ -18,7 +18,7 @@ impl SinkFactory for EchoSinkFactory {
         "Echo features"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
@@ -64,7 +64,7 @@ impl SinkFactory for Cesium3DTilesSinkFactory {
         "Writes features to a file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(Cesium3DTilesWriterParam))
     }
 

--- a/engine/runtime/action-sink/src/file/geojson.rs
+++ b/engine/runtime/action-sink/src/file/geojson.rs
@@ -29,7 +29,7 @@ impl SinkFactory for GeoJsonWriterFactory {
         "Writes features to a geojson file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(GeoJsonWriterParam))
     }
 

--- a/engine/runtime/action-sink/src/file/gltf.rs
+++ b/engine/runtime/action-sink/src/file/gltf.rs
@@ -47,7 +47,7 @@ impl SinkFactory for GltfWriterSinkFactory {
         "Writes features to a Gltf"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(GltfWriterParam))
     }
 

--- a/engine/runtime/action-sink/src/file/mvt/sink.rs
+++ b/engine/runtime/action-sink/src/file/mvt/sink.rs
@@ -49,7 +49,7 @@ impl SinkFactory for MVTSinkFactory {
         "Writes features to a file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(MVTWriterParam))
     }
 

--- a/engine/runtime/action-sink/src/file/writer.rs
+++ b/engine/runtime/action-sink/src/file/writer.rs
@@ -35,7 +35,7 @@ impl SinkFactory for FileWriterSinkFactory {
         "Writes features to a file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FileWriterParam))
     }
 

--- a/engine/runtime/action-sink/src/noop.rs
+++ b/engine/runtime/action-sink/src/noop.rs
@@ -18,7 +18,7 @@ impl SinkFactory for NoopSinkFactory {
         "noop sink"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         None
     }
 

--- a/engine/runtime/action-source/src/feature_creator.rs
+++ b/engine/runtime/action-source/src/feature_creator.rs
@@ -27,7 +27,7 @@ impl SourceFactory for FeatureCreatorFactory {
         "Creates features from expressions"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FeatureCreator))
     }
 

--- a/engine/runtime/action-source/src/file/path_extractor.rs
+++ b/engine/runtime/action-source/src/file/path_extractor.rs
@@ -36,7 +36,7 @@ impl SourceFactory for FilePathExtractorFactory {
         "Extracts files from a directory or an archive"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FilePathExtractor))
     }
 

--- a/engine/runtime/action-source/src/file/reader.rs
+++ b/engine/runtime/action-source/src/file/reader.rs
@@ -29,7 +29,7 @@ impl SourceFactory for FileReaderFactory {
         "Reads features from a file"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(FileReader))
     }
 

--- a/engine/runtime/action-wasm-processor/src/runtime_executor.rs
+++ b/engine/runtime/action-wasm-processor/src/runtime_executor.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for WasmRuntimeExecutorFactory {
         "Compiles scripts into .wasm and runs at the wasm runtime"
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(WasmRuntimeExecutorParam))
     }
 

--- a/engine/runtime/runtime/src/node.rs
+++ b/engine/runtime/runtime/src/node.rs
@@ -211,7 +211,7 @@ pub trait SourceFactory: Send + Sync + Debug + SourceFactoryClone {
     fn description(&self) -> &str {
         ""
     }
-    fn parameter_schema(&self) -> Option<schemars::Schema>;
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema>;
 
     fn categories(&self) -> &[&'static str] {
         &[]
@@ -275,7 +275,7 @@ pub trait ProcessorFactory: Send + Sync + Debug + ProcessorFactoryClone {
     fn description(&self) -> &str {
         ""
     }
-    fn parameter_schema(&self) -> Option<schemars::Schema>;
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema>;
 
     fn categories(&self) -> &[&'static str] {
         &[]
@@ -337,7 +337,7 @@ pub trait SinkFactory: Send + Sync + Debug + SinkFactoryClone {
     fn description(&self) -> &str {
         ""
     }
-    fn parameter_schema(&self) -> Option<schemars::Schema>;
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema>;
 
     fn categories(&self) -> &[&'static str] {
         &[]
@@ -402,7 +402,7 @@ impl ProcessorFactory for InputRouterFactory {
         "Action for first port forwarding for sub-workflows."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(InputRouter))
     }
 
@@ -484,7 +484,7 @@ impl ProcessorFactory for OutputRouterFactory {
         "Action for last port forwarding for sub-workflows."
     }
 
-    fn parameter_schema(&self) -> Option<schemars::Schema> {
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
         Some(schemars::schema_for!(OutputRouter))
     }
 

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -5,9 +5,12 @@
       "type": "processor",
       "description": "Overlays an area on another area",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -15,17 +18,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -49,25 +49,33 @@
       "type": "processor",
       "description": "Aggregates features by attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeAggregatorParam",
         "type": "object",
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/AggregateAttribute"
+              "$ref": "#/definitions/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "calculationAttribute": {
+            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -76,29 +84,21 @@
             ],
             "format": "int64"
           },
-          "calculationAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
           "method": {
-            "$ref": "#/$defs/Method"
+            "$ref": "#/definitions/Method"
           }
         },
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
-        "$defs": {
+        "definitions": {
           "AggregateAttribute": {
             "type": "object",
+            "required": [
+              "newAttribute"
+            ],
             "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
               "attribute": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Attribute"
+                    "$ref": "#/definitions/Attribute"
                   },
                   {
                     "type": "null"
@@ -108,17 +108,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
               }
-            },
-            "required": [
-              "newAttribute"
-            ]
+            }
           },
           "Attribute": {
             "type": "string"
@@ -152,21 +152,21 @@
       "type": "processor",
       "description": "Filters features by duplicate attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
+        "required": [
+          "filterBy"
+        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
-        "required": [
-          "filterBy"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -188,18 +188,18 @@
       "type": "processor",
       "description": "Extracts file path information from attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "attribute"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -222,45 +222,23 @@
       "type": "processor",
       "description": "Manages attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeManagerParam",
         "type": "object",
+        "required": [
+          "operations"
+        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Operation"
+              "$ref": "#/definitions/Operation"
             }
           }
         },
-        "required": [
-          "operations"
-        ],
-        "$defs": {
-          "Operation": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/$defs/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "attribute",
-              "method"
-            ]
+        "definitions": {
+          "Expr": {
+            "type": "string"
           },
           "Method": {
             "type": "string",
@@ -271,8 +249,30 @@
               "remove"
             ]
           },
-          "Expr": {
-            "type": "string"
+          "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/definitions/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
           }
         }
       },
@@ -292,47 +292,28 @@
       "type": "processor",
       "description": "Maps attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeMapperParam",
         "type": "object",
+        "required": [
+          "mappers"
+        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Mapper"
+              "$ref": "#/definitions/Mapper"
             }
           }
         },
-        "required": [
-          "mappers"
-        ],
-        "$defs": {
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -344,20 +325,39 @@
                   "null"
                 ]
               },
-              "multipleExpr": {
+              "expr": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "multipleExpr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "parentAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           }
         }
       },
@@ -394,12 +394,17 @@
       "type": "processor",
       "description": "Buffers a geometry",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Bufferer",
         "type": "object",
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/$defs/BufferType"
+            "$ref": "#/definitions/BufferType"
           },
           "distance": {
             "type": "number",
@@ -410,12 +415,7 @@
             "format": "double"
           }
         },
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
-        "$defs": {
+        "definitions": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -441,21 +441,20 @@
       "type": "processor",
       "description": "Renames attributes by adding/removing prefixes or suffixes, or replacing text",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
+        "required": [
+          "renameAction",
+          "renameType",
+          "renameValue"
+        ],
         "properties": {
-          "renameType": {
-            "$ref": "#/$defs/RenameType"
-          },
           "renameAction": {
-            "$ref": "#/$defs/RenameAction"
+            "$ref": "#/definitions/RenameAction"
           },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
+          "renameType": {
+            "$ref": "#/definitions/RenameType"
           },
           "renameValue": {
             "type": "string"
@@ -468,21 +467,15 @@
             "items": {
               "type": "string"
             }
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
-        "required": [
-          "renameType",
-          "renameAction",
-          "renameValue"
-        ],
-        "$defs": {
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
-            ]
-          },
+        "definitions": {
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -491,6 +484,13 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
+            ]
+          },
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
             ]
           }
         }
@@ -528,36 +528,36 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
+        "required": [
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -614,19 +614,19 @@
       "type": "processor",
       "description": "Sets the coordinate system of a feature",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "CoordinateSystemSetter",
         "type": "object",
+        "required": [
+          "epsgCode"
+        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
-        },
-        "required": [
-          "epsgCode"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -692,18 +692,18 @@
       "type": "processor",
       "description": "Extracts a feature’s first z coordinate value, storing it in an attribute.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ElevationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -725,18 +725,18 @@
       "type": "processor",
       "description": "Extrudes a polygon by a distance",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ExtruderParam",
         "type": "object",
-        "properties": {
-          "distance": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "distance"
         ],
-        "$defs": {
+        "properties": {
+          "distance": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -758,9 +758,13 @@
       "type": "processor",
       "description": "Counts features",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCounterParam",
         "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,18 +776,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -806,18 +806,18 @@
       "type": "source",
       "description": "Creates features from expressions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCreator",
         "type": "object",
-        "properties": {
-          "creator": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "creator"
         ],
-        "$defs": {
+        "properties": {
+          "creator": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -837,22 +837,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -875,35 +875,35 @@
       "type": "processor",
       "description": "Filters features based on conditions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilterParam",
         "type": "object",
+        "required": [
+          "conditions"
+        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Condition"
+              "$ref": "#/definitions/Condition"
             }
           }
         },
-        "required": [
-          "conditions"
-        ],
-        "$defs": {
+        "definitions": {
           "Condition": {
             "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/$defs/Port"
-              }
-            },
             "required": [
               "expr",
               "outputPort"
-            ]
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/definitions/Port"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -929,18 +929,18 @@
       "type": "processor",
       "description": "Filter Geometry by lod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureLodFilterParam",
         "type": "object",
-        "properties": {
-          "filterKey": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "filterKey"
         ],
-        "$defs": {
+        "properties": {
+          "filterKey": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -966,18 +966,34 @@
       "type": "processor",
       "description": "Merges features by attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "requestorAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "supplierAttribute": {
             "type": [
@@ -985,37 +1001,21 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1042,40 +1042,48 @@
       "type": "processor",
       "description": "Filters features based on conditions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1083,23 +1091,25 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1107,16 +1117,12 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1138,52 +1144,21 @@
       "type": "processor",
       "description": "Sorts features by attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureSorterParam",
         "type": "object",
+        "required": [
+          "sortBy"
+        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/SortBy"
+              "$ref": "#/definitions/SortBy"
             }
           }
         },
-        "required": [
-          "sortBy"
-        ],
-        "$defs": {
-          "SortBy": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/$defs/Order"
-              }
-            },
-            "required": [
-              "order"
-            ]
-          },
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1196,6 +1171,37 @@
               "ascending",
               "descending"
             ]
+          },
+          "SortBy": {
+            "type": "object",
+            "required": [
+              "order"
+            ],
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/definitions/Order"
+              }
+            }
           }
         }
       },
@@ -1215,34 +1221,34 @@
       "type": "processor",
       "description": "Transforms features by expressions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTransformerParam",
         "type": "object",
+        "required": [
+          "transformers"
+        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Transform"
+              "$ref": "#/definitions/Transform"
             }
           }
         },
-        "required": [
-          "transformers"
-        ],
-        "$defs": {
-          "Transform": {
-            "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
-            "required": [
-              "expr"
-            ]
-          },
+        "definitions": {
           "Expr": {
             "type": "string"
+          },
+          "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
           }
         }
       },
@@ -1262,9 +1268,12 @@
       "type": "processor",
       "description": "Filters features by feature type",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTypeFilter",
         "type": "object",
+        "required": [
+          "targetTypes"
+        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1272,10 +1281,7 @@
               "type": "string"
             }
           }
-        },
-        "required": [
-          "targetTypes"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1294,22 +1300,22 @@
       "type": "source",
       "description": "Extracts files from a directory or an archive",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePathExtractor",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1329,17 +1335,17 @@
       "type": "processor",
       "description": "Extracts properties from a file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePropertyExtractor",
         "type": "object",
+        "required": [
+          "filePathAttribute"
+        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        },
-        "required": [
-          "filePathAttribute"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1358,19 +1364,25 @@
       "type": "source",
       "description": "Reads features from a file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileReader",
         "oneOf": [
           {
             "title": "CSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1378,24 +1390,26 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "TSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1403,56 +1417,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "JSON",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "json"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "json"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "CityGML",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1472,76 +1486,88 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "properties": {
-              "format": {
-                "type": "string",
-                "const": "csv"
-              },
-              "output": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "tsv"
+                "enum": [
+                  "csv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               }
-            },
+            }
+          },
+          {
+            "type": "object",
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "json"
+                "enum": [
+                  "tsv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
-              },
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "excel"
+                "enum": [
+                  "excel"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1549,14 +1575,10 @@
                   "null"
                 ]
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1576,31 +1598,31 @@
       "type": "sink",
       "description": "Writes features to a geojson file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeoJsonWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -1619,18 +1641,18 @@
       "type": "processor",
       "description": "Coerces the geometry of a feature to a specific geometry",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryCoercer",
         "type": "object",
-        "properties": {
-          "coercerType": {
-            "$ref": "#/$defs/CoercerType"
-          }
-        },
         "required": [
           "coercerType"
         ],
-        "$defs": {
+        "properties": {
+          "coercerType": {
+            "$ref": "#/definitions/CoercerType"
+          }
+        },
+        "definitions": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1655,27 +1677,27 @@
       "type": "processor",
       "description": "Dissolve geometries",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1698,18 +1720,18 @@
       "type": "processor",
       "description": "Extracts geometry from a feature and adds it as an attribute.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryExtractor",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1731,44 +1753,50 @@
       "type": "processor",
       "description": "Filter geometry by type",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "none"
+                "enum": [
+                  "none"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "multiple"
+                "enum": [
+                  "multiple"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "geometryType"
+                "enum": [
+                  "geometryType"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           }
         ]
       },
@@ -1811,18 +1839,18 @@
       "type": "processor",
       "description": "Replaces the geometry of a feature with a new geometry.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryReplacer",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1860,21 +1888,21 @@
       "type": "processor",
       "description": "Validates the geometry of a feature",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryValidator",
         "type": "object",
+        "required": [
+          "validationTypes"
+        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/ValidationType"
+              "$ref": "#/definitions/ValidationType"
             }
           }
         },
-        "required": [
-          "validationTypes"
-        ],
-        "$defs": {
+        "definitions": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1922,24 +1950,24 @@
       "type": "sink",
       "description": "Writes features to a Gltf",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GltfWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1959,18 +1987,18 @@
       "type": "processor",
       "description": "Counts the number of holes in a geometry and adds it as an attribute.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HoleCounterParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2010,7 +2038,7 @@
       "type": "processor",
       "description": "Reprojects the geometry of a feature to a specified coordinate system",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2020,7 +2048,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
         }
       },
@@ -2040,17 +2068,17 @@
       "type": "processor",
       "description": "Action for first port forwarding for sub-workflows.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "InputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [],
@@ -2066,9 +2094,12 @@
       "type": "processor",
       "description": "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2076,17 +2107,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2110,18 +2138,18 @@
       "type": "processor",
       "description": "Explodes list attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ListExploder",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2143,34 +2171,34 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MVTWriterParam",
         "type": "object",
+        "required": [
+          "layerName",
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "layerName": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
+            "$ref": "#/definitions/Expr"
           },
           "maxZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "layerName",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2220,7 +2248,7 @@
       "type": "processor",
       "description": "Adds offsets to the feature's coordinates.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2263,18 +2291,18 @@
       "type": "processor",
       "description": "Extracts the orientation of a geometry from a feature and adds it as an attribute.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OrientationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2296,17 +2324,17 @@
       "type": "processor",
       "description": "Action for last port forwarding for sub-workflows.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OutputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -2507,22 +2535,22 @@
       "type": "processor",
       "description": "Extracts maxLod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MaxLodExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPathAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxLodAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "cityGmlPathAttribute",
           "maxLodAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPathAttribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxLodAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2544,18 +2572,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "UDXFolderExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "cityGmlPath"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2612,22 +2640,22 @@
       "type": "processor",
       "description": "Calls Rhai script",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "RhaiCallerParam",
         "type": "object",
-        "properties": {
-          "isTarget": {
-            "$ref": "#/$defs/Expr"
-          },
-          "process": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "isTarget",
           "process"
         ],
-        "$defs": {
+        "properties": {
+          "isTarget": {
+            "$ref": "#/definitions/Expr"
+          },
+          "process": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2649,24 +2677,27 @@
       "type": "processor",
       "description": "Calculates statistics of features",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "StatisticsCalculatorParam",
         "type": "object",
+        "required": [
+          "calculations"
+        ],
         "properties": {
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
@@ -2676,31 +2707,28 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Calculation"
+              "$ref": "#/definitions/Calculation"
             }
           }
         },
-        "required": [
-          "calculations"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
-              "newAttribute",
-              "expr"
-            ]
+              "expr",
+              "newAttribute"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -2724,38 +2752,38 @@
       "type": "processor",
       "description": "Replaces a three Dimension box with a polygon.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "properties": {
-          "minX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minZ": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
-          "minX",
-          "minY",
-          "minZ",
           "maxX",
           "maxY",
-          "maxZ"
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
         ],
-        "$defs": {
+        "properties": {
+          "maxX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minZ": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2777,42 +2805,42 @@
       "type": "processor",
       "description": "Replaces a three Dimension box with a polygon.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "properties": {
-          "angleDegree": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originZ": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "angleDegree",
-          "originX",
-          "originY",
-          "originZ",
           "directionX",
           "directionY",
-          "directionZ"
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
         ],
-        "$defs": {
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2867,18 +2895,18 @@
       "type": "processor",
       "description": "Reprojects the geometry of a feature to a specified coordinate system",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "VerticalReprojectorParam",
         "type": "object",
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/$defs/VerticalReprojectorType"
-          }
-        },
         "required": [
           "reprojectorType"
         ],
-        "$defs": {
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/definitions/VerticalReprojectorType"
+          }
+        },
+        "definitions": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2903,26 +2931,26 @@
       "type": "processor",
       "description": "Compiles scripts into .wasm and runs at the wasm runtime",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
+        "required": [
+          "processorType",
+          "programmingLanguage",
+          "sourceCodeFilePath"
+        ],
         "properties": {
-          "sourceCodeFilePath": {
-            "type": "string"
-          },
           "processorType": {
-            "$ref": "#/$defs/ProcessorType"
+            "$ref": "#/definitions/ProcessorType"
           },
           "programmingLanguage": {
-            "$ref": "#/$defs/ProgrammingLanguage"
+            "$ref": "#/definitions/ProgrammingLanguage"
+          },
+          "sourceCodeFilePath": {
+            "type": "string"
           }
         },
-        "required": [
-          "sourceCodeFilePath",
-          "processorType",
-          "programmingLanguage"
-        ],
-        "$defs": {
+        "definitions": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2953,39 +2981,41 @@
       "type": "processor",
       "description": "Fragment XML",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
             "properties": {
-              "elementsToMatch": {
-                "$ref": "#/$defs/Expr"
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               },
               "elementsToExclude": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
-              "attribute": {
-                "$ref": "#/$defs/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/definitions/Expr"
               },
               "source": {
                 "type": "string",
-                "const": "url"
+                "enum": [
+                  "url"
+                ]
               }
-            },
-            "required": [
-              "source",
-              "elementsToMatch",
-              "elementsToExclude",
-              "attribute"
-            ]
+            }
           }
         ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -3006,35 +3036,28 @@
       "type": "processor",
       "description": "Validates XML content",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlValidatorParam",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/$defs/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/$defs/ValidationType"
-          }
-        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/definitions/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/definitions/ValidationType"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
-            ]
           },
           "ValidationType": {
             "type": "string",
@@ -3042,6 +3065,13 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
             ]
           }
         }

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -5,9 +5,12 @@
       "type": "processor",
       "description": "Overlays an area on another area",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -15,17 +18,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -49,25 +49,33 @@
       "type": "processor",
       "description": "Aggregates features by attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeAggregatorParam",
         "type": "object",
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/AggregateAttribute"
+              "$ref": "#/definitions/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "calculationAttribute": {
+            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -76,29 +84,21 @@
             ],
             "format": "int64"
           },
-          "calculationAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
           "method": {
-            "$ref": "#/$defs/Method"
+            "$ref": "#/definitions/Method"
           }
         },
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
-        "$defs": {
+        "definitions": {
           "AggregateAttribute": {
             "type": "object",
+            "required": [
+              "newAttribute"
+            ],
             "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
               "attribute": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Attribute"
+                    "$ref": "#/definitions/Attribute"
                   },
                   {
                     "type": "null"
@@ -108,17 +108,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
               }
-            },
-            "required": [
-              "newAttribute"
-            ]
+            }
           },
           "Attribute": {
             "type": "string"
@@ -152,21 +152,21 @@
       "type": "processor",
       "description": "Filters features by duplicate attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
+        "required": [
+          "filterBy"
+        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
-        "required": [
-          "filterBy"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -188,18 +188,18 @@
       "type": "processor",
       "description": "Extracts file path information from attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "attribute"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -222,45 +222,23 @@
       "type": "processor",
       "description": "Manages attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeManagerParam",
         "type": "object",
+        "required": [
+          "operations"
+        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Operation"
+              "$ref": "#/definitions/Operation"
             }
           }
         },
-        "required": [
-          "operations"
-        ],
-        "$defs": {
-          "Operation": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/$defs/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "attribute",
-              "method"
-            ]
+        "definitions": {
+          "Expr": {
+            "type": "string"
           },
           "Method": {
             "type": "string",
@@ -271,8 +249,30 @@
               "remove"
             ]
           },
-          "Expr": {
-            "type": "string"
+          "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/definitions/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
           }
         }
       },
@@ -292,47 +292,28 @@
       "type": "processor",
       "description": "Maps attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeMapperParam",
         "type": "object",
+        "required": [
+          "mappers"
+        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Mapper"
+              "$ref": "#/definitions/Mapper"
             }
           }
         },
-        "required": [
-          "mappers"
-        ],
-        "$defs": {
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -344,20 +325,39 @@
                   "null"
                 ]
               },
-              "multipleExpr": {
+              "expr": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "multipleExpr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "parentAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           }
         }
       },
@@ -394,12 +394,17 @@
       "type": "processor",
       "description": "Buffers a geometry",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Bufferer",
         "type": "object",
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/$defs/BufferType"
+            "$ref": "#/definitions/BufferType"
           },
           "distance": {
             "type": "number",
@@ -410,12 +415,7 @@
             "format": "double"
           }
         },
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
-        "$defs": {
+        "definitions": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -441,21 +441,20 @@
       "type": "processor",
       "description": "Renames attributes by adding/removing prefixes or suffixes, or replacing text",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
+        "required": [
+          "renameAction",
+          "renameType",
+          "renameValue"
+        ],
         "properties": {
-          "renameType": {
-            "$ref": "#/$defs/RenameType"
-          },
           "renameAction": {
-            "$ref": "#/$defs/RenameAction"
+            "$ref": "#/definitions/RenameAction"
           },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
+          "renameType": {
+            "$ref": "#/definitions/RenameType"
           },
           "renameValue": {
             "type": "string"
@@ -468,21 +467,15 @@
             "items": {
               "type": "string"
             }
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
-        "required": [
-          "renameType",
-          "renameAction",
-          "renameValue"
-        ],
-        "$defs": {
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
-            ]
-          },
+        "definitions": {
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -491,6 +484,13 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
+            ]
+          },
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
             ]
           }
         }
@@ -528,36 +528,36 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
+        "required": [
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -614,19 +614,19 @@
       "type": "processor",
       "description": "Sets the coordinate system of a feature",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "CoordinateSystemSetter",
         "type": "object",
+        "required": [
+          "epsgCode"
+        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
-        },
-        "required": [
-          "epsgCode"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -692,18 +692,18 @@
       "type": "processor",
       "description": "Extracts a feature’s first z coordinate value, storing it in an attribute.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ElevationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -725,18 +725,18 @@
       "type": "processor",
       "description": "Extrudes a polygon by a distance",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ExtruderParam",
         "type": "object",
-        "properties": {
-          "distance": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "distance"
         ],
-        "$defs": {
+        "properties": {
+          "distance": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -758,9 +758,13 @@
       "type": "processor",
       "description": "Counts features",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCounterParam",
         "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,18 +776,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -806,18 +806,18 @@
       "type": "source",
       "description": "Creates features from expressions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCreator",
         "type": "object",
-        "properties": {
-          "creator": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "creator"
         ],
-        "$defs": {
+        "properties": {
+          "creator": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -837,22 +837,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -875,35 +875,35 @@
       "type": "processor",
       "description": "Filters features based on conditions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilterParam",
         "type": "object",
+        "required": [
+          "conditions"
+        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Condition"
+              "$ref": "#/definitions/Condition"
             }
           }
         },
-        "required": [
-          "conditions"
-        ],
-        "$defs": {
+        "definitions": {
           "Condition": {
             "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/$defs/Port"
-              }
-            },
             "required": [
               "expr",
               "outputPort"
-            ]
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/definitions/Port"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -929,18 +929,18 @@
       "type": "processor",
       "description": "Filter Geometry by lod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureLodFilterParam",
         "type": "object",
-        "properties": {
-          "filterKey": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "filterKey"
         ],
-        "$defs": {
+        "properties": {
+          "filterKey": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -966,18 +966,34 @@
       "type": "processor",
       "description": "Merges features by attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "requestorAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "supplierAttribute": {
             "type": [
@@ -985,37 +1001,21 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1042,40 +1042,48 @@
       "type": "processor",
       "description": "Filters features based on conditions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1083,23 +1091,25 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1107,16 +1117,12 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1138,52 +1144,21 @@
       "type": "processor",
       "description": "Sorts features by attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureSorterParam",
         "type": "object",
+        "required": [
+          "sortBy"
+        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/SortBy"
+              "$ref": "#/definitions/SortBy"
             }
           }
         },
-        "required": [
-          "sortBy"
-        ],
-        "$defs": {
-          "SortBy": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/$defs/Order"
-              }
-            },
-            "required": [
-              "order"
-            ]
-          },
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1196,6 +1171,37 @@
               "ascending",
               "descending"
             ]
+          },
+          "SortBy": {
+            "type": "object",
+            "required": [
+              "order"
+            ],
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/definitions/Order"
+              }
+            }
           }
         }
       },
@@ -1215,34 +1221,34 @@
       "type": "processor",
       "description": "Transforms features by expressions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTransformerParam",
         "type": "object",
+        "required": [
+          "transformers"
+        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Transform"
+              "$ref": "#/definitions/Transform"
             }
           }
         },
-        "required": [
-          "transformers"
-        ],
-        "$defs": {
-          "Transform": {
-            "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
-            "required": [
-              "expr"
-            ]
-          },
+        "definitions": {
           "Expr": {
             "type": "string"
+          },
+          "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
           }
         }
       },
@@ -1262,9 +1268,12 @@
       "type": "processor",
       "description": "Filters features by feature type",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTypeFilter",
         "type": "object",
+        "required": [
+          "targetTypes"
+        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1272,10 +1281,7 @@
               "type": "string"
             }
           }
-        },
-        "required": [
-          "targetTypes"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1294,22 +1300,22 @@
       "type": "source",
       "description": "Extracts files from a directory or an archive",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePathExtractor",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1329,17 +1335,17 @@
       "type": "processor",
       "description": "Extracts properties from a file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePropertyExtractor",
         "type": "object",
+        "required": [
+          "filePathAttribute"
+        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        },
-        "required": [
-          "filePathAttribute"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1358,19 +1364,25 @@
       "type": "source",
       "description": "Reads features from a file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileReader",
         "oneOf": [
           {
             "title": "CSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1378,24 +1390,26 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "TSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1403,56 +1417,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "JSON",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "json"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "json"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "CityGML",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1472,76 +1486,88 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "properties": {
-              "format": {
-                "type": "string",
-                "const": "csv"
-              },
-              "output": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "tsv"
+                "enum": [
+                  "csv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               }
-            },
+            }
+          },
+          {
+            "type": "object",
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "json"
+                "enum": [
+                  "tsv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
-              },
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "excel"
+                "enum": [
+                  "excel"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1549,14 +1575,10 @@
                   "null"
                 ]
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1576,31 +1598,31 @@
       "type": "sink",
       "description": "Writes features to a geojson file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeoJsonWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -1619,18 +1641,18 @@
       "type": "processor",
       "description": "Coerces the geometry of a feature to a specific geometry",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryCoercer",
         "type": "object",
-        "properties": {
-          "coercerType": {
-            "$ref": "#/$defs/CoercerType"
-          }
-        },
         "required": [
           "coercerType"
         ],
-        "$defs": {
+        "properties": {
+          "coercerType": {
+            "$ref": "#/definitions/CoercerType"
+          }
+        },
+        "definitions": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1655,27 +1677,27 @@
       "type": "processor",
       "description": "Dissolve geometries",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1698,18 +1720,18 @@
       "type": "processor",
       "description": "Extracts geometry from a feature and adds it as an attribute.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryExtractor",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1731,44 +1753,50 @@
       "type": "processor",
       "description": "Filter geometry by type",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "none"
+                "enum": [
+                  "none"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "multiple"
+                "enum": [
+                  "multiple"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "geometryType"
+                "enum": [
+                  "geometryType"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           }
         ]
       },
@@ -1811,18 +1839,18 @@
       "type": "processor",
       "description": "Replaces the geometry of a feature with a new geometry.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryReplacer",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1860,21 +1888,21 @@
       "type": "processor",
       "description": "Validates the geometry of a feature",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryValidator",
         "type": "object",
+        "required": [
+          "validationTypes"
+        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/ValidationType"
+              "$ref": "#/definitions/ValidationType"
             }
           }
         },
-        "required": [
-          "validationTypes"
-        ],
-        "$defs": {
+        "definitions": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1922,24 +1950,24 @@
       "type": "sink",
       "description": "Writes features to a Gltf",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GltfWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1959,18 +1987,18 @@
       "type": "processor",
       "description": "Counts the number of holes in a geometry and adds it as an attribute.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HoleCounterParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2010,7 +2038,7 @@
       "type": "processor",
       "description": "Reprojects the geometry of a feature to a specified coordinate system",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2020,7 +2048,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
         }
       },
@@ -2040,17 +2068,17 @@
       "type": "processor",
       "description": "Action for first port forwarding for sub-workflows.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "InputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [],
@@ -2066,9 +2094,12 @@
       "type": "processor",
       "description": "Intersection points are turned into point features that can contain the merged list of attributes of the original intersected lines.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2076,17 +2107,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2110,18 +2138,18 @@
       "type": "processor",
       "description": "Explodes list attributes",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ListExploder",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2143,34 +2171,34 @@
       "type": "sink",
       "description": "Writes features to a file",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MVTWriterParam",
         "type": "object",
+        "required": [
+          "layerName",
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "layerName": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
+            "$ref": "#/definitions/Expr"
           },
           "maxZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "layerName",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2220,7 +2248,7 @@
       "type": "processor",
       "description": "Adds offsets to the feature's coordinates.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2263,18 +2291,18 @@
       "type": "processor",
       "description": "Extracts the orientation of a geometry from a feature and adds it as an attribute.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OrientationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2296,17 +2324,17 @@
       "type": "processor",
       "description": "Action for last port forwarding for sub-workflows.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OutputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -2507,22 +2535,22 @@
       "type": "processor",
       "description": "Extracts maxLod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MaxLodExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPathAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxLodAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "cityGmlPathAttribute",
           "maxLodAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPathAttribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxLodAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2544,18 +2572,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "UDXFolderExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "cityGmlPath"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2612,22 +2640,22 @@
       "type": "processor",
       "description": "Calls Rhai script",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "RhaiCallerParam",
         "type": "object",
-        "properties": {
-          "isTarget": {
-            "$ref": "#/$defs/Expr"
-          },
-          "process": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "isTarget",
           "process"
         ],
-        "$defs": {
+        "properties": {
+          "isTarget": {
+            "$ref": "#/definitions/Expr"
+          },
+          "process": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2649,24 +2677,27 @@
       "type": "processor",
       "description": "Calculates statistics of features",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "StatisticsCalculatorParam",
         "type": "object",
+        "required": [
+          "calculations"
+        ],
         "properties": {
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
@@ -2676,31 +2707,28 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Calculation"
+              "$ref": "#/definitions/Calculation"
             }
           }
         },
-        "required": [
-          "calculations"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
-              "newAttribute",
-              "expr"
-            ]
+              "expr",
+              "newAttribute"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -2724,38 +2752,38 @@
       "type": "processor",
       "description": "Replaces a three Dimension box with a polygon.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "properties": {
-          "minX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minZ": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
-          "minX",
-          "minY",
-          "minZ",
           "maxX",
           "maxY",
-          "maxZ"
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
         ],
-        "$defs": {
+        "properties": {
+          "maxX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minZ": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2777,42 +2805,42 @@
       "type": "processor",
       "description": "Replaces a three Dimension box with a polygon.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "properties": {
-          "angleDegree": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originZ": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "angleDegree",
-          "originX",
-          "originY",
-          "originZ",
           "directionX",
           "directionY",
-          "directionZ"
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
         ],
-        "$defs": {
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2867,18 +2895,18 @@
       "type": "processor",
       "description": "Reprojects the geometry of a feature to a specified coordinate system",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "VerticalReprojectorParam",
         "type": "object",
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/$defs/VerticalReprojectorType"
-          }
-        },
         "required": [
           "reprojectorType"
         ],
-        "$defs": {
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/definitions/VerticalReprojectorType"
+          }
+        },
+        "definitions": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2903,26 +2931,26 @@
       "type": "processor",
       "description": "Compiles scripts into .wasm and runs at the wasm runtime",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
+        "required": [
+          "processorType",
+          "programmingLanguage",
+          "sourceCodeFilePath"
+        ],
         "properties": {
-          "sourceCodeFilePath": {
-            "type": "string"
-          },
           "processorType": {
-            "$ref": "#/$defs/ProcessorType"
+            "$ref": "#/definitions/ProcessorType"
           },
           "programmingLanguage": {
-            "$ref": "#/$defs/ProgrammingLanguage"
+            "$ref": "#/definitions/ProgrammingLanguage"
+          },
+          "sourceCodeFilePath": {
+            "type": "string"
           }
         },
-        "required": [
-          "sourceCodeFilePath",
-          "processorType",
-          "programmingLanguage"
-        ],
-        "$defs": {
+        "definitions": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2953,39 +2981,41 @@
       "type": "processor",
       "description": "Fragment XML",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
             "properties": {
-              "elementsToMatch": {
-                "$ref": "#/$defs/Expr"
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               },
               "elementsToExclude": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
-              "attribute": {
-                "$ref": "#/$defs/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/definitions/Expr"
               },
               "source": {
                 "type": "string",
-                "const": "url"
+                "enum": [
+                  "url"
+                ]
               }
-            },
-            "required": [
-              "source",
-              "elementsToMatch",
-              "elementsToExclude",
-              "attribute"
-            ]
+            }
           }
         ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -3006,35 +3036,28 @@
       "type": "processor",
       "description": "Validates XML content",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlValidatorParam",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/$defs/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/$defs/ValidationType"
-          }
-        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/definitions/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/definitions/ValidationType"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
-            ]
           },
           "ValidationType": {
             "type": "string",
@@ -3042,6 +3065,13 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
             ]
           }
         }

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -5,9 +5,12 @@
       "type": "processor",
       "description": "Superpone un área sobre otra área",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -15,17 +18,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -49,25 +49,33 @@
       "type": "processor",
       "description": "Agrupa las entidades según sus atributos",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeAggregatorParam",
         "type": "object",
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/AggregateAttribute"
+              "$ref": "#/definitions/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "calculationAttribute": {
+            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -76,29 +84,21 @@
             ],
             "format": "int64"
           },
-          "calculationAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
           "method": {
-            "$ref": "#/$defs/Method"
+            "$ref": "#/definitions/Method"
           }
         },
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
-        "$defs": {
+        "definitions": {
           "AggregateAttribute": {
             "type": "object",
+            "required": [
+              "newAttribute"
+            ],
             "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
               "attribute": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Attribute"
+                    "$ref": "#/definitions/Attribute"
                   },
                   {
                     "type": "null"
@@ -108,17 +108,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
               }
-            },
-            "required": [
-              "newAttribute"
-            ]
+            }
           },
           "Attribute": {
             "type": "string"
@@ -152,21 +152,21 @@
       "type": "processor",
       "description": "Filtra las entidades con atributos duplicados",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
+        "required": [
+          "filterBy"
+        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
-        "required": [
-          "filterBy"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -188,18 +188,18 @@
       "type": "processor",
       "description": "Extrae información de rutas de archivo a partir de atributos",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "attribute"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -222,45 +222,23 @@
       "type": "processor",
       "description": "Gestiona atributos",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeManagerParam",
         "type": "object",
+        "required": [
+          "operations"
+        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Operation"
+              "$ref": "#/definitions/Operation"
             }
           }
         },
-        "required": [
-          "operations"
-        ],
-        "$defs": {
-          "Operation": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/$defs/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "attribute",
-              "method"
-            ]
+        "definitions": {
+          "Expr": {
+            "type": "string"
           },
           "Method": {
             "type": "string",
@@ -271,8 +249,30 @@
               "remove"
             ]
           },
-          "Expr": {
-            "type": "string"
+          "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/definitions/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
           }
         }
       },
@@ -292,47 +292,28 @@
       "type": "processor",
       "description": "Asigna atributos",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeMapperParam",
         "type": "object",
+        "required": [
+          "mappers"
+        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Mapper"
+              "$ref": "#/definitions/Mapper"
             }
           }
         },
-        "required": [
-          "mappers"
-        ],
-        "$defs": {
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -344,20 +325,39 @@
                   "null"
                 ]
               },
-              "multipleExpr": {
+              "expr": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "multipleExpr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "parentAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           }
         }
       },
@@ -394,12 +394,17 @@
       "type": "processor",
       "description": "Crea un búfer alrededor de una geometría",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Bufferer",
         "type": "object",
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/$defs/BufferType"
+            "$ref": "#/definitions/BufferType"
           },
           "distance": {
             "type": "number",
@@ -410,12 +415,7 @@
             "format": "double"
           }
         },
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
-        "$defs": {
+        "definitions": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -441,21 +441,20 @@
       "type": "processor",
       "description": "Cambia el nombre de atributos añadiendo/eliminando prefijos o sufijos, o reemplazando texto",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
+        "required": [
+          "renameAction",
+          "renameType",
+          "renameValue"
+        ],
         "properties": {
-          "renameType": {
-            "$ref": "#/$defs/RenameType"
-          },
           "renameAction": {
-            "$ref": "#/$defs/RenameAction"
+            "$ref": "#/definitions/RenameAction"
           },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
+          "renameType": {
+            "$ref": "#/definitions/RenameType"
           },
           "renameValue": {
             "type": "string"
@@ -468,21 +467,15 @@
             "items": {
               "type": "string"
             }
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
-        "required": [
-          "renameType",
-          "renameAction",
-          "renameValue"
-        ],
-        "$defs": {
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
-            ]
-          },
+        "definitions": {
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -491,6 +484,13 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
+            ]
+          },
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
             ]
           }
         }
@@ -528,36 +528,36 @@
       "type": "sink",
       "description": "Escribe las entidades en un archivo",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
+        "required": [
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -614,19 +614,19 @@
       "type": "processor",
       "description": "Establece el sistema de coordenadas de una entidad",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "CoordinateSystemSetter",
         "type": "object",
+        "required": [
+          "epsgCode"
+        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
-        },
-        "required": [
-          "epsgCode"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -692,18 +692,18 @@
       "type": "processor",
       "description": "Extrae el primer valor de la coordenada z de una entidad y lo almacena en un atributo.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ElevationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -725,18 +725,18 @@
       "type": "processor",
       "description": "Extruye un polígono a una cierta distancia",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ExtruderParam",
         "type": "object",
-        "properties": {
-          "distance": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "distance"
         ],
-        "$defs": {
+        "properties": {
+          "distance": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -758,9 +758,13 @@
       "type": "processor",
       "description": "Cuenta entidades",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCounterParam",
         "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,18 +776,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -806,18 +806,18 @@
       "type": "source",
       "description": "Crea entidades a partir de expresiones",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCreator",
         "type": "object",
-        "properties": {
-          "creator": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "creator"
         ],
-        "$defs": {
+        "properties": {
+          "creator": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -837,22 +837,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -875,35 +875,35 @@
       "type": "processor",
       "description": "Filtra entidades según condiciones",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilterParam",
         "type": "object",
+        "required": [
+          "conditions"
+        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Condition"
+              "$ref": "#/definitions/Condition"
             }
           }
         },
-        "required": [
-          "conditions"
-        ],
-        "$defs": {
+        "definitions": {
           "Condition": {
             "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/$defs/Port"
-              }
-            },
             "required": [
               "expr",
               "outputPort"
-            ]
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/definitions/Port"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -929,18 +929,18 @@
       "type": "processor",
       "description": "Filter Geometry by lod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureLodFilterParam",
         "type": "object",
-        "properties": {
-          "filterKey": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "filterKey"
         ],
-        "$defs": {
+        "properties": {
+          "filterKey": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -966,18 +966,34 @@
       "type": "processor",
       "description": "Une entidades según sus atributos",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "requestorAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "supplierAttribute": {
             "type": [
@@ -985,37 +1001,21 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1042,40 +1042,48 @@
       "type": "processor",
       "description": "Filtra entidades según condiciones",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1083,23 +1091,25 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1107,16 +1117,12 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1138,52 +1144,21 @@
       "type": "processor",
       "description": "Ordena entidades por atributos",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureSorterParam",
         "type": "object",
+        "required": [
+          "sortBy"
+        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/SortBy"
+              "$ref": "#/definitions/SortBy"
             }
           }
         },
-        "required": [
-          "sortBy"
-        ],
-        "$defs": {
-          "SortBy": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/$defs/Order"
-              }
-            },
-            "required": [
-              "order"
-            ]
-          },
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1196,6 +1171,37 @@
               "ascending",
               "descending"
             ]
+          },
+          "SortBy": {
+            "type": "object",
+            "required": [
+              "order"
+            ],
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/definitions/Order"
+              }
+            }
           }
         }
       },
@@ -1215,34 +1221,34 @@
       "type": "processor",
       "description": "Transforma entidades mediante expresiones",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTransformerParam",
         "type": "object",
+        "required": [
+          "transformers"
+        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Transform"
+              "$ref": "#/definitions/Transform"
             }
           }
         },
-        "required": [
-          "transformers"
-        ],
-        "$defs": {
-          "Transform": {
-            "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
-            "required": [
-              "expr"
-            ]
-          },
+        "definitions": {
           "Expr": {
             "type": "string"
+          },
+          "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
           }
         }
       },
@@ -1262,9 +1268,12 @@
       "type": "processor",
       "description": "Filtra entidades por tipo de entidad",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTypeFilter",
         "type": "object",
+        "required": [
+          "targetTypes"
+        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1272,10 +1281,7 @@
               "type": "string"
             }
           }
-        },
-        "required": [
-          "targetTypes"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1294,22 +1300,22 @@
       "type": "source",
       "description": "Extrae archivos de un directorio o de un archivo comprimido",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePathExtractor",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1329,17 +1335,17 @@
       "type": "processor",
       "description": "Extrae propiedades de un archivo",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePropertyExtractor",
         "type": "object",
+        "required": [
+          "filePathAttribute"
+        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        },
-        "required": [
-          "filePathAttribute"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1358,19 +1364,25 @@
       "type": "source",
       "description": "Lee entidades desde un archivo",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileReader",
         "oneOf": [
           {
             "title": "CSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1378,24 +1390,26 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "TSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1403,56 +1417,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "JSON",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "json"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "json"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "CityGML",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1472,76 +1486,88 @@
       "type": "sink",
       "description": "Escribe entidades en un archivo",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "properties": {
-              "format": {
-                "type": "string",
-                "const": "csv"
-              },
-              "output": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "tsv"
+                "enum": [
+                  "csv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               }
-            },
+            }
+          },
+          {
+            "type": "object",
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "json"
+                "enum": [
+                  "tsv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
-              },
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "excel"
+                "enum": [
+                  "excel"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1549,14 +1575,10 @@
                   "null"
                 ]
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1576,31 +1598,31 @@
       "type": "sink",
       "description": "Escribe entidades en un archivo GeoJSON",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeoJsonWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -1619,18 +1641,18 @@
       "type": "processor",
       "description": "Fuerza la geometría de una entidad a una geometría específica",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryCoercer",
         "type": "object",
-        "properties": {
-          "coercerType": {
-            "$ref": "#/$defs/CoercerType"
-          }
-        },
         "required": [
           "coercerType"
         ],
-        "$defs": {
+        "properties": {
+          "coercerType": {
+            "$ref": "#/definitions/CoercerType"
+          }
+        },
+        "definitions": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1655,27 +1677,27 @@
       "type": "processor",
       "description": "Disuelve geometrías",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1698,18 +1720,18 @@
       "type": "processor",
       "description": "Extrae la geometría de una entidad y la añade como un atributo.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryExtractor",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1731,44 +1753,50 @@
       "type": "processor",
       "description": "Filtra la geometría por tipo",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "none"
+                "enum": [
+                  "none"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "multiple"
+                "enum": [
+                  "multiple"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "geometryType"
+                "enum": [
+                  "geometryType"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           }
         ]
       },
@@ -1811,18 +1839,18 @@
       "type": "processor",
       "description": "Reemplaza la geometría de una entidad con una nueva geometría.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryReplacer",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1860,21 +1888,21 @@
       "type": "processor",
       "description": "Valida la geometría de una entidad",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryValidator",
         "type": "object",
+        "required": [
+          "validationTypes"
+        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/ValidationType"
+              "$ref": "#/definitions/ValidationType"
             }
           }
         },
-        "required": [
-          "validationTypes"
-        ],
-        "$defs": {
+        "definitions": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1922,24 +1950,24 @@
       "type": "sink",
       "description": "Escribe entidades en un archivo Gltf",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GltfWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1959,18 +1987,18 @@
       "type": "processor",
       "description": "Cuenta el número de huecos en una geometría y lo agrega como atributo.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HoleCounterParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2010,7 +2038,7 @@
       "type": "processor",
       "description": "Reproyecta la geometría de una entidad a un sistema de coordenadas especificado",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2020,7 +2048,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
         }
       },
@@ -2040,17 +2068,17 @@
       "type": "processor",
       "description": "Acción para el reenvío del primer puerto en sub-flujos de trabajo.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "InputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [],
@@ -2066,9 +2094,12 @@
       "type": "processor",
       "description": "Los puntos de intersección se convierten en entidades de puntos que pueden contener la lista combinada de atributos de las líneas originales intersectadas.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2076,17 +2107,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2110,18 +2138,18 @@
       "type": "processor",
       "description": "Divide en varios elementos los atributos de tipo lista",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ListExploder",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2143,34 +2171,34 @@
       "type": "sink",
       "description": "Escribe entidades en un archivo",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MVTWriterParam",
         "type": "object",
+        "required": [
+          "layerName",
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "layerName": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
+            "$ref": "#/definitions/Expr"
           },
           "maxZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "layerName",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2220,7 +2248,7 @@
       "type": "processor",
       "description": "Añade desplazamientos a las coordenadas de la entidad.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2263,18 +2291,18 @@
       "type": "processor",
       "description": "Extrae la orientación de una geometría de una entidad y la agrega como un atributo.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OrientationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2296,17 +2324,17 @@
       "type": "processor",
       "description": "Acción para el reenvío del último puerto en sub-flujos de trabajo.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OutputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -2507,22 +2535,22 @@
       "type": "processor",
       "description": "Extracts maxLod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MaxLodExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPathAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxLodAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "cityGmlPathAttribute",
           "maxLodAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPathAttribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxLodAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2544,18 +2572,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "UDXFolderExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "cityGmlPath"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2612,22 +2640,22 @@
       "type": "processor",
       "description": "Llama a un script Rhai",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "RhaiCallerParam",
         "type": "object",
-        "properties": {
-          "isTarget": {
-            "$ref": "#/$defs/Expr"
-          },
-          "process": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "isTarget",
           "process"
         ],
-        "$defs": {
+        "properties": {
+          "isTarget": {
+            "$ref": "#/definitions/Expr"
+          },
+          "process": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2649,24 +2677,27 @@
       "type": "processor",
       "description": "Calcula estadísticas de las entidades",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "StatisticsCalculatorParam",
         "type": "object",
+        "required": [
+          "calculations"
+        ],
         "properties": {
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
@@ -2676,31 +2707,28 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Calculation"
+              "$ref": "#/definitions/Calculation"
             }
           }
         },
-        "required": [
-          "calculations"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
-              "newAttribute",
-              "expr"
-            ]
+              "expr",
+              "newAttribute"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -2724,38 +2752,38 @@
       "type": "processor",
       "description": "Reemplaza una caja tridimensional con un polígono.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "properties": {
-          "minX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minZ": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
-          "minX",
-          "minY",
-          "minZ",
           "maxX",
           "maxY",
-          "maxZ"
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
         ],
-        "$defs": {
+        "properties": {
+          "maxX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minZ": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2777,42 +2805,42 @@
       "type": "processor",
       "description": "Reemplaza una caja tridimensional con un polígono.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "properties": {
-          "angleDegree": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originZ": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "angleDegree",
-          "originX",
-          "originY",
-          "originZ",
           "directionX",
           "directionY",
-          "directionZ"
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
         ],
-        "$defs": {
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2867,18 +2895,18 @@
       "type": "processor",
       "description": "Reproyecta la geometría de una entidad a un sistema de coordenadas especificado",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "VerticalReprojectorParam",
         "type": "object",
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/$defs/VerticalReprojectorType"
-          }
-        },
         "required": [
           "reprojectorType"
         ],
-        "$defs": {
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/definitions/VerticalReprojectorType"
+          }
+        },
+        "definitions": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2903,26 +2931,26 @@
       "type": "processor",
       "description": "Compila scripts en .wasm y los ejecuta en tiempo de ejecución de wasm",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
+        "required": [
+          "processorType",
+          "programmingLanguage",
+          "sourceCodeFilePath"
+        ],
         "properties": {
-          "sourceCodeFilePath": {
-            "type": "string"
-          },
           "processorType": {
-            "$ref": "#/$defs/ProcessorType"
+            "$ref": "#/definitions/ProcessorType"
           },
           "programmingLanguage": {
-            "$ref": "#/$defs/ProgrammingLanguage"
+            "$ref": "#/definitions/ProgrammingLanguage"
+          },
+          "sourceCodeFilePath": {
+            "type": "string"
           }
         },
-        "required": [
-          "sourceCodeFilePath",
-          "processorType",
-          "programmingLanguage"
-        ],
-        "$defs": {
+        "definitions": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2953,39 +2981,41 @@
       "type": "processor",
       "description": "Fragmenta XML",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
             "properties": {
-              "elementsToMatch": {
-                "$ref": "#/$defs/Expr"
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               },
               "elementsToExclude": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
-              "attribute": {
-                "$ref": "#/$defs/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/definitions/Expr"
               },
               "source": {
                 "type": "string",
-                "const": "url"
+                "enum": [
+                  "url"
+                ]
               }
-            },
-            "required": [
-              "source",
-              "elementsToMatch",
-              "elementsToExclude",
-              "attribute"
-            ]
+            }
           }
         ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -3006,35 +3036,28 @@
       "type": "processor",
       "description": "Valida contenido XML",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlValidatorParam",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/$defs/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/$defs/ValidationType"
-          }
-        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/definitions/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/definitions/ValidationType"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
-            ]
           },
           "ValidationType": {
             "type": "string",
@@ -3042,6 +3065,13 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
             ]
           }
         }

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -5,9 +5,12 @@
       "type": "processor",
       "description": "Superpose une zone sur une autre zone",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -15,17 +18,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -49,25 +49,33 @@
       "type": "processor",
       "description": "Regroupe les entités selon leurs attributs",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeAggregatorParam",
         "type": "object",
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/AggregateAttribute"
+              "$ref": "#/definitions/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "calculationAttribute": {
+            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -76,29 +84,21 @@
             ],
             "format": "int64"
           },
-          "calculationAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
           "method": {
-            "$ref": "#/$defs/Method"
+            "$ref": "#/definitions/Method"
           }
         },
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
-        "$defs": {
+        "definitions": {
           "AggregateAttribute": {
             "type": "object",
+            "required": [
+              "newAttribute"
+            ],
             "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
               "attribute": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Attribute"
+                    "$ref": "#/definitions/Attribute"
                   },
                   {
                     "type": "null"
@@ -108,17 +108,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
               }
-            },
-            "required": [
-              "newAttribute"
-            ]
+            }
           },
           "Attribute": {
             "type": "string"
@@ -152,21 +152,21 @@
       "type": "processor",
       "description": "Filtre les entités possédant des attributs dupliqués",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
+        "required": [
+          "filterBy"
+        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
-        "required": [
-          "filterBy"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -188,18 +188,18 @@
       "type": "processor",
       "description": "Extrait des informations de chemins de fichier à partir des attributs",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "attribute"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -222,45 +222,23 @@
       "type": "processor",
       "description": "Gère les attributs",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeManagerParam",
         "type": "object",
+        "required": [
+          "operations"
+        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Operation"
+              "$ref": "#/definitions/Operation"
             }
           }
         },
-        "required": [
-          "operations"
-        ],
-        "$defs": {
-          "Operation": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/$defs/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "attribute",
-              "method"
-            ]
+        "definitions": {
+          "Expr": {
+            "type": "string"
           },
           "Method": {
             "type": "string",
@@ -271,8 +249,30 @@
               "remove"
             ]
           },
-          "Expr": {
-            "type": "string"
+          "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/definitions/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
           }
         }
       },
@@ -292,47 +292,28 @@
       "type": "processor",
       "description": "Assigne des attributs",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeMapperParam",
         "type": "object",
+        "required": [
+          "mappers"
+        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Mapper"
+              "$ref": "#/definitions/Mapper"
             }
           }
         },
-        "required": [
-          "mappers"
-        ],
-        "$defs": {
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -344,20 +325,39 @@
                   "null"
                 ]
               },
-              "multipleExpr": {
+              "expr": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "multipleExpr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "parentAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           }
         }
       },
@@ -394,12 +394,17 @@
       "type": "processor",
       "description": "Crée un tampon autour d'une géométrie",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Bufferer",
         "type": "object",
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/$defs/BufferType"
+            "$ref": "#/definitions/BufferType"
           },
           "distance": {
             "type": "number",
@@ -410,12 +415,7 @@
             "format": "double"
           }
         },
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
-        "$defs": {
+        "definitions": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -441,21 +441,20 @@
       "type": "processor",
       "description": "Renomme des attributs en ajoutant/supprimant des préfixes ou suffixes, ou en remplaçant du texte",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
+        "required": [
+          "renameAction",
+          "renameType",
+          "renameValue"
+        ],
         "properties": {
-          "renameType": {
-            "$ref": "#/$defs/RenameType"
-          },
           "renameAction": {
-            "$ref": "#/$defs/RenameAction"
+            "$ref": "#/definitions/RenameAction"
           },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
+          "renameType": {
+            "$ref": "#/definitions/RenameType"
           },
           "renameValue": {
             "type": "string"
@@ -468,21 +467,15 @@
             "items": {
               "type": "string"
             }
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
-        "required": [
-          "renameType",
-          "renameAction",
-          "renameValue"
-        ],
-        "$defs": {
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
-            ]
-          },
+        "definitions": {
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -491,6 +484,13 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
+            ]
+          },
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
             ]
           }
         }
@@ -528,36 +528,36 @@
       "type": "sink",
       "description": "Écrit les entités dans un fichier",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
+        "required": [
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -614,19 +614,19 @@
       "type": "processor",
       "description": "Définit le système de coordonnées d'une entité",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "CoordinateSystemSetter",
         "type": "object",
+        "required": [
+          "epsgCode"
+        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
-        },
-        "required": [
-          "epsgCode"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -692,18 +692,18 @@
       "type": "processor",
       "description": "Extrait la première valeur de la coordonnée z d'une entité et la stocke dans un attribut.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ElevationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -725,18 +725,18 @@
       "type": "processor",
       "description": "Extrue un polygone sur une certaine distance",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ExtruderParam",
         "type": "object",
-        "properties": {
-          "distance": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "distance"
         ],
-        "$defs": {
+        "properties": {
+          "distance": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -758,9 +758,13 @@
       "type": "processor",
       "description": "Compte les entités",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCounterParam",
         "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,18 +776,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -806,18 +806,18 @@
       "type": "source",
       "description": "Crée des entités à partir d'expressions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCreator",
         "type": "object",
-        "properties": {
-          "creator": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "creator"
         ],
-        "$defs": {
+        "properties": {
+          "creator": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -837,22 +837,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -875,35 +875,35 @@
       "type": "processor",
       "description": "Filtre les entités selon des conditions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilterParam",
         "type": "object",
+        "required": [
+          "conditions"
+        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Condition"
+              "$ref": "#/definitions/Condition"
             }
           }
         },
-        "required": [
-          "conditions"
-        ],
-        "$defs": {
+        "definitions": {
           "Condition": {
             "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/$defs/Port"
-              }
-            },
             "required": [
               "expr",
               "outputPort"
-            ]
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/definitions/Port"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -929,18 +929,18 @@
       "type": "processor",
       "description": "Filter Geometry by lod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureLodFilterParam",
         "type": "object",
-        "properties": {
-          "filterKey": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "filterKey"
         ],
-        "$defs": {
+        "properties": {
+          "filterKey": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -966,18 +966,34 @@
       "type": "processor",
       "description": "Fusionne des entités selon leurs attributs",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "requestorAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "supplierAttribute": {
             "type": [
@@ -985,37 +1001,21 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1042,40 +1042,48 @@
       "type": "processor",
       "description": "Filtre les entités selon des conditions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1083,23 +1091,25 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1107,16 +1117,12 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1138,52 +1144,21 @@
       "type": "processor",
       "description": "Trie les entités par attributs",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureSorterParam",
         "type": "object",
+        "required": [
+          "sortBy"
+        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/SortBy"
+              "$ref": "#/definitions/SortBy"
             }
           }
         },
-        "required": [
-          "sortBy"
-        ],
-        "$defs": {
-          "SortBy": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/$defs/Order"
-              }
-            },
-            "required": [
-              "order"
-            ]
-          },
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1196,6 +1171,37 @@
               "ascending",
               "descending"
             ]
+          },
+          "SortBy": {
+            "type": "object",
+            "required": [
+              "order"
+            ],
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/definitions/Order"
+              }
+            }
           }
         }
       },
@@ -1215,34 +1221,34 @@
       "type": "processor",
       "description": "Transforme les entités à l'aide d'expressions",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTransformerParam",
         "type": "object",
+        "required": [
+          "transformers"
+        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Transform"
+              "$ref": "#/definitions/Transform"
             }
           }
         },
-        "required": [
-          "transformers"
-        ],
-        "$defs": {
-          "Transform": {
-            "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
-            "required": [
-              "expr"
-            ]
-          },
+        "definitions": {
           "Expr": {
             "type": "string"
+          },
+          "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
           }
         }
       },
@@ -1262,9 +1268,12 @@
       "type": "processor",
       "description": "Filtre les entités par type",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTypeFilter",
         "type": "object",
+        "required": [
+          "targetTypes"
+        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1272,10 +1281,7 @@
               "type": "string"
             }
           }
-        },
-        "required": [
-          "targetTypes"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1294,22 +1300,22 @@
       "type": "source",
       "description": "Extrait des fichiers d'un répertoire ou d'une archive",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePathExtractor",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1329,17 +1335,17 @@
       "type": "processor",
       "description": "Extrait les propriétés d'un fichier",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePropertyExtractor",
         "type": "object",
+        "required": [
+          "filePathAttribute"
+        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        },
-        "required": [
-          "filePathAttribute"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1358,19 +1364,25 @@
       "type": "source",
       "description": "Lit des entités depuis un fichier",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileReader",
         "oneOf": [
           {
             "title": "CSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1378,24 +1390,26 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "TSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1403,56 +1417,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "JSON",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "json"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "json"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "CityGML",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1472,76 +1486,88 @@
       "type": "sink",
       "description": "Écrit des entités dans un fichier",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "properties": {
-              "format": {
-                "type": "string",
-                "const": "csv"
-              },
-              "output": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "tsv"
+                "enum": [
+                  "csv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               }
-            },
+            }
+          },
+          {
+            "type": "object",
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "json"
+                "enum": [
+                  "tsv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
-              },
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "excel"
+                "enum": [
+                  "excel"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1549,14 +1575,10 @@
                   "null"
                 ]
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1576,31 +1598,31 @@
       "type": "sink",
       "description": "Écrit des entités dans un fichier GeoJSON",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeoJsonWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -1619,18 +1641,18 @@
       "type": "processor",
       "description": "Force la géométrie d'une entité à une géométrie spécifique",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryCoercer",
         "type": "object",
-        "properties": {
-          "coercerType": {
-            "$ref": "#/$defs/CoercerType"
-          }
-        },
         "required": [
           "coercerType"
         ],
-        "$defs": {
+        "properties": {
+          "coercerType": {
+            "$ref": "#/definitions/CoercerType"
+          }
+        },
+        "definitions": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1655,27 +1677,27 @@
       "type": "processor",
       "description": "Dissout des géométries",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1698,18 +1720,18 @@
       "type": "processor",
       "description": "Extrait la géométrie d'une entité et l'ajoute comme attribut.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryExtractor",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1731,44 +1753,50 @@
       "type": "processor",
       "description": "Filtre la géométrie par type",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "none"
+                "enum": [
+                  "none"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "multiple"
+                "enum": [
+                  "multiple"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "geometryType"
+                "enum": [
+                  "geometryType"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           }
         ]
       },
@@ -1811,18 +1839,18 @@
       "type": "processor",
       "description": "Remplace la géométrie d'une entité par une nouvelle géométrie.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryReplacer",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1860,21 +1888,21 @@
       "type": "processor",
       "description": "Valide la géométrie d'une entité",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryValidator",
         "type": "object",
+        "required": [
+          "validationTypes"
+        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/ValidationType"
+              "$ref": "#/definitions/ValidationType"
             }
           }
         },
-        "required": [
-          "validationTypes"
-        ],
-        "$defs": {
+        "definitions": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1922,24 +1950,24 @@
       "type": "sink",
       "description": "Écrit des entités dans un fichier Gltf",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GltfWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1959,18 +1987,18 @@
       "type": "processor",
       "description": "Compte le nombre de trous dans une géométrie et l'ajoute comme attribut.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HoleCounterParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2010,7 +2038,7 @@
       "type": "processor",
       "description": "Reprojette la géométrie d'une entité dans un système de coordonnées spécifié",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2020,7 +2048,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
         }
       },
@@ -2040,17 +2068,17 @@
       "type": "processor",
       "description": "Action pour le renvoi du premier port dans les sous-flux de travail.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "InputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [],
@@ -2066,9 +2094,12 @@
       "type": "processor",
       "description": "Les points d'intersection deviennent des entités ponctuelles pouvant contenir la liste combinée des attributs des lignes d'origine intersectées.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2076,17 +2107,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2110,18 +2138,18 @@
       "type": "processor",
       "description": "Explose les attributs de type liste en plusieurs éléments",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ListExploder",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2143,34 +2171,34 @@
       "type": "sink",
       "description": "Écrit des entités dans un fichier",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MVTWriterParam",
         "type": "object",
+        "required": [
+          "layerName",
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "layerName": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
+            "$ref": "#/definitions/Expr"
           },
           "maxZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "layerName",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2220,7 +2248,7 @@
       "type": "processor",
       "description": "Ajoute des décalages aux coordonnées de l'entité.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2263,18 +2291,18 @@
       "type": "processor",
       "description": "Extrait l'orientation de la géométrie d'une entité et l'ajoute comme attribut.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OrientationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2296,17 +2324,17 @@
       "type": "processor",
       "description": "Action pour le renvoi du dernier port dans les sous-flux de travail.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OutputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -2507,22 +2535,22 @@
       "type": "processor",
       "description": "Extracts maxLod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MaxLodExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPathAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxLodAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "cityGmlPathAttribute",
           "maxLodAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPathAttribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxLodAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2544,18 +2572,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "UDXFolderExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "cityGmlPath"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2612,22 +2640,22 @@
       "type": "processor",
       "description": "Appelle un script Rhai",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "RhaiCallerParam",
         "type": "object",
-        "properties": {
-          "isTarget": {
-            "$ref": "#/$defs/Expr"
-          },
-          "process": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "isTarget",
           "process"
         ],
-        "$defs": {
+        "properties": {
+          "isTarget": {
+            "$ref": "#/definitions/Expr"
+          },
+          "process": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2649,24 +2677,27 @@
       "type": "processor",
       "description": "Calcule des statistiques sur les entités",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "StatisticsCalculatorParam",
         "type": "object",
+        "required": [
+          "calculations"
+        ],
         "properties": {
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
@@ -2676,31 +2707,28 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Calculation"
+              "$ref": "#/definitions/Calculation"
             }
           }
         },
-        "required": [
-          "calculations"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
-              "newAttribute",
-              "expr"
-            ]
+              "expr",
+              "newAttribute"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -2724,38 +2752,38 @@
       "type": "processor",
       "description": "Remplace un boîtier tridimensionnel par un polygone.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "properties": {
-          "minX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minZ": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
-          "minX",
-          "minY",
-          "minZ",
           "maxX",
           "maxY",
-          "maxZ"
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
         ],
-        "$defs": {
+        "properties": {
+          "maxX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minZ": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2777,42 +2805,42 @@
       "type": "processor",
       "description": "Remplace un boîtier tridimensionnel par un polygone.",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "properties": {
-          "angleDegree": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originZ": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "angleDegree",
-          "originX",
-          "originY",
-          "originZ",
           "directionX",
           "directionY",
-          "directionZ"
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
         ],
-        "$defs": {
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2867,18 +2895,18 @@
       "type": "processor",
       "description": "Reprojette la géométrie d'une entité dans un système de coordonnées spécifié",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "VerticalReprojectorParam",
         "type": "object",
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/$defs/VerticalReprojectorType"
-          }
-        },
         "required": [
           "reprojectorType"
         ],
-        "$defs": {
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/definitions/VerticalReprojectorType"
+          }
+        },
+        "definitions": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2903,26 +2931,26 @@
       "type": "processor",
       "description": "Compile des scripts en .wasm et les exécute dans un environnement d'exécution wasm",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
+        "required": [
+          "processorType",
+          "programmingLanguage",
+          "sourceCodeFilePath"
+        ],
         "properties": {
-          "sourceCodeFilePath": {
-            "type": "string"
-          },
           "processorType": {
-            "$ref": "#/$defs/ProcessorType"
+            "$ref": "#/definitions/ProcessorType"
           },
           "programmingLanguage": {
-            "$ref": "#/$defs/ProgrammingLanguage"
+            "$ref": "#/definitions/ProgrammingLanguage"
+          },
+          "sourceCodeFilePath": {
+            "type": "string"
           }
         },
-        "required": [
-          "sourceCodeFilePath",
-          "processorType",
-          "programmingLanguage"
-        ],
-        "$defs": {
+        "definitions": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2953,39 +2981,41 @@
       "type": "processor",
       "description": "Fragmente du XML",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
             "properties": {
-              "elementsToMatch": {
-                "$ref": "#/$defs/Expr"
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               },
               "elementsToExclude": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
-              "attribute": {
-                "$ref": "#/$defs/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/definitions/Expr"
               },
               "source": {
                 "type": "string",
-                "const": "url"
+                "enum": [
+                  "url"
+                ]
               }
-            },
-            "required": [
-              "source",
-              "elementsToMatch",
-              "elementsToExclude",
-              "attribute"
-            ]
+            }
           }
         ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -3006,35 +3036,28 @@
       "type": "processor",
       "description": "Valide le contenu XML",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlValidatorParam",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/$defs/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/$defs/ValidationType"
-          }
-        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/definitions/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/definitions/ValidationType"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
-            ]
           },
           "ValidationType": {
             "type": "string",
@@ -3042,6 +3065,13 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
             ]
           }
         }

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -5,9 +5,12 @@
       "type": "processor",
       "description": "あるエリアの上に別のエリアを重ね合わせる",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -15,17 +18,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -49,25 +49,33 @@
       "type": "processor",
       "description": "属性に基づいてフィーチャをグルーピングする",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeAggregatorParam",
         "type": "object",
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/AggregateAttribute"
+              "$ref": "#/definitions/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "calculationAttribute": {
+            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -76,29 +84,21 @@
             ],
             "format": "int64"
           },
-          "calculationAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
           "method": {
-            "$ref": "#/$defs/Method"
+            "$ref": "#/definitions/Method"
           }
         },
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
-        "$defs": {
+        "definitions": {
           "AggregateAttribute": {
             "type": "object",
+            "required": [
+              "newAttribute"
+            ],
             "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
               "attribute": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Attribute"
+                    "$ref": "#/definitions/Attribute"
                   },
                   {
                     "type": "null"
@@ -108,17 +108,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
               }
-            },
-            "required": [
-              "newAttribute"
-            ]
+            }
           },
           "Attribute": {
             "type": "string"
@@ -152,21 +152,21 @@
       "type": "processor",
       "description": "重複した属性を持つフィーチャをフィルタリングする",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
+        "required": [
+          "filterBy"
+        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
-        "required": [
-          "filterBy"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -188,18 +188,18 @@
       "type": "processor",
       "description": "属性からファイルパス情報を抽出する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "attribute"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -222,45 +222,23 @@
       "type": "processor",
       "description": "属性を管理する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeManagerParam",
         "type": "object",
+        "required": [
+          "operations"
+        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Operation"
+              "$ref": "#/definitions/Operation"
             }
           }
         },
-        "required": [
-          "operations"
-        ],
-        "$defs": {
-          "Operation": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/$defs/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "attribute",
-              "method"
-            ]
+        "definitions": {
+          "Expr": {
+            "type": "string"
           },
           "Method": {
             "type": "string",
@@ -271,8 +249,30 @@
               "remove"
             ]
           },
-          "Expr": {
-            "type": "string"
+          "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/definitions/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
           }
         }
       },
@@ -292,47 +292,28 @@
       "type": "processor",
       "description": "属性をマッピングする",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeMapperParam",
         "type": "object",
+        "required": [
+          "mappers"
+        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Mapper"
+              "$ref": "#/definitions/Mapper"
             }
           }
         },
-        "required": [
-          "mappers"
-        ],
-        "$defs": {
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -344,20 +325,39 @@
                   "null"
                 ]
               },
-              "multipleExpr": {
+              "expr": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "multipleExpr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "parentAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           }
         }
       },
@@ -394,12 +394,17 @@
       "type": "processor",
       "description": "ジオメトリの周囲にバッファを作成する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Bufferer",
         "type": "object",
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/$defs/BufferType"
+            "$ref": "#/definitions/BufferType"
           },
           "distance": {
             "type": "number",
@@ -410,12 +415,7 @@
             "format": "double"
           }
         },
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
-        "$defs": {
+        "definitions": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -441,21 +441,20 @@
       "type": "processor",
       "description": "属性名にプレフィックス／サフィックスを追加・削除、またはテキスト置換して一括でリネームする",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
+        "required": [
+          "renameAction",
+          "renameType",
+          "renameValue"
+        ],
         "properties": {
-          "renameType": {
-            "$ref": "#/$defs/RenameType"
-          },
           "renameAction": {
-            "$ref": "#/$defs/RenameAction"
+            "$ref": "#/definitions/RenameAction"
           },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
+          "renameType": {
+            "$ref": "#/definitions/RenameType"
           },
           "renameValue": {
             "type": "string"
@@ -468,21 +467,15 @@
             "items": {
               "type": "string"
             }
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
-        "required": [
-          "renameType",
-          "renameAction",
-          "renameValue"
-        ],
-        "$defs": {
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
-            ]
-          },
+        "definitions": {
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -491,6 +484,13 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
+            ]
+          },
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
             ]
           }
         }
@@ -528,36 +528,36 @@
       "type": "sink",
       "description": "フィーチャをファイルに書き出す",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
+        "required": [
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -614,19 +614,19 @@
       "type": "processor",
       "description": "フィーチャの座標系を設定する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "CoordinateSystemSetter",
         "type": "object",
+        "required": [
+          "epsgCode"
+        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
-        },
-        "required": [
-          "epsgCode"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -692,18 +692,18 @@
       "type": "processor",
       "description": "フィーチャの最初のZ座標値を抽出し、属性として格納する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ElevationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -725,18 +725,18 @@
       "type": "processor",
       "description": "ポリゴンを一定の距離で押し出す（エクストルード）",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ExtruderParam",
         "type": "object",
-        "properties": {
-          "distance": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "distance"
         ],
-        "$defs": {
+        "properties": {
+          "distance": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -758,9 +758,13 @@
       "type": "processor",
       "description": "フィーチャ数をカウントする",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCounterParam",
         "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,18 +776,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -806,18 +806,18 @@
       "type": "source",
       "description": "式に基づいてフィーチャを作成する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCreator",
         "type": "object",
-        "properties": {
-          "creator": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "creator"
         ],
-        "$defs": {
+        "properties": {
+          "creator": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -837,22 +837,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -875,35 +875,35 @@
       "type": "processor",
       "description": "条件に基づいてフィーチャをフィルタリングする",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilterParam",
         "type": "object",
+        "required": [
+          "conditions"
+        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Condition"
+              "$ref": "#/definitions/Condition"
             }
           }
         },
-        "required": [
-          "conditions"
-        ],
-        "$defs": {
+        "definitions": {
           "Condition": {
             "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/$defs/Port"
-              }
-            },
             "required": [
               "expr",
               "outputPort"
-            ]
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/definitions/Port"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -929,18 +929,18 @@
       "type": "processor",
       "description": "Filter Geometry by lod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureLodFilterParam",
         "type": "object",
-        "properties": {
-          "filterKey": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "filterKey"
         ],
-        "$defs": {
+        "properties": {
+          "filterKey": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -966,18 +966,34 @@
       "type": "processor",
       "description": "属性に基づいてフィーチャをマージする",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "requestorAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "supplierAttribute": {
             "type": [
@@ -985,37 +1001,21 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1042,40 +1042,48 @@
       "type": "processor",
       "description": "条件に基づいてフィーチャをフィルタリングする",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1083,23 +1091,25 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1107,16 +1117,12 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1138,52 +1144,21 @@
       "type": "processor",
       "description": "フィーチャを属性でソートする",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureSorterParam",
         "type": "object",
+        "required": [
+          "sortBy"
+        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/SortBy"
+              "$ref": "#/definitions/SortBy"
             }
           }
         },
-        "required": [
-          "sortBy"
-        ],
-        "$defs": {
-          "SortBy": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/$defs/Order"
-              }
-            },
-            "required": [
-              "order"
-            ]
-          },
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1196,6 +1171,37 @@
               "ascending",
               "descending"
             ]
+          },
+          "SortBy": {
+            "type": "object",
+            "required": [
+              "order"
+            ],
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/definitions/Order"
+              }
+            }
           }
         }
       },
@@ -1215,34 +1221,34 @@
       "type": "processor",
       "description": "式を用いてフィーチャを変換する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTransformerParam",
         "type": "object",
+        "required": [
+          "transformers"
+        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Transform"
+              "$ref": "#/definitions/Transform"
             }
           }
         },
-        "required": [
-          "transformers"
-        ],
-        "$defs": {
-          "Transform": {
-            "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
-            "required": [
-              "expr"
-            ]
-          },
+        "definitions": {
           "Expr": {
             "type": "string"
+          },
+          "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
           }
         }
       },
@@ -1262,9 +1268,12 @@
       "type": "processor",
       "description": "フィーチャタイプに基づいてフィーチャをフィルタリングする",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTypeFilter",
         "type": "object",
+        "required": [
+          "targetTypes"
+        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1272,10 +1281,7 @@
               "type": "string"
             }
           }
-        },
-        "required": [
-          "targetTypes"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1294,22 +1300,22 @@
       "type": "source",
       "description": "ディレクトリまたはアーカイブからファイルを抽出する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePathExtractor",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1329,17 +1335,17 @@
       "type": "processor",
       "description": "ファイルからプロパティを抽出する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePropertyExtractor",
         "type": "object",
+        "required": [
+          "filePathAttribute"
+        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        },
-        "required": [
-          "filePathAttribute"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1358,19 +1364,25 @@
       "type": "source",
       "description": "ファイルからフィーチャを読み込む",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileReader",
         "oneOf": [
           {
             "title": "CSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1378,24 +1390,26 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "TSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1403,56 +1417,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "JSON",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "json"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "json"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "CityGML",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1472,76 +1486,88 @@
       "type": "sink",
       "description": "フィーチャをファイルに書き出す",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "properties": {
-              "format": {
-                "type": "string",
-                "const": "csv"
-              },
-              "output": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "tsv"
+                "enum": [
+                  "csv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               }
-            },
+            }
+          },
+          {
+            "type": "object",
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "json"
+                "enum": [
+                  "tsv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
-              },
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "excel"
+                "enum": [
+                  "excel"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1549,14 +1575,10 @@
                   "null"
                 ]
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1576,31 +1598,31 @@
       "type": "sink",
       "description": "フィーチャをGeoJSONファイルに書き出す",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeoJsonWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -1619,18 +1641,18 @@
       "type": "processor",
       "description": "フィーチャのジオメトリを特定のジオメトリタイプに強制変換する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryCoercer",
         "type": "object",
-        "properties": {
-          "coercerType": {
-            "$ref": "#/$defs/CoercerType"
-          }
-        },
         "required": [
           "coercerType"
         ],
-        "$defs": {
+        "properties": {
+          "coercerType": {
+            "$ref": "#/definitions/CoercerType"
+          }
+        },
+        "definitions": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1655,27 +1677,27 @@
       "type": "processor",
       "description": "ジオメトリをディゾルブ（結合）する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1698,18 +1720,18 @@
       "type": "processor",
       "description": "フィーチャからジオメトリを抽出し、属性として追加する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryExtractor",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1731,44 +1753,50 @@
       "type": "processor",
       "description": "ジオメトリをタイプに基づいてフィルタリングする",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "none"
+                "enum": [
+                  "none"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "multiple"
+                "enum": [
+                  "multiple"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "geometryType"
+                "enum": [
+                  "geometryType"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           }
         ]
       },
@@ -1811,18 +1839,18 @@
       "type": "processor",
       "description": "フィーチャのジオメトリを新しいジオメトリで置き換える",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryReplacer",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1860,21 +1888,21 @@
       "type": "processor",
       "description": "フィーチャのジオメトリを検証する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryValidator",
         "type": "object",
+        "required": [
+          "validationTypes"
+        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/ValidationType"
+              "$ref": "#/definitions/ValidationType"
             }
           }
         },
-        "required": [
-          "validationTypes"
-        ],
-        "$defs": {
+        "definitions": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1922,24 +1950,24 @@
       "type": "sink",
       "description": "フィーチャをGltfファイルに書き出す",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GltfWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1959,18 +1987,18 @@
       "type": "processor",
       "description": "ジオメトリ内の穴の数をカウントし、属性として追加する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HoleCounterParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2010,7 +2038,7 @@
       "type": "processor",
       "description": "フィーチャのジオメトリを指定された座標系に水平再投影する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2020,7 +2048,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
         }
       },
@@ -2040,17 +2068,17 @@
       "type": "processor",
       "description": "サブワークフローで最初のポートを転送するアクション",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "InputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [],
@@ -2066,9 +2094,12 @@
       "type": "processor",
       "description": "交点を点フィーチャに変換し、元の交差したラインの属性リストを結合して含めることができる",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2076,17 +2107,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2110,18 +2138,18 @@
       "type": "processor",
       "description": "リスト属性を複数の要素に分解する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ListExploder",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2143,34 +2171,34 @@
       "type": "sink",
       "description": "フィーチャをファイルに書き出す",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MVTWriterParam",
         "type": "object",
+        "required": [
+          "layerName",
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "layerName": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
+            "$ref": "#/definitions/Expr"
           },
           "maxZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "layerName",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2220,7 +2248,7 @@
       "type": "processor",
       "description": "フィーチャの座標にオフセットを加える",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2263,18 +2291,18 @@
       "type": "processor",
       "description": "フィーチャのジオメトリの方向を抽出し、属性として追加する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OrientationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2296,17 +2324,17 @@
       "type": "processor",
       "description": "サブワークフローで最後のポートを転送するアクション",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OutputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -2507,22 +2535,22 @@
       "type": "processor",
       "description": "Extracts maxLod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MaxLodExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPathAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxLodAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "cityGmlPathAttribute",
           "maxLodAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPathAttribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxLodAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2544,18 +2572,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "UDXFolderExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "cityGmlPath"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2612,22 +2640,22 @@
       "type": "processor",
       "description": "Rhaiスクリプトを呼び出す",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "RhaiCallerParam",
         "type": "object",
-        "properties": {
-          "isTarget": {
-            "$ref": "#/$defs/Expr"
-          },
-          "process": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "isTarget",
           "process"
         ],
-        "$defs": {
+        "properties": {
+          "isTarget": {
+            "$ref": "#/definitions/Expr"
+          },
+          "process": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2649,24 +2677,27 @@
       "type": "processor",
       "description": "フィーチャの統計情報を計算する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "StatisticsCalculatorParam",
         "type": "object",
+        "required": [
+          "calculations"
+        ],
         "properties": {
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
@@ -2676,31 +2707,28 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Calculation"
+              "$ref": "#/definitions/Calculation"
             }
           }
         },
-        "required": [
-          "calculations"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
-              "newAttribute",
-              "expr"
-            ]
+              "expr",
+              "newAttribute"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -2724,38 +2752,38 @@
       "type": "processor",
       "description": "3次元ボックスをポリゴンで置き換える",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "properties": {
-          "minX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minZ": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
-          "minX",
-          "minY",
-          "minZ",
           "maxX",
           "maxY",
-          "maxZ"
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
         ],
-        "$defs": {
+        "properties": {
+          "maxX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minZ": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2777,42 +2805,42 @@
       "type": "processor",
       "description": "3次元ボックスをポリゴンで置き換える",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "properties": {
-          "angleDegree": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originZ": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "angleDegree",
-          "originX",
-          "originY",
-          "originZ",
           "directionX",
           "directionY",
-          "directionZ"
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
         ],
-        "$defs": {
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2867,18 +2895,18 @@
       "type": "processor",
       "description": "フィーチャのジオメトリを指定された座標系に垂直再投影する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "VerticalReprojectorParam",
         "type": "object",
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/$defs/VerticalReprojectorType"
-          }
-        },
         "required": [
           "reprojectorType"
         ],
-        "$defs": {
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/definitions/VerticalReprojectorType"
+          }
+        },
+        "definitions": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2903,26 +2931,26 @@
       "type": "processor",
       "description": "スクリプトを.wasmにコンパイルし、wasmランタイムで実行する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
+        "required": [
+          "processorType",
+          "programmingLanguage",
+          "sourceCodeFilePath"
+        ],
         "properties": {
-          "sourceCodeFilePath": {
-            "type": "string"
-          },
           "processorType": {
-            "$ref": "#/$defs/ProcessorType"
+            "$ref": "#/definitions/ProcessorType"
           },
           "programmingLanguage": {
-            "$ref": "#/$defs/ProgrammingLanguage"
+            "$ref": "#/definitions/ProgrammingLanguage"
+          },
+          "sourceCodeFilePath": {
+            "type": "string"
           }
         },
-        "required": [
-          "sourceCodeFilePath",
-          "processorType",
-          "programmingLanguage"
-        ],
-        "$defs": {
+        "definitions": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2953,39 +2981,41 @@
       "type": "processor",
       "description": "XMLを分割する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
             "properties": {
-              "elementsToMatch": {
-                "$ref": "#/$defs/Expr"
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               },
               "elementsToExclude": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
-              "attribute": {
-                "$ref": "#/$defs/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/definitions/Expr"
               },
               "source": {
                 "type": "string",
-                "const": "url"
+                "enum": [
+                  "url"
+                ]
               }
-            },
-            "required": [
-              "source",
-              "elementsToMatch",
-              "elementsToExclude",
-              "attribute"
-            ]
+            }
           }
         ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -3006,35 +3036,28 @@
       "type": "processor",
       "description": "XMLコンテンツを検証する",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlValidatorParam",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/$defs/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/$defs/ValidationType"
-          }
-        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/definitions/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/definitions/ValidationType"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
-            ]
           },
           "ValidationType": {
             "type": "string",
@@ -3042,6 +3065,13 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
             ]
           }
         }

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -5,9 +5,12 @@
       "type": "processor",
       "description": "在一个区域上叠加另一个区域",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AreaOnAreaOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -15,17 +18,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -49,25 +49,33 @@
       "type": "processor",
       "description": "根据属性对实体进行分组",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeAggregatorParam",
         "type": "object",
+        "required": [
+          "aggregateAttributes",
+          "calculationAttribute",
+          "method"
+        ],
         "properties": {
           "aggregateAttributes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/AggregateAttribute"
+              "$ref": "#/definitions/AggregateAttribute"
             }
           },
           "calculation": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
+          },
+          "calculationAttribute": {
+            "$ref": "#/definitions/Attribute"
           },
           "calculationValue": {
             "type": [
@@ -76,29 +84,21 @@
             ],
             "format": "int64"
           },
-          "calculationAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
           "method": {
-            "$ref": "#/$defs/Method"
+            "$ref": "#/definitions/Method"
           }
         },
-        "required": [
-          "aggregateAttributes",
-          "calculationAttribute",
-          "method"
-        ],
-        "$defs": {
+        "definitions": {
           "AggregateAttribute": {
             "type": "object",
+            "required": [
+              "newAttribute"
+            ],
             "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
               "attribute": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Attribute"
+                    "$ref": "#/definitions/Attribute"
                   },
                   {
                     "type": "null"
@@ -108,17 +108,17 @@
               "attributeValue": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
               }
-            },
-            "required": [
-              "newAttribute"
-            ]
+            }
           },
           "Attribute": {
             "type": "string"
@@ -152,21 +152,21 @@
       "type": "processor",
       "description": "筛选具有重复属性的实体",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeDuplicateFilterParam",
         "type": "object",
+        "required": [
+          "filterBy"
+        ],
         "properties": {
           "filterBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
-        "required": [
-          "filterBy"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -188,18 +188,18 @@
       "type": "processor",
       "description": "从属性中提取文件路径信息",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeFilePathInfoExtractor",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "attribute"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -222,45 +222,23 @@
       "type": "processor",
       "description": "管理属性",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeManagerParam",
         "type": "object",
+        "required": [
+          "operations"
+        ],
         "properties": {
           "operations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Operation"
+              "$ref": "#/definitions/Operation"
             }
           }
         },
-        "required": [
-          "operations"
-        ],
-        "$defs": {
-          "Operation": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "type": "string"
-              },
-              "method": {
-                "$ref": "#/$defs/Method"
-              },
-              "value": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              }
-            },
-            "required": [
-              "attribute",
-              "method"
-            ]
+        "definitions": {
+          "Expr": {
+            "type": "string"
           },
           "Method": {
             "type": "string",
@@ -271,8 +249,30 @@
               "remove"
             ]
           },
-          "Expr": {
-            "type": "string"
+          "Operation": {
+            "type": "object",
+            "required": [
+              "attribute",
+              "method"
+            ],
+            "properties": {
+              "attribute": {
+                "type": "string"
+              },
+              "method": {
+                "$ref": "#/definitions/Method"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            }
           }
         }
       },
@@ -292,47 +292,28 @@
       "type": "processor",
       "description": "分配属性",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "AttributeMapperParam",
         "type": "object",
+        "required": [
+          "mappers"
+        ],
         "properties": {
           "mappers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Mapper"
+              "$ref": "#/definitions/Mapper"
             }
           }
         },
-        "required": [
-          "mappers"
-        ],
-        "$defs": {
+        "definitions": {
+          "Expr": {
+            "type": "string"
+          },
           "Mapper": {
             "type": "object",
             "properties": {
               "attribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "expr": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "valueAttribute": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "parentAttribute": {
                 "type": [
                   "string",
                   "null"
@@ -344,20 +325,39 @@
                   "null"
                 ]
               },
-              "multipleExpr": {
+              "expr": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "multipleExpr": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "parentAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "valueAttribute": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           }
         }
       },
@@ -394,12 +394,17 @@
       "type": "processor",
       "description": "在几何图形周围创建缓冲区",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Bufferer",
         "type": "object",
+        "required": [
+          "bufferType",
+          "distance",
+          "interpolationAngle"
+        ],
         "properties": {
           "bufferType": {
-            "$ref": "#/$defs/BufferType"
+            "$ref": "#/definitions/BufferType"
           },
           "distance": {
             "type": "number",
@@ -410,12 +415,7 @@
             "format": "double"
           }
         },
-        "required": [
-          "bufferType",
-          "distance",
-          "interpolationAngle"
-        ],
-        "$defs": {
+        "definitions": {
           "BufferType": {
             "type": "string",
             "enum": [
@@ -441,21 +441,20 @@
       "type": "processor",
       "description": "通过添加/删除前缀或后缀，或替换文本来重命名属性",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "BulkAttributeRenamerParam",
         "type": "object",
+        "required": [
+          "renameAction",
+          "renameType",
+          "renameValue"
+        ],
         "properties": {
-          "renameType": {
-            "$ref": "#/$defs/RenameType"
-          },
           "renameAction": {
-            "$ref": "#/$defs/RenameAction"
+            "$ref": "#/definitions/RenameAction"
           },
-          "textToFind": {
-            "type": [
-              "string",
-              "null"
-            ]
+          "renameType": {
+            "$ref": "#/definitions/RenameType"
           },
           "renameValue": {
             "type": "string"
@@ -468,21 +467,15 @@
             "items": {
               "type": "string"
             }
+          },
+          "textToFind": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
-        "required": [
-          "renameType",
-          "renameAction",
-          "renameValue"
-        ],
-        "$defs": {
-          "RenameType": {
-            "type": "string",
-            "enum": [
-              "All",
-              "Selected"
-            ]
-          },
+        "definitions": {
           "RenameAction": {
             "type": "string",
             "enum": [
@@ -491,6 +484,13 @@
               "RemovePrefix",
               "RemoveSuffix",
               "StringReplace"
+            ]
+          },
+          "RenameType": {
+            "type": "string",
+            "enum": [
+              "All",
+              "Selected"
             ]
           }
         }
@@ -528,36 +528,36 @@
       "type": "sink",
       "description": "将实体写入文件",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "Cesium3DTilesWriterParam",
         "type": "object",
+        "required": [
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
-          "maxZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "maxZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -614,19 +614,19 @@
       "type": "processor",
       "description": "设置实体的坐标系",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "CoordinateSystemSetter",
         "type": "object",
+        "required": [
+          "epsgCode"
+        ],
         "properties": {
           "epsgCode": {
             "type": "integer",
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
-        },
-        "required": [
-          "epsgCode"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -692,18 +692,18 @@
       "type": "processor",
       "description": "提取实体的第一个z坐标值并存储为一个属性",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ElevationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -725,18 +725,18 @@
       "type": "processor",
       "description": "沿一定距离拉伸多边形",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ExtruderParam",
         "type": "object",
-        "properties": {
-          "distance": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "distance"
         ],
-        "$defs": {
+        "properties": {
+          "distance": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -758,9 +758,13 @@
       "type": "processor",
       "description": "统计实体数量",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCounterParam",
         "type": "object",
+        "required": [
+          "countStart",
+          "outputAttribute"
+        ],
         "properties": {
           "countStart": {
             "type": "integer",
@@ -772,18 +776,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
             "type": "string"
           }
         },
-        "required": [
-          "countStart",
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -806,18 +806,18 @@
       "type": "source",
       "description": "根据表达式创建实体",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureCreator",
         "type": "object",
-        "properties": {
-          "creator": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "creator"
         ],
-        "$defs": {
+        "properties": {
+          "creator": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -837,22 +837,22 @@
       "type": "processor",
       "description": "Extracts features by file path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilePathExtractorParam",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -875,35 +875,35 @@
       "type": "processor",
       "description": "根据条件筛选实体",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureFilterParam",
         "type": "object",
+        "required": [
+          "conditions"
+        ],
         "properties": {
           "conditions": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Condition"
+              "$ref": "#/definitions/Condition"
             }
           }
         },
-        "required": [
-          "conditions"
-        ],
-        "$defs": {
+        "definitions": {
           "Condition": {
             "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              },
-              "outputPort": {
-                "$ref": "#/$defs/Port"
-              }
-            },
             "required": [
               "expr",
               "outputPort"
-            ]
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "outputPort": {
+                "$ref": "#/definitions/Port"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -929,18 +929,18 @@
       "type": "processor",
       "description": "Filter Geometry by lod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureLodFilterParam",
         "type": "object",
-        "properties": {
-          "filterKey": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "filterKey"
         ],
-        "$defs": {
+        "properties": {
+          "filterKey": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -966,18 +966,34 @@
       "type": "processor",
       "description": "根据属性合并实体",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureMergerParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "requestorAttribute": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "requestorAttributeValue": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "supplierAttribute": {
             "type": [
@@ -985,37 +1001,21 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "requestorAttributeValue": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/Expr"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "supplierAttributeValue": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               {
                 "type": "null"
               }
             ]
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1042,40 +1042,48 @@
       "type": "processor",
       "description": "根据条件筛选实体",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureReaderParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1083,23 +1091,25 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1107,16 +1117,12 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1138,52 +1144,21 @@
       "type": "processor",
       "description": "根据属性对实体排序",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureSorterParam",
         "type": "object",
+        "required": [
+          "sortBy"
+        ],
         "properties": {
           "sortBy": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/SortBy"
+              "$ref": "#/definitions/SortBy"
             }
           }
         },
-        "required": [
-          "sortBy"
-        ],
-        "$defs": {
-          "SortBy": {
-            "type": "object",
-            "properties": {
-              "attribute": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Attribute"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "attributeValue": {
-                "anyOf": [
-                  {
-                    "$ref": "#/$defs/Expr"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
-              "order": {
-                "$ref": "#/$defs/Order"
-              }
-            },
-            "required": [
-              "order"
-            ]
-          },
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
@@ -1196,6 +1171,37 @@
               "ascending",
               "descending"
             ]
+          },
+          "SortBy": {
+            "type": "object",
+            "required": [
+              "order"
+            ],
+            "properties": {
+              "attribute": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "attributeValue": {
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Expr"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "order": {
+                "$ref": "#/definitions/Order"
+              }
+            }
           }
         }
       },
@@ -1215,34 +1221,34 @@
       "type": "processor",
       "description": "通过表达式转换实体",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTransformerParam",
         "type": "object",
+        "required": [
+          "transformers"
+        ],
         "properties": {
           "transformers": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Transform"
+              "$ref": "#/definitions/Transform"
             }
           }
         },
-        "required": [
-          "transformers"
-        ],
-        "$defs": {
-          "Transform": {
-            "type": "object",
-            "properties": {
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
-            "required": [
-              "expr"
-            ]
-          },
+        "definitions": {
           "Expr": {
             "type": "string"
+          },
+          "Transform": {
+            "type": "object",
+            "required": [
+              "expr"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              }
+            }
           }
         }
       },
@@ -1262,9 +1268,12 @@
       "type": "processor",
       "description": "根据类型筛选实体",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FeatureTypeFilter",
         "type": "object",
+        "required": [
+          "targetTypes"
+        ],
         "properties": {
           "targetTypes": {
             "type": "array",
@@ -1272,10 +1281,7 @@
               "type": "string"
             }
           }
-        },
-        "required": [
-          "targetTypes"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1294,22 +1300,22 @@
       "type": "source",
       "description": "从目录或归档文件中提取文件",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePathExtractor",
         "type": "object",
+        "required": [
+          "extractArchive",
+          "sourceDataset"
+        ],
         "properties": {
-          "sourceDataset": {
-            "$ref": "#/$defs/Expr"
-          },
           "extractArchive": {
             "type": "boolean"
+          },
+          "sourceDataset": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "sourceDataset",
-          "extractArchive"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1329,17 +1335,17 @@
       "type": "processor",
       "description": "提取文件的属性",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FilePropertyExtractor",
         "type": "object",
+        "required": [
+          "filePathAttribute"
+        ],
         "properties": {
           "filePathAttribute": {
             "type": "string"
           }
-        },
-        "required": [
-          "filePathAttribute"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -1358,19 +1364,25 @@
       "type": "source",
       "description": "从文件中读取实体",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileReader",
         "oneOf": [
           {
             "title": "CSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "csv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "csv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1378,24 +1390,26 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "TSV",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "tsv"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "tsv"
+                ]
               },
               "offset": {
                 "type": [
@@ -1403,56 +1417,56 @@
                   "null"
                 ],
                 "format": "uint",
-                "minimum": 0
+                "minimum": 0.0
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "JSON",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
+              "dataset": {
+                "$ref": "#/definitions/Expr"
+              },
               "format": {
                 "type": "string",
-                "const": "json"
-              },
-              "dataset": {
-                "$ref": "#/$defs/Expr"
+                "enum": [
+                  "json"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           },
           {
             "title": "CityGML",
             "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
             "properties": {
-              "format": {
-                "type": "string",
-                "const": "citygml"
-              },
               "dataset": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "flatten": {
                 "type": [
                   "boolean",
                   "null"
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "citygml"
+                ]
               }
-            },
-            "required": [
-              "format",
-              "dataset"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1472,76 +1486,88 @@
       "type": "sink",
       "description": "将实体写入文件",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "FileWriterParam",
         "oneOf": [
           {
             "type": "object",
-            "properties": {
-              "format": {
-                "type": "string",
-                "const": "csv"
-              },
-              "output": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "tsv"
+                "enum": [
+                  "csv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               }
-            },
+            }
+          },
+          {
+            "type": "object",
             "required": [
               "format",
               "output"
-            ]
-          },
-          {
-            "type": "object",
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "json"
+                "enum": [
+                  "tsv"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
-              },
+                "$ref": "#/definitions/Expr"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
+            "properties": {
               "converter": {
                 "anyOf": [
                   {
-                    "$ref": "#/$defs/Expr"
+                    "$ref": "#/definitions/Expr"
                   },
                   {
                     "type": "null"
                   }
                 ]
+              },
+              "format": {
+                "type": "string",
+                "enum": [
+                  "json"
+                ]
+              },
+              "output": {
+                "$ref": "#/definitions/Expr"
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "format",
+              "output"
+            ],
             "properties": {
               "format": {
                 "type": "string",
-                "const": "excel"
+                "enum": [
+                  "excel"
+                ]
               },
               "output": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
               "sheetName": {
                 "type": [
@@ -1549,14 +1575,10 @@
                   "null"
                 ]
               }
-            },
-            "required": [
-              "format",
-              "output"
-            ]
+            }
           }
         ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1576,31 +1598,31 @@
       "type": "sink",
       "description": "将实体写入 GeoJSON 文件",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeoJsonWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -1619,18 +1641,18 @@
       "type": "processor",
       "description": "强制将实体几何转换为特定几何类型",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryCoercer",
         "type": "object",
-        "properties": {
-          "coercerType": {
-            "$ref": "#/$defs/CoercerType"
-          }
-        },
         "required": [
           "coercerType"
         ],
-        "$defs": {
+        "properties": {
+          "coercerType": {
+            "$ref": "#/definitions/CoercerType"
+          }
+        },
+        "definitions": {
           "CoercerType": {
             "type": "string",
             "enum": [
@@ -1655,27 +1677,27 @@
       "type": "processor",
       "description": "溶解几何体",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryDissolverParam",
         "type": "object",
         "properties": {
+          "completeGrouped": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "type": [
               "array",
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
-          },
-          "completeGrouped": {
-            "type": [
-              "boolean",
-              "null"
-            ]
           }
         },
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1698,18 +1720,18 @@
       "type": "processor",
       "description": "提取实体的几何并作为属性添加",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryExtractor",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1731,44 +1753,50 @@
       "type": "processor",
       "description": "根据类型筛选几何",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryFilterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "none"
+                "enum": [
+                  "none"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "multiple"
+                "enum": [
+                  "multiple"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           },
           {
             "type": "object",
+            "required": [
+              "filterType"
+            ],
             "properties": {
               "filterType": {
                 "type": "string",
-                "const": "geometryType"
+                "enum": [
+                  "geometryType"
+                ]
               }
-            },
-            "required": [
-              "filterType"
-            ]
+            }
           }
         ]
       },
@@ -1811,18 +1839,18 @@
       "type": "processor",
       "description": "用新几何替换实体的几何",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryReplacer",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -1860,21 +1888,21 @@
       "type": "processor",
       "description": "验证实体的几何",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GeometryValidator",
         "type": "object",
+        "required": [
+          "validationTypes"
+        ],
         "properties": {
           "validationTypes": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/ValidationType"
+              "$ref": "#/definitions/ValidationType"
             }
           }
         },
-        "required": [
-          "validationTypes"
-        ],
-        "$defs": {
+        "definitions": {
           "ValidationType": {
             "type": "string",
             "enum": [
@@ -1922,24 +1950,24 @@
       "type": "sink",
       "description": "将实体写入Gltf文件",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "GltfWriterParam",
         "type": "object",
+        "required": [
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "attachTexture": {
             "type": [
               "boolean",
               "null"
             ]
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -1959,18 +1987,18 @@
       "type": "processor",
       "description": "统计几何中的孔数量并作为属性添加",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HoleCounterParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2010,7 +2038,7 @@
       "type": "processor",
       "description": "将实体的几何重投影到指定坐标系",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "HorizontalReprojectorParam",
         "type": "object",
         "properties": {
@@ -2020,7 +2048,7 @@
               "null"
             ],
             "format": "uint16",
-            "minimum": 0
+            "minimum": 0.0
           }
         }
       },
@@ -2040,17 +2068,17 @@
       "type": "processor",
       "description": "用于子工作流中最初一个端口转发的操作",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "InputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [],
@@ -2066,9 +2094,12 @@
       "type": "processor",
       "description": "交点转换为点实体，并可包含原始相交线段组合的属性列表",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "LineOnLineOverlayerParam",
         "type": "object",
+        "required": [
+          "outputAttribute"
+        ],
         "properties": {
           "groupBy": {
             "type": [
@@ -2076,17 +2107,14 @@
               "null"
             ],
             "items": {
-              "$ref": "#/$defs/Attribute"
+              "$ref": "#/definitions/Attribute"
             }
           },
           "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
+            "$ref": "#/definitions/Attribute"
           }
         },
-        "required": [
-          "outputAttribute"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2110,18 +2138,18 @@
       "type": "processor",
       "description": "将列表类型的属性拆分为多个元素",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ListExploder",
         "type": "object",
-        "properties": {
-          "sourceAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "sourceAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "sourceAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2143,34 +2171,34 @@
       "type": "sink",
       "description": "将实体写入文件",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MVTWriterParam",
         "type": "object",
+        "required": [
+          "layerName",
+          "maxZoom",
+          "minZoom",
+          "output"
+        ],
         "properties": {
-          "output": {
-            "$ref": "#/$defs/Expr"
-          },
           "layerName": {
-            "$ref": "#/$defs/Expr"
-          },
-          "minZoom": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0
+            "$ref": "#/definitions/Expr"
           },
           "maxZoom": {
             "type": "integer",
             "format": "uint8",
-            "minimum": 0
+            "minimum": 0.0
+          },
+          "minZoom": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "output": {
+            "$ref": "#/definitions/Expr"
           }
         },
-        "required": [
-          "output",
-          "layerName",
-          "minZoom",
-          "maxZoom"
-        ],
-        "$defs": {
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2220,7 +2248,7 @@
       "type": "processor",
       "description": "为实体的坐标添加偏移",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OffsetterParam",
         "type": "object",
         "properties": {
@@ -2263,18 +2291,18 @@
       "type": "processor",
       "description": "提取实体几何的方向并作为属性添加",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OrientationExtractorParam",
         "type": "object",
-        "properties": {
-          "outputAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "outputAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "outputAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2296,17 +2324,17 @@
       "type": "processor",
       "description": "用于子工作流中最后一个端口转发的操作",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "OutputRouter",
         "type": "object",
+        "required": [
+          "routingPort"
+        ],
         "properties": {
           "routingPort": {
             "type": "string"
           }
-        },
-        "required": [
-          "routingPort"
-        ]
+        }
       },
       "builtin": true,
       "inputPorts": [
@@ -2507,22 +2535,22 @@
       "type": "processor",
       "description": "Extracts maxLod",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "MaxLodExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPathAttribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxLodAttribute": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
           "cityGmlPathAttribute",
           "maxLodAttribute"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPathAttribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxLodAttribute": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2544,18 +2572,18 @@
       "type": "processor",
       "description": "Extracts UDX folders from cityGML path",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "UDXFolderExtractorParam",
         "type": "object",
-        "properties": {
-          "cityGmlPath": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "cityGmlPath"
         ],
-        "$defs": {
+        "properties": {
+          "cityGmlPath": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2612,22 +2640,22 @@
       "type": "processor",
       "description": "调用Rhai脚本",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "RhaiCallerParam",
         "type": "object",
-        "properties": {
-          "isTarget": {
-            "$ref": "#/$defs/Expr"
-          },
-          "process": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "isTarget",
           "process"
         ],
-        "$defs": {
+        "properties": {
+          "isTarget": {
+            "$ref": "#/definitions/Expr"
+          },
+          "process": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2649,24 +2677,27 @@
       "type": "processor",
       "description": "计算实体的统计信息",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "StatisticsCalculatorParam",
         "type": "object",
+        "required": [
+          "calculations"
+        ],
         "properties": {
-          "aggregateName": {
+          "aggregateAttribute": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "aggregateAttribute": {
+          "aggregateName": {
             "anyOf": [
               {
-                "$ref": "#/$defs/Attribute"
+                "$ref": "#/definitions/Attribute"
               },
               {
                 "type": "null"
@@ -2676,31 +2707,28 @@
           "calculations": {
             "type": "array",
             "items": {
-              "$ref": "#/$defs/Calculation"
+              "$ref": "#/definitions/Calculation"
             }
           }
         },
-        "required": [
-          "calculations"
-        ],
-        "$defs": {
+        "definitions": {
           "Attribute": {
             "type": "string"
           },
           "Calculation": {
             "type": "object",
-            "properties": {
-              "newAttribute": {
-                "$ref": "#/$defs/Attribute"
-              },
-              "expr": {
-                "$ref": "#/$defs/Expr"
-              }
-            },
             "required": [
-              "newAttribute",
-              "expr"
-            ]
+              "expr",
+              "newAttribute"
+            ],
+            "properties": {
+              "expr": {
+                "$ref": "#/definitions/Expr"
+              },
+              "newAttribute": {
+                "$ref": "#/definitions/Attribute"
+              }
+            }
           },
           "Expr": {
             "type": "string"
@@ -2724,38 +2752,38 @@
       "type": "processor",
       "description": "用多边形替换三维盒子",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionBoxReplacer",
         "type": "object",
-        "properties": {
-          "minX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "minZ": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxX": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxY": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "maxZ": {
-            "$ref": "#/$defs/Attribute"
-          }
-        },
         "required": [
-          "minX",
-          "minY",
-          "minZ",
           "maxX",
           "maxY",
-          "maxZ"
+          "maxZ",
+          "minX",
+          "minY",
+          "minZ"
         ],
-        "$defs": {
+        "properties": {
+          "maxX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "maxZ": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minX": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minY": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "minZ": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
           }
@@ -2777,42 +2805,42 @@
       "type": "processor",
       "description": "用多边形替换三维盒子",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "ThreeDimensionRotatorParam",
         "type": "object",
-        "properties": {
-          "angleDegree": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "originZ": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionX": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionY": {
-            "$ref": "#/$defs/Expr"
-          },
-          "directionZ": {
-            "$ref": "#/$defs/Expr"
-          }
-        },
         "required": [
           "angleDegree",
-          "originX",
-          "originY",
-          "originZ",
           "directionX",
           "directionY",
-          "directionZ"
+          "directionZ",
+          "originX",
+          "originY",
+          "originZ"
         ],
-        "$defs": {
+        "properties": {
+          "angleDegree": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "directionZ": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originX": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originY": {
+            "$ref": "#/definitions/Expr"
+          },
+          "originZ": {
+            "$ref": "#/definitions/Expr"
+          }
+        },
+        "definitions": {
           "Expr": {
             "type": "string"
           }
@@ -2867,18 +2895,18 @@
       "type": "processor",
       "description": "将实体的几何重投影到指定坐标系",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "VerticalReprojectorParam",
         "type": "object",
-        "properties": {
-          "reprojectorType": {
-            "$ref": "#/$defs/VerticalReprojectorType"
-          }
-        },
         "required": [
           "reprojectorType"
         ],
-        "$defs": {
+        "properties": {
+          "reprojectorType": {
+            "$ref": "#/definitions/VerticalReprojectorType"
+          }
+        },
+        "definitions": {
           "VerticalReprojectorType": {
             "type": "string",
             "enum": [
@@ -2903,26 +2931,26 @@
       "type": "processor",
       "description": "将脚本编译为.wasm并在wasm运行环境中执行",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "WasmRuntimeExecutorParam",
         "type": "object",
+        "required": [
+          "processorType",
+          "programmingLanguage",
+          "sourceCodeFilePath"
+        ],
         "properties": {
-          "sourceCodeFilePath": {
-            "type": "string"
-          },
           "processorType": {
-            "$ref": "#/$defs/ProcessorType"
+            "$ref": "#/definitions/ProcessorType"
           },
           "programmingLanguage": {
-            "$ref": "#/$defs/ProgrammingLanguage"
+            "$ref": "#/definitions/ProgrammingLanguage"
+          },
+          "sourceCodeFilePath": {
+            "type": "string"
           }
         },
-        "required": [
-          "sourceCodeFilePath",
-          "processorType",
-          "programmingLanguage"
-        ],
-        "$defs": {
+        "definitions": {
           "ProcessorType": {
             "type": "string",
             "enum": [
@@ -2953,39 +2981,41 @@
       "type": "processor",
       "description": "分割XML",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlFragmenterParam",
         "oneOf": [
           {
             "type": "object",
+            "required": [
+              "attribute",
+              "elementsToExclude",
+              "elementsToMatch",
+              "source"
+            ],
             "properties": {
-              "elementsToMatch": {
-                "$ref": "#/$defs/Expr"
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               },
               "elementsToExclude": {
-                "$ref": "#/$defs/Expr"
+                "$ref": "#/definitions/Expr"
               },
-              "attribute": {
-                "$ref": "#/$defs/Attribute"
+              "elementsToMatch": {
+                "$ref": "#/definitions/Expr"
               },
               "source": {
                 "type": "string",
-                "const": "url"
+                "enum": [
+                  "url"
+                ]
               }
-            },
-            "required": [
-              "source",
-              "elementsToMatch",
-              "elementsToExclude",
-              "attribute"
-            ]
+            }
           }
         ],
-        "$defs": {
-          "Expr": {
+        "definitions": {
+          "Attribute": {
             "type": "string"
           },
-          "Attribute": {
+          "Expr": {
             "type": "string"
           }
         }
@@ -3006,35 +3036,28 @@
       "type": "processor",
       "description": "验证XML内容",
       "parameter": {
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$schema": "http://json-schema.org/draft-07/schema#",
         "title": "XmlValidatorParam",
         "type": "object",
-        "properties": {
-          "attribute": {
-            "$ref": "#/$defs/Attribute"
-          },
-          "inputType": {
-            "$ref": "#/$defs/XmlInputType"
-          },
-          "validationType": {
-            "$ref": "#/$defs/ValidationType"
-          }
-        },
         "required": [
           "attribute",
           "inputType",
           "validationType"
         ],
-        "$defs": {
+        "properties": {
+          "attribute": {
+            "$ref": "#/definitions/Attribute"
+          },
+          "inputType": {
+            "$ref": "#/definitions/XmlInputType"
+          },
+          "validationType": {
+            "$ref": "#/definitions/ValidationType"
+          }
+        },
+        "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
-            ]
           },
           "ValidationType": {
             "type": "string",
@@ -3042,6 +3065,13 @@
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
+            ]
+          },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
             ]
           }
         }


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
    - Updated `schemars` library version from `1.0.0-alpha.17` to `0.8.21`
    - Modified library features from `["chrono04", "uuid1"]` to `["chrono", "uuid1"]`

- **Schema Changes**
    - Updated method return type from `Option<schemars::Schema>` to `Option<schemars::schema::RootSchema>` across multiple factories and processors
    - This change affects schema generation and validation across various components of the system

- **Refactoring**
    - Standardized schema method signatures in source, processor, and sink factories
    - Updated JSON schema references in `actions.json` from draft 2020-12 to draft 2019-07

<!-- end of auto-generated comment: release notes by coderabbit.ai -->