### PR TITLE
feat(websocket): implement graceful shutdown with sufficient time for YDoc saving[FLOW-BE-92]

### DIFF
--- a/server/websocket/src/bin/websocket.rs
+++ b/server/websocket/src/bin/websocket.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use tracing::error;
+use uuid::Uuid;
 use websocket::{
     conf::Config, pool::BroadcastPool, server::start_server, storage::gcs::GcsStore,
     storage::redis::RedisStore, AppState,
@@ -58,6 +59,9 @@ async fn main() {
     let pool = Arc::new(BroadcastPool::new(store, redis_store));
     tracing::info!("Broadcast pool initialized");
 
+    let instance_id = Uuid::new_v4().to_string();
+    tracing::info!("Generated instance ID: {}", instance_id);
+
     let state = Arc::new({
         #[cfg(feature = "auth")]
         {
@@ -69,11 +73,15 @@ async fn main() {
                 }
             };
             tracing::info!("Auth service initialized");
-            AppState { pool, auth }
+            AppState {
+                pool,
+                auth,
+                instance_id,
+            }
         }
         #[cfg(not(feature = "auth"))]
         {
-            AppState { pool }
+            AppState { pool, instance_id }
         }
     });
 

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -611,7 +611,7 @@ impl BroadcastGroup {
         redis_store: Option<&Arc<RedisStore>>,
         doc_name: Option<&String>,
         redis_ttl: Option<usize>,
-        gcs_store: Option<&Arc<GcsStore>>,
+        _gcs_store: Option<&Arc<GcsStore>>,
     ) -> Result<Option<Message>, Error> {
         match msg {
             Message::Sync(msg) => {

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -805,6 +805,8 @@ impl Subscription {
             let _ = sync_complete.await;
         }
 
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
         let res = select! {
             r1 = self.sink_task => r1,
             r2 = self.stream_task => r2,

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -647,57 +647,6 @@ impl BroadcastGroup {
                         let awareness = awareness.write().await;
                         let decoded_update = Update::decode_v1(&update)?;
 
-                        // {
-                        //     let doc = awareness.doc();
-                        //     let mut txn = doc.transact_mut();
-                        //     if let Some(workflows) = txn.get_array("workflows") {
-                        //         let len = workflows.len(&txn);
-                        //         match len {
-                        //             0 => (),
-                        //             1 => {
-                        //                 if let (Some(store), Some(doc_name)) = (gcs_store, doc_name)
-                        //                 {
-                        //                     let state_vector = StateVector::default();
-                        //                     let full_update =
-                        //                         txn.encode_state_as_update_v1(&state_vector);
-                        //                     let store_clone = store.clone();
-                        //                     let doc_name_clone = doc_name.clone();
-
-                        //                     if let Some(redis_store) = redis_store {
-                        //                         let rs = redis_store.clone();
-                        //                         let dn = doc_name.clone();
-                        //                         tokio::spawn(async move {
-                        //                             if let Err(e) =
-                        //                                 rs.clear_pending_updates(&dn).await
-                        //                             {
-                        //                                 tracing::warn!(
-                        //                                     "Failed to clear Redis updates: {}",
-                        //                                     e
-                        //                                 );
-                        //                             }
-                        //                         });
-                        //                     }
-
-                        //                     tokio::spawn(async move {
-                        //                         if let Err(e) = store_clone
-                        //                             .push_update(&doc_name_clone, &full_update)
-                        //                             .await
-                        //                         {
-                        //                             tracing::error!("Failed to save initial workflow to GCS: {}", e);
-                        //                         } else {
-                        //                             tracing::info!("Successfully saved initial workflow to GCS");
-                        //                         }
-                        //                     });
-                        //                 }
-                        //             }
-                        //             n => {
-                        //                 tracing::warn!("Found {} workflows, cleaning up extras", n);
-                        //                 workflows.remove_range(&mut txn, 1, n - 1);
-                        //             }
-                        //         }
-                        //     }
-                        // }
-
                         protocol.handle_sync_step2(&awareness, decoded_update)
                     }
                     SyncMessage::Update(update) => {

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -22,7 +22,6 @@ use yrs::sync::protocol::{MSG_SYNC, MSG_SYNC_UPDATE};
 use yrs::sync::{DefaultProtocol, Error, Message, Protocol, SyncMessage};
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1};
-use yrs::Array;
 use yrs::{Doc, ReadTxn, StateVector, Transact, Update};
 const MSG_SYNC_STEP1: u8 = 0;
 const MSG_SYNC_STEP2: u8 = 1;
@@ -94,6 +93,8 @@ impl BroadcastGroup {
             let doc_name_clone = doc_name.clone();
             let redis_store = self.redis_store.clone();
             let pending_updates = self.pending_updates.clone();
+            let shutdown_flag = Arc::new(AtomicBool::new(false));
+            let shutdown_flag_clone = shutdown_flag.clone();
 
             tokio::spawn(async move {
                 let updates = {
@@ -136,18 +137,27 @@ impl BroadcastGroup {
                                         );
                                     }
 
+                                    shutdown_flag_clone
+                                        .store(true, std::sync::atomic::Ordering::SeqCst);
                                     return;
                                 }
-                                Ok(_) => return,
+                                Ok(_) => {
+                                    shutdown_flag_clone
+                                        .store(true, std::sync::atomic::Ordering::SeqCst);
+                                    return;
+                                }
                                 Err(e) => {
                                     tracing::warn!(
                                         "Failed to load pending updates from Redis: {}",
                                         e
                                     );
+                                    shutdown_flag_clone
+                                        .store(true, std::sync::atomic::Ordering::SeqCst);
                                     return;
                                 }
                             };
                         }
+                        shutdown_flag_clone.store(true, std::sync::atomic::Ordering::SeqCst);
                         return;
                     }
                     std::mem::take(&mut *pending)
@@ -176,6 +186,17 @@ impl BroadcastGroup {
                     if let Err(e) = redis_store.clear_pending_updates(&doc_name_clone).await {
                         tracing::warn!("Failed to clear pending updates from Redis: {}", e);
                     }
+                }
+
+                shutdown_flag_clone.store(true, std::sync::atomic::Ordering::SeqCst);
+            });
+
+            tokio::spawn(async move {
+                for _ in 0..10 {
+                    if shutdown_flag.load(std::sync::atomic::Ordering::SeqCst) {
+                        break;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                 }
             });
         }
@@ -626,56 +647,56 @@ impl BroadcastGroup {
                         let awareness = awareness.write().await;
                         let decoded_update = Update::decode_v1(&update)?;
 
-                        {
-                            let doc = awareness.doc();
-                            let mut txn = doc.transact_mut();
-                            if let Some(workflows) = txn.get_array("workflows") {
-                                let len = workflows.len(&txn);
-                                match len {
-                                    0 => (),
-                                    1 => {
-                                        if let (Some(store), Some(doc_name)) = (gcs_store, doc_name)
-                                        {
-                                            let state_vector = StateVector::default();
-                                            let full_update =
-                                                txn.encode_state_as_update_v1(&state_vector);
-                                            let store_clone = store.clone();
-                                            let doc_name_clone = doc_name.clone();
+                        // {
+                        //     let doc = awareness.doc();
+                        //     let mut txn = doc.transact_mut();
+                        //     if let Some(workflows) = txn.get_array("workflows") {
+                        //         let len = workflows.len(&txn);
+                        //         match len {
+                        //             0 => (),
+                        //             1 => {
+                        //                 if let (Some(store), Some(doc_name)) = (gcs_store, doc_name)
+                        //                 {
+                        //                     let state_vector = StateVector::default();
+                        //                     let full_update =
+                        //                         txn.encode_state_as_update_v1(&state_vector);
+                        //                     let store_clone = store.clone();
+                        //                     let doc_name_clone = doc_name.clone();
 
-                                            if let Some(redis_store) = redis_store {
-                                                let rs = redis_store.clone();
-                                                let dn = doc_name.clone();
-                                                tokio::spawn(async move {
-                                                    if let Err(e) =
-                                                        rs.clear_pending_updates(&dn).await
-                                                    {
-                                                        tracing::warn!(
-                                                            "Failed to clear Redis updates: {}",
-                                                            e
-                                                        );
-                                                    }
-                                                });
-                                            }
+                        //                     if let Some(redis_store) = redis_store {
+                        //                         let rs = redis_store.clone();
+                        //                         let dn = doc_name.clone();
+                        //                         tokio::spawn(async move {
+                        //                             if let Err(e) =
+                        //                                 rs.clear_pending_updates(&dn).await
+                        //                             {
+                        //                                 tracing::warn!(
+                        //                                     "Failed to clear Redis updates: {}",
+                        //                                     e
+                        //                                 );
+                        //                             }
+                        //                         });
+                        //                     }
 
-                                            tokio::spawn(async move {
-                                                if let Err(e) = store_clone
-                                                    .push_update(&doc_name_clone, &full_update)
-                                                    .await
-                                                {
-                                                    tracing::error!("Failed to save initial workflow to GCS: {}", e);
-                                                } else {
-                                                    tracing::info!("Successfully saved initial workflow to GCS");
-                                                }
-                                            });
-                                        }
-                                    }
-                                    n => {
-                                        tracing::warn!("Found {} workflows, cleaning up extras", n);
-                                        workflows.remove_range(&mut txn, 1, n - 1);
-                                    }
-                                }
-                            }
-                        }
+                        //                     tokio::spawn(async move {
+                        //                         if let Err(e) = store_clone
+                        //                             .push_update(&doc_name_clone, &full_update)
+                        //                             .await
+                        //                         {
+                        //                             tracing::error!("Failed to save initial workflow to GCS: {}", e);
+                        //                         } else {
+                        //                             tracing::info!("Successfully saved initial workflow to GCS");
+                        //                         }
+                        //                     });
+                        //                 }
+                        //             }
+                        //             n => {
+                        //                 tracing::warn!("Found {} workflows, cleaning up extras", n);
+                        //                 workflows.remove_range(&mut txn, 1, n - 1);
+                        //             }
+                        //         }
+                        //     }
+                        // }
 
                         protocol.handle_sync_step2(&awareness, decoded_update)
                     }
@@ -761,6 +782,66 @@ impl BroadcastGroup {
             }
         }
     }
+
+    pub async fn shutdown(&self) -> Result<()> {
+        self.shutdown_complete
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        if let (Some(store), Some(doc_name)) = (&self.storage, &self.doc_name) {
+            let pending_updates = {
+                let mut guard = self.pending_updates.lock().await;
+                if guard.is_empty() {
+                    Vec::new()
+                } else {
+                    std::mem::take(&mut *guard)
+                }
+            };
+
+            if !pending_updates.is_empty() {
+                tracing::info!(
+                    "Flushing {} pending updates for document '{}'",
+                    pending_updates.len(),
+                    doc_name
+                );
+
+                let doc = Doc::new();
+                let mut txn = doc.transact_mut();
+
+                let mut has_updates = false;
+                for update in pending_updates.iter() {
+                    if let Ok(decoded) = Update::decode_v1(update) {
+                        if txn.apply_update(decoded).is_ok() {
+                            has_updates = true;
+                        }
+                    }
+                }
+
+                if has_updates {
+                    let state_vector = StateVector::default();
+                    let merged_update = txn.encode_state_as_update_v1(&state_vector);
+
+                    if let Err(e) = store.push_update(doc_name, &merged_update).await {
+                        tracing::error!(
+                            "Failed to flush updates for document '{}': {}",
+                            doc_name,
+                            e
+                        );
+                        return Err(anyhow!("Failed to flush updates: {}", e));
+                    }
+
+                    tracing::info!("Successfully flushed updates for document '{}'", doc_name);
+                }
+            }
+
+            if let Some(redis_store) = &self.redis_store {
+                if let Err(e) = redis_store.clear_pending_updates(doc_name).await {
+                    tracing::warn!("Failed to clear pending updates from Redis: {}", e);
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl Drop for BroadcastGroup {
@@ -779,14 +860,22 @@ impl Drop for BroadcastGroup {
 
         self.awareness_updater.abort();
 
-        if !self
-            .shutdown_complete
-            .load(std::sync::atomic::Ordering::SeqCst)
-        {
-            if let (Some(_store), Some(doc_name)) = (&self.storage, &self.doc_name) {
+        self.shutdown_complete
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        if let (Some(_store), Some(doc_name)) = (&self.storage, &self.doc_name) {
+            let pending_count = {
+                match self.pending_updates.try_lock() {
+                    Ok(guard) => guard.len(),
+                    Err(_) => 0,
+                }
+            };
+
+            if pending_count > 0 {
                 tracing::warn!(
-                    "Document '{}' may have pending updates that weren't flushed",
-                    doc_name
+                    "Document '{}' may have pending updates that weren't flushed (count: {})",
+                    doc_name,
+                    pending_count
                 );
             }
         }

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -128,15 +128,6 @@ impl BroadcastGroup {
                                         .await;
                                     }
 
-                                    if let Err(e) =
-                                        redis_store.clear_pending_updates(&doc_name_clone).await
-                                    {
-                                        tracing::warn!(
-                                            "Failed to clear pending updates from Redis: {}",
-                                            e
-                                        );
-                                    }
-
                                     shutdown_flag_clone
                                         .store(true, std::sync::atomic::Ordering::SeqCst);
                                     return;

--- a/server/websocket/src/broadcast/pool.rs
+++ b/server/websocket/src/broadcast/pool.rs
@@ -50,34 +50,9 @@ impl BroadcastPool {
     }
 
     pub async fn get_or_create_group(&self, doc_id: &str) -> Result<Arc<BroadcastGroup>> {
-        if let Some(group) = self.groups.get(doc_id) {
-            let group_clone = group.clone();
-            drop(group);
-
-            if let Some(redis_store) = &self.redis_store {
-                if let Ok(has_updates) = redis_store.has_pending_updates(doc_id).await {
-                    if has_updates {
-                        if let Ok(updates) = redis_store.get_pending_updates(doc_id).await {
-                            if !updates.is_empty() {
-                                let _ = self.apply_updates_to_doc(&group_clone, updates).await;
-                            }
-                        }
-                    }
-                }
-            }
-
-            return Ok(group_clone);
-        }
-
         if !self.docs_in_creation.insert(doc_id.to_string()) {
             for delay_ms in [1, 2, 5, 10, 20, 50] {
                 tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
-
-                if let Some(group) = self.groups.get(doc_id) {
-                    let group_clone = group.clone();
-                    drop(group);
-                    return Ok(group_clone);
-                }
 
                 if self.docs_in_creation.insert(doc_id.to_string()) {
                     break;
@@ -117,8 +92,6 @@ impl BroadcastPool {
             }
         }
 
-        let group: Arc<BroadcastGroup>;
-
         let awareness: AwarenessRef = {
             let doc = Doc::new();
             let mut updates_from_redis = Vec::new();
@@ -144,7 +117,7 @@ impl BroadcastPool {
             Arc::new(tokio::sync::RwLock::new(Awareness::new(doc)))
         };
 
-        group = Arc::new(
+        let group = Arc::new(
             BroadcastGroup::with_storage(
                 awareness,
                 self.buffer_capacity,
@@ -158,37 +131,33 @@ impl BroadcastPool {
             .await?,
         );
 
-        if let Some(group) = self.groups.get(doc_id) {
-            return Ok(group.clone());
-        }
-
         self.groups.insert(doc_id.to_string(), group.clone());
 
         Ok(group)
     }
 
-    async fn apply_updates_to_doc(
-        &self,
-        group: &Arc<BroadcastGroup>,
-        updates: Vec<Vec<u8>>,
-    ) -> Result<()> {
-        if updates.is_empty() {
-            return Ok(());
-        }
+    // async fn apply_updates_to_doc(
+    //     &self,
+    //     group: &Arc<BroadcastGroup>,
+    //     updates: Vec<Vec<u8>>,
+    // ) -> Result<()> {
+    //     if updates.is_empty() {
+    //         return Ok(());
+    //     }
 
-        let awareness = group.awareness();
-        let awareness_lock = awareness.read().await;
-        let doc = awareness_lock.doc();
-        let mut txn = doc.transact_mut();
+    //     let awareness = group.awareness();
+    //     let awareness_lock = awareness.read().await;
+    //     let doc = awareness_lock.doc();
+    //     let mut txn = doc.transact_mut();
 
-        for update in &updates {
-            if let Ok(decoded) = yrs::updates::decoder::Decode::decode_v1(update) {
-                let _ = txn.apply_update(decoded);
-            }
-        }
+    //     for update in &updates {
+    //         if let Ok(decoded) = yrs::updates::decoder::Decode::decode_v1(update) {
+    //             let _ = txn.apply_update(decoded);
+    //         }
+    //     }
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
     pub async fn cleanup_empty_groups(&self) {
         self.groups.retain(|_, group| {

--- a/server/websocket/src/broadcast/pool.rs
+++ b/server/websocket/src/broadcast/pool.rs
@@ -49,10 +49,38 @@ impl BroadcastPool {
         self.store.clone()
     }
 
+    pub fn get_redis_store(&self) -> Option<Arc<RedisStore>> {
+        self.redis_store.clone()
+    }
+
     pub async fn get_or_create_group(&self, doc_id: &str) -> Result<Arc<BroadcastGroup>> {
+        if let Some(group) = self.groups.get(doc_id) {
+            let group_clone = group.clone();
+            drop(group);
+
+            if let Some(redis_store) = &self.redis_store {
+                if let Ok(has_updates) = redis_store.has_pending_updates(doc_id).await {
+                    if has_updates {
+                        if let Ok(updates) = redis_store.get_pending_updates(doc_id).await {
+                            if !updates.is_empty() {
+                                let _ = self.apply_updates_to_doc(&group_clone, updates).await;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return Ok(group_clone);
+        }
         if !self.docs_in_creation.insert(doc_id.to_string()) {
             for delay_ms in [1, 2, 5, 10, 20, 50] {
                 tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+
+                if let Some(group) = self.groups.get(doc_id) {
+                    let group_clone = group.clone();
+                    drop(group);
+                    return Ok(group_clone);
+                }
 
                 if self.docs_in_creation.insert(doc_id.to_string()) {
                     break;
@@ -92,6 +120,8 @@ impl BroadcastPool {
             }
         }
 
+        let group: Arc<BroadcastGroup>;
+
         let awareness: AwarenessRef = {
             let doc = Doc::new();
             let mut updates_from_redis = Vec::new();
@@ -117,7 +147,7 @@ impl BroadcastPool {
             Arc::new(tokio::sync::RwLock::new(Awareness::new(doc)))
         };
 
-        let group = Arc::new(
+        group = Arc::new(
             BroadcastGroup::with_storage(
                 awareness,
                 self.buffer_capacity,
@@ -131,33 +161,37 @@ impl BroadcastPool {
             .await?,
         );
 
+        if let Some(group) = self.groups.get(doc_id) {
+            return Ok(group.clone());
+        }
+
         self.groups.insert(doc_id.to_string(), group.clone());
 
         Ok(group)
     }
 
-    // async fn apply_updates_to_doc(
-    //     &self,
-    //     group: &Arc<BroadcastGroup>,
-    //     updates: Vec<Vec<u8>>,
-    // ) -> Result<()> {
-    //     if updates.is_empty() {
-    //         return Ok(());
-    //     }
+    async fn apply_updates_to_doc(
+        &self,
+        group: &Arc<BroadcastGroup>,
+        updates: Vec<Vec<u8>>,
+    ) -> Result<()> {
+        if updates.is_empty() {
+            return Ok(());
+        }
 
-    //     let awareness = group.awareness();
-    //     let awareness_lock = awareness.read().await;
-    //     let doc = awareness_lock.doc();
-    //     let mut txn = doc.transact_mut();
+        let awareness = group.awareness();
+        let awareness_lock = awareness.read().await;
+        let doc = awareness_lock.doc();
+        let mut txn = doc.transact_mut();
 
-    //     for update in &updates {
-    //         if let Ok(decoded) = yrs::updates::decoder::Decode::decode_v1(update) {
-    //             let _ = txn.apply_update(decoded);
-    //         }
-    //     }
+        for update in &updates {
+            if let Ok(decoded) = yrs::updates::decoder::Decode::decode_v1(update) {
+                let _ = txn.apply_update(decoded);
+            }
+        }
 
-    //     Ok(())
-    // }
+        Ok(())
+    }
 
     pub async fn cleanup_empty_groups(&self) {
         self.groups.retain(|_, group| {
@@ -166,12 +200,37 @@ impl BroadcastPool {
         });
     }
 
-    pub async fn remove_connection(&self, doc_id: &str) {
+    pub async fn remove_connection(&self, doc_id: &str, instance_id: &str) {
         if let Some(group) = self.groups.get(doc_id) {
             let group_clone = group.clone();
             let remaining = group.decrement_connections();
 
             if remaining == 0 && group_clone.connection_count() == 0 {
+                if let Some(redis_store) = &self.redis_store {
+                    if let Err(e) = redis_store.release_doc_instance(doc_id, instance_id).await {
+                        tracing::warn!(
+                            "Failed to release document instance registration for '{}': {}",
+                            doc_id,
+                            e
+                        );
+                    } else {
+                        tracing::info!("Released document instance registration for '{}'", doc_id);
+                    }
+                }
+
+                if let Err(e) = group_clone.shutdown().await {
+                    tracing::warn!(
+                        "Failed to shutdown broadcast group for document '{}': {}",
+                        doc_id,
+                        e
+                    );
+                } else {
+                    tracing::info!(
+                        "Successfully shutdown broadcast group for document '{}'",
+                        doc_id
+                    );
+                }
+
                 self.groups.remove(doc_id);
             }
         }

--- a/server/websocket/src/lib.rs
+++ b/server/websocket/src/lib.rs
@@ -41,12 +41,14 @@ pub struct RollbackQuery {
 pub struct AppState {
     pub pool: Arc<BroadcastPool>,
     pub auth: Arc<AuthService>,
+    pub instance_id: String,
 }
 
 #[cfg(not(feature = "auth"))]
 #[derive(Clone, Debug)]
 pub struct AppState {
     pub pool: Arc<BroadcastPool>,
+    pub instance_id: String,
 }
 
 #[cfg(feature = "auth")]

--- a/server/websocket/src/ws.rs
+++ b/server/websocket/src/ws.rs
@@ -169,6 +169,38 @@ pub async fn ws_handler(
         }
     }
 
+    if let Some(redis_store) = state.pool.get_redis_store() {
+        match redis_store.get_doc_instance(&doc_id).await {
+            Ok(Some(instance_id)) if instance_id != state.instance_id => {
+                tracing::info!(
+                    "Document {} is already being handled by instance {}",
+                    doc_id,
+                    instance_id
+                );
+
+                return ws.on_upgrade(move |mut socket| async move {
+                    let close_frame = axum::extract::ws::CloseFrame {
+                        code: 1012,
+                        reason: format!("instance:{}", instance_id).into(),
+                    };
+
+                    let _ = socket.send(Message::Close(Some(close_frame))).await;
+                });
+            }
+            Ok(_) => {
+                if let Err(e) = redis_store
+                    .register_doc_instance(&doc_id, &state.instance_id, 60)
+                    .await
+                {
+                    tracing::warn!("Failed to register instance for document {}: {}", doc_id, e);
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to check document instance: {}", e);
+            }
+        }
+    }
+
     let bcast = match state.pool.get_or_create_group(&doc_id).await {
         Ok(group) => group,
         Err(e) => {
@@ -180,8 +212,38 @@ pub async fn ws_handler(
         }
     };
 
+    if let Some(redis_store) = state.pool.get_redis_store() {
+        let redis_store_clone = redis_store.clone();
+        let doc_id_clone = doc_id.clone();
+        let instance_id = state.instance_id.clone();
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(30));
+            loop {
+                interval.tick().await;
+                if let Err(e) = redis_store_clone
+                    .refresh_doc_instance(&doc_id_clone, &instance_id, 60)
+                    .await
+                {
+                    tracing::warn!(
+                        "Failed to refresh instance registration for document {}: {}",
+                        doc_id_clone,
+                        e
+                    );
+                }
+            }
+        });
+    }
+
     ws.on_upgrade(move |socket| {
-        handle_socket(socket, bcast, doc_id, state.pool.clone(), user_token)
+        handle_socket(
+            socket,
+            bcast,
+            doc_id,
+            state.pool.clone(),
+            user_token,
+            state.instance_id.clone(),
+        )
     })
 }
 
@@ -191,6 +253,7 @@ async fn handle_socket(
     doc_id: String,
     pool: Arc<BroadcastPool>,
     user_token: Option<String>,
+    instance_id: String,
 ) {
     let (sender, receiver) = socket.split();
 
@@ -206,7 +269,7 @@ async fn handle_socket(
     if let Err(e) = result {
         tracing::error!("WebSocket connection error: {}", e);
     }
-    pool.remove_connection(&doc_id).await;
+    pool.remove_connection(&doc_id, &instance_id).await;
 }
 
 fn normalize_doc_id(doc_id: &str) -> String {

--- a/ui/src/features/Editor/hooks.ts
+++ b/ui/src/features/Editor/hooks.ts
@@ -260,7 +260,7 @@ export default ({
     //   callback: () => handleYWorkflowAddFromSelection(nodes, edges),
     // },
   ]);
-
+  console.log(yWorkflows.length);
   return {
     currentWorkflowId,
     openWorkflows,


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a consistent session identifier for WebSocket connections to enhance state management.
  - Improved document instance registration with periodic refresh, ensuring smoother connection handling.
  - Added a graceful shutdown process that safely processes pending updates before termination.
  - Enhanced RedisStore functionality with new methods for managing document instances.
  - Added the ability to retrieve the Redis store associated with the BroadcastPool.
  - Implemented logging of the number of workflows available in the Editor feature.

- **Bug Fixes**
  - Improved connection handling logic to ensure graceful termination tasks are executed properly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->