### PR TITLE
feat(engine): Implemented Unifier

### DIFF
--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -3327,6 +3327,43 @@ Forces a geometry to be two dimensional.
 ### Category
 * Geometry
 
+## Unifier
+### Type
+* processor
+### Description
+Unifies features grouped by specified attributes
+### Parameters
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UnifierParam",
+  "type": "object",
+  "properties": {
+    "groupBy": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Attribute"
+      }
+    }
+  },
+  "definitions": {
+    "Attribute": {
+      "type": "string"
+    }
+  }
+}
+```
+### Input Ports
+* default
+### Output Ports
+* area
+* rejected
+### Category
+* Geometry
+
 ## VertexRemover
 ### Type
 * processor

--- a/engine/runtime/action-processor/src/geometry.rs
+++ b/engine/runtime/action-processor/src/geometry.rs
@@ -29,6 +29,7 @@ pub(crate) mod three_dimension_box_replacer;
 pub(crate) mod three_dimension_rotator;
 pub(crate) mod two_dimension_forcer;
 pub(super) mod types;
+pub(crate) mod unifier;
 pub mod validator;
 pub(crate) mod value_filter;
 pub(crate) mod vertex_remover;

--- a/engine/runtime/action-processor/src/geometry/errors.rs
+++ b/engine/runtime/action-processor/src/geometry/errors.rs
@@ -103,6 +103,10 @@ pub(super) enum GeometryProcessorError {
     OffsetterFactory(String),
     #[error("Offsetter error: {0}")]
     Offsetter(String),
+    #[error("Unifier Factory error: {0}")]
+    UnifierFactory(String),
+    #[error("Unifier error: {0}")]
+    Unifier(String),
 }
 
 pub(super) type Result<T, E = GeometryProcessorError> = std::result::Result<T, E>;

--- a/engine/runtime/action-processor/src/geometry/mapping.rs
+++ b/engine/runtime/action-processor/src/geometry/mapping.rs
@@ -18,9 +18,9 @@ use super::{
     refiner::RefinerFactory, replacer::GeometryReplacerFactory, splitter::GeometrySplitterFactory,
     three_dimension_box_replacer::ThreeDimensionBoxReplacerFactory,
     three_dimension_rotator::ThreeDimensionRotatorFactory,
-    two_dimension_forcer::TwoDimensionForcerFactory, validator::GeometryValidatorFactory,
-    value_filter::GeometryValueFilterFactory, vertex_remover::VertexRemoverFactory,
-    vertical_reprojector::VerticalReprojectorFactory,
+    two_dimension_forcer::TwoDimensionForcerFactory, unifier::UnifierFactory,
+    validator::GeometryValidatorFactory, value_filter::GeometryValueFilterFactory,
+    vertex_remover::VertexRemoverFactory, vertical_reprojector::VerticalReprojectorFactory,
 };
 
 pub static ACTION_FACTORY_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
@@ -58,6 +58,7 @@ pub static ACTION_FACTORY_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(
         Box::<DimensionFilterFactory>::default(),
         Box::<OffsetterFactory>::default(),
         Box::<ConvexHullAccumulatorFactory>::default(),
+        Box::<UnifierFactory>::default(),
     ];
     factories
         .into_iter()

--- a/engine/runtime/action-processor/src/geometry/unifier.rs
+++ b/engine/runtime/action-processor/src/geometry/unifier.rs
@@ -1,0 +1,250 @@
+use std::collections::HashMap;
+
+use once_cell::sync::Lazy;
+use reearth_flow_geometry::{
+    algorithm::bool_ops::BooleanOps, types::multi_polygon::MultiPolygon2D,
+};
+use reearth_flow_runtime::{
+    channels::ProcessorChannelForwarder,
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT, REJECTED_PORT},
+};
+use reearth_flow_types::{Attribute, AttributeValue, Feature, GeometryValue};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::errors::GeometryProcessorError;
+
+pub static AREA_PORT: Lazy<Port> = Lazy::new(|| Port::new("area"));
+
+#[derive(Debug, Clone, Default)]
+pub struct UnifierFactory;
+
+impl ProcessorFactory for UnifierFactory {
+    fn name(&self) -> &str {
+        "Unifier"
+    }
+
+    fn description(&self) -> &str {
+        "unifies features grouped by specified attributes"
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        Some(schemars::schema_for!(UnifierParam))
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["Geometry"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![AREA_PORT.clone(), REJECTED_PORT.clone()]
+    }
+
+    fn build(
+        &self,
+        _ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        let param: UnifierParam = if let Some(with) = with {
+            let value: Value = serde_json::to_value(with).map_err(|e| {
+                GeometryProcessorError::UnifierFactory(format!(
+                    "Failed to serialize 'with' parameter: {}",
+                    e
+                ))
+            })?;
+            serde_json::from_value(value).map_err(|e| {
+                GeometryProcessorError::UnifierFactory(format!(
+                    "Failed to deserialize 'with' parameter: {}",
+                    e
+                ))
+            })?
+        } else {
+            return Err(GeometryProcessorError::UnifierFactory(
+                "Missing required parameter `with`".to_string(),
+            )
+            .into());
+        };
+        let process = Unifier {
+            group_by: param.group_by,
+            buffer: HashMap::new(),
+        };
+
+        Ok(Box::new(process))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UnifierParam {
+    group_by: Option<Vec<Attribute>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Unifier {
+    group_by: Option<Vec<Attribute>>,
+    buffer: HashMap<AttributeValue, Vec<Feature>>,
+}
+
+impl Processor for Unifier {
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        let feature = &ctx.feature;
+        let geometry = &feature.geometry;
+        if geometry.is_empty() {
+            fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));
+            return Ok(());
+        }
+        match &geometry.value {
+            GeometryValue::None => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+            GeometryValue::FlowGeometry2D(_) => {
+                let key = if let Some(group_by) = &self.group_by {
+                    AttributeValue::Array(
+                        group_by
+                            .iter()
+                            .filter_map(|attr| feature.attributes.get(attr).cloned())
+                            .collect(),
+                    )
+                } else {
+                    AttributeValue::Null
+                };
+
+                if !self.buffer.contains_key(&key) {
+                    // グループが切り替わったタイミングで、バッファ内の地物について Unite 処理を実行
+                    for unified in self.unify() {
+                        fw.send(ctx.new_with_feature_and_port(unified, AREA_PORT.clone()));
+                    }
+                    self.buffer.clear();
+                }
+
+                self.buffer
+                    .entry(key.clone())
+                    .or_default()
+                    .push(feature.clone());
+            }
+            _ => {
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(
+        &self,
+        ctx: NodeContext,
+        fw: &mut dyn ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        for unified in self.unify() {
+            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                &ctx,
+                unified,
+                AREA_PORT.clone(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "Unifier"
+    }
+}
+
+impl Unifier {
+    fn unify(&self) -> Vec<Feature> {
+        let mut unified = Vec::new();
+        for buffer in self.buffer.values() {
+            let buffered_features_2d = buffer
+                .iter()
+                .filter(|f| matches!(&f.geometry.value, GeometryValue::FlowGeometry2D(_)))
+                .collect::<Vec<_>>();
+
+            let features = self.unify_2d(buffered_features_2d);
+            unified.extend(features);
+        }
+        unified
+    }
+
+    fn unify_2d(&self, buffered_features_2d: Vec<&Feature>) -> Vec<Feature> {
+        // let multi_polygon_2d = buffered_features_2d.iter().fold(
+        //     None,
+        //     |multi_polygon_acc: Option<_>, feature_incoming| {
+        //         let geometry_incoming = feature_incoming.geometry.value.as_flow_geometry_2d()?;
+        //         let multi_polygon_incoming =
+        //             if let Some(multi_polygon) = geometry_incoming.as_multi_polygon() {
+        //                 multi_polygon
+        //             } else if let Some(polygon) = geometry_incoming.as_polygon() {
+        //                 MultiPolygon2D::new(vec![polygon])
+        //             } else {
+        //                 return multi_polygon_acc;
+        //             };
+
+        //         let mutli_polygon_acc = if let Some(mutli_polygon_acc) = multi_polygon_acc {
+        //             mutli_polygon_acc
+        //         } else {
+        //             return Some(multi_polygon_incoming);
+        //         };
+
+        //         let unite = multi_polygon_incoming.union(&mutli_polygon_acc);
+        //         Some(unite)
+        //     },
+        // );
+
+        let mut unified_polygons = Vec::new();
+        for geometry_incoming in buffered_features_2d
+            .iter()
+            .filter_map(|f| f.geometry.value.as_flow_geometry_2d())
+        {
+            let multi_polygon_incoming =
+                if let Some(multi_polygon) = geometry_incoming.as_multi_polygon() {
+                    multi_polygon
+                } else if let Some(polygon) = geometry_incoming.as_polygon() {
+                    MultiPolygon2D::new(vec![polygon])
+                } else {
+                    continue;
+                };
+
+            let mut new_unified_polygons = Vec::new();
+
+            if unified_polygons.is_empty() {
+                new_unified_polygons.push(multi_polygon_incoming);
+            } else {
+                let mut multi_polygon_incoming_rest = multi_polygon_incoming.clone();
+                for unified_polygon in &unified_polygons {
+                    multi_polygon_incoming_rest =
+                        multi_polygon_incoming_rest.difference(unified_polygon);
+                }
+                new_unified_polygons.push(multi_polygon_incoming_rest);
+                for unified_polygon in &unified_polygons {
+                    let intersected = multi_polygon_incoming.intersection(unified_polygon);
+                    new_unified_polygons.push(intersected);
+                    let difference = unified_polygon.difference(&multi_polygon_incoming);
+                    new_unified_polygons.push(difference);
+                }
+            }
+
+            unified_polygons = new_unified_polygons;
+        }
+
+        let mut features = Vec::new();
+        for multi_polygon_2d in unified_polygons {
+            let mut feature = Feature::new();
+            feature.geometry.value = GeometryValue::FlowGeometry2D(multi_polygon_2d.into());
+            features.push(feature);
+        }
+        features
+    }
+}

--- a/engine/runtime/action-processor/src/geometry/unifier.rs
+++ b/engine/runtime/action-processor/src/geometry/unifier.rs
@@ -29,7 +29,7 @@ impl ProcessorFactory for UnifierFactory {
     }
 
     fn description(&self) -> &str {
-        "unifies features grouped by specified attributes"
+        "Unifies features grouped by specified attributes"
     }
 
     fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {

--- a/engine/runtime/examples/fixture/workflow/requirement/plateau4/a001-7/unifier.yml
+++ b/engine/runtime/examples/fixture/workflow/requirement/plateau4/a001-7/unifier.yml
@@ -33,7 +33,6 @@ graphs:
         action: Unifier
         with:
           groupBy:
-            - municipality
             - boundary
 
       - id: f5e66920-24c0-4c70-ae16-6be1ed3b906c

--- a/engine/runtime/examples/fixture/workflow/requirement/plateau4/a001-7/unifier.yml
+++ b/engine/runtime/examples/fixture/workflow/requirement/plateau4/a001-7/unifier.yml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/workflow.json
+id: 3da19dc4-1ebd-4762-8250-2a4bc8043409
+name: "unifier-workflow"
+entryGraphId: 3e3450c8-2344-4728-afa9-5fdb81eec33a
+with:
+  geojson: !include ./files/tsugaru_strait.geojson.txt
+  outputPath:
+graphs:
+  - id: 3e3450c8-2344-4728-afa9-5fdb81eec33a
+    name: entry_point
+    nodes:
+      - id: 90f40a3e-61d3-48e2-a328-e7226c2ad1ae
+        name: FileReader
+        type: action
+        action: FileReader
+        with:
+          format: geojson
+          inline: |
+            env.get("geojson")
+      
+      - id: 61e89fd2-ea66-4fa1-b426-6f84484a9d38
+        name: Buffer
+        type: action
+        action: Bufferer
+        with:
+          bufferType: area2d
+          distance: 0.02
+          interpolationAngle: 0.01
+
+      - id: 61e89fd2-ea66-4fa1-b426-6f84484a9d40
+        name: Unifier
+        type: action
+        action: Unifier
+        with:
+          groupBy:
+            - municipality
+            - boundary
+
+      - id: f5e66920-24c0-4c70-ae16-6be1ed3b906c
+        name: GeoJsonWriter
+        type: action
+        action: GeoJsonWriter
+        with:
+          output: |
+            file::join_path(env.get("outputPath"), "bufferer.geojson")
+
+
+      - id: f5e66920-24c0-4c70-ae16-6be1ed3b906d
+        name: GeoJsonWriter
+        type: action
+        action: GeoJsonWriter
+        with:
+          output: |
+            file::join_path(env.get("outputPath"), "unifier.geojson")
+
+    edges:
+      - id: c064cf52-705f-443a-b2de-6795266c540d
+        from: 90f40a3e-61d3-48e2-a328-e7226c2ad1ae
+        to: 61e89fd2-ea66-4fa1-b426-6f84484a9d38
+        fromPort: default
+        toPort: default
+      - id: c064cf52-705f-443a-b2de-6795266c540d
+        from: 61e89fd2-ea66-4fa1-b426-6f84484a9d38
+        to: 61e89fd2-ea66-4fa1-b426-6f84484a9d40
+        fromPort: default
+        toPort: default
+      - id: c064cf52-705f-443a-b2de-6795266c540d
+        from: 61e89fd2-ea66-4fa1-b426-6f84484a9d38
+        to: f5e66920-24c0-4c70-ae16-6be1ed3b906c
+        fromPort: default
+        toPort: default
+      - id: c81ea200-9aa1-4522-9f72-10e8b9184cb9
+        from: 61e89fd2-ea66-4fa1-b426-6f84484a9d40
+        to: f5e66920-24c0-4c70-ae16-6be1ed3b906d
+        fromPort: area
+        toPort: default

--- a/engine/runtime/geometry/src/types/multi_polygon.rs
+++ b/engine/runtime/geometry/src/types/multi_polygon.rs
@@ -109,7 +109,7 @@ impl<T: CoordNum, Z: CoordNum> MultiPolygon<T, Z> {
 
     pub fn bounding_box(&self) -> Option<Rect<T, Z>> {
         let rects = self.0.iter().map(|p| p.bounding_box());
-        let mut rects = rects.filter_map(|r| r);
+        let mut rects = rects.flatten();
         let first = rects.next()?;
 
         Some(rects.fold(first, |acc, r| acc.merge(r)))

--- a/engine/runtime/geometry/src/types/multi_polygon.rs
+++ b/engine/runtime/geometry/src/types/multi_polygon.rs
@@ -17,6 +17,7 @@ use super::coordnum::{CoordFloat, CoordNum};
 use super::line_string::LineString;
 use super::no_value::NoValue;
 use super::polygon::{Polygon, Polygon2D};
+use super::rect::Rect;
 use super::traits::Elevation;
 
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone, Debug, Hash)]
@@ -104,6 +105,14 @@ impl<T: CoordNum, Z: CoordNum> MultiPolygon<T, Z> {
 
     pub fn range(&self, range: Range<usize>) -> Vec<Polygon<T, Z>> {
         self.0[range].to_vec()
+    }
+
+    pub fn bounding_box(&self) -> Option<Rect<T, Z>> {
+        let rects = self.0.iter().map(|p| p.bounding_box());
+        let mut rects = rects.filter_map(|r| r);
+        let first = rects.next()?;
+
+        Some(rects.fold(first, |acc, r| acc.merge(r)))
     }
 }
 

--- a/engine/runtime/geometry/src/types/polygon.rs
+++ b/engine/runtime/geometry/src/types/polygon.rs
@@ -17,6 +17,7 @@ use crate::algorithm::line_intersection::{line_intersection, LineIntersection};
 use crate::algorithm::GeoFloat;
 
 use super::conversion::geojson::create_polygon_type;
+use super::coordinate::Coordinate;
 use super::coordnum::{CoordFloat, CoordNum};
 use super::face::Face;
 use super::line::Line;
@@ -210,6 +211,45 @@ impl<T: CoordNum, Z: CoordNum> Polygon<T, Z> {
             is_valid: errors.is_empty(),
             errors,
         }
+    }
+
+    pub fn bounding_box(&self) -> Option<Rect<T, Z>> {
+        let coords = self
+            .rings()
+            .into_iter()
+            .flat_map(|ring| ring.into_iter().map(|point| (point.x, point.y, point.z)))
+            .collect::<Vec<_>>();
+
+        if coords.is_empty() {
+            return None;
+        }
+
+        let (mut min_x, mut min_y, mut min_z) = coords[0];
+        let (mut max_x, mut max_y, mut max_z) = coords[0];
+
+        for coord in coords.iter().skip(1) {
+            let (x, y, z) = coord;
+            if *x < min_x {
+                min_x = *x;
+            } else if *x > max_x {
+                max_x = *x;
+            }
+            if *y < min_y {
+                min_y = *y;
+            } else if *y > max_y {
+                max_y = *y;
+            }
+
+            if *z < min_z {
+                min_z = *z;
+            } else if *z > max_z {
+                max_z = *z;
+            }
+        }
+        Some(Rect::new(
+            Coordinate::new__(min_x, min_y, min_z),
+            Coordinate::new__(max_x, max_y, max_z),
+        ))
     }
 }
 

--- a/engine/runtime/geometry/src/types/rect.rs
+++ b/engine/runtime/geometry/src/types/rect.rs
@@ -98,6 +98,13 @@ impl<T: CoordNum, Z: CoordNum> Rect<T, Z> {
         ]
     }
 
+    pub fn overlap(&self, other: &Rect<T, Z>) -> bool {
+        self.min.x <= other.max.x
+            && self.max.x >= other.min.x
+            && self.min.y <= other.max.y
+            && self.max.y >= other.min.y
+    }
+
     pub fn has_valid_bounds(&self) -> bool {
         self.min.x <= self.max.x && self.min.y <= self.max.y && self.min.z <= self.max.z
     }
@@ -267,5 +274,21 @@ mod test {
     fn rect_width() {
         let rect = Rect::new((10, 10), (20, 20));
         assert_eq!(rect.width(), 10);
+    }
+
+    #[test]
+    fn rect_overlap() {
+        let rect1 = Rect::new((10, 10), (20, 20));
+        let rect2 = Rect::new((15, 15), (25, 25));
+        assert!(rect1.overlap(&rect2));
+
+        let rect3 = Rect::new((20, 20), (30, 30));
+        assert!(!rect1.overlap(&rect3));
+
+        let rect4 = Rect::new((5, 5), (15, 15));
+        assert!(rect1.overlap(&rect4));
+
+        let rect5 = Rect::new((0, 0), (5, 5));
+        assert!(!rect1.overlap(&rect5));
     }
 }

--- a/engine/runtime/geometry/src/types/rect.rs
+++ b/engine/runtime/geometry/src/types/rect.rs
@@ -320,7 +320,7 @@ mod test {
         assert!(rect1.overlap(&rect2));
 
         let rect3 = Rect::new((20, 20), (30, 30));
-        assert!(!rect1.overlap(&rect3));
+        assert!(rect1.overlap(&rect3));
 
         let rect4 = Rect::new((5, 5), (15, 15));
         assert!(rect1.overlap(&rect4));

--- a/engine/runtime/geometry/src/types/rect.rs
+++ b/engine/runtime/geometry/src/types/rect.rs
@@ -98,6 +98,43 @@ impl<T: CoordNum, Z: CoordNum> Rect<T, Z> {
         ]
     }
 
+    pub fn merge(self, other: Self) -> Self {
+        let min_x = if self.min.x < other.min.x {
+            self.min.x
+        } else {
+            other.min.x
+        };
+        let min_y = if self.min.y < other.min.y {
+            self.min.y
+        } else {
+            other.min.y
+        };
+        let min_z = if self.min.z < other.min.z {
+            self.min.z
+        } else {
+            other.min.z
+        };
+        let max_x = if self.max.x > other.max.x {
+            self.max.x
+        } else {
+            other.max.x
+        };
+        let max_y = if self.max.y > other.max.y {
+            self.max.y
+        } else {
+            other.max.y
+        };
+        let max_z = if self.max.z > other.max.z {
+            self.max.z
+        } else {
+            other.max.z
+        };
+        Self {
+            min: Coordinate::new__(min_x, min_y, min_z),
+            max: Coordinate::new__(max_x, max_y, max_z),
+        }
+    }
+
     pub fn overlap(&self, other: &Rect<T, Z>) -> bool {
         self.min.x <= other.max.x
             && self.max.x >= other.min.x

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -3370,6 +3370,43 @@
       ]
     },
     {
+      "name": "Unifier",
+      "type": "processor",
+      "description": "Unifies features grouped by specified attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "UnifierParam",
+        "type": "object",
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "VertexRemover",
       "type": "processor",
       "description": "Removes specific vertices from a feature’s geometry",

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -3370,6 +3370,43 @@
       ]
     },
     {
+      "name": "Unifier",
+      "type": "processor",
+      "description": "Unifies features grouped by specified attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "UnifierParam",
+        "type": "object",
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "VertexRemover",
       "type": "processor",
       "description": "Removes specific vertices from a feature’s geometry",

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -3370,6 +3370,43 @@
       ]
     },
     {
+      "name": "Unifier",
+      "type": "processor",
+      "description": "Unifies features grouped by specified attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "UnifierParam",
+        "type": "object",
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "VertexRemover",
       "type": "processor",
       "description": "Elimina vértices específicos de la geometría de una entidad",

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -3370,6 +3370,43 @@
       ]
     },
     {
+      "name": "Unifier",
+      "type": "processor",
+      "description": "Unifies features grouped by specified attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "UnifierParam",
+        "type": "object",
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "VertexRemover",
       "type": "processor",
       "description": "Supprime des sommets spécifiques de la géométrie d'une entité",

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -3370,6 +3370,43 @@
       ]
     },
     {
+      "name": "Unifier",
+      "type": "processor",
+      "description": "Unifies features grouped by specified attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "UnifierParam",
+        "type": "object",
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "VertexRemover",
       "type": "processor",
       "description": "フィーチャのジオメトリから特定の頂点を削除する",

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -3370,6 +3370,43 @@
       ]
     },
     {
+      "name": "Unifier",
+      "type": "processor",
+      "description": "Unifies features grouped by specified attributes",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "UnifierParam",
+        "type": "object",
+        "properties": {
+          "groupBy": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": true,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "area",
+        "rejected"
+      ],
+      "categories": [
+        "Geometry"
+      ]
+    },
+    {
       "name": "VertexRemover",
       "type": "processor",
       "description": "从实体的几何中删除特定的顶点",


### PR DESCRIPTION
# Overview

- Implemented `Unifier` as a new action.
- Some methods and tests are newly implemented for `Rect`, `Polygon` and `Multipolygon`, which creates bounding boxes for features.
- Added workflows for test.

## How I tested

```
$ cd engine
$ yaml-include runtime/examples/fixture/workflow/requirement/plateau4/a001-7/unifier.yml | cargo run --package reearth-flow-cli -- run --var="outputPath=${output path}" --workflow -
```

## Screenshot

![Screenshot from 2025-02-11 19-46-29](https://github.com/user-attachments/assets/02e9896c-7225-48ec-9c9e-17891c2b5386)

## Memo

- Spatial indexes will be needed for better performance.
  This implementation uses a nested loop to check all pairs of overlapped features with their Minimum Bounding Rectangles as a naive approach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new geometry unification processor that groups and processes spatial features based on attributes.
  - Integrated an updated workflow configuration to support comprehensive geospatial data pipelines.
  - Enhanced spatial analysis with capabilities such as bounding box computation, rectangle merging, and overlap detection.
  - Expanded the processing schema to include support for unified geometry handling across multiple locales.

- **Tests**
  - Added test coverage for the new spatial overlap functionality to ensure robust performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->