### PR TITLE
feat(ui): Hide reader/writer for toolbox on subworkflows

### DIFF
--- a/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
@@ -31,43 +31,57 @@ type Props = {
   canRedo: boolean;
   onRedo?: () => void;
   onUndo?: () => void;
+  mainWorkFlowId?: string;
+  currentWorkflowId: string;
 };
 
-const Toolbox: React.FC<Props> = ({ canUndo, canRedo, onRedo, onUndo }) => {
+const Toolbox: React.FC<Props> = ({
+  canUndo,
+  canRedo,
+  onRedo,
+  onUndo,
+  mainWorkFlowId,
+  currentWorkflowId,
+}) => {
   const t = useT();
 
   const availableTools: Tool[] = [
     {
-      id: "reader",
+      id: "reader" as const,
       name: t("Reader Node"),
       icon: <Database weight="thin" />,
     },
     {
-      id: "transformer",
+      id: "transformer" as const,
       name: t("Transformer Node"),
       icon: <Lightning weight="thin" />,
     },
     {
-      id: "writer",
+      id: "writer" as const,
       name: t("Writer Node"),
       icon: <Disc weight="thin" />,
     },
     {
-      id: "note",
+      id: "note" as const,
       name: t("Note"),
       icon: <Note weight="thin" />,
     },
     {
-      id: "batch",
+      id: "batch" as const,
       name: t("Batch Node"),
       icon: <RectangleDashed weight="thin" />,
     },
     {
-      id: "subworkflow",
+      id: "subworkflow" as const,
       name: t("Subworkflow Node"),
       icon: <Graph weight="thin" />,
     },
-  ];
+  ].filter((tool) => {
+    if (mainWorkFlowId !== currentWorkflowId) {
+      return tool.id !== "reader" && tool.id !== "writer";
+    }
+    return true;
+  });
 
   const availableActions: Action[] = [
     {
@@ -97,7 +111,7 @@ const Toolbox: React.FC<Props> = ({ canUndo, canRedo, onRedo, onUndo }) => {
       <div className="flex size-12 rounded bg-secondary">
         <div
           className={`
-          flex w-full justify-center rounded align-middle 
+          flex w-full justify-center rounded align-middle
           ${
             nodeType === "reader"
               ? "bg-node-reader/60"

--- a/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
@@ -31,8 +31,7 @@ type Props = {
   canRedo: boolean;
   onRedo?: () => void;
   onUndo?: () => void;
-  mainWorkFlowId?: string;
-  currentWorkflowId: string;
+  isMainWorkflow: boolean;
 };
 
 const Toolbox: React.FC<Props> = ({
@@ -40,8 +39,7 @@ const Toolbox: React.FC<Props> = ({
   canRedo,
   onRedo,
   onUndo,
-  mainWorkFlowId,
-  currentWorkflowId,
+  isMainWorkflow,
 }) => {
   const t = useT();
 
@@ -77,7 +75,7 @@ const Toolbox: React.FC<Props> = ({
       icon: <Graph weight="thin" />,
     },
   ].filter((tool) => {
-    if (mainWorkFlowId !== currentWorkflowId) {
+    if (!isMainWorkflow) {
       return tool.id !== "reader" && tool.id !== "writer";
     }
     return true;

--- a/ui/src/features/Editor/components/OverlayUI/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/index.tsx
@@ -29,6 +29,8 @@ type OverlayUIProps = {
   onNodePickerClose: () => void;
   onWorkflowUndo: () => void;
   onWorkflowRedo: () => void;
+  mainWorkflowId?: string;
+  currentWorkflowId: string;
   children?: React.ReactNode;
 };
 
@@ -43,6 +45,8 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
   onNodePickerClose,
   onWorkflowUndo,
   onWorkflowRedo,
+  mainWorkflowId,
+  currentWorkflowId,
   children: canvas,
 }) => {
   // const { devMode } = config();
@@ -58,6 +62,8 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
           canRedo={canRedo}
           onRedo={onWorkflowRedo}
           onUndo={onWorkflowUndo}
+          mainWorkFlowId={mainWorkflowId}
+          currentWorkflowId={currentWorkflowId}
         />
         <ActionBar
           allowedToDeploy={allowedToDeploy}

--- a/ui/src/features/Editor/components/OverlayUI/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/index.tsx
@@ -29,8 +29,7 @@ type OverlayUIProps = {
   onNodePickerClose: () => void;
   onWorkflowUndo: () => void;
   onWorkflowRedo: () => void;
-  mainWorkflowId?: string;
-  currentWorkflowId: string;
+  isMainWorkflow: boolean;
   children?: React.ReactNode;
 };
 
@@ -45,8 +44,7 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
   onNodePickerClose,
   onWorkflowUndo,
   onWorkflowRedo,
-  mainWorkflowId,
-  currentWorkflowId,
+  isMainWorkflow,
   children: canvas,
 }) => {
   // const { devMode } = config();
@@ -62,8 +60,7 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
           canRedo={canRedo}
           onRedo={onWorkflowRedo}
           onUndo={onWorkflowUndo}
-          mainWorkFlowId={mainWorkflowId}
-          currentWorkflowId={currentWorkflowId}
+          isMainWorkflow={isMainWorkflow}
         />
         <ActionBar
           allowedToDeploy={allowedToDeploy}

--- a/ui/src/features/Editor/index.tsx
+++ b/ui/src/features/Editor/index.tsx
@@ -51,7 +51,7 @@ export default function Editor({
     handleWorkflowUndo,
     handleWorkflowRename,
   } = useHooks({ yWorkflows, undoManager, undoTrackerActionWrapper });
-
+  const isMainWorkflow = openWorkflows[0]?.id === currentWorkflowId;
   return (
     <div className="flex h-screen flex-col">
       <div className="relative flex flex-1">
@@ -73,8 +73,7 @@ export default function Editor({
             onWorkflowRedo={handleWorkflowRedo}
             onNodesChange={handleNodesUpdate}
             onNodePickerClose={handleNodePickerClose}
-            mainWorkflowId={openWorkflows[0]?.id}
-            currentWorkflowId={currentWorkflowId}>
+            isMainWorkflow={isMainWorkflow}>
             <Canvas
               nodes={nodes}
               edges={edges}

--- a/ui/src/features/Editor/index.tsx
+++ b/ui/src/features/Editor/index.tsx
@@ -2,6 +2,8 @@ import { Array as YArray, UndoManager as YUndoManager } from "yjs";
 
 import { YWorkflow } from "@flow/lib/yjs/utils";
 
+import { useIsMainWorkflow } from "../KeyboardShortcutDialog/useHooks";
+
 import {
   BottomPanel,
   Canvas,
@@ -51,7 +53,7 @@ export default function Editor({
     handleWorkflowUndo,
     handleWorkflowRename,
   } = useHooks({ yWorkflows, undoManager, undoTrackerActionWrapper });
-  const isMainWorkflow = openWorkflows[0]?.id === currentWorkflowId;
+  const isMainWorkflow = useIsMainWorkflow(currentWorkflowId);
   return (
     <div className="flex h-screen flex-col">
       <div className="relative flex flex-1">

--- a/ui/src/features/Editor/index.tsx
+++ b/ui/src/features/Editor/index.tsx
@@ -72,7 +72,9 @@ export default function Editor({
             onWorkflowUndo={handleWorkflowUndo}
             onWorkflowRedo={handleWorkflowRedo}
             onNodesChange={handleNodesUpdate}
-            onNodePickerClose={handleNodePickerClose}>
+            onNodePickerClose={handleNodePickerClose}
+            mainWorkflowId={openWorkflows[0]?.id}
+            currentWorkflowId={currentWorkflowId}>
             <Canvas
               nodes={nodes}
               edges={edges}

--- a/ui/src/features/KeyboardShortcutDialog/useHooks.ts
+++ b/ui/src/features/KeyboardShortcutDialog/useHooks.ts
@@ -1,3 +1,6 @@
+import { useMemo } from "react";
+
+import { DEFAULT_ENTRY_GRAPH_ID } from "@flow/global-constants";
 import { useT } from "@flow/lib/i18n";
 import {
   Shortcuts,
@@ -8,6 +11,12 @@ import {
   EditorKeys,
   GeneralKeys,
 } from "@flow/types";
+
+export const useIsMainWorkflow = (currentWorkflowId: string | undefined) => {
+  return useMemo(() => {
+    return currentWorkflowId === DEFAULT_ENTRY_GRAPH_ID;
+  }, [currentWorkflowId]);
+};
 
 export default () => {
   const t = useT();


### PR DESCRIPTION
# Overview
Reader and Writer Toolbox options were available for subwork flows
## What I've done
These have now been hidden for subworkflows
## What I haven't done

## How I tested
Manuallly
## Screenshot

## Which point I want you to review particularly

## Memo
Possible refactors/improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced workflow management by introducing `mainWorkflowId` and `currentWorkflowId` props
	- Implemented conditional tool filtering based on workflow context

- **Improvements**
	- Updated component interfaces to support more granular workflow tracking
	- Refined toolbox behavior to adapt to different workflow scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->