### PR TITLE
fix(ui): removed shortcut for subworkflow on selection

### DIFF
--- a/ui/src/features/Editor/hooks.ts
+++ b/ui/src/features/Editor/hooks.ts
@@ -51,7 +51,7 @@ export default ({
     rawWorkflows,
     currentYWorkflow,
     handleYWorkflowAdd,
-    handleYWorkflowAddFromSelection,
+    // handleYWorkflowAddFromSelection,
     handleYWorkflowUpdate,
     handleYNodesAdd,
     handleYNodesChange,
@@ -252,10 +252,10 @@ export default ({
       keyBinding: { key: "z", commandKey: true },
       callback: handleYWorkflowUndo,
     },
-    {
-      keyBinding: { key: "s", commandKey: false },
-      callback: () => handleYWorkflowAddFromSelection(nodes, edges),
-    },
+    // {
+    //   keyBinding: { key: "s", commandKey: false },
+    //   callback: () => handleYWorkflowAddFromSelection(nodes, edges),
+    // },
   ]);
 
   return {

--- a/ui/src/features/KeyboardShortcutDialog/useHooks.ts
+++ b/ui/src/features/KeyboardShortcutDialog/useHooks.ts
@@ -43,10 +43,10 @@ export default () => {
         keyBinding: EditorKeyBindings["writerDialog"],
         description: t("Open the writer dialog"),
       },
-      {
-        keyBinding: EditorKeyBindings["groupToSubWorkFlow"],
-        description: t("Create new sub workflow from selected nodes"),
-      },
+      // {
+      //   keyBinding: EditorKeyBindings["groupToSubWorkFlow"],
+      //   description: t("Create new sub workflow from selected nodes"),
+      // },
       {
         keyBinding: EditorKeyBindings["bottomPanelLogs"],
         description: t("Toggle the logs panel"),


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Disabled the keyboard shortcut that previously added workflows from a selection.
	- Removed the shortcut for creating a new sub-workflow from the editor’s shortcut dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->