### PR TITLE
fix(ui): removed tempYDoc

### DIFF
--- a/ui/src/features/Editor/components/RightPanel/components/VersionHistory/hooks.ts
+++ b/ui/src/features/Editor/components/RightPanel/components/VersionHistory/hooks.ts
@@ -83,11 +83,8 @@ export default ({
 
       const convertedUpdates = new Uint8Array(updates);
 
-      const tempYDoc = new Y.Doc();
-      Y.applyUpdate(tempYDoc, convertedUpdates);
-
       const getMetadata = (key: string): "Text" | "Map" | "Array" => {
-        const sharedType = tempYDoc.share.get(key);
+        const sharedType = yDoc.share.get(key);
         if (sharedType instanceof Y.Text) return "Text";
         if (sharedType instanceof Y.Map) return "Map";
         if (sharedType instanceof Y.Array) return "Array";
@@ -104,7 +101,6 @@ export default ({
       console.error("Project Rollback Failed:", error);
     }
     setIsReverting(false);
-    // setOpenVersionChangeDialog(false);
   }, [
     selectedProjectSnapshotVersion,
     useRollbackProject,


### PR DESCRIPTION
# Overview
Refactor versioning logic to see if it can be simplified. 
## What I've done
Removed the tempYDoc from outside the function as it is not needed as we can get the sharedTypes from the current yDoc
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the project rollback process to enhance efficiency and reliability when recovering previous versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->