### PR TITLE
ci: Update GCP auth method from SA key to Workload Identity 

### DIFF
--- a/.github/workflows/build_deploy_api.yml
+++ b/.github/workflows/build_deploy_api.yml
@@ -133,16 +133,20 @@ jobs:
     needs: build-docker-image
     runs-on: ubuntu-latest
     if: ${{ inputs.name == 'nightly' }}
+    permissions:
+      contents: read
+      id-token: write
     env:
       IMAGE: reearth/reearth-flow-api:nightly
-      IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-api:nightly
+      IMAGE_GCP: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-flow-api:nightly
       GCP_REGION: us-central1
       CLOUD_RUN_SERVICE: reearth-flow-api
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/build_deploy_ui.yml
+++ b/.github/workflows/build_deploy_ui.yml
@@ -114,16 +114,20 @@ jobs:
     needs: build-docker-image
     runs-on: ubuntu-latest
     if: ${{ inputs.name == 'nightly' }}
+    permissions:
+      contents: read
+      id-token: write
     env:
       IMAGE: reearth/reearth-flow-web:nightly
-      IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-web:nightly
+      IMAGE_GCP: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-flow-web:nightly
       GCP_REGION: us-central1
       CLOUD_RUN_SERVICE: reearth-flow-web
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/build_deploy_websocket.yml
+++ b/.github/workflows/build_deploy_websocket.yml
@@ -65,9 +65,12 @@ jobs:
     needs: build-websocket
     runs-on: ubuntu-latest
     if: ${{ inputs.name != 'blank' || inputs.new_tag != 'blank' }}
+    permissions:
+      contents: read
+      id-token: write
     env:
       IMAGE_NAME: reearth/reearth-flow-websocket
-      IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-websocket
+      IMAGE_GCP: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-flow-websocket
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -87,7 +90,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3
@@ -149,15 +153,19 @@ jobs:
     needs: build-docker-image
     runs-on: ubuntu-latest
     if: ${{ inputs.name == 'nightly' }}
+    permissions:
+      contents: read
+      id-token: write
     env:
-      IMAGE: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-websocket:nightly
+      IMAGE: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-flow-websocket:nightly
       GCP_REGION: us-central1
       CLOUD_RUN_SERVICE: reearth-flow-websocket
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2

--- a/.github/workflows/build_docker_push_worker.yml
+++ b/.github/workflows/build_docker_push_worker.yml
@@ -65,9 +65,12 @@ jobs:
     needs: build-worker
     runs-on: ubuntu-latest
     if: ${{ inputs.name != 'blank' || inputs.new_tag != 'blank' }}
+    permissions:
+      contents: read
+      id-token: write
     env:
       IMAGE_NAME: reearth/reearth-flow-worker
-      IMAGE_GCP: us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-worker
+      IMAGE_GCP: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-flow-worker
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -87,7 +90,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Log in to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: changed files for api
         id: api
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v45
         with:
             files: |
               api/**
@@ -31,7 +31,7 @@ jobs:
 
       - name: changed files for ui
         id: ui
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v45
         with:
           files: |
             ui/**
@@ -43,7 +43,7 @@ jobs:
 
       - name: changed files for websocket
         id: websocket
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v45
         with:
           files: |
             websocket/**
@@ -53,7 +53,7 @@ jobs:
 
       - name: changed files for engine
         id: engine
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v45
         with:
           files: |
             engine/**


### PR DESCRIPTION
# Overview
- Update auth method from SA key to Workload Identity 
- Bump tj-actions/changed-files from v41 to v45
## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced our deployment and continuous integration processes for improved reliability and security.
  - Shifted to dynamic configuration for deployment parameters, ensuring more robust handling of sensitive data.
  - Updated authentication measures to align with modern security practices, promoting smoother and safer service delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->