### PR TITLE
fix(ui): added reset button for colours.

### DIFF
--- a/ui/src/components/SchemaForm/Templates/BaseInputTemplate.tsx
+++ b/ui/src/components/SchemaForm/Templates/BaseInputTemplate.tsx
@@ -9,7 +9,8 @@ import {
 } from "@rjsf/utils";
 import { ChangeEvent, useRef } from "react";
 
-import { Input, TextArea } from "@flow/components";
+import { Button, Input, TextArea } from "@flow/components";
+import { useT } from "@flow/lib/i18n";
 
 /** The `BaseInputTemplate` is the template to use to render the basic `<input>` component for the `core` theme.
  * It is used as the template for rendering many of the <input> based widgets that differ by `type` and callbacks only.
@@ -77,25 +78,42 @@ const BaseInputTemplate = <
       onChangeOverride || onChange(value === "" ? options.emptyValue : value)
     );
   };
+  const t = useT();
   // For most text-based params we want TextArea. But for certain schema format types, we want Input to get the appropriate styling @billcookie
   if (schema.format === "color") {
+    const defaultColor = schema.default || "#000000";
     return (
-      <Input
-        id={id}
-        name={id}
-        placeholder={placeholder}
-        autoFocus={autofocus}
-        required={required}
-        disabled={disabled || readonly}
-        {...otherProps}
-        value={value || value === 0 ? value : ""}
-        onChange={(e) =>
-          onChangeOverride ||
-          onChange(e.target.value === "" ? options.emptyValue : e.target.value)
-        }
-        {...textFieldProps}
-        aria-describedby={ariaDescribedByIds<T>(id, !!schema.examples)}
-      />
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <Input
+            id={id}
+            name={id}
+            placeholder={placeholder}
+            autoFocus={autofocus}
+            required={required}
+            disabled={disabled || readonly}
+            {...otherProps}
+            value={value || value === 0 ? value : ""}
+            onChange={(e) =>
+              onChangeOverride ||
+              onChange(
+                e.target.value === "" ? options.emptyValue : e.target.value,
+              )
+            }
+            className="h-9 w-full cursor-pointer p-1"
+          />
+          {value !== defaultColor && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onChange(defaultColor)}
+              className="h-9 px-2">
+              {t("Reset Color")}
+            </Button>
+          )}
+        </div>
+      </div>
     );
   }
   return (

--- a/ui/src/lib/i18n/locales/en.json
+++ b/ui/src/lib/i18n/locales/en.json
@@ -15,6 +15,7 @@
   "Reset Logs": "",
   "Invalid data": "",
   "Error with the schema": "",
+  "Reset Color": "",
   "Submit": "Submit",
   "No content to display": "",
   "Select Language": "",

--- a/ui/src/lib/i18n/locales/es.json
+++ b/ui/src/lib/i18n/locales/es.json
@@ -15,6 +15,7 @@
   "Reset Logs": "",
   "Invalid data": "Datos inválidos",
   "Error with the schema": "Error con el esquema",
+  "Reset Color": "",
   "Submit": "Enviar",
   "No content to display": "No hay contenido para mostrar",
   "Select Language": "Seleccionar idioma",

--- a/ui/src/lib/i18n/locales/fr.json
+++ b/ui/src/lib/i18n/locales/fr.json
@@ -15,6 +15,7 @@
   "Reset Logs": "",
   "Invalid data": "Données invalid",
   "Error with the schema": "Erreur avec le schéma",
+  "Reset Color": "",
   "Submit": "Soumettre",
   "No content to display": "Aucun contenu à afficher",
   "Select Language": "Sélectionner la langue",

--- a/ui/src/lib/i18n/locales/ja.json
+++ b/ui/src/lib/i18n/locales/ja.json
@@ -15,6 +15,7 @@
   "Reset Logs": "ログをリセット",
   "Invalid data": "無効なデータ",
   "Error with the schema": "スキーマエラー",
+  "Reset Color": "色をリセット",
   "Submit": "送信",
   "No content to display": "表示するコンテンツがありません",
   "Select Language": "言語を選択",

--- a/ui/src/lib/i18n/locales/zh.json
+++ b/ui/src/lib/i18n/locales/zh.json
@@ -15,6 +15,7 @@
   "Reset Logs": "重置日志",
   "Invalid data": "无效数据",
   "Error with the schema": "模式错误",
+  "Reset Color": "",
   "Submit": "提交",
   "No content to display": "没有内容可显示",
   "Select Language": "选择语言",

--- a/ui/src/lib/reactFlow/nodeTypes/BatchNode/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/BatchNode/index.tsx
@@ -19,9 +19,15 @@ const batchNodeSchema: RJSFSchema = {
     backgroundColor: {
       type: "string",
       format: "color",
+      default: "#323236",
       title: "Background Color",
     },
-    textColor: { type: "string", format: "color", title: "Text Color" },
+    textColor: {
+      type: "string",
+      format: "color",
+      title: "Text Color",
+      default: "#fafafa",
+    },
   },
 };
 

--- a/ui/src/lib/reactFlow/nodeTypes/NoteNode/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/NoteNode/index.tsx
@@ -18,10 +18,16 @@ const noteNodeSchema: RJSFSchema = {
   properties: {
     customName: { type: "string", title: "Name" },
     description: { type: "string", format: "textarea", title: "Description" },
-    textColor: { type: "string", format: "color", title: "Text Color" },
+    textColor: {
+      type: "string",
+      format: "color",
+      default: "#fafafa",
+      title: "Text Color",
+    },
     backgroundColor: {
       type: "string",
       format: "color",
+      default: "#212121",
       title: "Background Color",
     },
   },


### PR DESCRIPTION
# Overview
Users could not reset the note or batch node text or background colour.
## What I've done
Button has been added to allow resetting to default colours. 
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Reset Color button in color input fields, allowing users to quickly revert to a default color.
	- Enhanced the layout for color inputs for improved usability.
	- Expanded language support by adding multi-language labels for the new reset feature.
	- Applied consistent default color settings for visual node elements to improve appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->