### PR TITLE
fix(api): deployment deletion now removes only specified deployment[FLOW-BE-26]

### DIFF
--- a/server/api/internal/usecase/interactor/deployment.go
+++ b/server/api/internal/usecase/interactor/deployment.go
@@ -268,21 +268,14 @@ func (i *Deployment) Delete(ctx context.Context, deploymentID id.DeploymentID) (
 		return err
 	}
 
-	versions, err := i.deploymentRepo.FindVersions(ctx, dep.Workspace(), dep.Project())
-	if err != nil {
-		return err
-	}
-
-	for _, version := range versions {
-		if url, _ := url.Parse(version.WorkflowURL()); url != nil {
-			if err := i.file.RemoveWorkflow(ctx, url); err != nil {
-				return err
-			}
-		}
-
-		if err := i.deploymentRepo.Remove(ctx, version.ID()); err != nil {
+	if url, _ := url.Parse(dep.WorkflowURL()); url != nil {
+		if err := i.file.RemoveWorkflow(ctx, url); err != nil {
 			return err
 		}
+	}
+
+	if err := i.deploymentRepo.Remove(ctx, deploymentID); err != nil {
+		return err
 	}
 
 	tx.Commit()

--- a/server/api/internal/usecase/interactor/deployment.go
+++ b/server/api/internal/usecase/interactor/deployment.go
@@ -268,14 +268,33 @@ func (i *Deployment) Delete(ctx context.Context, deploymentID id.DeploymentID) (
 		return err
 	}
 
-	if url, _ := url.Parse(dep.WorkflowURL()); url != nil {
-		if err := i.file.RemoveWorkflow(ctx, url); err != nil {
+	if dep.Project() != nil {
+		versions, err := i.deploymentRepo.FindVersions(ctx, dep.Workspace(), dep.Project())
+		if err != nil {
 			return err
 		}
-	}
 
-	if err := i.deploymentRepo.Remove(ctx, deploymentID); err != nil {
-		return err
+		for _, version := range versions {
+			if url, _ := url.Parse(version.WorkflowURL()); url != nil {
+				if err := i.file.RemoveWorkflow(ctx, url); err != nil {
+					return err
+				}
+			}
+
+			if err := i.deploymentRepo.Remove(ctx, version.ID()); err != nil {
+				return err
+			}
+		}
+	} else {
+		if url, _ := url.Parse(dep.WorkflowURL()); url != nil {
+			if err := i.file.RemoveWorkflow(ctx, url); err != nil {
+				return err
+			}
+		}
+
+		if err := i.deploymentRepo.Remove(ctx, deploymentID); err != nil {
+			return err
+		}
 	}
 
 	tx.Commit()


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the deployment deletion process, now directly handling the associated workflow. This update simplifies operations and improves efficiency without impacting user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->