### PR TITLE
fix(api): remove permission check from job monitoring

### DIFF
--- a/api/internal/usecase/interactor/deployment.go
+++ b/api/internal/usecase/interactor/deployment.go
@@ -293,7 +293,6 @@ func (i *Deployment) Execute(ctx context.Context, p interfaces.ExecuteDeployment
 	if err != nil {
 		return nil, interfaces.ErrJobCreationFailed
 	}
-
 	j.SetGCPJobID(gcpJobID)
 
 	if err := i.job.StartMonitoring(ctx, j, operator); err != nil {

--- a/api/internal/usecase/interactor/job.go
+++ b/api/internal/usecase/interactor/job.go
@@ -80,11 +80,6 @@ func (i *Job) GetStatus(ctx context.Context, jobID id.JobID, operator *usecase.O
 func (i *Job) StartMonitoring(ctx context.Context, j *job.Job, operator *usecase.Operator) error {
 	log.Debugfc(ctx, "job: starting monitoring for jobID=%s workspace=%s", j.ID(), j.Workspace())
 
-	if err := i.CanReadWorkspace(j.Workspace(), operator); err != nil {
-		log.Debugfc(ctx, "job: permission check failed for workspace=%s: %v", j.Workspace(), err)
-		return err
-	}
-
 	i.monitoringMu.Lock()
 	if cancel, exists := i.monitoring[j.ID().String()]; exists {
 		log.Debugfc(ctx, "job: cancelling existing monitoring for jobID=%s", j.ID())


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Changes**
	- Removed workspace permission checks for job monitoring
	- Removed GCP job ID setting during job submission

- **Potential Impact**
	- Jobs can now be monitored without explicit workspace access verification
	- Job tracking mechanism may be affected by the removal of GCP job ID assignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->