### PR TITLE
feat(engine): add sevenz module with decompression functionality and error handling

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -540,6 +540,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,6 +1980,17 @@ dependencies = [
  "libc",
  "libredox",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "filetime_creation"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c25b5d475550e559de5b0c0084761c65325444e3b6c9e298af9cefe7a9ef3a5f"
+dependencies = [
+ "cfg-if",
+ "filetime",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3768,6 +3794,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rust"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baab2bbbd7d75a144d671e9ff79270e903957d92fb7386fd39034c709bd2661"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4091,6 +4126,17 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "nt-time"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80ed00a745ff41e580c582f92922e7fdedf05e2849e67ba5b638aead6645baf4"
+dependencies = [
+ "chrono",
+ "rand 0.8.5",
+ "time",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -5983,6 +6029,23 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "reearth-flow-sevenz"
+version = "0.0.2"
+dependencies = [
+ "bit-set",
+ "byteorder",
+ "crc",
+ "filetime_creation",
+ "lzma-rust",
+ "nt-time",
+ "rand 0.8.5",
+ "regex",
+ "ring",
+ "tempfile",
+ "thiserror 2.0.9",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -58,6 +58,7 @@ reearth-flow-gltf = { path = "runtime/gltf" }
 reearth-flow-macros = { path = "runtime/macros" }
 reearth-flow-runner = { path = "runtime/runner" }
 reearth-flow-runtime = { path = "runtime/runtime" }
+reearth-flow-sevenz = { path = "runtime/sevenz" }
 reearth-flow-state = { path = "runtime/state" }
 reearth-flow-storage = { path = "runtime/storage" }
 reearth-flow-telemetry = { path = "runtime/telemetry" }

--- a/engine/runtime/sevenz/Cargo.toml
+++ b/engine/runtime/sevenz/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+description = "Re:Earth Flow sevenz"
+name = "reearth-flow-sevenz"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+bit-set = "0.8.0"
+byteorder = "1.5.0"
+crc = "3.2.1"
+filetime_creation = "0.2.0"
+lzma-rust = "0.1.7"
+nt-time = "0.10.4"
+rand.workspace = true
+regex.workspace = true
+ring = "0.17.8"
+tempfile.workspace = true
+thiserror.workspace = true

--- a/engine/runtime/sevenz/src/archive.rs
+++ b/engine/runtime/sevenz/src/archive.rs
@@ -1,0 +1,281 @@
+use bit_set::BitSet;
+use nt_time::FileTime;
+
+use crate::folder::*;
+
+pub(crate) const SIGNATURE_HEADER_SIZE: u64 = 32;
+pub(crate) const SEVEN_Z_SIGNATURE: &[u8] = &[b'7', b'z', 0xBC, 0xAF, 0x27, 0x1C];
+
+pub(crate) const K_END: u8 = 0x00;
+pub(crate) const K_HEADER: u8 = 0x01;
+pub(crate) const K_ARCHIVE_PROPERTIES: u8 = 0x02;
+pub(crate) const K_ADDITIONAL_STREAMS_INFO: u8 = 0x03;
+pub(crate) const K_MAIN_STREAMS_INFO: u8 = 0x04;
+pub(crate) const K_FILES_INFO: u8 = 0x05;
+pub(crate) const K_PACK_INFO: u8 = 0x06;
+pub(crate) const K_UNPACK_INFO: u8 = 0x07;
+pub(crate) const K_SUB_STREAMS_INFO: u8 = 0x08;
+pub(crate) const K_SIZE: u8 = 0x09;
+pub(crate) const K_CRC: u8 = 0x0A;
+pub(crate) const K_FOLDER: u8 = 0x0B;
+pub(crate) const K_CODERS_UNPACK_SIZE: u8 = 0x0C;
+pub(crate) const K_NUM_UNPACK_STREAM: u8 = 0x0D;
+pub(crate) const K_EMPTY_STREAM: u8 = 0x0E;
+pub(crate) const K_EMPTY_FILE: u8 = 0x0F;
+pub(crate) const K_ANTI: u8 = 0x10;
+pub(crate) const K_NAME: u8 = 0x11;
+pub(crate) const K_C_TIME: u8 = 0x12;
+pub(crate) const K_A_TIME: u8 = 0x13;
+pub(crate) const K_M_TIME: u8 = 0x14;
+pub(crate) const K_WIN_ATTRIBUTES: u8 = 0x15;
+pub(crate) const K_ENCODED_HEADER: u8 = 0x17;
+pub(crate) const K_START_POS: u8 = 0x18;
+pub(crate) const K_DUMMY: u8 = 0x19;
+
+#[derive(Debug, Default, Clone)]
+pub struct Archive {
+    /// Offset from beginning of file + SIGNATURE_HEADER_SIZE to packed streams.
+    pub pack_pos: u64,
+    pub pack_sizes: Vec<u64>,
+    pub pack_crcs_defined: bit_set::BitSet,
+    pub pack_crcs: Vec<u64>,
+    pub folders: Vec<Folder>,
+    pub sub_streams_info: Option<SubStreamsInfo>,
+    pub files: Vec<SevenZArchiveEntry>,
+    pub stream_map: StreamMap,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SubStreamsInfo {
+    pub unpack_sizes: Vec<u64>,
+    pub has_crc: BitSet,
+    pub crcs: Vec<u64>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SevenZArchiveEntry {
+    pub name: String,
+    pub has_stream: bool,
+    pub is_directory: bool,
+    pub is_anti_item: bool,
+    pub has_creation_date: bool,
+    pub has_last_modified_date: bool,
+    pub has_access_date: bool,
+    pub creation_date: FileTime,
+    pub last_modified_date: FileTime,
+    pub access_date: FileTime,
+    pub has_windows_attributes: bool,
+    pub windows_attributes: u32,
+    pub has_crc: bool,
+    pub crc: u64,
+    pub compressed_crc: u64,
+    pub size: u64,
+    pub compressed_size: u64,
+}
+
+impl SevenZArchiveEntry {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
+    }
+
+    pub fn is_directory(&self) -> bool {
+        self.is_directory
+    }
+
+    pub fn has_stream(&self) -> bool {
+        self.has_stream
+    }
+
+    pub fn creation_date(&self) -> FileTime {
+        self.creation_date
+    }
+
+    pub fn last_modified_date(&self) -> FileTime {
+        self.last_modified_date
+    }
+
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    pub fn windows_attributes(&self) -> u32 {
+        self.windows_attributes
+    }
+
+    pub fn access_date(&self) -> FileTime {
+        self.access_date
+    }
+
+    pub fn is_anti_item(&self) -> bool {
+        self.is_anti_item
+    }
+
+    pub fn from_path(path: impl AsRef<std::path::Path>, entry_name: String) -> SevenZArchiveEntry {
+        let path = path.as_ref();
+        #[cfg(target_os = "windows")]
+        let entry_name = {
+            let mut name_bytes = entry_name.into_bytes();
+            for b in &mut name_bytes {
+                if *b == b'\\' {
+                    *b = b'/';
+                }
+            }
+            String::from_utf8(name_bytes).unwrap()
+        };
+        let mut entry = SevenZArchiveEntry {
+            name: entry_name,
+            has_stream: path.is_file(),
+            is_directory: path.is_dir(),
+            ..Default::default()
+        };
+
+        if let Ok(meta) = path.metadata() {
+            if let Ok(modified) = meta.modified() {
+                if let Ok(date) = modified.try_into() {
+                    entry.last_modified_date = date;
+                    entry.has_last_modified_date = entry.last_modified_date.to_raw() > 0;
+                }
+            }
+            if let Ok(date) = meta.created() {
+                if let Ok(date) = date.try_into() {
+                    entry.creation_date = date;
+                    entry.has_creation_date = entry.creation_date.to_raw() > 0;
+                }
+            }
+            if let Ok(date) = meta.accessed() {
+                if let Ok(date) = date.try_into() {
+                    entry.access_date = date;
+                    entry.has_access_date = entry.access_date.to_raw() > 0;
+                }
+            }
+        }
+        entry
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SevenZMethodConfiguration {
+    pub method: SevenZMethod,
+}
+
+impl From<SevenZMethod> for SevenZMethodConfiguration {
+    fn from(value: SevenZMethod) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Clone for SevenZMethodConfiguration {
+    fn clone(&self) -> Self {
+        Self {
+            method: self.method,
+        }
+    }
+}
+
+impl SevenZMethodConfiguration {
+    pub fn new(method: SevenZMethod) -> Self {
+        Self { method }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default, Hash)]
+pub struct SevenZMethod(&'static str, &'static [u8]);
+
+impl SevenZMethod {
+    pub const ID_COPY: &'static [u8] = &[0x00];
+
+    pub const ID_LZMA: &'static [u8] = &[0x03, 0x01, 0x01];
+    pub const ID_LZMA2: &'static [u8] = &[0x21];
+    pub const ID_ZSTD: &'static [u8] = &[4, 247, 17, 1];
+    pub const ID_DEFLATE: &'static [u8] = &[0x04, 0x01, 0x08];
+    pub const ID_DEFLATE64: &'static [u8] = &[0x04, 0x01, 0x09];
+
+    pub const ID_BCJ_X86: &'static [u8] = &[0x03, 0x03, 0x01, 0x03];
+    pub const ID_BCJ_PPC: &'static [u8] = &[0x03, 0x03, 0x02, 0x05];
+    pub const ID_BCJ_IA64: &'static [u8] = &[0x03, 0x03, 0x04, 0x01];
+    pub const ID_BCJ_ARM: &'static [u8] = &[0x03, 0x03, 0x05, 0x01];
+    pub const ID_BCJ_ARM_THUMB: &'static [u8] = &[0x03, 0x03, 0x07, 0x01];
+    pub const ID_BCJ_SPARC: &'static [u8] = &[0x03, 0x03, 0x08, 0x05];
+    pub const ID_DELTA: &'static [u8] = &[0x03];
+    pub const ID_BZIP2: &'static [u8] = &[0x04, 0x02, 0x02];
+    pub const ID_AES256SHA256: &'static [u8] = &[0x06, 0xf1, 0x07, 0x01];
+    pub const ID_BCJ2: &'static [u8] = &[0x03, 0x03, 0x01, 0x1B];
+    /// no compression
+    pub const COPY: SevenZMethod = Self("COPY", Self::ID_COPY);
+
+    pub const LZMA: Self = Self("LZMA", Self::ID_LZMA);
+    pub const LZMA2: Self = Self("LZMA2", Self::ID_LZMA2);
+    pub const ZSTD: Self = Self("ZSTD", Self::ID_ZSTD);
+
+    pub const DEFLATE: Self = Self("DEFLATE", Self::ID_DEFLATE);
+    pub const DEFLATE64: Self = Self("DEFLATE64", Self::ID_DEFLATE64);
+
+    pub const BZIP2: Self = Self("BZIP2", Self::ID_BZIP2);
+    pub const AES256SHA256: Self = Self("AES256SHA256", Self::ID_AES256SHA256);
+
+    pub const BCJ_X86_FILTER: Self = Self("BCJ_X86", Self::ID_BCJ_X86);
+    pub const BCJ_PPC_FILTER: Self = Self("BCJ_PPC", Self::ID_BCJ_PPC);
+    pub const BCJ_IA64_FILTER: Self = Self("BCJ_IA64", Self::ID_BCJ_IA64);
+    pub const BCJ_ARM_FILTER: Self = Self("BCJ_ARM", Self::ID_BCJ_ARM);
+    pub const BCJ_ARM_THUMB_FILTER: Self = Self("BCJ_ARM_THUMB", Self::ID_BCJ_ARM_THUMB);
+    pub const BCJ_SPARC_FILTER: Self = Self("BCJ_SPARC", Self::ID_BCJ_SPARC);
+    pub const DELTA_FILTER: Self = Self("DELTA", Self::ID_DELTA);
+    pub const BCJ2_FILTER: Self = Self("BCJ2", Self::ID_BCJ2);
+
+    const METHODS: &'static [&'static SevenZMethod] = &[
+        &Self::COPY,
+        &Self::ZSTD,
+        &Self::LZMA,
+        &Self::LZMA2,
+        &Self::DEFLATE,
+        &Self::DEFLATE64,
+        &Self::BZIP2,
+        &Self::AES256SHA256,
+        &Self::BCJ_X86_FILTER,
+        &Self::BCJ_PPC_FILTER,
+        &Self::BCJ_IA64_FILTER,
+        &Self::BCJ_ARM_FILTER,
+        &Self::BCJ_ARM_THUMB_FILTER,
+        &Self::BCJ_SPARC_FILTER,
+        &Self::DELTA_FILTER,
+        &Self::BCJ2_FILTER,
+    ];
+
+    #[inline]
+    pub const fn name(&self) -> &'static str {
+        self.0
+    }
+
+    #[inline]
+    pub const fn id(&self) -> &'static [u8] {
+        self.1
+    }
+
+    #[inline]
+    pub fn by_id(id: &[u8]) -> Option<Self> {
+        Self::METHODS
+            .iter()
+            .find(|item| item.id() == id)
+            .cloned()
+            .cloned()
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct StreamMap {
+    pub folder_first_pack_stream_index: Vec<usize>,
+    pub pack_stream_offsets: Vec<u64>,
+    pub folder_first_file_index: Vec<usize>,
+    pub file_folder_index: Vec<Option<usize>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct StartHeader {
+    pub(crate) next_header_offset: u64,
+    pub(crate) next_header_size: u64,
+    pub(crate) next_header_crc: u64,
+}

--- a/engine/runtime/sevenz/src/bcj2.rs
+++ b/engine/runtime/sevenz/src/bcj2.rs
@@ -1,0 +1,438 @@
+use std::io::Read;
+
+use byteorder::{BigEndian, ReadBytesExt};
+
+pub const BCJ2_NUM_STREAMS: usize = 4;
+
+pub const BCJ2_STREAM_MAIN: usize = 0;
+pub const BCJ2_STREAM_CALL: usize = 1;
+pub const BCJ2_STREAM_JUMP: usize = 2;
+pub const BCJ2_STREAM_RC: usize = 3;
+
+pub const BCJ2_DEC_STATE_ORIG_0: usize = BCJ2_NUM_STREAMS;
+pub const BCJ2_DEC_STATE_ORIG_3: usize = BCJ2_NUM_STREAMS + 3;
+pub const BCJ2_DEC_STATE_ORIG: usize = BCJ2_NUM_STREAMS + 4;
+pub const BCJ2_DEC_STATE_OK: usize = BCJ2_NUM_STREAMS + 5;
+
+pub const NUM_MODEL_BITS: u16 = 11;
+pub const BIT_MODEL_TOTAL: u16 = 1 << NUM_MODEL_BITS;
+pub const NUM_MOVE_BITS: u16 = 5;
+pub const K_TOP_VALUE: u32 = 1 << 24;
+
+const BUF_SIZE: usize = 1 << 18;
+
+pub struct Bcj2Coder {
+    bufs: Vec<u8>,
+    // buf_sizes: [usize; BCJ2_NUM_STREAMS],
+}
+
+impl Bcj2Coder {
+    fn buf_at(&mut self, i: usize) -> &mut [u8] {
+        let i = i * BUF_SIZE;
+        &mut self.bufs[i..i + BUF_SIZE]
+    }
+}
+
+impl Default for Bcj2Coder {
+    fn default() -> Self {
+        let buf_len = BUF_SIZE * (BCJ2_NUM_STREAMS);
+        Self {
+            bufs: vec![0; buf_len],
+        }
+    }
+}
+
+pub struct BCJ2Reader<R> {
+    base: Bcj2Coder,
+    inputs: Vec<R>,
+    decoder: Bcj2Decoder,
+    extra_read_sizes: [usize; BCJ2_NUM_STREAMS],
+    read_res: [bool; BCJ2_NUM_STREAMS],
+    uncompressed_size: u64,
+}
+
+impl<R> BCJ2Reader<R> {
+    pub fn new(inputs: Vec<R>, uncompressed_size: u64) -> Self {
+        Self {
+            base: Default::default(),
+            inputs,
+            decoder: Bcj2Decoder::new(),
+            extra_read_sizes: [0; BCJ2_NUM_STREAMS],
+            read_res: [true; BCJ2_NUM_STREAMS],
+            uncompressed_size,
+        }
+        .init()
+    }
+
+    fn init(mut self) -> Self {
+        let mut v = 0;
+        for i in 0..BCJ2_NUM_STREAMS {
+            self.decoder.bufs[i] = v;
+            self.decoder.lims[i] = v;
+            v += BUF_SIZE;
+        }
+
+        self
+    }
+}
+
+impl<R: Read> Read for BCJ2Reader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let mut dest_buf = buf;
+        if dest_buf.len() > self.uncompressed_size as usize {
+            dest_buf = &mut dest_buf[..self.uncompressed_size as usize];
+        }
+        if dest_buf.is_empty() {
+            return Ok(0);
+        }
+        let mut result_size = 0;
+        self.decoder.set_dest(0);
+        let mut offset = 0;
+        loop {
+            if !self.decoder.decode(&mut self.base.bufs, dest_buf) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "bcj2 decode error",
+                ));
+            }
+
+            {
+                let cur_size = self.decoder.dest() - offset;
+                if cur_size != 0 {
+                    result_size += cur_size;
+                    self.uncompressed_size -= cur_size as u64;
+                    offset += cur_size;
+                }
+            }
+
+            if self.decoder.state >= BCJ2_NUM_STREAMS {
+                break;
+            }
+            let mut total_read = self.extra_read_sizes[self.decoder.state];
+            {
+                let buf_index = self.decoder.state * BUF_SIZE;
+                let from = self.decoder.bufs[self.decoder.state];
+                for i in 0..total_read {
+                    let b = self.base.bufs[from + i];
+                    self.base.bufs[buf_index + i] = b;
+                }
+                self.decoder.lims[self.decoder.state] = buf_index;
+                self.decoder.bufs[self.decoder.state] = buf_index;
+            }
+            if !self.read_res[self.decoder.state] {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "bcj2 decode error:2",
+                ));
+            }
+
+            loop {
+                let cur_size = BUF_SIZE - total_read;
+                let cur_size = self.inputs[self.decoder.state].read(
+                    &mut self.base.buf_at(self.decoder.state)[total_read..total_read + cur_size],
+                )?;
+                if cur_size == 0 {
+                    break;
+                }
+                total_read += cur_size;
+                if !(total_read < 4 && bcj2_is_32bit_stream(self.decoder.state)) {
+                    break;
+                }
+            }
+
+            if total_read == 0 {
+                break;
+            }
+
+            if bcj2_is_32bit_stream(self.decoder.state) {
+                let extra_size = total_read & 3;
+                self.extra_read_sizes[self.decoder.state] = extra_size;
+                if total_read < 4 {
+                    if result_size != 0 {
+                        return Ok(result_size);
+                    }
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "bcj2 decode error:3",
+                    ));
+                }
+                total_read -= extra_size;
+            }
+            self.decoder.lims[self.decoder.state] = total_read + self.decoder.state * BUF_SIZE;
+        }
+
+        if self.uncompressed_size == 0 {
+            if self.decoder.code != 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "bcj2 decode error:4",
+                ));
+            }
+            if self.decoder.state != BCJ2_STREAM_MAIN && self.decoder.state != BCJ2_DEC_STATE_ORIG {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "bcj2 decode error:5",
+                ));
+            }
+        }
+        Ok(result_size)
+    }
+}
+
+#[derive(Debug)]
+pub struct Bcj2Decoder {
+    pub(crate) bufs: [usize; BCJ2_NUM_STREAMS],
+    pub(crate) lims: [usize; BCJ2_NUM_STREAMS],
+    dest: usize,
+
+    pub(crate) state: usize, /* BCJ2_STREAM_MAIN has more priority than BCJ2_STATE_ORIG */
+
+    ip: u32,
+    temp: [u8; 4],
+    range: u32,
+    pub(crate) code: u32,
+    probs: [u16; 2 + 256],
+}
+
+impl Bcj2Decoder {
+    pub fn dest(&self) -> usize {
+        self.dest
+    }
+
+    pub fn set_dest(&mut self, dest: usize) {
+        self.dest = dest;
+    }
+    pub fn new() -> Self {
+        Self {
+            bufs: Default::default(),
+            lims: Default::default(),
+            dest: Default::default(),
+            state: BCJ2_DEC_STATE_OK,
+            ip: Default::default(),
+            temp: Default::default(),
+            range: Default::default(),
+            code: Default::default(),
+            probs: [BIT_MODEL_TOTAL >> 1; 2 + 256],
+        }
+    }
+
+    pub fn decode(&mut self, src_bufs: &mut [u8], dest_buf: &mut [u8]) -> bool {
+        let dest_lim = dest_buf.len();
+        if self.range <= 5 {
+            self.state = BCJ2_DEC_STATE_OK;
+            while self.range != 5 {
+                if self.range == 1 && self.code != 0 {
+                    return false;
+                }
+                if self.bufs[BCJ2_STREAM_RC] == self.lims[BCJ2_STREAM_RC] {
+                    self.state = BCJ2_STREAM_RC;
+                    return true;
+                }
+
+                self.code = (self.code << 8) | src_bufs[self.bufs[BCJ2_STREAM_RC]] as u32;
+                self.bufs[BCJ2_STREAM_RC] = self.bufs[BCJ2_STREAM_RC].wrapping_add(1);
+                self.range += 1;
+            }
+
+            if self.code == 0xFFFFFFFF {
+                return false;
+            }
+
+            self.range = 0xFFFFFFFF;
+        } else if self.state >= BCJ2_DEC_STATE_ORIG_0 {
+            while self.state <= BCJ2_DEC_STATE_ORIG_3 {
+                let dest = self.dest;
+                if dest == dest_lim {
+                    return true;
+                }
+                dest_buf[dest] = self.temp[self.state - BCJ2_DEC_STATE_ORIG_0];
+                self.state += 1;
+                self.dest = dest + 1;
+            }
+        }
+
+        loop {
+            if bcj2_is_32bit_stream(self.state) {
+                self.state = BCJ2_DEC_STATE_OK;
+            } else {
+                if self.range < K_TOP_VALUE {
+                    if self.bufs[BCJ2_STREAM_RC] == self.lims[BCJ2_STREAM_RC] {
+                        self.state = BCJ2_STREAM_RC;
+                        return true;
+                    }
+                    self.range <<= 8;
+                    self.code = (self.code << 8) | src_bufs[self.bufs[BCJ2_STREAM_RC]] as u32;
+                    self.bufs[BCJ2_STREAM_RC] = self.bufs[BCJ2_STREAM_RC].wrapping_add(1);
+                }
+
+                {
+                    let mut src = self.bufs[BCJ2_STREAM_MAIN];
+                    let mut num = self.lims[BCJ2_STREAM_MAIN] - src;
+
+                    if num == 0 {
+                        self.state = BCJ2_STREAM_MAIN;
+                        return true;
+                    }
+
+                    let mut dest = self.dest;
+                    if num > (dest_lim - dest) {
+                        num = dest_lim - dest;
+                        if num == 0 {
+                            self.state = BCJ2_DEC_STATE_ORIG;
+                            return true;
+                        }
+                    }
+
+                    let src_lim = src + num;
+
+                    if self.temp[3] == 0x0F && (src_bufs[src] & 0xF0) == 0x80 {
+                        dest_buf[dest] = src_bufs[src];
+                    } else {
+                        loop {
+                            let b = src_bufs[src];
+                            dest_buf[dest] = b;
+                            if b != 0x0F {
+                                if (b & 0xFE) == 0xE8 {
+                                    break;
+                                }
+                                dest += 1;
+                                src += 1;
+                                if src != src_lim {
+                                    continue;
+                                }
+                                break;
+                            }
+                            dest += 1;
+                            src += 1;
+                            if src == src_lim {
+                                break;
+                            }
+                            if (src_bufs[src] & 0xF0) != 0x80 {
+                                continue;
+                            }
+                            dest_buf[dest] = src_bufs[src];
+                            break;
+                        }
+                    }
+
+                    num = src - self.bufs[BCJ2_STREAM_MAIN];
+
+                    if src == src_lim {
+                        self.temp[3] = src_bufs[src - 1];
+                        self.bufs[BCJ2_STREAM_MAIN] = src;
+                        self.ip += num as u32;
+                        self.dest += num;
+                        self.state = if self.bufs[BCJ2_STREAM_MAIN] == self.lims[BCJ2_STREAM_MAIN] {
+                            BCJ2_STREAM_MAIN
+                        } else {
+                            BCJ2_DEC_STATE_ORIG
+                        };
+                        return true;
+                    }
+
+                    {
+                        let b = src_bufs[src];
+                        let prev = if num == 0 {
+                            self.temp[3]
+                        } else {
+                            src_bufs[src - 1]
+                        };
+
+                        self.temp[3] = b;
+                        self.bufs[BCJ2_STREAM_MAIN] = src + 1;
+                        num += 1;
+                        self.ip += num as u32;
+                        self.dest += num;
+
+                        let prob = &mut self.probs[if b == 0xE8 {
+                            2 + prev as usize
+                        } else if b == 0xE9 {
+                            1
+                        } else {
+                            0
+                        }];
+
+                        //   _IF_BIT_0
+                        let ttt = *prob;
+                        let bound = (self.range >> NUM_MODEL_BITS) * ttt as u32;
+                        if self.code < bound {
+                            // _UPDATE_0
+                            self.range = bound;
+                            *prob = (ttt + ((BIT_MODEL_TOTAL - ttt) >> NUM_MOVE_BITS)) as _;
+                            continue;
+                        }
+                        //   _UPDATE_1
+                        self.range -= bound;
+                        self.code -= bound;
+                        *prob = ttt - (ttt >> NUM_MOVE_BITS);
+                    }
+                }
+            }
+
+            {
+                let cj = if self.temp[3] == 0xE8 {
+                    BCJ2_STREAM_CALL
+                } else {
+                    BCJ2_STREAM_JUMP
+                };
+                let cur = self.bufs[cj];
+
+                if cur == self.lims[cj] {
+                    self.state = cj;
+                    break;
+                }
+
+                let mut val = if let Ok(v) = (&mut &src_bufs[cur..]).read_u32::<BigEndian>() {
+                    v
+                } else {
+                    return false;
+                };
+                self.bufs[cj] = cur + 4;
+
+                self.ip += 4;
+                val = val.wrapping_sub(self.ip);
+                let dest = self.dest;
+                let rem = dest_lim - dest;
+
+                if rem < 4 {
+                    self.temp[0] = val as u8;
+                    if rem > 0 {
+                        dest_buf[dest] = val as u8;
+                    }
+                    val >>= 8;
+                    self.temp[1] = val as u8;
+                    if rem > 1 {
+                        dest_buf[dest + 1] = val as u8;
+                    }
+                    val >>= 8;
+                    self.temp[2] = val as u8;
+                    if rem > 2 {
+                        dest_buf[dest + 2] = val as u8;
+                    }
+                    val >>= 8;
+                    self.temp[3] = val as u8;
+                    self.dest = dest + rem;
+                    self.state = BCJ2_DEC_STATE_ORIG_0 + rem;
+                    break;
+                }
+                dest_buf[dest..dest + 4].copy_from_slice(&val.to_le_bytes());
+                //   SetUi32(dest, val);
+                self.temp[3] = (val >> 24) as u8;
+                self.dest = dest + 4;
+            }
+        }
+
+        if self.range < K_TOP_VALUE && self.bufs[BCJ2_STREAM_RC] != self.lims[BCJ2_STREAM_RC] {
+            self.range <<= 8;
+            self.code = (self.code << 8) | src_bufs[self.bufs[BCJ2_STREAM_RC]] as u32;
+            self.bufs[BCJ2_STREAM_RC] = self.bufs[BCJ2_STREAM_RC].wrapping_add(1);
+        }
+
+        true
+    }
+}
+
+#[inline(always)]
+pub(crate) fn bcj2_is_32bit_stream(s: usize) -> bool {
+    (s) == BCJ2_STREAM_CALL || (s) == BCJ2_STREAM_JUMP
+}

--- a/engine/runtime/sevenz/src/de_funcs.rs
+++ b/engine/runtime/sevenz/src/de_funcs.rs
@@ -1,6 +1,6 @@
+use std::io::SeekFrom;
 use std::io::{Read, Seek};
 use std::path::{Path, PathBuf};
-use std::io::SeekFrom;
 
 use crate::archive::SevenZArchiveEntry;
 use crate::error::Error;
@@ -80,7 +80,7 @@ pub fn default_entry_extract_fn(
                     entry.creation_date().into(),
                 )),
             )
-            .unwrap_or_default();
+            .map_err(Error::io)?;
         }
     }
     Ok(true)

--- a/engine/runtime/sevenz/src/de_funcs.rs
+++ b/engine/runtime/sevenz/src/de_funcs.rs
@@ -1,0 +1,87 @@
+use std::io::{Read, Seek};
+use std::path::{Path, PathBuf};
+use std::io::SeekFrom;
+
+use crate::archive::SevenZArchiveEntry;
+use crate::error::Error;
+use crate::reader::SevenZReader;
+
+/// decompress a source reader to [dest] path
+#[inline]
+pub fn decompress<R: Read + Seek>(src_reader: R, dest: impl AsRef<Path>) -> Result<(), Error> {
+    decompress_with_extract_fn(src_reader, dest, default_entry_extract_fn)
+}
+
+#[inline]
+pub fn decompress_with_extract_fn<R: Read + Seek>(
+    src_reader: R,
+    dest: impl AsRef<Path>,
+    extract_fn: impl FnMut(&SevenZArchiveEntry, &mut dyn Read, &PathBuf) -> Result<bool, Error>,
+) -> Result<(), Error> {
+    decompress_impl(src_reader, dest, extract_fn)
+}
+
+fn decompress_impl<R: Read + Seek>(
+    mut src_reader: R,
+    dest: impl AsRef<Path>,
+    mut extract_fn: impl FnMut(&SevenZArchiveEntry, &mut dyn Read, &PathBuf) -> Result<bool, Error>,
+) -> Result<(), Error> {
+    let pos = src_reader.stream_position().map_err(Error::io)?;
+    let len = src_reader.seek(SeekFrom::End(0)).map_err(Error::io)?;
+    src_reader.seek(SeekFrom::Start(pos)).map_err(Error::io)?;
+    let mut seven = SevenZReader::new(src_reader, len)?;
+    let dest = PathBuf::from(dest.as_ref());
+    if !dest.exists() {
+        std::fs::create_dir_all(&dest).map_err(Error::io)?;
+    }
+    seven.for_each_entries(|entry, reader| {
+        let dest_path = dest.join(entry.name());
+        extract_fn(entry, reader, &dest_path)
+    })?;
+
+    Ok(())
+}
+
+pub fn default_entry_extract_fn(
+    entry: &SevenZArchiveEntry,
+    reader: &mut dyn Read,
+    dest: &PathBuf,
+) -> Result<bool, Error> {
+    use std::{fs::File, io::BufWriter};
+
+    if entry.is_directory() {
+        let dir = dest;
+        if !dir.exists() {
+            std::fs::create_dir_all(dir).map_err(Error::io)?;
+        }
+    } else {
+        let path = dest;
+        path.parent().and_then(|p| {
+            if !p.exists() {
+                std::fs::create_dir_all(p).ok()
+            } else {
+                None
+            }
+        });
+        let file = File::create(path)
+            .map_err(|e| Error::file_open(e, path.to_string_lossy().to_string()))?;
+        if entry.size() > 0 {
+            let mut writer = BufWriter::new(file);
+            std::io::copy(reader, &mut writer).map_err(Error::io)?;
+            filetime_creation::set_file_handle_times(
+                writer.get_ref(),
+                Some(filetime_creation::FileTime::from_system_time(
+                    entry.access_date().into(),
+                )),
+                Some(filetime_creation::FileTime::from_system_time(
+                    entry.last_modified_date().into(),
+                )),
+                Some(filetime_creation::FileTime::from_system_time(
+                    entry.creation_date().into(),
+                )),
+            )
+            .unwrap_or_default();
+        }
+    }
+    Ok(true)
+}

--- a/engine/runtime/sevenz/src/decoders.rs
+++ b/engine/runtime/sevenz/src/decoders.rs
@@ -56,7 +56,7 @@ pub fn add_decoder<I: Read>(
             if mem_size > max_mem_limit_kb {
                 return Err(Error::MaxMemLimited {
                     max_kb: max_mem_limit_kb,
-                    actaul_kb: mem_size,
+                    actual_kb: mem_size,
                 });
             }
             let lz = LZMA2Reader::new(input, dic_size, None);
@@ -87,6 +87,9 @@ fn get_lzma2_dic_size(coder: &Coder) -> Result<u32, Error> {
 
 #[inline]
 fn get_lzma_dic_size(coder: &Coder) -> Result<u32, Error> {
+    if coder.properties.len() < 5 {
+        return Err(Error::other("LZMA properties too short"));
+    }
     let mut props = &coder.properties[1..5];
     props.read_u32::<LittleEndian>().map_err(Error::io)
 }

--- a/engine/runtime/sevenz/src/decoders.rs
+++ b/engine/runtime/sevenz/src/decoders.rs
@@ -1,0 +1,92 @@
+use std::io::Read;
+
+use byteorder::{LittleEndian, ReadBytesExt};
+
+use lzma_rust::{lzma2_get_memery_usage, LZMA2Reader, LZMAReader};
+
+use crate::{archive::SevenZMethod, error::Error, folder::Coder};
+
+pub enum Decoder<R: Read> {
+    Copy(R),
+    Lzma(LZMAReader<R>),
+    Lzma2(LZMA2Reader<R>),
+}
+
+impl<R: Read> Read for Decoder<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Decoder::Copy(r) => r.read(buf),
+            Decoder::Lzma(r) => r.read(buf),
+            Decoder::Lzma2(r) => r.read(buf),
+        }
+    }
+}
+
+pub fn add_decoder<I: Read>(
+    input: I,
+    uncompressed_len: usize,
+    coder: &Coder,
+    max_mem_limit_kb: usize,
+) -> Result<Decoder<I>, Error> {
+    let method = SevenZMethod::by_id(coder.decompression_method_id());
+    let method = if let Some(m) = method {
+        m
+    } else {
+        return Err(Error::Unsupported(format!(
+            "{:?}",
+            coder.decompression_method_id()
+        )));
+    };
+    match method.id() {
+        SevenZMethod::ID_COPY => Ok(Decoder::Copy(input)),
+        SevenZMethod::ID_LZMA => {
+            let dict_size = get_lzma_dic_size(coder)?;
+            if coder.properties.is_empty() {
+                return Err(Error::Other("LZMA properties too short".into()));
+            }
+            let props = coder.properties[0];
+            let lz =
+                LZMAReader::new_with_props(input, uncompressed_len as _, props, dict_size, None)
+                    .map_err(Error::io)?;
+            Ok(Decoder::Lzma(lz))
+        }
+        SevenZMethod::ID_LZMA2 => {
+            let dic_size = get_lzma2_dic_size(coder)?;
+            let mem_size = lzma2_get_memery_usage(dic_size) as usize;
+            if mem_size > max_mem_limit_kb {
+                return Err(Error::MaxMemLimited {
+                    max_kb: max_mem_limit_kb,
+                    actaul_kb: mem_size,
+                });
+            }
+            let lz = LZMA2Reader::new(input, dic_size, None);
+            Ok(Decoder::Lzma2(lz))
+        }
+        _ => Err(Error::Unsupported(method.name().to_string())),
+    }
+}
+
+#[inline]
+fn get_lzma2_dic_size(coder: &Coder) -> Result<u32, Error> {
+    if coder.properties.is_empty() {
+        return Err(Error::other("LZMA2 properties too short"));
+    }
+    let dict_size_bits = 0xff & coder.properties[0] as u32;
+    if (dict_size_bits & (!0x3f)) != 0 {
+        return Err(Error::other("Unsupported LZMA2 property bits"));
+    }
+    if dict_size_bits > 40 {
+        return Err(Error::other("Dictionary larger than 4GiB maximum size"));
+    }
+    if dict_size_bits == 40 {
+        return Ok(0xFFFFFFFF);
+    }
+    let size = (2 | (dict_size_bits & 0x1)) << (dict_size_bits / 2 + 11);
+    Ok(size)
+}
+
+#[inline]
+fn get_lzma_dic_size(coder: &Coder) -> Result<u32, Error> {
+    let mut props = &coder.properties[1..5];
+    props.read_u32::<LittleEndian>().map_err(Error::io)
+}

--- a/engine/runtime/sevenz/src/error.rs
+++ b/engine/runtime/sevenz/src/error.rs
@@ -4,11 +4,11 @@ use std::borrow::Cow;
 pub enum Error {
     #[error("BadSignature:")]
     BadSignature([u8; 6]),
-    #[error("Unsupported Version:")]
+    #[error("Unsupported Version")]
     UnsupportedVersion { major: u8, minor: u8 },
-    #[error("ChecksumVerificationFailed: ")]
+    #[error("ChecksumVerificationFailed")]
     ChecksumVerificationFailed,
-    #[error("NextHeaderCrcMismatch: ")]
+    #[error("NextHeaderCrcMismatch")]
     NextHeaderCrcMismatch,
     #[error("FileIoError: {0}")]
     Io(std::io::Error, Cow<'static, str>),
@@ -27,7 +27,7 @@ pub enum Error {
     #[error("ExternalUnsupported")]
     ExternalUnsupported,
     #[error("MaxMemLimited")]
-    MaxMemLimited { max_kb: usize, actaul_kb: usize },
+    MaxMemLimited { max_kb: usize, actual_kb: usize },
     #[error("Unsupported")]
     Unsupported(String),
 }

--- a/engine/runtime/sevenz/src/error.rs
+++ b/engine/runtime/sevenz/src/error.rs
@@ -1,0 +1,64 @@
+use std::borrow::Cow;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("BadSignature:")]
+    BadSignature([u8; 6]),
+    #[error("Unsupported Version:")]
+    UnsupportedVersion { major: u8, minor: u8 },
+    #[error("ChecksumVerificationFailed: ")]
+    ChecksumVerificationFailed,
+    #[error("NextHeaderCrcMismatch: ")]
+    NextHeaderCrcMismatch,
+    #[error("FileIoError: {0}")]
+    Io(std::io::Error, Cow<'static, str>),
+    #[error("Other")]
+    Other(Cow<'static, str>),
+    #[error("BadTerminatedStreamsInfo")]
+    BadTerminatedStreamsInfo(u8),
+    #[error("BadTerminatedUnpackInfo")]
+    BadTerminatedUnpackInfo,
+    #[error("BadTerminatedPackInfo")]
+    BadTerminatedPackInfo(u8),
+    #[error("BadTerminatedSubStreamsInfo")]
+    BadTerminatedSubStreamsInfo,
+    #[error("BadTerminatedheader")]
+    BadTerminatedheader(u8),
+    #[error("ExternalUnsupported")]
+    ExternalUnsupported,
+    #[error("MaxMemLimited")]
+    MaxMemLimited { max_kb: usize, actaul_kb: usize },
+    #[error("Unsupported")]
+    Unsupported(String),
+}
+
+impl From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        Self::io(value)
+    }
+}
+
+impl Error {
+    #[inline]
+    pub fn other<S: Into<Cow<'static, str>>>(s: S) -> Self {
+        Self::Other(s.into())
+    }
+    #[inline]
+    pub fn unsupported<S: ToString>(s: S) -> Self {
+        Self::Unsupported(s.to_string())
+    }
+
+    #[inline]
+    pub fn io(e: std::io::Error) -> Self {
+        Self::io_msg(e, "")
+    }
+    #[inline]
+    pub fn io_msg(e: std::io::Error, msg: impl Into<Cow<'static, str>>) -> Self {
+        Self::Io(e, msg.into())
+    }
+
+    #[inline]
+    pub(crate) fn file_open(e: std::io::Error, filename: impl Into<Cow<'static, str>>) -> Self {
+        Self::Io(e, filename.into())
+    }
+}

--- a/engine/runtime/sevenz/src/folder.rs
+++ b/engine/runtime/sevenz/src/folder.rs
@@ -1,0 +1,111 @@
+#![allow(unused)]
+
+#[derive(Debug, Default, Clone)]
+pub struct Folder {
+    pub coders: Vec<Coder>,
+    pub total_input_streams: usize,
+    pub total_output_streams: usize,
+    pub bind_pairs: Vec<BindPair>,
+    pub packed_streams: Vec<u64>,
+    pub unpack_sizes: Vec<u64>,
+    pub has_crc: bool,
+    pub crc: u64,
+    pub num_unpack_sub_streams: usize,
+}
+
+impl Folder {
+    pub fn find_bind_pair_for_in_stream(&self, index: usize) -> Option<usize> {
+        let index = index as u64;
+        (0..self.bind_pairs.len()).find(|&i| self.bind_pairs[i].in_index == index)
+    }
+
+    pub fn find_bind_pair_for_out_stream(&self, index: usize) -> Option<usize> {
+        let index = index as u64;
+        (0..self.bind_pairs.len()).find(|&i| self.bind_pairs[i].out_index == index)
+    }
+
+    pub fn get_unpack_size(&self) -> u64 {
+        if self.total_output_streams == 0 {
+            return 0;
+        }
+        for i in (0..self.total_output_streams).rev() {
+            if self.find_bind_pair_for_out_stream(i).is_none() {
+                return self.unpack_sizes[i];
+            }
+        }
+        0
+    }
+
+    pub fn get_unpack_size_for_coder(&self, coder: &Coder) -> u64 {
+        for i in 0..self.coders.len() {
+            if std::ptr::eq(&self.coders[i], coder) {
+                return self.unpack_sizes[i];
+            }
+        }
+        0
+    }
+
+    pub fn get_unpack_size_at_index(&self, index: usize) -> u64 {
+        self.unpack_sizes.get(index).cloned().unwrap_or_default()
+    }
+
+    pub fn ordered_coder_iter(&self) -> OrderedCoderIter {
+        OrderedCoderIter::new(self)
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Coder {
+    decompression_method_id: [u8; 0xf],
+    pub id_size: usize,
+    pub num_in_streams: u64,
+    pub num_out_streams: u64,
+    pub properties: Vec<u8>,
+}
+
+impl Coder {
+    pub fn decompression_method_id(&self) -> &[u8] {
+        &self.decompression_method_id[0..self.id_size]
+    }
+    pub fn decompression_method_id_mut(&mut self) -> &mut [u8] {
+        &mut self.decompression_method_id[0..self.id_size]
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct BindPair {
+    pub in_index: u64,
+    pub out_index: u64,
+}
+
+pub struct OrderedCoderIter<'a> {
+    folder: &'a Folder,
+    current: Option<u64>,
+}
+impl<'a> OrderedCoderIter<'a> {
+    fn new(folder: &'a Folder) -> Self {
+        let current = folder.packed_streams.first().copied();
+        Self { folder, current }
+    }
+}
+
+impl<'a> Iterator for OrderedCoderIter<'a> {
+    type Item = (usize, &'a Coder);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(i) = self.current {
+            self.current = if let Some(pair) = self.folder.find_bind_pair_for_out_stream(i as usize)
+            {
+                Some(self.folder.bind_pairs[pair].in_index)
+            } else {
+                None
+            };
+            self.folder
+                .coders
+                .get(i as usize)
+                .map(|item| (i as usize, item))
+        } else {
+            None
+        }
+    }
+}

--- a/engine/runtime/sevenz/src/lib.rs
+++ b/engine/runtime/sevenz/src/lib.rs
@@ -1,0 +1,9 @@
+pub(crate) mod archive;
+pub(crate) mod bcj2;
+pub mod de_funcs;
+pub(crate) mod decoders;
+pub(crate) mod error;
+pub(crate) mod folder;
+pub(crate) mod reader;
+
+pub use de_funcs::*;

--- a/engine/runtime/sevenz/src/reader.rs
+++ b/engine/runtime/sevenz/src/reader.rs
@@ -68,6 +68,9 @@ impl<R: Read + Seek> Seek for SeekableBoundedReader<R> {
         if new_pos < 0 {
             return Err(std::io::Error::new(ErrorKind::Other, "SeekBeforeStart"));
         }
+        if new_pos > self.bounds.1 as i64 {
+            return Err(std::io::Error::new(ErrorKind::Other, "SeekBeyondEnd"));
+        }
         self.cur = new_pos as u64;
         self.inner.seek(SeekFrom::Start(self.cur))
     }

--- a/engine/runtime/sevenz/src/reader.rs
+++ b/engine/runtime/sevenz/src/reader.rs
@@ -1,0 +1,1418 @@
+use std::io::{ErrorKind, Read, Seek, SeekFrom};
+
+use bit_set::BitSet;
+use crc::Crc;
+
+use crate::{archive::*, decoders::add_decoder, error::Error, folder::*};
+pub(crate) const CRC32: Crc<u32> = Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
+const MAX_MEM_LIMIT_KB: usize = usize::MAX / 1024;
+
+#[allow(dead_code)]
+pub(crate) trait SeedRead: Read + Seek {}
+
+pub struct BoundedReader<R: Read> {
+    inner: R,
+    remain: usize,
+}
+
+impl<R: Read> BoundedReader<R> {
+    pub fn new(inner: R, max_size: usize) -> Self {
+        Self {
+            inner,
+            remain: max_size,
+        }
+    }
+}
+
+impl<R: Read> Read for BoundedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.remain == 0 {
+            return Ok(0);
+        }
+        let remain = self.remain;
+        let buf2 = if buf.len() < remain {
+            buf
+        } else {
+            &mut buf[..remain]
+        };
+        match self.inner.read(buf2) {
+            Ok(size) => {
+                if self.remain < size {
+                    self.remain = 0;
+                } else {
+                    self.remain -= size;
+                }
+                Ok(size)
+            }
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct SeekableBoundedReader<R: Read + Seek> {
+    inner: R,
+    cur: u64,
+    bounds: (u64, u64),
+}
+
+impl<R: Read + Seek> SeedRead for SeekableBoundedReader<R> {}
+
+impl<R: Read + Seek> Seek for SeekableBoundedReader<R> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let new_pos = match pos {
+            SeekFrom::Start(pos) => self.bounds.0 as i64 + pos as i64,
+            SeekFrom::End(pos) => self.bounds.1 as i64 + pos,
+            SeekFrom::Current(pos) => self.cur as i64 + pos,
+        };
+        if new_pos < 0 {
+            return Err(std::io::Error::new(ErrorKind::Other, "SeekBeforeStart"));
+        }
+        self.cur = new_pos as u64;
+        self.inner.seek(SeekFrom::Start(self.cur))
+    }
+}
+
+impl<R: Read + Seek> Read for SeekableBoundedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.cur >= self.bounds.1 {
+            return Ok(0);
+        }
+        if self.stream_position()? != self.cur {
+            self.inner.seek(SeekFrom::Start(self.cur))?;
+        }
+        let buf2 = if buf.len() < (self.bounds.1 - self.cur) as usize {
+            buf
+        } else {
+            &mut buf[..(self.bounds.1 - self.cur) as usize]
+        };
+        let size = self.inner.read(buf2)?;
+        self.cur += size as u64;
+        Ok(size)
+    }
+}
+
+impl<R: Read + Seek> SeekableBoundedReader<R> {
+    pub fn new(inner: R, bounds: (u64, u64)) -> Self {
+        Self {
+            inner,
+            cur: bounds.0,
+            bounds,
+        }
+    }
+}
+
+struct Crc32VerifyingReader<R> {
+    inner: R,
+    crc_digest: crc::Digest<'static, u32>,
+    expected_value: u64,
+    remaining: i64,
+}
+
+impl<R: Read> Crc32VerifyingReader<R> {
+    fn new(inner: R, remaining: usize, expected_value: u64) -> Self {
+        Self {
+            inner,
+            crc_digest: CRC32.digest(),
+            expected_value,
+            remaining: remaining as i64,
+        }
+    }
+}
+
+impl<R: Read> Read for Crc32VerifyingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.remaining <= 0 {
+            return Ok(0);
+        }
+        let size = self.inner.read(buf)?;
+        if size > 0 {
+            self.remaining -= size as i64;
+            self.crc_digest.update(&buf[..size]);
+        }
+        if self.remaining <= 0 {
+            let d = std::mem::replace(&mut self.crc_digest, CRC32.digest()).finalize();
+            if d as u64 != self.expected_value {
+                return Err(std::io::Error::new(
+                    ErrorKind::Other,
+                    Error::ChecksumVerificationFailed,
+                ));
+            }
+        }
+        Ok(size)
+    }
+}
+
+impl Archive {
+    /// Read 7z file archive info use the specified `reader`.
+    /// -[`reader_len`] the `reader` stream length
+    /// -[`password`] Archive password encoded in utf16 little endian.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use std::io::{Read,Seek};
+    /// use std::fs::File;
+    ///
+    /// let mut reader = File::open("example.7z").unwrap();
+    /// let len = reader.metadata().unwrap().len();
+    ///
+    /// let archive = Archive::read(&mut reader, len).unwrap();
+    ///
+    /// //let archive = Archive::read(&mut reader,len, &[]);// for unencrypted file
+    /// for entry in &archive.files {
+    ///     println!("{}", entry.name());
+    /// }
+    /// ```
+    pub fn read<R: Read + Seek>(reader: &mut R, reader_len: u64) -> Result<Archive, Error> {
+        let mut signature = [0; 6];
+        reader.read_exact(&mut signature).map_err(Error::io)?;
+        if signature != SEVEN_Z_SIGNATURE {
+            return Err(Error::BadSignature(signature));
+        }
+        let mut versions = [0; 2];
+        reader.read_exact(&mut versions).map_err(Error::io)?;
+        let version_major = versions[0];
+        let version_minor = versions[1];
+        if version_major != 0 {
+            return Err(Error::UnsupportedVersion {
+                major: version_major,
+                minor: version_minor,
+            });
+        }
+
+        let start_header_crc = read_u32(reader)?;
+
+        let header_valid = if start_header_crc == 0 {
+            let current_position = reader.stream_position().map_err(Error::io)?;
+            let mut buf = [0; 20];
+            reader.read_exact(&mut buf).map_err(Error::io)?;
+            reader
+                .seek(std::io::SeekFrom::Start(current_position))
+                .map_err(Error::io)?;
+            buf.iter().any(|a| *a != 0)
+        } else {
+            true
+        };
+        if header_valid {
+            let start_header = Self::read_start_header(reader, start_header_crc)?;
+            Self::init_archive(reader, start_header, true)
+        } else {
+            Self::try_to_locale_end_header(reader, reader_len)
+        }
+    }
+
+    fn read_start_header<R: Read>(
+        reader: &mut R,
+        start_header_crc: u32,
+    ) -> Result<StartHeader, Error> {
+        let mut buf = [0; 20];
+        reader.read_exact(&mut buf).map_err(Error::io)?;
+        let value = crc32_cksum(&buf);
+        if value != start_header_crc {
+            return Err(Error::ChecksumVerificationFailed);
+        }
+        let mut buf_read = buf.as_slice();
+        let offset = read_u64le(&mut buf_read)?;
+
+        let size = read_u64le(&mut buf_read)?;
+        let crc = read_u32(&mut buf_read)?;
+        Ok(StartHeader {
+            next_header_offset: offset,
+            next_header_size: size,
+            next_header_crc: crc as u64,
+        })
+    }
+
+    fn read_header<R: Read + Seek>(header: &mut R, archive: &mut Archive) -> Result<(), Error> {
+        let mut nid = read_u8(header)?;
+        if nid == K_ARCHIVE_PROPERTIES {
+            Self::read_archive_properties(header)?;
+            nid = read_u8(header)?;
+        }
+
+        if nid == K_ADDITIONAL_STREAMS_INFO {
+            return Err(Error::other("Additional streams unsupported"));
+        }
+        if nid == K_MAIN_STREAMS_INFO {
+            Self::read_streams_info(header, archive)?;
+            nid = read_u8(header)?;
+        }
+        if nid == K_FILES_INFO {
+            Self::read_files_info(header, archive)?;
+            nid = read_u8(header)?;
+        }
+        if nid != K_END {
+            return Err(Error::BadTerminatedheader(nid));
+        }
+
+        Ok(())
+    }
+
+    fn read_archive_properties<R: Read + Seek>(header: &mut R) -> Result<(), Error> {
+        let mut nid = read_u8(header)?;
+        while nid != K_END {
+            let property_size = read_usize(header, "propertySize")?;
+            header
+                .seek(SeekFrom::Current(property_size as i64))
+                .map_err(Error::io)?;
+            nid = read_u8(header)?;
+        }
+        Ok(())
+    }
+
+    fn try_to_locale_end_header<R: Read + Seek>(
+        reader: &mut R,
+        reader_len: u64,
+    ) -> Result<Self, Error> {
+        let search_limit = 1024 * 1024;
+        let prev_data_size = reader.stream_position().map_err(Error::io)? + 20;
+        let size = reader_len;
+        let min_pos = if reader.stream_position().map_err(Error::io)? + search_limit > size {
+            reader.stream_position().map_err(Error::io)?
+        } else {
+            size - search_limit
+        };
+        let mut pos = reader_len - 1;
+        while pos > min_pos {
+            pos -= 1;
+
+            reader
+                .seek(std::io::SeekFrom::Start(pos))
+                .map_err(Error::io)?;
+            let nid = read_u8(reader)?;
+            if nid == K_ENCODED_HEADER || nid == K_HEADER {
+                let start_header = StartHeader {
+                    next_header_offset: pos - prev_data_size,
+                    next_header_size: reader_len - pos,
+                    next_header_crc: 0,
+                };
+                let result = Self::init_archive(reader, start_header, false)?;
+
+                if !result.files.is_empty() {
+                    return Ok(result);
+                }
+            }
+        }
+        Err(Error::other(
+            "Start header corrupt and unable to guess end header",
+        ))
+    }
+
+    fn init_archive<R: Read + Seek>(
+        reader: &mut R,
+        start_header: StartHeader,
+        verify_crc: bool,
+    ) -> Result<Self, Error> {
+        if start_header.next_header_size > usize::MAX as u64 {
+            return Err(Error::other(format!(
+                "Cannot handle next_header_size {}",
+                start_header.next_header_size
+            )));
+        }
+
+        let next_header_size_int = start_header.next_header_size as usize;
+
+        reader
+            .seek(SeekFrom::Start(
+                SIGNATURE_HEADER_SIZE + start_header.next_header_offset,
+            ))
+            .map_err(Error::io)?;
+
+        let mut buf = vec![0; next_header_size_int];
+        reader.read_exact(&mut buf).map_err(Error::io)?;
+        if verify_crc && crc32_cksum(&buf) as u64 != start_header.next_header_crc {
+            return Err(Error::NextHeaderCrcMismatch);
+        }
+
+        let mut archive = Archive::default();
+        let mut buf_reader = buf.as_slice();
+        let mut nid = read_u8(&mut buf_reader)?;
+        let mut header = if nid == K_ENCODED_HEADER {
+            let (mut out_reader, buf_size) =
+                Self::read_encoded_header(&mut buf_reader, reader, &mut archive)?;
+            buf.clear();
+            buf.resize(buf_size, 0);
+            out_reader.read_exact(&mut buf).map_err(Error::io)?;
+            archive = Archive::default();
+            buf_reader = buf.as_slice();
+            nid = read_u8(&mut buf_reader)?;
+            buf_reader
+        } else {
+            buf_reader
+        };
+        let mut header = std::io::Cursor::new(&mut header);
+        if nid == K_HEADER {
+            Self::read_header(&mut header, &mut archive)?;
+        } else {
+            return Err(Error::other("Broken or unsupported archive: no Header"));
+        }
+        Ok(archive)
+    }
+
+    fn read_encoded_header<'r, R: Read, RI: 'r + Read + Seek>(
+        header: &mut R,
+        reader: &'r mut RI,
+        archive: &mut Archive,
+    ) -> Result<(Box<dyn Read + 'r>, usize), Error> {
+        Self::read_streams_info(header, archive)?;
+        let folder = archive
+            .folders
+            .first()
+            .ok_or(Error::other("no folders, can't read encoded header"))?;
+        let first_pack_stream_index = 0;
+        let folder_offset = SIGNATURE_HEADER_SIZE + archive.pack_pos;
+        if archive.pack_sizes.is_empty() {
+            return Err(Error::other("no packed streams, can't read encoded header"));
+        }
+
+        reader
+            .seek(SeekFrom::Start(folder_offset))
+            .map_err(Error::io)?;
+        let coder_len = folder.coders.len();
+        let unpack_size = folder.get_unpack_size() as usize;
+        let pack_size = archive.pack_sizes[first_pack_stream_index] as usize;
+        let input_reader =
+            SeekableBoundedReader::new(reader, (folder_offset, folder_offset + pack_size as u64));
+        let mut decoder: Box<dyn Read> = Box::new(input_reader);
+        let mut decoder = if coder_len > 0 {
+            for (index, coder) in folder.ordered_coder_iter() {
+                if coder.num_in_streams != 1 || coder.num_out_streams != 1 {
+                    return Err(Error::other(
+                        "Multi input/output stream coders are not yet supported",
+                    ));
+                }
+                let next = crate::decoders::add_decoder(
+                    decoder,
+                    folder.get_unpack_size_at_index(index) as usize,
+                    coder,
+                    MAX_MEM_LIMIT_KB,
+                )?;
+                decoder = Box::new(next);
+            }
+            decoder
+        } else {
+            decoder
+        };
+        if folder.has_crc {
+            decoder = Box::new(Crc32VerifyingReader::new(decoder, unpack_size, folder.crc));
+        }
+
+        Ok((decoder, unpack_size))
+    }
+
+    fn read_streams_info<R: Read>(header: &mut R, archive: &mut Archive) -> Result<(), Error> {
+        let mut nid = read_u8(header)?;
+        if nid == K_PACK_INFO {
+            Self::read_pack_info(header, archive)?;
+            nid = read_u8(header)?;
+        }
+
+        if nid == K_UNPACK_INFO {
+            Self::read_unpack_info(header, archive)?;
+            nid = read_u8(header)?;
+        } else {
+            archive.folders.clear();
+        }
+        if nid == K_SUB_STREAMS_INFO {
+            Self::read_sub_streams_info(header, archive)?;
+            nid = read_u8(header)?;
+        }
+        if nid != K_END {
+            return Err(Error::BadTerminatedStreamsInfo(nid));
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::needless_range_loop)]
+    fn read_files_info<R: Read + Seek>(header: &mut R, archive: &mut Archive) -> Result<(), Error> {
+        let num_files = read_usize(header, "num files")?;
+        let mut files: Vec<SevenZArchiveEntry> = vec![Default::default(); num_files];
+
+        let mut is_empty_stream: Option<BitSet> = None;
+        let mut is_empty_file: Option<BitSet> = None;
+        let mut is_anti: Option<BitSet> = None;
+        loop {
+            let prop_type = read_u8(header)?;
+            if prop_type == 0 {
+                break;
+            }
+            let size = read_u64(header)?;
+            match prop_type {
+                K_EMPTY_STREAM => {
+                    is_empty_stream = Some(read_bits(header, num_files)?);
+                }
+                K_EMPTY_FILE => {
+                    let n = if let Some(s) = &is_empty_stream {
+                        s.len()
+                    } else {
+                        return Err(Error::other(
+                            "Header format error: kEmptyStream must appear before kEmptyFile",
+                        ));
+                    };
+                    is_empty_file = Some(read_bits(header, n)?);
+                }
+                K_ANTI => {
+                    let n = if let Some(s) = is_empty_stream.as_ref() {
+                        s.len()
+                    } else {
+                        return Err(Error::other(
+                            "Header format error: kEmptyStream must appear before kEmptyFile",
+                        ));
+                    };
+                    is_anti = Some(read_bits(header, n)?);
+                }
+                K_NAME => {
+                    let external = read_u8(header)?;
+                    if external != 0 {
+                        return Err(Error::other("Not implemented:external != 0"));
+                    }
+                    if (size - 1) & 1 != 0 {
+                        return Err(Error::other("file names length invalid"));
+                    }
+
+                    let size = assert_usize(size, "file names length")?;
+                    // let mut names = vec![0u8; size - 1];
+                    // header.read_exact(&mut names).map_err(Error::io)?;
+                    let names_reader = NamesReader::new(header, size - 1);
+
+                    let mut next_file = 0;
+                    for s in names_reader {
+                        files[next_file].name = s?;
+                        next_file += 1;
+                    }
+
+                    if next_file != files.len() {
+                        return Err(Error::other("Error parsing file names"));
+                    }
+                }
+                K_C_TIME => {
+                    let times_defined = read_all_or_bits(header, num_files)?;
+                    let external = read_u8(header)?;
+                    if external != 0 {
+                        return Err(Error::other(format!(
+                            "kCTime Unimplemented:external={}",
+                            external
+                        )));
+                    }
+                    for i in 0..num_files {
+                        files[i].has_creation_date = times_defined.contains(i);
+                        if files[i].has_creation_date {
+                            files[i].creation_date = read_u64le(header)?.into();
+                        }
+                    }
+                }
+                K_A_TIME => {
+                    let times_defined = read_all_or_bits(header, num_files)?;
+                    let external = read_u8(header)?;
+                    if external != 0 {
+                        return Err(Error::other(format!(
+                            "kATime Unimplemented:external={}",
+                            external
+                        )));
+                    }
+                    for i in 0..num_files {
+                        files[i].has_access_date = times_defined.contains(i);
+                        if files[i].has_access_date {
+                            files[i].access_date = read_u64le(header)?.into();
+                        }
+                    }
+                }
+                K_M_TIME => {
+                    let times_defined = read_all_or_bits(header, num_files)?;
+                    let external = read_u8(header)?;
+                    if external != 0 {
+                        return Err(Error::other(format!(
+                            "kMTime Unimplemented:external={}",
+                            external
+                        )));
+                    }
+                    for i in 0..num_files {
+                        files[i].has_last_modified_date = times_defined.contains(i);
+                        if files[i].has_last_modified_date {
+                            files[i].last_modified_date = read_u64le(header)?.into();
+                        }
+                    }
+                }
+                K_WIN_ATTRIBUTES => {
+                    let times_defined = read_all_or_bits(header, num_files)?;
+                    let external = read_u8(header)?;
+                    if external != 0 {
+                        return Err(Error::other(format!(
+                            "kWinAttributes Unimplemented:external={}",
+                            external
+                        )));
+                    }
+                    for i in 0..num_files {
+                        files[i].has_windows_attributes = times_defined.contains(i);
+                        if files[i].has_windows_attributes {
+                            files[i].windows_attributes = read_u32(header)?;
+                        }
+                    }
+                }
+                K_START_POS => return Err(Error::other("kStartPos is unsupported, please report")),
+                K_DUMMY => {
+                    header
+                        .seek(SeekFrom::Current(size as i64))
+                        .map_err(Error::io)?;
+                }
+                _ => {
+                    header
+                        .seek(SeekFrom::Current(size as i64))
+                        .map_err(Error::io)?;
+                }
+            };
+        }
+
+        let mut non_empty_file_counter = 0;
+        let mut empty_file_counter = 0;
+        for i in 0..files.len() {
+            let file = &mut files[i];
+            file.has_stream = is_empty_stream
+                .as_ref()
+                .map(|s| !s.contains(i))
+                .unwrap_or(true);
+            if file.has_stream {
+                let sub_stream_info = if let Some(s) = archive.sub_streams_info.as_ref() {
+                    s
+                } else {
+                    return Err(Error::other(
+                        "Archive contains file with streams but no subStreamsInfo",
+                    ));
+                };
+                file.is_directory = false;
+                file.is_anti_item = false;
+                file.has_crc = sub_stream_info.has_crc.contains(non_empty_file_counter);
+                file.crc = sub_stream_info.crcs[non_empty_file_counter];
+                file.size = sub_stream_info.unpack_sizes[non_empty_file_counter];
+                non_empty_file_counter += 1;
+            } else {
+                file.is_directory = if let Some(s) = &is_empty_file {
+                    !s.contains(empty_file_counter)
+                } else {
+                    true
+                };
+                file.is_anti_item = is_anti
+                    .as_ref()
+                    .map(|s| s.contains(empty_file_counter))
+                    .unwrap_or(false);
+                file.has_crc = false;
+                file.size = 0;
+                empty_file_counter += 1;
+            }
+        }
+        archive.files = files;
+
+        Self::calculate_stream_map(archive)?;
+        Ok(())
+    }
+
+    fn calculate_stream_map(archive: &mut Archive) -> Result<(), Error> {
+        let mut stream_map = StreamMap::default();
+
+        let mut next_folder_pack_stream_index = 0;
+        let num_folders = archive.folders.len();
+        stream_map.folder_first_pack_stream_index = vec![0; num_folders];
+        for i in 0..num_folders {
+            stream_map.folder_first_pack_stream_index[i] = next_folder_pack_stream_index;
+            next_folder_pack_stream_index += archive.folders[i].packed_streams.len();
+        }
+
+        let mut next_pack_stream_offset = 0;
+        let num_pack_sizes = archive.pack_sizes.len();
+        stream_map.pack_stream_offsets = vec![0; num_pack_sizes];
+        for i in 0..num_pack_sizes {
+            stream_map.pack_stream_offsets[i] = next_pack_stream_offset;
+            next_pack_stream_offset += archive.pack_sizes[i];
+        }
+
+        stream_map.folder_first_file_index = vec![0; num_folders];
+        stream_map.file_folder_index = vec![None; archive.files.len()];
+        let mut next_folder_index = 0;
+        let mut next_folder_unpack_stream_index = 0;
+        for i in 0..archive.files.len() {
+            if !archive.files[i].has_stream && next_folder_unpack_stream_index == 0 {
+                stream_map.file_folder_index[i] = None;
+                continue;
+            }
+            if next_folder_unpack_stream_index == 0 {
+                while next_folder_index < archive.folders.len() {
+                    stream_map.folder_first_file_index[next_folder_index] = i;
+                    if archive.folders[next_folder_index].num_unpack_sub_streams > 0 {
+                        break;
+                    }
+                    next_folder_index += 1;
+                }
+                if next_folder_index >= archive.folders.len() {
+                    return Err(Error::other("Too few folders in archive"));
+                }
+            }
+            stream_map.file_folder_index[i] = Some(next_folder_index);
+            if !archive.files[i].has_stream {
+                continue;
+            }
+
+            //set `compressed_size` of first file in block
+            if stream_map.folder_first_file_index[next_folder_index] == i {
+                let first_pack_stream_index =
+                    stream_map.folder_first_pack_stream_index[next_folder_index];
+                let pack_size = archive.pack_sizes[first_pack_stream_index];
+
+                archive.files[i].compressed_size = pack_size;
+            }
+
+            next_folder_unpack_stream_index += 1;
+            if next_folder_unpack_stream_index
+                >= archive.folders[next_folder_index].num_unpack_sub_streams
+            {
+                next_folder_index += 1;
+                next_folder_unpack_stream_index = 0;
+            }
+        }
+
+        archive.stream_map = stream_map;
+        Ok(())
+    }
+
+    fn read_pack_info<R: Read>(header: &mut R, archive: &mut Archive) -> Result<(), Error> {
+        archive.pack_pos = read_u64(header)?;
+        let num_pack_streams = read_usize(header, "num pack streams")?;
+        let mut nid = read_u8(header)?;
+        if nid == K_SIZE {
+            archive.pack_sizes = vec![0u64; num_pack_streams];
+            for i in 0..archive.pack_sizes.len() {
+                archive.pack_sizes[i] = read_u64(header)?;
+            }
+            nid = read_u8(header)?;
+        }
+
+        if nid == K_CRC {
+            archive.pack_crcs_defined = read_all_or_bits(header, num_pack_streams)?;
+            archive.pack_crcs = vec![0; num_pack_streams];
+            for i in 0..num_pack_streams {
+                if archive.pack_crcs_defined.contains(i) {
+                    archive.pack_crcs[i] = read_u32(header)? as u64;
+                }
+            }
+            nid = read_u8(header)?;
+        }
+
+        if nid != K_END {
+            return Err(Error::BadTerminatedPackInfo(nid));
+        }
+
+        Ok(())
+    }
+    fn read_unpack_info<R: Read>(header: &mut R, archive: &mut Archive) -> Result<(), Error> {
+        let nid = read_u8(header)?;
+        if nid != K_FOLDER {
+            return Err(Error::other(format!("Expected kFolder, got {}", nid)));
+        }
+        let num_folders = read_usize(header, "num folders")?;
+
+        archive.folders.reserve_exact(num_folders);
+        let external = read_u8(header)?;
+        if external != 0 {
+            return Err(Error::ExternalUnsupported);
+        }
+
+        for _ in 0..num_folders {
+            archive.folders.push(Self::read_folder(header)?);
+        }
+
+        let nid = read_u8(header)?;
+        if nid != K_CODERS_UNPACK_SIZE {
+            return Err(Error::other(format!(
+                "Expected kCodersUnpackSize, got {}",
+                nid
+            )));
+        }
+
+        for folder in archive.folders.iter_mut() {
+            let tos = folder.total_output_streams;
+            folder.unpack_sizes.reserve_exact(tos);
+            for _ in 0..tos {
+                folder.unpack_sizes.push(read_u64(header)?);
+            }
+        }
+
+        let mut nid = read_u8(header)?;
+        if nid == K_CRC {
+            let crcs_defined = read_all_or_bits(header, num_folders)?;
+            for i in 0..num_folders {
+                if crcs_defined.contains(i) {
+                    archive.folders[i].has_crc = true;
+                    archive.folders[i].crc = read_u32(header)? as u64;
+                } else {
+                    archive.folders[i].has_crc = false;
+                }
+            }
+            nid = read_u8(header)?;
+        }
+        if nid != K_END {
+            return Err(Error::BadTerminatedUnpackInfo);
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::needless_range_loop)]
+    fn read_sub_streams_info<R: Read>(header: &mut R, archive: &mut Archive) -> Result<(), Error> {
+        for folder in archive.folders.iter_mut() {
+            folder.num_unpack_sub_streams = 1;
+        }
+        let mut total_unpack_streams = archive.folders.len();
+
+        let mut nid = read_u8(header)?;
+        if nid == K_NUM_UNPACK_STREAM {
+            total_unpack_streams = 0;
+            for folder in archive.folders.iter_mut() {
+                let num_streams = read_usize(header, "numStreams")?;
+                folder.num_unpack_sub_streams = num_streams;
+                total_unpack_streams += num_streams;
+            }
+            nid = read_u8(header)?;
+        }
+
+        let mut sub_streams_info = SubStreamsInfo::default();
+        sub_streams_info
+            .unpack_sizes
+            .resize(total_unpack_streams, Default::default());
+        sub_streams_info
+            .has_crc
+            .reserve_len_exact(total_unpack_streams);
+        sub_streams_info.crcs = vec![0; total_unpack_streams];
+
+        let mut next_unpack_stream = 0;
+        for folder in archive.folders.iter() {
+            if folder.num_unpack_sub_streams == 0 {
+                continue;
+            }
+            let mut sum = 0;
+            if nid == K_SIZE {
+                for _i in 0..folder.num_unpack_sub_streams - 1 {
+                    let size = read_u64(header)?;
+                    sub_streams_info.unpack_sizes[next_unpack_stream] = size;
+                    next_unpack_stream += 1;
+                    sum += size;
+                }
+            }
+            if sum > folder.get_unpack_size() {
+                return Err(Error::other(
+                    "sum of unpack sizes of folder exceeds total unpack size",
+                ));
+            }
+            sub_streams_info.unpack_sizes[next_unpack_stream] = folder.get_unpack_size() - sum;
+            next_unpack_stream += 1;
+        }
+        if nid == K_SIZE {
+            nid = read_u8(header)?;
+        }
+
+        let mut num_digests = 0;
+        for folder in archive.folders.iter() {
+            if folder.num_unpack_sub_streams != 1 || !folder.has_crc {
+                num_digests += folder.num_unpack_sub_streams;
+            }
+        }
+
+        if nid == K_CRC {
+            let has_missing_crc = read_all_or_bits(header, num_digests)?;
+            let mut missing_crcs = vec![0; num_digests];
+            for i in 0..num_digests {
+                if has_missing_crc.contains(i) {
+                    missing_crcs[i] = read_u32(header)? as u64;
+                }
+            }
+            let mut next_crc = 0;
+            let mut next_missing_crc = 0;
+            for folder in archive.folders.iter() {
+                if folder.num_unpack_sub_streams == 1 && folder.has_crc {
+                    sub_streams_info.has_crc.insert(next_crc);
+                    sub_streams_info.crcs[next_crc] = folder.crc;
+                    next_crc += 1;
+                } else {
+                    for _i in 0..folder.num_unpack_sub_streams {
+                        if has_missing_crc.contains(next_missing_crc) {
+                            sub_streams_info.has_crc.insert(next_crc);
+                        } else {
+                            sub_streams_info.has_crc.remove(next_crc);
+                        }
+                        sub_streams_info.crcs[next_crc] = missing_crcs[next_missing_crc];
+                        next_crc += 1;
+                        next_missing_crc += 1;
+                    }
+                }
+            }
+
+            nid = read_u8(header)?;
+        }
+
+        if nid != K_END {
+            return Err(Error::BadTerminatedSubStreamsInfo);
+        }
+
+        archive.sub_streams_info = Some(sub_streams_info);
+        Ok(())
+    }
+
+    #[allow(clippy::needless_range_loop)]
+    fn read_folder<R: Read>(header: &mut R) -> Result<Folder, Error> {
+        let mut folder = Folder::default();
+
+        let num_coders = read_usize(header, "num coders")?;
+        let mut coders = Vec::with_capacity(num_coders);
+        let mut total_in_streams = 0;
+        let mut total_out_streams = 0;
+        for _i in 0..num_coders {
+            let mut coder = Coder::default();
+            let bits = read_u8(header)?;
+            let id_size = bits & 0xf;
+            let is_simple = (bits & 0x10) == 0;
+            let has_attributes = (bits & 0x20) != 0;
+            let more_alternative_methods = (bits & 0x80) != 0;
+
+            coder.id_size = id_size as usize;
+
+            header
+                .read(coder.decompression_method_id_mut())
+                .map_err(Error::io)?;
+            if is_simple {
+                coder.num_in_streams = 1;
+                coder.num_out_streams = 1;
+            } else {
+                coder.num_in_streams = read_u64(header)?;
+                coder.num_out_streams = read_u64(header)?;
+            }
+            total_in_streams += coder.num_in_streams;
+            total_out_streams += coder.num_out_streams;
+            if has_attributes {
+                let properties_size = read_usize(header, "properties size")?;
+                let mut props = vec![0u8; properties_size];
+                header.read(&mut props).map_err(Error::io)?;
+                coder.properties = props;
+            }
+            coders.push(coder);
+            // would need to keep looping as above:
+            if more_alternative_methods {
+                return Err(Error::other("Alternative methods are unsupported, please report. The reference implementation doesn't support them either."));
+            }
+        }
+        folder.coders = coders;
+        let total_in_streams = assert_usize(total_in_streams, "totalInStreams")?;
+        let total_out_streams = assert_usize(total_out_streams, "totalOutStreams")?;
+        folder.total_input_streams = total_in_streams;
+        folder.total_output_streams = total_out_streams;
+
+        if total_out_streams == 0 {
+            return Err(Error::other("Total output streams can't be 0"));
+        }
+        let num_bind_pairs = total_out_streams - 1;
+        let mut bind_pairs = Vec::with_capacity(num_bind_pairs);
+        for _ in 0..num_bind_pairs {
+            let bp = BindPair {
+                in_index: read_u64(header)?,
+                out_index: read_u64(header)?,
+            };
+            bind_pairs.push(bp);
+        }
+        folder.bind_pairs = bind_pairs;
+
+        if total_in_streams < num_bind_pairs {
+            return Err(Error::other(
+                "Total input streams can't be less than the number of bind pairs",
+            ));
+        }
+        let num_packed_streams = total_in_streams - num_bind_pairs;
+        let mut packed_streams = vec![0; num_packed_streams];
+        if num_packed_streams == 1 {
+            let mut index = u64::MAX;
+            for i in 0..total_in_streams {
+                if folder.find_bind_pair_for_in_stream(i).is_none() {
+                    index = i as u64;
+                    break;
+                }
+            }
+            if index == u64::MAX {
+                return Err(Error::other("Couldn't find stream's bind pair index"));
+            }
+            packed_streams[0] = index;
+        } else {
+            for i in 0..num_packed_streams {
+                packed_streams[i] = read_u64(header)?;
+            }
+        }
+        folder.packed_streams = packed_streams;
+
+        Ok(folder)
+    }
+}
+
+#[inline]
+fn crc32_cksum(data: &[u8]) -> u32 {
+    CRC32.checksum(data)
+}
+
+#[inline]
+fn read_usize<R: Read>(reader: &mut R, field: &str) -> Result<usize, Error> {
+    let size = read_u64(reader)?;
+    assert_usize(size, field)
+}
+
+#[inline]
+fn assert_usize(size: u64, field: &str) -> Result<usize, Error> {
+    if size > usize::MAX as u64 {
+        return Err(Error::other(format!("Cannot handle {} {}", field, size)));
+    }
+    Ok(size as usize)
+}
+
+#[inline]
+fn read_u64le<R: Read>(reader: &mut R) -> Result<u64, Error> {
+    let mut buf = [0; 8];
+    reader.read_exact(&mut buf).map_err(Error::io)?;
+    Ok(u64::from_le_bytes(buf))
+}
+
+fn read_u64<R: Read>(reader: &mut R) -> Result<u64, Error> {
+    let first = read_u8(reader)? as u64;
+    let mut mask = 0x80_u64;
+    let mut value = 0;
+    for i in 0..8 {
+        if (first & mask) == 0 {
+            return Ok(value | ((first & (mask - 1)) << (8 * i)));
+        }
+        let b = read_u8(reader)? as u64;
+        value |= b << (8 * i);
+        mask >>= 1;
+    }
+    Ok(value)
+}
+
+#[inline(always)]
+fn read_u32<R: Read>(reader: &mut R) -> Result<u32, Error> {
+    let mut buf = [0; 4];
+    reader.read_exact(&mut buf).map_err(Error::io)?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+#[inline(always)]
+fn read_u8<R: Read>(reader: &mut R) -> Result<u8, Error> {
+    let mut buf = [0];
+    reader.read_exact(&mut buf).map_err(Error::io)?;
+    Ok(buf[0])
+}
+
+fn read_all_or_bits<R: Read>(header: &mut R, size: usize) -> Result<BitSet, Error> {
+    let all = read_u8(header)?;
+    if all != 0 {
+        let mut bits = BitSet::with_capacity(size);
+        for i in 0..size {
+            bits.insert(i);
+        }
+        Ok(bits)
+    } else {
+        read_bits(header, size)
+    }
+}
+
+fn read_bits<R: Read>(header: &mut R, size: usize) -> Result<BitSet, Error> {
+    let mut bits = BitSet::with_capacity(size);
+    let mut mask = 0u32;
+    let mut cache = 0u32;
+    for i in 0..size {
+        if mask == 0 {
+            mask = 0x80;
+            cache = read_u8(header)? as u32;
+        }
+        if (cache & mask) != 0 {
+            bits.insert(i);
+        }
+        mask >>= 1;
+    }
+    Ok(bits)
+}
+
+struct NamesReader<'a, R: Read> {
+    max_bytes: usize,
+    read_bytes: usize,
+    cache: Vec<u16>,
+    reader: &'a mut R,
+}
+
+impl<'a, R: Read> NamesReader<'a, R> {
+    fn new(reader: &'a mut R, max_bytes: usize) -> Self {
+        Self {
+            max_bytes,
+            reader,
+            read_bytes: 0,
+            cache: Vec::with_capacity(16),
+        }
+    }
+}
+
+impl<R: Read> Iterator for NamesReader<'_, R> {
+    type Item = Result<String, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.max_bytes <= self.read_bytes {
+            return None;
+        }
+        self.cache.clear();
+        let mut buf = [0; 2];
+        while self.read_bytes < self.max_bytes {
+            let r = self.reader.read_exact(&mut buf).map_err(Error::io);
+            self.read_bytes += 2;
+            if let Err(e) = r {
+                return Some(Err(e));
+            }
+            let u = u16::from_le_bytes(buf);
+            if u == 0 {
+                break;
+            }
+            self.cache.push(u);
+        }
+
+        Some(String::from_utf16(&self.cache).map_err(|e| Error::other(e.to_string())))
+    }
+}
+
+pub struct SevenZReader<R: Read + Seek> {
+    source: R,
+    archive: Archive,
+}
+
+impl<R: Read + Seek> SevenZReader<R> {
+    #[inline]
+    pub fn new(mut source: R, reader_len: u64) -> Result<Self, Error> {
+        let archive = Archive::read(&mut source, reader_len)?;
+        Ok(Self { source, archive })
+    }
+
+    fn build_decode_stack<'r>(
+        source: &'r mut R,
+        archive: &Archive,
+        folder_index: usize,
+    ) -> Result<(Box<dyn Read + 'r>, usize), Error> {
+        let folder = &archive.folders[folder_index];
+        if folder.total_input_streams > folder.total_output_streams {
+            return Self::build_decode_stack2(source, archive, folder_index);
+        }
+        let first_pack_stream_index =
+            archive.stream_map.folder_first_pack_stream_index[folder_index];
+        let folder_offset = SIGNATURE_HEADER_SIZE
+            + archive.pack_pos
+            + archive.stream_map.pack_stream_offsets[first_pack_stream_index];
+
+        source
+            .seek(SeekFrom::Start(folder_offset))
+            .map_err(Error::io)?;
+        let pack_size = archive.pack_sizes[first_pack_stream_index] as usize;
+
+        let mut decoder: Box<dyn Read> = Box::new(BoundedReader::new(source, pack_size));
+        let folder = &archive.folders[folder_index];
+        for (index, coder) in folder.ordered_coder_iter() {
+            if coder.num_in_streams != 1 || coder.num_out_streams != 1 {
+                return Err(Error::unsupported(
+                    "Multi input/output stream coders are not yet supported",
+                ));
+            }
+            let next = crate::decoders::add_decoder(
+                decoder,
+                folder.get_unpack_size_at_index(index) as usize,
+                coder,
+                MAX_MEM_LIMIT_KB,
+            )?;
+            decoder = Box::new(next);
+        }
+        if folder.has_crc {
+            decoder = Box::new(Crc32VerifyingReader::new(
+                decoder,
+                folder.get_unpack_size() as usize,
+                folder.crc,
+            ));
+        }
+
+        Ok((decoder, pack_size))
+    }
+
+    #[allow(clippy::needless_range_loop)]
+    fn build_decode_stack2<'r>(
+        source: &'r mut R,
+        archive: &Archive,
+        folder_index: usize,
+    ) -> Result<(Box<dyn Read + 'r>, usize), Error> {
+        const MAX_CODER_COUNT: usize = 32;
+        let folder = &archive.folders[folder_index];
+        if folder.coders.len() > MAX_CODER_COUNT {
+            return Err(Error::unsupported(format!(
+                "Too many coders: {}",
+                folder.coders.len()
+            )));
+        }
+
+        assert!(folder.total_input_streams > folder.total_output_streams);
+        let source = ReaderPtr::new(source);
+        let first_pack_stream_index =
+            archive.stream_map.folder_first_pack_stream_index[folder_index];
+        let start_pos = SIGNATURE_HEADER_SIZE + archive.pack_pos;
+        let offsets = &archive.stream_map.pack_stream_offsets[first_pack_stream_index..];
+
+        let mut sources = Vec::with_capacity(folder.packed_streams.len());
+        for i in 0..folder.packed_streams.len() {
+            let pack_pos = start_pos + offsets[i];
+            let pack_size = archive.pack_sizes[first_pack_stream_index + i];
+            let pack_reader =
+                SeekableBoundedReader::new(source.clone(), (pack_pos, pack_pos + pack_size));
+            sources.push(pack_reader);
+        }
+
+        let mut coder_to_stream_map = [usize::MAX; MAX_CODER_COUNT];
+
+        let mut si = 0;
+        for i in 0..folder.coders.len() {
+            coder_to_stream_map[i] = si;
+            si += folder.coders[i].num_in_streams as usize;
+        }
+
+        let main_coder_index = {
+            let mut coder_used = [false; MAX_CODER_COUNT];
+            for bp in folder.bind_pairs.iter() {
+                coder_used[bp.out_index as usize] = true;
+            }
+            let mut mci = 0;
+            for i in 0..folder.coders.len() {
+                if !coder_used[i] {
+                    mci = i;
+                    break;
+                }
+            }
+            mci
+        };
+
+        let id = folder.coders[main_coder_index].decompression_method_id();
+        if id != SevenZMethod::ID_BCJ2 {
+            return Err(Error::unsupported(format!("Unsupported method: {:?}", id)));
+        }
+
+        let num_in_streams = folder.coders[main_coder_index].num_in_streams as usize;
+        let mut inputs: Vec<Box<dyn Read>> = Vec::with_capacity(num_in_streams);
+        let start_i = coder_to_stream_map[main_coder_index];
+        for i in start_i..num_in_streams + start_i {
+            inputs.push(Self::get_in_stream(
+                folder,
+                &sources,
+                &coder_to_stream_map,
+                i,
+            )?);
+        }
+        let mut decoder: Box<dyn Read> = Box::new(crate::bcj2::BCJ2Reader::new(
+            inputs,
+            folder.get_unpack_size(),
+        ));
+        if folder.has_crc {
+            decoder = Box::new(Crc32VerifyingReader::new(
+                decoder,
+                folder.get_unpack_size() as usize,
+                folder.crc,
+            ));
+        }
+        Ok((
+            decoder,
+            archive.pack_sizes[first_pack_stream_index] as usize,
+        ))
+    }
+
+    fn get_in_stream<'r>(
+        folder: &Folder,
+        sources: &[SeekableBoundedReader<ReaderPtr<R>>],
+        coder_to_stream_map: &[usize],
+        in_stream_index: usize,
+    ) -> Result<Box<dyn Read + 'r>, Error>
+    where
+        R: 'r,
+    {
+        let index = folder
+            .packed_streams
+            .iter()
+            .position(|&i| i == in_stream_index as u64);
+        if let Some(index) = index {
+            return Ok(Box::new(sources[index].clone()));
+        }
+
+        let bp = folder
+            .find_bind_pair_for_in_stream(in_stream_index)
+            .ok_or_else(|| {
+                Error::other(format!(
+                    "Couldn't find bind pair for stream {}",
+                    in_stream_index
+                ))
+            })?;
+        let index = folder.bind_pairs[bp].out_index as usize;
+
+        Self::get_in_stream2(folder, sources, coder_to_stream_map, index)
+    }
+
+    fn get_in_stream2<'r>(
+        folder: &Folder,
+        sources: &[SeekableBoundedReader<ReaderPtr<R>>],
+        coder_to_stream_map: &[usize],
+        in_stream_index: usize,
+    ) -> Result<Box<dyn Read + 'r>, Error>
+    where
+        R: 'r,
+    {
+        let coder = &folder.coders[in_stream_index];
+        let start_index = coder_to_stream_map[in_stream_index];
+        if start_index == usize::MAX {
+            return Err(Error::other("in_stream_index out of range"));
+        }
+        let uncompressed_len = folder.unpack_sizes[in_stream_index] as usize;
+        if coder.num_in_streams == 1 {
+            let input = Self::get_in_stream(folder, sources, coder_to_stream_map, start_index)?;
+
+            let decoder = add_decoder(input, uncompressed_len, coder, MAX_MEM_LIMIT_KB)?;
+            return Ok(Box::new(decoder));
+        }
+        Err(Error::unsupported(
+            "Multi input stream coders are not yet supported",
+        ))
+    }
+
+    /// Takes a closure to decode each files in the archive.
+    ///
+    /// Attention about solid archive:
+    /// When decoding a solid archive, the data to be decompressed depends on the data in front of it,
+    /// you cannot simply skip the previous data and only decompress the data in the back.
+    ///
+    /// See [ChecksumVerificationFailed](https://github.com/dyz1990/sevenz-rust/issues/31).
+    ///
+    /// To speed up decompression, you can check this example [examples/forder_dec.rs](https://github.com/dyz1990/sevenz-rust/blob/main/examples/forder_dec.rs).
+    /// And this example [mt_decompress.rs](https://github.com/dyz1990/sevenz-rust/blob/main/examples/mt_decompress.rs) if you want use multi-thread.
+    ///
+    pub fn for_each_entries<F: FnMut(&SevenZArchiveEntry, &mut dyn Read) -> Result<bool, Error>>(
+        &mut self,
+        mut each: F,
+    ) -> Result<(), Error> {
+        let folder_count = self.archive.folders.len();
+        for folder_index in 0..folder_count {
+            let forder_dec = BlockDecoder::new(folder_index, &self.archive, &mut self.source);
+            forder_dec.for_each_entries(&mut each)?;
+        }
+        // decode empty files
+        for file_index in 0..self.archive.files.len() {
+            let folder_index = self.archive.stream_map.file_folder_index[file_index];
+            if folder_index.is_none() {
+                let file = &self.archive.files[file_index];
+                let empty_reader: &mut dyn Read = &mut ([0u8; 0].as_slice());
+                if !each(file, empty_reader)? {
+                    return Ok(());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Alias for ['BlockDecoder'], used for compatibility purposes.
+#[allow(unused)]
+#[deprecated]
+pub type FolderDecoder<'a, R> = BlockDecoder<'a, R>;
+
+pub struct BlockDecoder<'a, R: Read + Seek> {
+    folder_index: usize,
+    archive: &'a Archive,
+    source: &'a mut R,
+}
+
+impl<'a, R: Read + Seek> BlockDecoder<'a, R> {
+    pub fn new(folder_index: usize, archive: &'a Archive, source: &'a mut R) -> Self {
+        Self {
+            folder_index,
+            archive,
+            source,
+        }
+    }
+
+    /// Takes a closure to decode each files in this block.
+    ///
+    /// When decoding files in a block, the data to be decompressed depends on the data in front of it,
+    /// you cannot simply skip the previous data and only decompress the data in the back.
+    ///
+    /// See [ChecksumVerificationFailed](https://github.com/dyz1990/sevenz-rust/issues/31).
+    ///
+    /// To speed up decompression, you can check this example [examples/forder_dec.rs](https://github.com/dyz1990/sevenz-rust/blob/main/examples/forder_dec.rs).
+    /// And this example [mt_decompress.rs](https://github.com/dyz1990/sevenz-rust/blob/main/examples/mt_decompress.rs) if you want use multi-thread.
+    ///
+    pub fn for_each_entries<F: FnMut(&SevenZArchiveEntry, &mut dyn Read) -> Result<bool, Error>>(
+        self,
+        each: &mut F,
+    ) -> Result<bool, Error> {
+        let Self {
+            folder_index,
+            archive,
+            source,
+        } = self;
+        let (mut folder_reader, _size) =
+            SevenZReader::build_decode_stack(source, archive, folder_index)?;
+        let start = archive.stream_map.folder_first_file_index[folder_index];
+        let file_count = archive.folders[folder_index].num_unpack_sub_streams;
+
+        for file_index in start..(file_count + start) {
+            let file = &archive.files[file_index];
+            if file.has_stream && file.size > 0 {
+                let mut decoder: Box<dyn Read> =
+                    Box::new(BoundedReader::new(&mut folder_reader, file.size as usize));
+                if file.has_crc {
+                    decoder = Box::new(Crc32VerifyingReader::new(
+                        decoder,
+                        file.size as usize,
+                        file.crc,
+                    ));
+                }
+                if !each(file, &mut decoder)? {
+                    return Ok(false);
+                }
+            } else {
+                let empty_reader: &mut dyn Read = &mut ([0u8; 0].as_slice());
+                if !each(file, empty_reader)? {
+                    return Ok(false);
+                }
+            }
+        }
+        Ok(true)
+    }
+}
+
+#[derive(Debug, Copy)]
+struct ReaderPtr<R> {
+    reader: *mut R,
+}
+
+impl<R> Clone for ReaderPtr<R> {
+    fn clone(&self) -> Self {
+        Self {
+            reader: self.reader,
+        }
+    }
+}
+
+impl<R> ReaderPtr<R> {
+    fn new(reader: &mut R) -> Self {
+        Self {
+            reader: reader as *mut R,
+        }
+    }
+}
+
+impl<R: Read> Read for ReaderPtr<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        unsafe { (*self.reader).read(buf) }
+    }
+}
+
+impl<R: Seek> Seek for ReaderPtr<R> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        unsafe { (*self.reader).seek(pos) }
+    }
+}


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Based on the comprehensive changes, here are the updated release notes:

- **New Features**
  - Added support for 7z archive decompression.
  - Implemented BCJ2 decoding functionality.
  - Introduced customizable extraction behavior for decompression.
  - Enhanced error handling for various archive operations.

- **Technical Improvements**
  - Created modular architecture for handling compressed archives.
  - Implemented multiple decompression methods (LZMA, LZMA2).
  - Improved stream and reader management for archive processing.
  - Added new readers for CRC verification and bounded reading.

- **Dependencies**
  - Added new internal dependencies for archive handling.
  - Integrated compression and stream processing libraries.

The changes represent a significant enhancement to the project's archive processing capabilities, focusing on providing a flexible and robust 7z archive decompression system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->