### PR TITLE
fix(ui): BASE_URL moved into useFetch

### DIFF
--- a/ui/src/lib/fetch/transformers/useFetch.ts
+++ b/ui/src/lib/fetch/transformers/useFetch.ts
@@ -12,8 +12,6 @@ enum ActionFetchKeys {
   segregated = "segregated",
 }
 
-const BASE_URL = config().api;
-
 const CHANGE_NAMES: Record<string, string> = {
   processor: "transformer",
   sink: "writer",
@@ -74,6 +72,7 @@ export const fetcher = async <T extends Action[] | Segregated | Action>(
 };
 
 export const useFetch = () => {
+  const BASE_URL = config().api;
   const useGetActionsFetch = (lang: string) =>
     useQuery({
       queryKey: [ActionFetchKeys.actions, lang],


### PR DESCRIPTION
# Overview
BASE_URL became undefined when actions were called
## What I've done
Moved BASE_URL into the useFetch
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the declaration of a configuration constant to improve scoping within the fetch utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->