### PR TITLE
refactor(websocket): adjust buffer capacity and improve document hand…

### DIFF
--- a/server/websocket/src/broadcast/pool.rs
+++ b/server/websocket/src/broadcast/pool.rs
@@ -25,7 +25,7 @@ impl BroadcastPool {
             store,
             redis_store,
             groups: DashMap::new(),
-            buffer_capacity: 512,
+            buffer_capacity: 256,
             docs_in_creation: DashSet::new(),
         }
     }
@@ -148,7 +148,7 @@ impl BroadcastPool {
             let awareness_clone = awareness.clone();
 
             tokio::spawn(async move {
-                tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
                 let awareness_guard = awareness_clone.read().await;
                 let doc = awareness_guard.doc();

--- a/server/websocket/src/doc/handler.rs
+++ b/server/websocket/src/doc/handler.rs
@@ -14,20 +14,7 @@ use crate::thrift::document::{
     RollbackRequest, RollbackResponse,
 };
 
-#[derive(Debug, Clone)]
-struct Document {
-    pub id: String,
-    pub updates: Vec<u8>,
-    pub version: u64,
-    pub timestamp: chrono::DateTime<chrono::Utc>,
-}
-
-#[derive(Debug, Clone)]
-struct HistoryItem {
-    pub version: u64,
-    pub updates: Vec<u8>,
-    pub timestamp: chrono::DateTime<chrono::Utc>,
-}
+use crate::doc::types::{Document, HistoryItem};
 
 pub struct DocumentHandler {
     storage: Arc<GcsStore>,

--- a/server/websocket/src/doc/mod.rs
+++ b/server/websocket/src/doc/mod.rs
@@ -1,3 +1,4 @@
 mod handler;
+mod types;
 
 pub use handler::DocumentHandler;

--- a/server/websocket/src/doc/types.rs
+++ b/server/websocket/src/doc/types.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Clone)]
-struct Document {
+pub struct Document {
     pub id: String,
     pub updates: Vec<u8>,
     pub version: u64,
@@ -7,13 +7,8 @@ struct Document {
 }
 
 #[derive(Debug, Clone)]
-struct HistoryItem {
+pub struct HistoryItem {
     pub version: u64,
     pub updates: Vec<u8>,
     pub timestamp: chrono::DateTime<chrono::Utc>,
-}
-
-pub struct DocumentHandler {
-    storage: Arc<GcsStore>,
-    runtime: Handle,
 }


### PR DESCRIPTION
…ling timing

* Reduced buffer capacity in BroadcastPool from 512 to 256.
* Decreased sleep duration in document awareness handling from 2 seconds to 1 second.
* Moved Document and HistoryItem structs to a new types module for better organization.

# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized real-time update operations by fine-tuning asynchronous processes for a more responsive experience.
  - Streamlined document handling by consolidating core data definitions, ensuring consistent and efficient tracking of document states and history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->