### PR TITLE
fix(ui): Text Area and Input Fix for Params

### DIFF
--- a/ui/src/components/SchemaForm/Templates/BaseInputTemplate.tsx
+++ b/ui/src/components/SchemaForm/Templates/BaseInputTemplate.tsx
@@ -77,7 +77,7 @@ const BaseInputTemplate = <
       onChangeOverride || onChange(value === "" ? options.emptyValue : value)
     );
   };
-  // For most text-based params we want TextArea. But for certain schema format types, we want Input to get the appropriate styling @billcookie 
+  // For most text-based params we want TextArea. But for certain schema format types, we want Input to get the appropriate styling @billcookie
   if (schema.format === "color") {
     return (
       <Input

--- a/ui/src/components/SchemaForm/Templates/BaseInputTemplate.tsx
+++ b/ui/src/components/SchemaForm/Templates/BaseInputTemplate.tsx
@@ -9,7 +9,7 @@ import {
 } from "@rjsf/utils";
 import { ChangeEvent, useRef } from "react";
 
-import { TextArea } from "@flow/components";
+import { Input, TextArea } from "@flow/components";
 
 /** The `BaseInputTemplate` is the template to use to render the basic `<input>` component for the `core` theme.
  * It is used as the template for rendering many of the <input> based widgets that differ by `type` and callbacks only.
@@ -77,7 +77,27 @@ const BaseInputTemplate = <
       onChangeOverride || onChange(value === "" ? options.emptyValue : value)
     );
   };
-
+  // We want the default to be textarea as for most params they will be long strings, however, for color and future formats we can set as input to get the correct styling @billcookie
+  if (schema.format === "color") {
+    return (
+      <Input
+        id={id}
+        name={id}
+        placeholder={placeholder}
+        autoFocus={autofocus}
+        required={required}
+        disabled={disabled || readonly}
+        {...otherProps}
+        value={value || value === 0 ? value : ""}
+        onChange={(e) =>
+          onChangeOverride ||
+          onChange(e.target.value === "" ? options.emptyValue : e.target.value)
+        }
+        {...textFieldProps}
+        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
+      />
+    );
+  }
   return (
     <>
       <TextArea

--- a/ui/src/components/SchemaForm/Templates/BaseInputTemplate.tsx
+++ b/ui/src/components/SchemaForm/Templates/BaseInputTemplate.tsx
@@ -77,7 +77,7 @@ const BaseInputTemplate = <
       onChangeOverride || onChange(value === "" ? options.emptyValue : value)
     );
   };
-  // We want the default to be textarea as for most params they will be long strings, however, for color and future formats we can set as input to get the correct styling @billcookie
+  // For most text-based params we want TextArea. But for certain schema format types, we want Input to get the appropriate styling @billcookie 
   if (schema.format === "color") {
     return (
       <Input

--- a/ui/src/features/Editor/components/Canvas/components/Nodes/NoteNode/index.tsx
+++ b/ui/src/features/Editor/components/Canvas/components/Nodes/NoteNode/index.tsx
@@ -113,11 +113,6 @@ const NoteNode: React.FC<NoteNodeProps> = ({ data, ...props }) => {
         <div
           ref={(element) => {
             if (element) {
-              element.style.setProperty(
-                "background-color",
-                rgbaColor,
-                "important",
-              );
               if (element)
                 element.style.setProperty(
                   "color",
@@ -126,23 +121,7 @@ const NoteNode: React.FC<NoteNodeProps> = ({ data, ...props }) => {
                 );
             }
           }}>
-          <p
-            ref={(element) => {
-              if (element) {
-                element.style.setProperty(
-                  "background-color",
-                  rgbaColor,
-                  "important",
-                );
-                if (element)
-                  element.style.setProperty(
-                    "color",
-                    data.params?.textColor || "",
-                    "important",
-                  );
-              }
-            }}
-            className="nowheel nodrag size-full resize-none bg-transparent text-xs focus-visible:outline-none">
+          <p className="nowheel nodrag size-full resize-none bg-transparent text-xs focus-visible:outline-none">
             {data.params?.description}
           </p>
         </div>


### PR DESCRIPTION
# Overview
As we changed the RJSF BaseInputTemplate to be a textarea rather than an input it caused all params to be a text area (e.g. color picker etc)

## What I've done
Params that have a different format like color will now be input with a simple conditional. This might be expanded in the future as we expand param customization etc.
## What I haven't done

## How I tested
Manually
## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Form inputs now adapt based on the field type, allowing for specialized controls for color inputs.
  
- **Refactor**
	- Note display has been streamlined by removing redundant background styling and outdated text input elements, resulting in a cleaner and more consistent interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->