### PR TITLE
feat(engine): Ensure cleanup call is executed in both success and failure cases in command.rs [FLOW-BE-94]

### DIFF
--- a/engine/worker/src/command.rs
+++ b/engine/worker/src/command.rs
@@ -171,7 +171,6 @@ impl RunWorkerCommand {
         let job_result = match result {
             Ok(_) => {
                 if node_failure_handler.all_success() {
-                    self.cleanup(&meta, &storage_resolver).await?;
                     JobResult::Success
                 } else {
                     tracing::error!("Failed nodes: {:?}", node_failure_handler.failed_nodes());
@@ -180,6 +179,7 @@ impl RunWorkerCommand {
             }
             Err(_) => JobResult::Failed,
         };
+        self.cleanup(&meta, &storage_resolver).await?;
         let pubsub = PubSubBackend::try_from(self.pubsub_backend.as_str())
             .await
             .map_err(crate::errors::Error::init)?;


### PR DESCRIPTION
# Overview
This pull request includes changes to the `engine/worker/src/command.rs` file to adjust the cleanup process in the `RunWorkerCommand` implementation. The most important changes involve moving the cleanup call to ensure it is always executed regardless of the job result.

Changes to cleanup process:

* [`engine/worker/src/command.rs`](diffhunk://#diff-b76379618575e6337dfe5e8e3653b74bde84b2d8a8ad9836ae52da1afdf7fac9L174): Removed the call to `self.cleanup(&meta, &storage_resolver).await?` from within the success condition of the job result match block.
* [`engine/worker/src/command.rs`](diffhunk://#diff-b76379618575e6337dfe5e8e3653b74bde84b2d8a8ad9836ae52da1afdf7fac9R182): Added the call to `self.cleanup(&meta, &storage_resolver).await?` after determining the job result, ensuring it runs regardless of the job outcome.
## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated system behavior to ensure that cleanup tasks are executed following every job process, regardless of outcome. This change promotes smoother operation, enhanced stability, and reduces issues that could arise from conditional cleanup execution, contributing to a more consistent overall experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->