### PR TITLE
fix(ui): added params on click useYNodes node change

### DIFF
--- a/ui/src/features/Editor/components/ParamsPanel/index.tsx
+++ b/ui/src/features/Editor/components/ParamsPanel/index.tsx
@@ -1,5 +1,6 @@
 import { X } from "@phosphor-icons/react";
-import { memo, useCallback } from "react";
+import { useReactFlow } from "@xyflow/react";
+import { memo, useCallback, useEffect, useRef } from "react";
 
 import { IconButton } from "@flow/components";
 import { Node } from "@flow/types";
@@ -31,6 +32,25 @@ const ParamsPanel: React.FC<Props> = ({ selected, onParamsSubmit }) => {
     [onParamsSubmit, handleClose],
   );
 
+  const { getViewport, setViewport } = useReactFlow();
+
+  const previousViewportRef = useRef<{
+    x: number;
+    y: number;
+    zoom: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (selected) {
+      if (!previousViewportRef.current) {
+        const { x, y, zoom } = getViewport();
+        previousViewportRef.current = { x, y, zoom };
+      }
+    } else if (!selected && previousViewportRef.current) {
+      setViewport(previousViewportRef.current, { duration: 400 });
+      previousViewportRef.current = null;
+    }
+  }, [setViewport, getViewport, selected]);
   return (
     <>
       <div

--- a/ui/src/features/Editor/components/ParamsPanel/index.tsx
+++ b/ui/src/features/Editor/components/ParamsPanel/index.tsx
@@ -42,8 +42,8 @@ const ParamsPanel: React.FC<Props> = ({ selected, onParamsSubmit }) => {
 
   useEffect(() => {
     if (selected && !previousViewportRef.current) {
-        const { x, y, zoom } = getViewport();
-        previousViewportRef.current = { x, y, zoom };
+      const { x, y, zoom } = getViewport();
+      previousViewportRef.current = { x, y, zoom };
     } else if (!selected && previousViewportRef.current) {
       setViewport(previousViewportRef.current, { duration: 400 });
       previousViewportRef.current = null;

--- a/ui/src/features/Editor/components/ParamsPanel/index.tsx
+++ b/ui/src/features/Editor/components/ParamsPanel/index.tsx
@@ -41,11 +41,9 @@ const ParamsPanel: React.FC<Props> = ({ selected, onParamsSubmit }) => {
   } | null>(null);
 
   useEffect(() => {
-    if (selected) {
-      if (!previousViewportRef.current) {
+    if (selected && !previousViewportRef.current) {
         const { x, y, zoom } = getViewport();
         previousViewportRef.current = { x, y, zoom };
-      }
     } else if (!selected && previousViewportRef.current) {
       setViewport(previousViewportRef.current, { duration: 400 });
       previousViewportRef.current = null;

--- a/ui/src/features/Editor/hooks.ts
+++ b/ui/src/features/Editor/hooks.ts
@@ -1,3 +1,4 @@
+import { useReactFlow } from "@xyflow/react";
 import { MouseEvent, useCallback, useMemo, useState } from "react";
 import { useY } from "react-yjs";
 import { Array as YArray, UndoManager as YUndoManager } from "yjs";
@@ -44,6 +45,7 @@ export default ({
 
   const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([]);
   const [selectedEdgeIds, setSelectedEdgeIds] = useState<string[]>([]);
+  const { fitView } = useReactFlow();
 
   const {
     canUndo,
@@ -124,14 +126,19 @@ export default ({
   });
 
   const handleNodeDoubleClick = useCallback(
-    (_e: MouseEvent, node: Node) => {
+    (_e: MouseEvent | undefined, node: Node) => {
       if (node.type === "subworkflow") {
         handleWorkflowOpen(node.id);
       } else {
+        fitView({
+          nodes: [{ id: node.id }],
+          duration: 500,
+          padding: 2,
+        });
         handleNodeLocking(node.id);
       }
     },
-    [handleWorkflowOpen, handleNodeLocking],
+    [handleWorkflowOpen, fitView, handleNodeLocking],
   );
 
   const { handleCopy, handlePaste } = useCanvasCopyPaste({

--- a/ui/src/features/Editor/index.tsx
+++ b/ui/src/features/Editor/index.tsx
@@ -71,8 +71,9 @@ export default function Editor({
           onNodesAdd={handleNodesAdd}
           isMainWorkflow={isMainWorkflow}
           hasReader={hasReader}
-          // onNodeDoubleClick={handleNodeDoubleClick}
-          // selected={locallyLockedNode}
+          onNodesChange={handleNodesChange}
+          onNodeDoubleClick={handleNodeDoubleClick}
+          selected={locallyLockedNode}
         />
         <div className="flex flex-1 flex-col">
           <OverlayUI


### PR DESCRIPTION
# Overview
Added onDoubleClick and params open
## What I've done
Used the useYNode onchange to track the change
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly
Want to make sure that this is not causing any issues with React Flows internal state or desync etc
## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced node interaction with optimized double-click responses and refined selection handling, delivering quicker and more consistent visual feedback.
  - Introduced dynamic viewport management that captures and smoothly restores previous view states during node interactions, ensuring seamless navigation.
  - These enhancements provide a more responsive and intuitive interface, elevating the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->