### PR TITLE
feat(engine): add FeatureDuplicateFilter to process and filter duplicate features

### DIFF
--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -821,6 +821,20 @@ Creates features from expressions
 ### Category
 * Feature
 
+## FeatureDuplicateFilter
+### Type
+* processor
+### Description
+Filters features by duplicate feature
+### Parameters
+* No parameters
+### Input Ports
+* default
+### Output Ports
+* default
+### Category
+* Feature
+
 ## FeatureFilePathExtractor
 ### Type
 * processor

--- a/engine/runtime/action-processor/src/feature.rs
+++ b/engine/runtime/action-processor/src/feature.rs
@@ -1,4 +1,5 @@
 pub(crate) mod counter;
+pub(crate) mod duplicate_filter;
 pub(crate) mod errors;
 pub(crate) mod file_path_extractor;
 pub(crate) mod filter;

--- a/engine/runtime/action-processor/src/feature/duplicate_filter.rs
+++ b/engine/runtime/action-processor/src/feature/duplicate_filter.rs
@@ -1,0 +1,114 @@
+use std::collections::{HashMap, HashSet};
+
+use reearth_flow_runtime::{
+    channels::ProcessorChannelForwarder,
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
+};
+use reearth_flow_types::Feature;
+use serde_json::Value;
+
+#[derive(Debug, Clone, Default)]
+pub struct FeatureDuplicateFilterFactory;
+
+impl ProcessorFactory for FeatureDuplicateFilterFactory {
+    fn name(&self) -> &str {
+        "FeatureDuplicateFilter"
+    }
+
+    fn description(&self) -> &str {
+        "Filters features by duplicate feature"
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        None
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["Feature"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn build(
+        &self,
+        _ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        _with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        let process = FeatureDuplicateFilter {
+            buffer: HashSet::new(),
+        };
+        Ok(Box::new(process))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FeatureDuplicateFilter {
+    buffer: HashSet<Feature>,
+}
+
+impl Processor for FeatureDuplicateFilter {
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        _fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        self.buffer.insert(ctx.feature);
+        Ok(())
+    }
+
+    fn finish(
+        &self,
+        ctx: NodeContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        for feature in self.buffer.iter() {
+            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                &ctx,
+                feature.clone(),
+                DEFAULT_PORT.clone(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "FeatureDuplicateFilter"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::utils::{create_default_execute_context, MockProcessorChannelForwarder};
+
+    use super::*;
+
+    #[test]
+    fn test_filter() {
+        let mut fw = MockProcessorChannelForwarder::default();
+        let feature = Feature::default();
+        let ctx = create_default_execute_context(&feature);
+        let mut filter = FeatureDuplicateFilter {
+            buffer: HashSet::new(),
+        };
+        filter.process(ctx, &mut fw).unwrap();
+        let ctx = create_default_execute_context(&feature);
+        filter.process(ctx, &mut fw).unwrap();
+        let feature = Feature::default();
+        let ctx = create_default_execute_context(&feature);
+        filter.process(ctx, &mut fw).unwrap();
+        filter.finish(NodeContext::default(), &mut fw).unwrap();
+        assert_eq!(fw.send_ports.first().cloned(), Some(DEFAULT_PORT.clone()));
+        assert_eq!(fw.send_ports.len(), 2,);
+    }
+}

--- a/engine/runtime/action-processor/src/feature/errors.rs
+++ b/engine/runtime/action-processor/src/feature/errors.rs
@@ -39,6 +39,10 @@ pub(crate) enum FeatureProcessorError {
     LodFilterFactory(String),
     #[error("LodFilter error: {0}")]
     LodFilter(String),
+    #[error("DuplicateFilterFactory error: {0}")]
+    DuplicateFilterFactory(String),
+    #[error("DuplicateFilter error: {0}")]
+    DuplicateFilter(String),
 }
 
 #[allow(dead_code)]

--- a/engine/runtime/action-processor/src/feature/lod_filter.rs
+++ b/engine/runtime/action-processor/src/feature/lod_filter.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 
 use super::errors::FeatureProcessorError;
 
+pub static UP_TO_LOD0: Lazy<Port> = Lazy::new(|| Port::new("up_to_lod0"));
 pub static UP_TO_LOD1: Lazy<Port> = Lazy::new(|| Port::new("up_to_lod1"));
 pub static UP_TO_LOD2: Lazy<Port> = Lazy::new(|| Port::new("up_to_lod2"));
 pub static UP_TO_LOD3: Lazy<Port> = Lazy::new(|| Port::new("up_to_lod3"));
@@ -181,11 +182,19 @@ impl FeatureLodFilter {
             fw.send(ctx.as_executor_context(feature.clone(), UNFILTERED_PORT.clone()));
             return;
         };
+        if lod.has_lod(0) {
+            let feature = feature.clone();
+            fw.send(ctx.as_executor_context(feature, UP_TO_LOD0.clone()));
+        }
         if lod.has_lod(1) {
             let feature = feature.clone();
             fw.send(ctx.as_executor_context(feature, UP_TO_LOD1.clone()));
         }
-        if lod_count.max_lod >= 2 && (lod.has_lod(2) || (lod.has_lod(1) && !lod.has_lod(2))) {
+        if lod_count.max_lod >= 2
+            && (lod.has_lod(2)
+                || (lod.has_lod(1) && !lod.has_lod(2))
+                || (lod.has_lod(0) && !lod.has_lod(2) && !lod.has_lod(1)))
+        {
             let feature = feature.clone();
             fw.send(ctx.as_executor_context(feature, UP_TO_LOD2.clone()));
         }

--- a/engine/runtime/action-processor/src/feature/mapping.rs
+++ b/engine/runtime/action-processor/src/feature/mapping.rs
@@ -4,11 +4,12 @@ use once_cell::sync::Lazy;
 use reearth_flow_runtime::node::{NodeKind, ProcessorFactory};
 
 use super::{
-    counter::FeatureCounterFactory, file_path_extractor::FeatureFilePathExtractorFactory,
-    filter::FeatureFilterFactory, list_exploder::ListExploderFactory,
-    lod_filter::FeatureLodFilterFactory, merger::FeatureMergerFactory,
-    reader::FeatureReaderFactory, rhai::RhaiCallerFactory, sorter::FeatureSorterFactory,
-    transformer::FeatureTransformerFactory, type_filter::FeatureTypeFilterFactory,
+    counter::FeatureCounterFactory, duplicate_filter::FeatureDuplicateFilterFactory,
+    file_path_extractor::FeatureFilePathExtractorFactory, filter::FeatureFilterFactory,
+    list_exploder::ListExploderFactory, lod_filter::FeatureLodFilterFactory,
+    merger::FeatureMergerFactory, reader::FeatureReaderFactory, rhai::RhaiCallerFactory,
+    sorter::FeatureSorterFactory, transformer::FeatureTransformerFactory,
+    type_filter::FeatureTypeFilterFactory,
 };
 
 pub static ACTION_FACTORY_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
@@ -24,6 +25,7 @@ pub static ACTION_FACTORY_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(
         Box::<FeatureTypeFilterFactory>::default(),
         Box::<FeatureFilePathExtractorFactory>::default(),
         Box::<FeatureLodFilterFactory>::default(),
+        Box::<FeatureDuplicateFilterFactory>::default(),
     ];
     factories
         .into_iter()

--- a/engine/runtime/runtime/src/executor_operation.rs
+++ b/engine/runtime/runtime/src/executor_operation.rs
@@ -220,6 +220,17 @@ impl From<Context> for NodeContext {
     }
 }
 
+impl From<ExecutorContext> for NodeContext {
+    fn from(ctx: ExecutorContext) -> Self {
+        Self {
+            expr_engine: ctx.expr_engine,
+            storage_resolver: ctx.storage_resolver,
+            kv_store: ctx.kv_store,
+            event_hub: ctx.event_hub,
+        }
+    }
+}
+
 impl Default for NodeContext {
     fn default() -> Self {
         Self {

--- a/engine/runtime/types/src/feature.rs
+++ b/engine/runtime/types/src/feature.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashMap, fmt::Display, sync::Arc};
+use std::{
+    collections::HashMap,
+    fmt::Display,
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 use nutype::nutype;
 use reearth_flow_common::{str, xml::XmlXpathValue};
@@ -67,6 +72,12 @@ impl From<HashMap<String, AttributeValue>> for Feature {
             metadata: Default::default(),
             geometry: Default::default(),
         }
+    }
+}
+
+impl Hash for Feature {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
     }
 }
 

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -833,6 +833,22 @@
       ]
     },
     {
+      "name": "FeatureDuplicateFilter",
+      "type": "processor",
+      "description": "Filters features by duplicate feature",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
       "name": "FeatureFilePathExtractor",
       "type": "processor",
       "description": "Extracts features by file path",

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -833,6 +833,22 @@
       ]
     },
     {
+      "name": "FeatureDuplicateFilter",
+      "type": "processor",
+      "description": "Filters features by duplicate feature",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
       "name": "FeatureFilePathExtractor",
       "type": "processor",
       "description": "Extracts features by file path",

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -833,6 +833,22 @@
       ]
     },
     {
+      "name": "FeatureDuplicateFilter",
+      "type": "processor",
+      "description": "Filters features by duplicate feature",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
       "name": "FeatureFilePathExtractor",
       "type": "processor",
       "description": "Extracts features by file path",

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -833,6 +833,22 @@
       ]
     },
     {
+      "name": "FeatureDuplicateFilter",
+      "type": "processor",
+      "description": "Filters features by duplicate feature",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
       "name": "FeatureFilePathExtractor",
       "type": "processor",
       "description": "Extracts features by file path",

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -833,6 +833,22 @@
       ]
     },
     {
+      "name": "FeatureDuplicateFilter",
+      "type": "processor",
+      "description": "Filters features by duplicate feature",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
       "name": "FeatureFilePathExtractor",
       "type": "processor",
       "description": "Extracts features by file path",

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -833,6 +833,22 @@
       ]
     },
     {
+      "name": "FeatureDuplicateFilter",
+      "type": "processor",
+      "description": "Filters features by duplicate feature",
+      "parameter": null,
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "default"
+      ],
+      "categories": [
+        "Feature"
+      ]
+    },
+    {
       "name": "FeatureFilePathExtractor",
       "type": "processor",
       "description": "Extracts features by file path",


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new `FeatureDuplicateFilter` processor to filter out duplicate features during data processing
	- Introduced new Level of Detail (LOD) ports for more granular feature routing
	- Enhanced feature processing with duplicate detection and filtering capabilities

- **Improvements**
	- Added support for hashing features to enable use in hash-based collections
	- Improved interoperability between `ExecutorContext` and `NodeContext`

- **Technical Enhancements**
	- Updated error handling for feature processing
	- Added multilingual support for the new feature duplicate filter processor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->