### PR TITLE
chore(api): make description required for triggers

### DIFF
--- a/api/gql/deployment.graphql
+++ b/api/gql/deployment.graphql
@@ -19,7 +19,7 @@ input CreateDeploymentInput {
   workspaceId: ID!
   file: Upload!
   projectId: ID
-  description: String
+  description: String!
 }
 
 input DeleteDeploymentInput {

--- a/api/gql/trigger.graphql
+++ b/api/gql/trigger.graphql
@@ -8,7 +8,7 @@ type Trigger implements Node {
     deployment: Deployment!
     deploymentId: ID!
     eventSource: EventSourceType!
-    description: String 
+    description: String!
     authToken: String
     timeInterval: TimeInterval
 }
@@ -40,7 +40,7 @@ input APIDriverInput {
 input CreateTriggerInput {
     workspaceId: ID!
     deploymentId: ID!
-    description: String
+    description: String!
     timeDriverInput: TimeDriverInput
     apiDriverInput: APIDriverInput
 }

--- a/api/internal/adapter/gql/generated.go
+++ b/api/internal/adapter/gql/generated.go
@@ -2214,7 +2214,7 @@ input CreateDeploymentInput {
   workspaceId: ID!
   file: Upload!
   projectId: ID
-  description: String
+  description: String!
 }
 
 input DeleteDeploymentInput {
@@ -2510,7 +2510,7 @@ extend type Mutation {
     deployment: Deployment!
     deploymentId: ID!
     eventSource: EventSourceType!
-    description: String 
+    description: String!
     authToken: String
     timeInterval: TimeInterval
 }
@@ -2542,7 +2542,7 @@ input APIDriverInput {
 input CreateTriggerInput {
     workspaceId: ID!
     deploymentId: ID!
-    description: String
+    description: String!
     timeDriverInput: TimeDriverInput
     apiDriverInput: APIDriverInput
 }
@@ -11856,11 +11856,14 @@ func (ec *executionContext) _Trigger_description(ctx context.Context, field grap
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Trigger_description(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -15003,7 +15006,7 @@ func (ec *executionContext) unmarshalInputCreateDeploymentInput(ctx context.Cont
 			it.ProjectID = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -15092,7 +15095,7 @@ func (ec *executionContext) unmarshalInputCreateTriggerInput(ctx context.Context
 			it.DeploymentID = data
 		case "description":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("description"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -18462,6 +18465,9 @@ func (ec *executionContext) _Trigger(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "description":
 			out.Values[i] = ec._Trigger_description(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "authToken":
 			out.Values[i] = ec._Trigger_authToken(ctx, field, obj)
 		case "timeInterval":

--- a/api/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/api/internal/adapter/gql/gqlmodel/models_gen.go
@@ -71,7 +71,7 @@ type CreateDeploymentInput struct {
 	WorkspaceID ID             `json:"workspaceId"`
 	File        graphql.Upload `json:"file"`
 	ProjectID   *ID            `json:"projectId,omitempty"`
-	Description *string        `json:"description,omitempty"`
+	Description string         `json:"description"`
 }
 
 type CreateProjectInput struct {
@@ -84,7 +84,7 @@ type CreateProjectInput struct {
 type CreateTriggerInput struct {
 	WorkspaceID     ID               `json:"workspaceId"`
 	DeploymentID    ID               `json:"deploymentId"`
-	Description     *string          `json:"description,omitempty"`
+	Description     string           `json:"description"`
 	TimeDriverInput *TimeDriverInput `json:"timeDriverInput,omitempty"`
 	APIDriverInput  *APIDriverInput  `json:"apiDriverInput,omitempty"`
 }
@@ -360,7 +360,7 @@ type Trigger struct {
 	Deployment    *Deployment     `json:"deployment"`
 	DeploymentID  ID              `json:"deploymentId"`
 	EventSource   EventSourceType `json:"eventSource"`
-	Description   *string         `json:"description,omitempty"`
+	Description   string          `json:"description"`
 	AuthToken     *string         `json:"authToken,omitempty"`
 	TimeInterval  *TimeInterval   `json:"timeInterval,omitempty"`
 }

--- a/api/internal/adapter/gql/resolver_mutation_trigger.go
+++ b/api/internal/adapter/gql/resolver_mutation_trigger.go
@@ -24,7 +24,7 @@ func (r *mutationResolver) CreateTrigger(ctx context.Context, input gqlmodel.Cre
 	param.WorkspaceID = wsid
 	param.DeploymentID = did
 
-	param.Description = *input.Description
+	param.Description = input.Description
 
 	if input.TimeDriverInput != nil {
 		param.EventSource = "TIME_DRIVEN"

--- a/api/internal/infrastructure/mongo/mongodoc/trigger.go
+++ b/api/internal/infrastructure/mongo/mongodoc/trigger.go
@@ -37,14 +37,10 @@ func NewTrigger(t *trigger.Trigger) (*TriggerDocument, string) {
 		ID:           tid,
 		WorkspaceID:  t.Workspace().String(),
 		DeploymentID: t.Deployment().String(),
+		Description:  t.Description(),
 		EventSource:  string(t.EventSource()),
 		CreatedAt:    t.CreatedAt(),
 		UpdatedAt:    t.UpdatedAt(),
-	}
-
-	if description := t.Description(); description != nil {
-		at := string(*description)
-		doc.Description = at
 	}
 
 	if timeInterval := t.TimeInterval(); timeInterval != nil {

--- a/api/internal/usecase/interactor/deployment.go
+++ b/api/internal/usecase/interactor/deployment.go
@@ -108,6 +108,7 @@ func (i *Deployment) Create(ctx context.Context, dp interfaces.CreateDeploymentP
 
 	d := deployment.New().
 		NewID().
+		Description(dp.Description).
 		Workspace(dp.Workspace).
 		WorkflowURL(url.String())
 
@@ -132,10 +133,6 @@ func (i *Deployment) Create(ctx context.Context, dp interfaces.CreateDeploymentP
 	} else {
 		d = d.Version("v0")
 		d = d.IsHead(false)
-	}
-
-	if dp.Description != nil {
-		d = d.Description(*dp.Description)
 	}
 
 	dep, err := d.Build()

--- a/api/internal/usecase/interfaces/deployment.go
+++ b/api/internal/usecase/interfaces/deployment.go
@@ -17,7 +17,7 @@ type CreateDeploymentParam struct {
 	Project     *id.ProjectID
 	Workspace   accountdomain.WorkspaceID
 	Workflow    *file.File
-	Description *string
+	Description string
 }
 
 type UpdateDeploymentParam struct {

--- a/api/pkg/trigger/builder.go
+++ b/api/pkg/trigger/builder.go
@@ -64,7 +64,7 @@ func (b *Builder) Deployment(deployment DeploymentID) *Builder {
 }
 
 func (b *Builder) Description(description string) *Builder {
-	b.t.description = &description
+	b.t.description = description
 	return b
 }
 

--- a/api/pkg/trigger/builder.go
+++ b/api/pkg/trigger/builder.go
@@ -23,6 +23,9 @@ func (b *Builder) Build() (*Trigger, error) {
 	if b.t.deploymentId.IsNil() {
 		return nil, errors.New("deployment is required")
 	}
+	if b.t.description == "" {
+		return nil, errors.New("description is required")
+	}
 	if b.t.eventSource == "" {
 		return nil, errors.New("event source is required")
 	}

--- a/api/pkg/trigger/trigger.go
+++ b/api/pkg/trigger/trigger.go
@@ -28,7 +28,7 @@ type Trigger struct {
 	lastTriggered *time.Time
 	workspaceId   WorkspaceID
 	deploymentId  DeploymentID
-	description   *string
+	description   string
 	eventSource   EventSourceType
 	authToken     *string
 	timeInterval  *TimeInterval
@@ -54,7 +54,7 @@ func (t *Trigger) Workspace() WorkspaceID {
 	return t.workspaceId
 }
 
-func (t *Trigger) Description() *string {
+func (t *Trigger) Description() string {
 	return t.description
 }
 

--- a/api/pkg/trigger/trigger.go
+++ b/api/pkg/trigger/trigger.go
@@ -90,7 +90,7 @@ func (t *Trigger) SetEventSource(eventSource EventSourceType) {
 }
 
 func (t *Trigger) SetDescription(description string) {
-	t.description = &description
+	t.description = description
 	t.updatedAt = time.Now()
 }
 


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - None

- **Bug Fixes**
  - None

- **Breaking Changes**
  - Description field is now mandatory for creating deployments and triggers.
  - Removed optional description fields across multiple GraphQL input types.

- **Improvements**
  - Enforced stricter input validation for deployment and trigger descriptions.
  - Simplified description handling in various system components.

- **Refactor**
  - Updated type definitions to remove nullable description fields.
  - Modified input parameter handling to require descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->