### PR TITLE
feat(engine): integrate sevenz support for file extraction in action processor

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5664,6 +5664,7 @@ dependencies = [
  "reearth-flow-eval-expr",
  "reearth-flow-geometry",
  "reearth-flow-runtime",
+ "reearth-flow-sevenz",
  "reearth-flow-state",
  "reearth-flow-storage",
  "reearth-flow-types",

--- a/engine/runtime/action-processor/Cargo.toml
+++ b/engine/runtime/action-processor/Cargo.toml
@@ -16,10 +16,10 @@ reearth-flow-common.workspace = true
 reearth-flow-eval-expr.workspace = true
 reearth-flow-geometry.workspace = true
 reearth-flow-runtime.workspace = true
+reearth-flow-sevenz.workspace = true
 reearth-flow-state.workspace = true
 reearth-flow-storage.workspace = true
 reearth-flow-types.workspace = true
-reearth-flow-sevenz.workspace = true
 
 nusamai-citygml.workspace = true
 nusamai-plateau.workspace = true

--- a/engine/runtime/action-processor/Cargo.toml
+++ b/engine/runtime/action-processor/Cargo.toml
@@ -19,6 +19,7 @@ reearth-flow-runtime.workspace = true
 reearth-flow-state.workspace = true
 reearth-flow-storage.workspace = true
 reearth-flow-types.workspace = true
+reearth-flow-sevenz.workspace = true
 
 nusamai-citygml.workspace = true
 nusamai-plateau.workspace = true

--- a/engine/runtime/sevenz/src/error.rs
+++ b/engine/runtime/sevenz/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     Io(std::io::Error, Cow<'static, str>),
     #[error("Other")]
     Other(Cow<'static, str>),
+    #[error("Unknown: {0}")]
+    Unknown(String),
     #[error("BadTerminatedStreamsInfo")]
     BadTerminatedStreamsInfo(u8),
     #[error("BadTerminatedUnpackInfo")]

--- a/engine/runtime/sevenz/src/lib.rs
+++ b/engine/runtime/sevenz/src/lib.rs
@@ -7,3 +7,4 @@ pub(crate) mod folder;
 pub(crate) mod reader;
 
 pub use de_funcs::*;
+pub use error::Error;


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for extracting `.7z` and `.7zip` archive formats in the file path extractor.
	- Enhanced error handling capabilities with a new error variant for unknown errors.

- **Dependency Updates**
	- Added `reearth-flow-sevenz` package as a workspace dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->