### PR TITLE
feat(websocket): update GCS storage only on disconnect

### DIFF
--- a/server/websocket/src/bin/websocket.rs
+++ b/server/websocket/src/bin/websocket.rs
@@ -32,10 +32,10 @@ async fn main() {
         }
     };
 
-    if let Err(e) = websocket::ensure_bucket(&store.client, &config.gcs.bucket_name).await {
-        error!("Failed to ensure bucket exists: {}", e);
-        std::process::exit(1);
-    }
+    // if let Err(e) = websocket::ensure_bucket(&store.client, &config.gcs.bucket_name).await {
+    //     error!("Failed to ensure bucket exists: {}", e);
+    //     std::process::exit(1);
+    // }
 
     let store = Arc::new(store);
     tracing::info!("GCS store initialized");

--- a/server/websocket/src/bin/websocket.rs
+++ b/server/websocket/src/bin/websocket.rs
@@ -32,10 +32,10 @@ async fn main() {
         }
     };
 
-    // if let Err(e) = ensure_bucket(&store.client, &config.gcs.bucket_name).await {
-    //     error!("Failed to ensure bucket exists: {}", e);
-    //     std::process::exit(1);
-    // }
+    if let Err(e) = websocket::ensure_bucket(&store.client, &config.gcs.bucket_name).await {
+        error!("Failed to ensure bucket exists: {}", e);
+        std::process::exit(1);
+    }
 
     let store = Arc::new(store);
     tracing::info!("GCS store initialized");

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -309,7 +309,6 @@ impl BroadcastGroup {
             None
         };
 
-        // Execute both operations concurrently if Redis is enabled
         match redis_future {
             Some(redis_future) => {
                 tracing::info!(

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -573,7 +573,7 @@ impl Drop for BroadcastGroup {
         self.awareness_updater.abort();
 
         if let (Some(store), Some(doc_name)) = (&self.storage, &self.doc_name) {
-            let doc_name_log = doc_name.clone(); // Clone for logging
+            let doc_name_log = doc_name.clone();
             tracing::info!("Preparing to store updates for document '{}'", doc_name_log);
 
             if let Ok(rt) = tokio::runtime::Handle::try_current() {

--- a/server/websocket/src/storage/gcs/mod.rs
+++ b/server/websocket/src/storage/gcs/mod.rs
@@ -265,7 +265,7 @@ impl KVStore for GcsStore {
     }
 
     async fn batch_upsert(&self, entries: &[(&[u8], &[u8])]) -> Result<(), Self::Error> {
-        const BATCH_SIZE: usize = 100;
+        const BATCH_SIZE: usize = 2;
         const BATCH_TIMEOUT: Duration = Duration::from_secs(1);
 
         let mut current_batch = Vec::new();


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented a buffering mechanism for temporarily holding updates until disconnection, with a manual flush option.
  - Introduced batch processing for update operations, enhancing efficiency and reducing delays.

- **Bug Fixes**
  - Improved error handling for cloud storage verification, leading to more reliable error reporting and system stability.
  - Enhanced connection cleanup to ensure pending updates are safely processed before termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->