### PR TITLE
chore(api): save sharing token instead sharing url with project

### DIFF
--- a/server/api/gql/project.graphql
+++ b/server/api/gql/project.graphql
@@ -10,7 +10,7 @@ type Project implements Node {
   name: String!
   parameters: [Parameter!]!
   updatedAt: DateTime!
-  sharedUrl: String
+  sharedToken: String
   version: Int!
   workspace: Workspace
   workspaceId: ID!

--- a/server/api/gql/projectAccess.graphql
+++ b/server/api/gql/projectAccess.graphql
@@ -12,7 +12,7 @@ input UnshareProjectInput {
 
 type ProjectSharingInfoPayload {
   projectId: ID!
-  sharingUrl: String
+  sharingToken: String
 }
 
 type SharedProjectPayload {

--- a/server/api/internal/adapter/gql/generated.go
+++ b/server/api/internal/adapter/gql/generated.go
@@ -230,7 +230,7 @@ type ComplexityRoot struct {
 		IsBasicAuthActive func(childComplexity int) int
 		Name              func(childComplexity int) int
 		Parameters        func(childComplexity int) int
-		SharedURL         func(childComplexity int) int
+		SharedToken       func(childComplexity int) int
 		UpdatedAt         func(childComplexity int) int
 		Version           func(childComplexity int) int
 		Workspace         func(childComplexity int) int
@@ -255,8 +255,8 @@ type ComplexityRoot struct {
 	}
 
 	ProjectSharingInfoPayload struct {
-		ProjectID  func(childComplexity int) int
-		SharingURL func(childComplexity int) int
+		ProjectID    func(childComplexity int) int
+		SharingToken func(childComplexity int) int
 	}
 
 	ProjectSnapshot struct {
@@ -1420,12 +1420,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Project.Parameters(childComplexity), true
 
-	case "Project.sharedUrl":
-		if e.complexity.Project.SharedURL == nil {
+	case "Project.sharedToken":
+		if e.complexity.Project.SharedToken == nil {
 			break
 		}
 
-		return e.complexity.Project.SharedURL(childComplexity), true
+		return e.complexity.Project.SharedToken(childComplexity), true
 
 	case "Project.updatedAt":
 		if e.complexity.Project.UpdatedAt == nil {
@@ -1518,12 +1518,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ProjectSharingInfoPayload.ProjectID(childComplexity), true
 
-	case "ProjectSharingInfoPayload.sharingUrl":
-		if e.complexity.ProjectSharingInfoPayload.SharingURL == nil {
+	case "ProjectSharingInfoPayload.sharingToken":
+		if e.complexity.ProjectSharingInfoPayload.SharingToken == nil {
 			break
 		}
 
-		return e.complexity.ProjectSharingInfoPayload.SharingURL(childComplexity), true
+		return e.complexity.ProjectSharingInfoPayload.SharingToken(childComplexity), true
 
 	case "ProjectSnapshot.timestamp":
 		if e.complexity.ProjectSnapshot.Timestamp == nil {
@@ -2595,7 +2595,7 @@ extend type Mutation {
   name: String!
   parameters: [Parameter!]!
   updatedAt: DateTime!
-  sharedUrl: String
+  sharedToken: String
   version: Int!
   workspace: Workspace
   workspaceId: ID!
@@ -2684,7 +2684,7 @@ input UnshareProjectInput {
 
 type ProjectSharingInfoPayload {
   projectId: ID!
-  sharingUrl: String
+  sharingToken: String
 }
 
 type SharedProjectPayload {
@@ -5126,8 +5126,8 @@ func (ec *executionContext) fieldContext_Deployment_project(_ context.Context, f
 				return ec.fieldContext_Project_parameters(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_Project_updatedAt(ctx, field)
-			case "sharedUrl":
-				return ec.fieldContext_Project_sharedUrl(ctx, field)
+			case "sharedToken":
+				return ec.fieldContext_Project_sharedToken(ctx, field)
 			case "version":
 				return ec.fieldContext_Project_version(ctx, field)
 			case "workspace":
@@ -9669,8 +9669,8 @@ func (ec *executionContext) fieldContext_Project_updatedAt(_ context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _Project_sharedUrl(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Project) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Project_sharedUrl(ctx, field)
+func (ec *executionContext) _Project_sharedToken(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.Project) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Project_sharedToken(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -9683,7 +9683,7 @@ func (ec *executionContext) _Project_sharedUrl(ctx context.Context, field graphq
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.SharedURL, nil
+		return obj.SharedToken, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -9697,7 +9697,7 @@ func (ec *executionContext) _Project_sharedUrl(ctx context.Context, field graphq
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Project_sharedUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Project_sharedToken(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Project",
 		Field:      field,
@@ -9914,8 +9914,8 @@ func (ec *executionContext) fieldContext_ProjectConnection_nodes(_ context.Conte
 				return ec.fieldContext_Project_parameters(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_Project_updatedAt(ctx, field)
-			case "sharedUrl":
-				return ec.fieldContext_Project_sharedUrl(ctx, field)
+			case "sharedToken":
+				return ec.fieldContext_Project_sharedToken(ctx, field)
 			case "version":
 				return ec.fieldContext_Project_version(ctx, field)
 			case "workspace":
@@ -10262,8 +10262,8 @@ func (ec *executionContext) fieldContext_ProjectPayload_project(_ context.Contex
 				return ec.fieldContext_Project_parameters(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_Project_updatedAt(ctx, field)
-			case "sharedUrl":
-				return ec.fieldContext_Project_sharedUrl(ctx, field)
+			case "sharedToken":
+				return ec.fieldContext_Project_sharedToken(ctx, field)
 			case "version":
 				return ec.fieldContext_Project_version(ctx, field)
 			case "workspace":
@@ -10321,8 +10321,8 @@ func (ec *executionContext) fieldContext_ProjectSharingInfoPayload_projectId(_ c
 	return fc, nil
 }
 
-func (ec *executionContext) _ProjectSharingInfoPayload_sharingUrl(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.ProjectSharingInfoPayload) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ProjectSharingInfoPayload_sharingUrl(ctx, field)
+func (ec *executionContext) _ProjectSharingInfoPayload_sharingToken(ctx context.Context, field graphql.CollectedField, obj *gqlmodel.ProjectSharingInfoPayload) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ProjectSharingInfoPayload_sharingToken(ctx, field)
 	if err != nil {
 		return graphql.Null
 	}
@@ -10335,7 +10335,7 @@ func (ec *executionContext) _ProjectSharingInfoPayload_sharingUrl(ctx context.Co
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.SharingURL, nil
+		return obj.SharingToken, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -10349,7 +10349,7 @@ func (ec *executionContext) _ProjectSharingInfoPayload_sharingUrl(ctx context.Co
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_ProjectSharingInfoPayload_sharingUrl(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_ProjectSharingInfoPayload_sharingToken(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ProjectSharingInfoPayload",
 		Field:      field,
@@ -11391,8 +11391,8 @@ func (ec *executionContext) fieldContext_Query_projectSharingInfo(ctx context.Co
 			switch field.Name {
 			case "projectId":
 				return ec.fieldContext_ProjectSharingInfoPayload_projectId(ctx, field)
-			case "sharingUrl":
-				return ec.fieldContext_ProjectSharingInfoPayload_sharingUrl(ctx, field)
+			case "sharingToken":
+				return ec.fieldContext_ProjectSharingInfoPayload_sharingToken(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ProjectSharingInfoPayload", field.Name)
 		},
@@ -12063,8 +12063,8 @@ func (ec *executionContext) fieldContext_SharedProjectPayload_project(_ context.
 				return ec.fieldContext_Project_parameters(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_Project_updatedAt(ctx, field)
-			case "sharedUrl":
-				return ec.fieldContext_Project_sharedUrl(ctx, field)
+			case "sharedToken":
+				return ec.fieldContext_Project_sharedToken(ctx, field)
 			case "version":
 				return ec.fieldContext_Project_version(ctx, field)
 			case "workspace":
@@ -18432,8 +18432,8 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "sharedUrl":
-			out.Values[i] = ec._Project_sharedUrl(ctx, field, obj)
+		case "sharedToken":
+			out.Values[i] = ec._Project_sharedToken(ctx, field, obj)
 		case "version":
 			out.Values[i] = ec._Project_version(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -18689,8 +18689,8 @@ func (ec *executionContext) _ProjectSharingInfoPayload(ctx context.Context, sel 
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
-		case "sharingUrl":
-			out.Values[i] = ec._ProjectSharingInfoPayload_sharingUrl(ctx, field, obj)
+		case "sharingToken":
+			out.Values[i] = ec._ProjectSharingInfoPayload_sharingToken(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/server/api/internal/adapter/gql/gqlmodel/convert_project.go
+++ b/server/api/internal/adapter/gql/gqlmodel/convert_project.go
@@ -9,9 +9,9 @@ func ToProject(p *project.Project) *Project {
 		return nil
 	}
 
-	var sharedURL *string
-	if p.SharedURL() != nil {
-		sharedURL = p.SharedURL()
+	var sharedToken *string
+	if p.SharedToken() != nil {
+		sharedToken = p.SharedToken()
 	}
 
 	return &Project{
@@ -23,7 +23,7 @@ func ToProject(p *project.Project) *Project {
 		BasicAuthPassword: p.BasicAuthPassword(),
 		Name:              p.Name(),
 		Description:       p.Description(),
-		SharedURL:         sharedURL,
+		SharedToken:       sharedToken,
 		UpdatedAt:         p.UpdatedAt(),
 		WorkspaceID:       IDFrom(p.Workspace()),
 	}

--- a/server/api/internal/adapter/gql/gqlmodel/models_gen.go
+++ b/server/api/internal/adapter/gql/gqlmodel/models_gen.go
@@ -266,7 +266,7 @@ type Project struct {
 	Name              string       `json:"name"`
 	Parameters        []*Parameter `json:"parameters"`
 	UpdatedAt         time.Time    `json:"updatedAt"`
-	SharedURL         *string      `json:"sharedUrl,omitempty"`
+	SharedToken       *string      `json:"sharedToken,omitempty"`
 	Version           int          `json:"version"`
 	Workspace         *Workspace   `json:"workspace,omitempty"`
 	WorkspaceID       ID           `json:"workspaceId"`
@@ -296,8 +296,8 @@ type ProjectPayload struct {
 }
 
 type ProjectSharingInfoPayload struct {
-	ProjectID  ID      `json:"projectId"`
-	SharingURL *string `json:"sharingUrl,omitempty"`
+	ProjectID    ID      `json:"projectId"`
+	SharingToken *string `json:"sharingToken,omitempty"`
 }
 
 type ProjectSnapshot struct {

--- a/server/api/internal/adapter/gql/resolver_projectAccess.go
+++ b/server/api/internal/adapter/gql/resolver_projectAccess.go
@@ -18,8 +18,8 @@ func (r *queryResolver) ProjectSharingInfo(ctx context.Context, projectId gqlmod
 	}
 
 	return &gqlmodel.ProjectSharingInfoPayload{
-		ProjectID:  projectId,
-		SharingURL: project.SharedURL,
+		ProjectID:    projectId,
+		SharingToken: project.SharedToken,
 	}, nil
 }
 

--- a/server/api/internal/infrastructure/mongo/mongodoc/project.go
+++ b/server/api/internal/infrastructure/mongo/mongodoc/project.go
@@ -36,7 +36,7 @@ type ProjectDocument struct {
 	PublicImage       string
 	PublicNoIndex     bool
 	PublicTitle       string
-	SharedURL         string
+	SharedToken       string
 
 	// Analytics
 	EnableGA   bool
@@ -54,9 +54,9 @@ func NewProjectConsumer(workspaces []accountdomain.WorkspaceID) *ProjectConsumer
 func NewProject(project *project.Project) (*ProjectDocument, string) {
 	pid := project.ID().String()
 
-	var sharedURL string
-	if project.SharedURL() != nil {
-		sharedURL = *project.SharedURL()
+	var sharedToken string
+	if project.SharedToken() != nil {
+		sharedToken = *project.SharedToken()
 	}
 
 	return &ProjectDocument{
@@ -67,7 +67,7 @@ func NewProject(project *project.Project) (*ProjectDocument, string) {
 		Description:       project.Description(),
 		IsBasicAuthActive: project.IsBasicAuthActive(),
 		Name:              project.Name(),
-		SharedURL:         sharedURL,
+		SharedToken:       sharedToken,
 		UpdatedAt:         project.UpdatedAt(),
 		Workflow:          project.Workflow().String(),
 		Workspace:         project.Workspace().String(),
@@ -87,9 +87,9 @@ func (d *ProjectDocument) Model() (*project.Project, error) {
 
 	wid, _ := id.WorkflowIDFrom(d.Workflow)
 
-	var sharedURL *string
-	if d.SharedURL != "" {
-		sharedURL = &d.SharedURL
+	var sharedToken *string
+	if d.SharedToken != "" {
+		sharedToken = &d.SharedToken
 	}
 
 	return project.New().
@@ -100,7 +100,7 @@ func (d *ProjectDocument) Model() (*project.Project, error) {
 		IsArchived(d.Archived).
 		IsBasicAuthActive(d.IsBasicAuthActive).
 		Name(d.Name).
-		SharedURL(sharedURL).
+		SharedToken(sharedToken).
 		UpdatedAt(d.UpdatedAt).
 		Workflow(wid).
 		Workspace(tid).

--- a/server/api/internal/usecase/interactor/projectAccess.go
+++ b/server/api/internal/usecase/interactor/projectAccess.go
@@ -96,12 +96,12 @@ func (i *ProjectAccess) Share(ctx context.Context, projectID id.ProjectID, opera
 		return "", err
 	}
 
-	sharingUrl, err = pa.SharingURL(i.config.Host, i.config.SharedPath)
+	sharingToken := pa.Token()
 	if err != nil {
 		return "", err
 	}
 
-	prj.SetSharedURL(&sharingUrl)
+	prj.SetSharedToken(&sharingToken)
 	err = i.projectRepo.Save(ctx, prj)
 	if err != nil {
 		return "", fmt.Errorf("failed to update project with sharing URL: %w", err)
@@ -150,7 +150,7 @@ func (i *ProjectAccess) Unshare(ctx context.Context, projectID id.ProjectID, ope
 		return err
 	}
 
-	prj.SetSharedURL(nil)
+	prj.SetSharedToken(nil)
 	err = i.projectRepo.Save(ctx, prj)
 	if err != nil {
 		return fmt.Errorf("failed to update project to remove sharing URL: %w", err)

--- a/server/api/internal/usecase/interactor/projectAccess.go
+++ b/server/api/internal/usecase/interactor/projectAccess.go
@@ -107,6 +107,11 @@ func (i *ProjectAccess) Share(ctx context.Context, projectID id.ProjectID, opera
 		return "", fmt.Errorf("failed to update project with sharing URL: %w", err)
 	}
 
+	sharingUrl, err = pa.SharingURL(i.config.Host, i.config.SharedPath)
+	if err != nil {
+		return "", err
+	}
+
 	tx.Commit()
 	return sharingUrl, nil
 }

--- a/server/api/pkg/project/builder.go
+++ b/server/api/pkg/project/builder.go
@@ -71,8 +71,8 @@ func (b *Builder) NewID() *Builder {
 	return b
 }
 
-func (b *Builder) SharedURL(sharedURL *string) *Builder {
-	b.p.sharedUrl = sharedURL
+func (b *Builder) SharedToken(sharedToken *string) *Builder {
+	b.p.sharedToken = sharedToken
 	return b
 }
 

--- a/server/api/pkg/project/project.go
+++ b/server/api/pkg/project/project.go
@@ -15,7 +15,7 @@ type Project struct {
 	isArchived        bool
 	isBasicAuthActive bool
 	name              string
-	sharedUrl         *string
+	sharedToken       *string
 	updatedAt         time.Time
 	workflow          WorkflowID
 	workspace         WorkspaceID
@@ -53,8 +53,8 @@ func (p *Project) Name() string {
 	return p.name
 }
 
-func (p *Project) SharedURL() *string {
-	return p.sharedUrl
+func (p *Project) SharedToken() *string {
+	return p.sharedToken
 }
 
 func (p *Project) SetArchived(isArchived bool) {
@@ -77,8 +77,8 @@ func (p *Project) SetIsBasicAuthActive(isBasicAuthActive bool) {
 	p.updatedAt = time.Now()
 }
 
-func (p *Project) SetSharedURL(sharedUrl *string) {
-	p.sharedUrl = sharedUrl
+func (p *Project) SetSharedToken(sharedToken *string) {
+	p.sharedToken = sharedToken
 	p.updatedAt = time.Now()
 }
 


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the project sharing functionality to use a token-based system rather than a link-based approach. Users sharing projects will now receive a sharing token, enhancing consistency and security in the sharing process while maintaining the existing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->