### PR TITLE
fix(ui): batch nodes

### DIFF
--- a/ui/src/features/Editor/components/Canvas/components/Nodes/BatchNode/index.tsx
+++ b/ui/src/features/Editor/components/Canvas/components/Nodes/BatchNode/index.tsx
@@ -4,8 +4,6 @@ import { memo, useCallback } from "react";
 
 import { Node } from "@flow/types";
 
-import useBatch from "../../../useBatch";
-
 export type BatchNodeProps = NodeProps<Node>;
 
 export const initialSize = { width: 300, height: 200 };
@@ -19,8 +17,8 @@ export const baseBatchNode = {
 const minSize = { width: 250, height: 150 };
 
 const BatchNode: React.FC<BatchNodeProps> = ({ data, selected, id }) => {
-  const { getNodes, setNodes } = useReactFlow<Node>();
-  const { handleNodeDropInBatch } = useBatch();
+  const { getNodes } = useReactFlow<Node>();
+  // const { handleNodeDropInBatch } = useBatch();
 
   const getChildNodesBoundary = useCallback(() => {
     const nodes = getNodes();
@@ -46,23 +44,23 @@ const BatchNode: React.FC<BatchNodeProps> = ({ data, selected, id }) => {
     };
   }, [getNodes, id]);
 
-  const handleOnEndResize = useCallback(() => {
-    const allNodes = getNodes();
-    let updatedNodes = allNodes;
-    const initialParentCount = allNodes.filter((node) => node.parentId).length;
+  // const handleOnEndResize = useCallback(() => {
+  //   const allNodes = getNodes();
+  //   let updatedNodes = allNodes;
+  //   const initialParentCount = allNodes.filter((node) => node.parentId).length;
 
-    const nonBatchNodes = allNodes.filter((node) => node.type !== "batch");
-    nonBatchNodes.forEach((node) => {
-      updatedNodes = handleNodeDropInBatch(node, updatedNodes);
-    });
-    const finalParentCount = updatedNodes.filter(
-      (node) => node.parentId,
-    ).length;
+  //   const nonBatchNodes = allNodes.filter((node) => node.type !== "batch");
+  //   nonBatchNodes.forEach((node) => {
+  //     updatedNodes = handleNodeDropInBatch(node, updatedNodes);
+  //   });
+  //   const finalParentCount = updatedNodes.filter(
+  //     (node) => node.parentId,
+  //   ).length;
 
-    if (finalParentCount !== initialParentCount) {
-      setNodes(updatedNodes);
-    }
-  }, [getNodes, setNodes, handleNodeDropInBatch]);
+  //   if (finalParentCount !== initialParentCount) {
+  //     setNodes(updatedNodes);
+  //   }
+  // }, [getNodes, setNodes, handleNodeDropInBatch]);
   // No need to memoize as we want to update because bounds will change on resize
   const bounds = getChildNodesBoundary();
 
@@ -85,7 +83,8 @@ const BatchNode: React.FC<BatchNodeProps> = ({ data, selected, id }) => {
           }}
           minWidth={bounds.width}
           minHeight={bounds.height}
-          onResizeEnd={handleOnEndResize}
+          onResize={() => "asldfkjsadf"}
+          // onResizeEnd={handleOnEndResize}
         />
       )}
       <div

--- a/ui/src/features/Editor/components/Canvas/components/Nodes/GeneralNode/index.tsx
+++ b/ui/src/features/Editor/components/Canvas/components/Nodes/GeneralNode/index.tsx
@@ -4,15 +4,14 @@ import {
   DoubleArrowRightIcon,
   PlayIcon,
 } from "@radix-ui/react-icons";
-import { NodeProps, useReactFlow } from "@xyflow/react";
-import { memo, useEffect, useRef, useState } from "react";
+import { NodeProps } from "@xyflow/react";
+import { memo, useEffect, useState } from "react";
 
 import { IconButton } from "@flow/components";
 import { useDoubleClick } from "@flow/hooks";
 import { Node } from "@flow/types";
 import type { NodePosition, NodeType } from "@flow/types";
 
-import useBatch from "../../../useBatch";
 import { getPropsFrom } from "../utils";
 
 import { Handles } from "./components";
@@ -34,13 +33,8 @@ const GeneralNode: React.FC<GeneralNodeProps> = ({
   type,
   selected,
   id,
-  dragging,
 }) => {
   const { officialName, customName, status, inputs, outputs } = data;
-  const isDragging = useRef<boolean>(dragging);
-
-  const { setNodes, getInternalNode } = useReactFlow<Node>();
-  const { handleNodeDropInBatch } = useBatch();
 
   const [hardSelect, setHardSelect] = useState<boolean>(false);
 
@@ -55,20 +49,6 @@ const GeneralNode: React.FC<GeneralNodeProps> = ({
   }, [id, selected, hardSelect]);
 
   const metaProps = getPropsFrom(status);
-
-  useEffect(() => {
-    if (isDragging.current && !dragging) {
-      isDragging.current = false;
-
-      setNodes((nds) => {
-        const thisNode = getInternalNode(id);
-        if (!thisNode) return nds;
-        return handleNodeDropInBatch(thisNode, nds);
-      });
-    } else if (dragging && !isDragging.current) {
-      isDragging.current = true;
-    }
-  }, [id, dragging, handleNodeDropInBatch, setNodes, getInternalNode]);
 
   return (
     <div className="rounded-sm bg-secondary" onDoubleClick={handleDoubleClick}>

--- a/ui/src/features/Editor/components/Canvas/hooks.ts
+++ b/ui/src/features/Editor/components/Canvas/hooks.ts
@@ -60,9 +60,9 @@ export default ({
   const {
     handleNodesChange,
     handleNodesDelete,
+    handleNodeDragOver,
     handleNodeDragStop,
     handleNodeDrop,
-    handleNodeDragOver,
   } = useNodes({
     nodes,
     edges,

--- a/ui/src/features/Editor/components/Canvas/useBatch.ts
+++ b/ui/src/features/Editor/components/Canvas/useBatch.ts
@@ -4,96 +4,124 @@ import { useCallback } from "react";
 import { Node } from "@flow/types";
 
 export default () => {
-  const { getInternalNode, isNodeIntersecting } = useReactFlow();
+  const { getInternalNode, getIntersectingNodes } = useReactFlow();
 
-  const handleAddToBatch = useCallback(
-    (draggedNode: Node, hoveredNode: Node, nodes: Node[]) => {
-      const internalNode = getInternalNode(draggedNode.id);
-      const updatedNode: Node = { ...draggedNode };
-
-      // Check if dragged node isn't already a child to the group
-      if (!draggedNode.parentId) {
-        updatedNode.parentId = hoveredNode.id;
-
-        const posX = internalNode?.position.x || updatedNode.position.x;
-        const posY = internalNode?.position.y || updatedNode.position.y;
-
-        if (posX && posY) {
-          updatedNode.position = {
-            x: posX - hoveredNode.position.x,
-            y: posY - hoveredNode.position.y,
+  const calculateNewRelativePosition = useCallback(
+    (droppedNode: Node, parentNode: Node) => {
+      // If the dragged node has a parent already, and is moving to a new parent,
+      // we need to un-offset it first, before re-offsetting it to the new parent.
+      if (droppedNode.parentId) {
+        const oldParentNode = getInternalNode(droppedNode.parentId);
+        if (oldParentNode) {
+          const actualCanvasPosition = {
+            x: droppedNode.position.x + oldParentNode.position.x,
+            y: droppedNode.position.y + oldParentNode.position.y,
+          };
+          return {
+            x: actualCanvasPosition.x - parentNode.position.x,
+            y: actualCanvasPosition.y - parentNode.position.y,
           };
         }
-        const newNodes: Node[] = nodes.filter((n) => n.id !== updatedNode.id);
-        newNodes.push(updatedNode);
-        return newNodes;
-      } else {
-        return nodes;
       }
+
+      return {
+        x: droppedNode.position.x - parentNode.position.x,
+        y: droppedNode.position.y - parentNode.position.y,
+      };
     },
     [getInternalNode],
+  );
+
+  const handleAddToBatch = useCallback(
+    (droppedNode: Node, parentNode: Node) => {
+      const updatedNode: Node = { ...droppedNode };
+
+      // Check if dragged node isn't already a child to the group
+      if (droppedNode.parentId !== parentNode.id) {
+        updatedNode.parentId = parentNode.id;
+
+        const updatedPosition = calculateNewRelativePosition(
+          droppedNode,
+          parentNode,
+        );
+        if (updatedPosition) {
+          updatedNode.position = updatedPosition;
+        }
+
+        return updatedNode;
+      } else {
+        return droppedNode;
+      }
+    },
+    [calculateNewRelativePosition],
   );
 
   const handleRemoveFromBatch = useCallback(
-    (draggedNode: Node, hoveredNode: Node, nodes: Node[]) => {
+    (draggedNode: Node): Node => {
+      if (!draggedNode.parentId) return draggedNode;
       const internalNode = getInternalNode(draggedNode.id);
       const updatedNode: Node = { ...draggedNode };
 
+      const parentNode = getInternalNode(draggedNode.parentId);
+
       // Check if dragged node is a child to the group
-      if (draggedNode.parentId === hoveredNode.id) {
-        updatedNode.parentId = undefined;
 
-        const posX = internalNode?.position.x;
-        const posY = internalNode?.position.y;
-        if (posX && posY) {
-          updatedNode.position = {
-            x: posX + hoveredNode.position.x,
-            y: posY + hoveredNode.position.y,
-          };
-        }
+      updatedNode.parentId = undefined;
 
-        return nodes.map((n) => {
-          if (n.id === draggedNode.id) {
-            n = updatedNode;
-          }
-          return n;
-        });
-      } else {
-        return nodes;
+      // This return will cause the dragged node's position to be moved unexpectedly.
+      // In most cases, this return will not happen, so its okay (though not ideal).
+      if (!parentNode) return updatedNode;
+
+      const posX = internalNode?.position.x;
+      const posY = internalNode?.position.y;
+      if (posX && posY) {
+        updatedNode.position = {
+          x: posX + parentNode.position.x,
+          y: posY + parentNode.position.y,
+        };
       }
+
+      return updatedNode;
     },
     [getInternalNode],
   );
 
-  const handleNodeDropInBatch = useCallback(
-    (droppedNode: Node, nodes: Node[]) => {
-      let newNodes: Node[] = nodes;
+  const handleNodesDropInBatch = useCallback(
+    (droppedNodes: Node[]): Node[] | undefined => {
+      if (droppedNodes.length === 0) return;
 
-      nodes.forEach((nd) => {
-        if (nd.type === "batch") {
-          //safety check to make sure there's a height and width
-          if (nd.measured?.height && nd.measured?.width) {
-            const rec = {
-              height: nd.measured.height,
-              width: nd.measured.width,
-              ...nd.position,
-            };
+      let newNodes: Node[] | undefined = undefined;
 
-            // Check if the dragged node is inside the group
-            if (isNodeIntersecting(droppedNode, rec, false)) {
-              newNodes = handleAddToBatch(droppedNode, nd, newNodes);
-            } else {
-              newNodes = handleRemoveFromBatch(droppedNode, nd, newNodes);
-            }
+      const intersectingSets = droppedNodes.map(
+        (n) => new Set(getIntersectingNodes(n, false) as Node[]),
+      );
+
+      const parentNode = [...intersectingSets[0]]
+        .filter((node) => intersectingSets.every((set) => set.has(node)))
+        .find((node) => node.type === "batch");
+
+      droppedNodes.forEach((node) => {
+        //safety check to make sure there's a height and width
+        if (node.measured?.height && node.measured?.width) {
+          // Check if the dragged node is inside the batch
+          if (parentNode) {
+            newNodes = [
+              ...(newNodes ?? []),
+              handleAddToBatch(node, parentNode),
+            ];
+            // Check if the dragged node is a child to a batch
+          } else if (node.parentId) {
+            newNodes = [...(newNodes ?? []), handleRemoveFromBatch(node)];
           }
         }
       });
+
       return newNodes;
     },
-    [handleAddToBatch, handleRemoveFromBatch, isNodeIntersecting],
+    [getIntersectingNodes, handleAddToBatch, handleRemoveFromBatch],
   );
 
   return {
-    handleNodeDropInBatch,
+    handleNodesDropInBatch,
   };
 };

--- a/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
@@ -72,7 +72,6 @@ const Toolbox: React.FC<Props> = ({
       id: "batch" as const,
       name: t("Batch Node"),
       icon: <RectangleDashed weight="thin" />,
-      disabled: true, // TODO: Enable batch node after fixing batch implementation
     },
     {
       id: "subworkflow" as const,

--- a/ui/src/lib/yjs/conversions/rebuildWorkflow.ts
+++ b/ui/src/lib/yjs/conversions/rebuildWorkflow.ts
@@ -17,6 +17,7 @@ export const reassembleNode = (yNode: YNode): Node => {
     width: (yNode.get("measured") as Y.Map<any>)?.get("width"),
     height: (yNode.get("measured") as Y.Map<any>)?.get("height"),
   };
+  const parentId = yNode.get("parentId")?.toString();
 
   const data: NodeData = {
     officialName: (yNode.get("data") as Y.Map<any>)
@@ -88,6 +89,7 @@ export const reassembleNode = (yNode: YNode): Node => {
     id,
     position,
     measured,
+    parentId,
     type,
     dragging,
     data,

--- a/ui/src/lib/yjs/conversions/yWorkflowConstructor.ts
+++ b/ui/src/lib/yjs/conversions/yWorkflowConstructor.ts
@@ -17,6 +17,7 @@ export const yNodeConstructor = (node: Node): YNode => {
     dragging: false,
     position: toYjsMap(node.position),
     measured: toYjsMap(node.measured),
+    parentId: toYjsText(node.parentId),
     // Reference src/types/node.ts for the NodeData type
     data: toYjsMap({
       officialName: toYjsText(node.data.officialName),

--- a/ui/src/lib/yjs/useYNode.ts
+++ b/ui/src/lib/yjs/useYNode.ts
@@ -38,11 +38,12 @@ export default ({
           }
         });
 
-        // NOTE: if node is batch, we need to put it at the front
-        // If its not a batch, we need to do useBatch stuff to
-        // find if it becomes a batch's child
+        // If any new nodes are batches, we need to put it at the front
+        const insertIndex = newNodes.some((n) => n.type === "batch")
+          ? 0
+          : yNodes.length;
 
-        yNodes.insert(yNodes.length, newYNodes);
+        yNodes.insert(insertIndex, newYNodes);
       });
     },
     [currentYWorkflow, setSelectedNodeIds, undoTrackerActionWrapper],
@@ -73,6 +74,16 @@ export default ({
                 newPosition.set("x", change.position.x);
                 newPosition.set("y", change.position.y);
                 existing?.yNode.set("position", newPosition);
+              }
+              break;
+            }
+            case "replace": {
+              const existing = existingNodesMap.get(change.id);
+
+              if (existing && change.item) {
+                const newNode = yNodeConstructor(change.item);
+                yNodes.delete(existing.index, 1);
+                yNodes.insert(existing.index, [newNode]);
               }
               break;
             }


### PR DESCRIPTION
# Overview
After fixing collaborative editing's implementation, due to batch's complexity, we disabled it and left it out of that PR.

This PR addresses everything around batching:
- Adding a batch (specifically moving it to the beginning of the nodes array)
- Adding nodes to the batch
- Removing nodes from the batch
- Resizing the batch over other nodes to make them children

Additions to prev functionality:
- Can add note nodes to batches now (with the caveat of **resizing notes to be stuck inside the parent batch's borders still needing to be done**)

What I haven't done:
- Limiting Note node resizing to the borders of its parent batch
- Getting node handles to be recognized as part of the node (without this, handles wiill hang out of the batch, but the node will still be a child. As well, you can resize the batch so that the children's handles hang off the edge)