### PR TITLE
fix(ui): hide file upload from project-based deployments

### DIFF
--- a/ui/src/features/WorkspaceDeployments/components/DeploymentEditDialog/index.tsx
+++ b/ui/src/features/WorkspaceDeployments/components/DeploymentEditDialog/index.tsx
@@ -40,21 +40,23 @@ const DeploymentEditDialog: React.FC<Props> = ({
       <DialogContent size="sm">
         <DialogTitle>{t("Edit Deployment")}</DialogTitle>
         <DialogContentWrapper>
-          <DialogContentSection className="flex flex-col">
-            <Label>{t("Workflow file: ")}</Label>
-            <Input
-              type="file"
-              accept={ALLOWED_WORKFLOW_FILE_EXTENSIONS}
-              onChange={handleWorkflowFileUpload}
-            />
-            {invalidFile && (
-              <p className="text-xs text-red-500 dark:text-red-400">
-                {t(
-                  "There is a problem with file you tried to upload. Please verify its contents and try again.",
-                )}
-              </p>
-            )}
-          </DialogContentSection>
+          {!selectedDeployment.projectName && (
+            <DialogContentSection className="flex flex-col">
+              <Label>{t("Workflow file: ")}</Label>
+              <Input
+                type="file"
+                accept={ALLOWED_WORKFLOW_FILE_EXTENSIONS}
+                onChange={handleWorkflowFileUpload}
+              />
+              {invalidFile && (
+                <p className="text-xs text-red-500 dark:text-red-400">
+                  {t(
+                    "There is a problem with file you tried to upload. Please verify its contents and try again.",
+                  )}
+                </p>
+              )}
+            </DialogContentSection>
+          )}
           <div className="border-b border-primary text-center" />
           <DialogContentSection className="flex flex-col">
             <Label>{t("Description")}</Label>


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the deployment workflow so that the file upload option for workflow files now appears only when no project name is assigned, ensuring a more relevant and streamlined user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->