### PR TITLE
feat(api): implement project snapshot query and add flush to gcs api[FLOW-BE-117]

### DIFF
--- a/server/api/e2e/gql_document_test.go
+++ b/server/api/e2e/gql_document_test.go
@@ -122,7 +122,6 @@ func documentTestInterceptor(next http.Handler) http.Handler {
 				historyResp := make([]map[string]any, len(history))
 				for i, h := range history {
 					historyResp[i] = map[string]any{
-						"updates":   h.Updates,
 						"version":   h.Version,
 						"timestamp": h.Timestamp,
 					}
@@ -141,24 +140,37 @@ func documentTestInterceptor(next http.Handler) http.Handler {
 				}
 				return
 
-			} else if isProjectHistoryMetadataQuery(gqlRequest.Query) {
-				projectID, ok := getProjectIDFromVariables(gqlRequest.Variables)
+			} else if isProjectSnapshotQuery(gqlRequest.Query) {
+				projectID, version, ok := getProjectIDAndVersionFromVariables(gqlRequest.Variables)
 				if !ok || projectID != docPId.String() {
-					http.Error(w, "Invalid project ID", http.StatusBadRequest)
+					http.Error(w, "Invalid project ID or version", http.StatusBadRequest)
 					return
 				}
 
-				metadataResp := make([]map[string]any, len(history))
-				for i, h := range history {
-					metadataResp[i] = map[string]any{
-						"version":   h.Version,
-						"timestamp": h.Timestamp,
+				var targetVersion *ws.History
+				for _, h := range history {
+					if int(h.Version) == version {
+						targetVersion = h
+						break
 					}
+				}
+
+				if targetVersion == nil {
+					http.Error(w, "Version not found", http.StatusBadRequest)
+					return
+				}
+
+				snapshotResp := []map[string]any{
+					{
+						"updates":   targetVersion.Updates,
+						"version":   targetVersion.Version,
+						"timestamp": targetVersion.Timestamp,
+					},
 				}
 
 				resp := map[string]any{
 					"data": map[string]any{
-						"projectHistoryMetadata": metadataResp,
+						"projectSnapshot": snapshotResp,
 					},
 				}
 				w.Header().Set("Content-Type", "application/json")
@@ -211,11 +223,11 @@ func isLatestProjectSnapshotQuery(query string) bool {
 }
 
 func isProjectHistoryQuery(query string) bool {
-	return strings.Contains(query, "projectHistory") && !strings.Contains(query, "projectHistoryMetadata")
+	return strings.Contains(query, "projectHistory") && !strings.Contains(query, "projectSnapshot")
 }
 
-func isProjectHistoryMetadataQuery(query string) bool {
-	return strings.Contains(query, "projectHistoryMetadata")
+func isProjectSnapshotQuery(query string) bool {
+	return strings.Contains(query, "projectSnapshot")
 }
 
 func isRollbackProjectMutation(query string) bool {
@@ -272,9 +284,9 @@ func TestDocumentOperations(t *testing.T) {
 
 	testLatestProjectSnapshot(t, testClient, docPId.String())
 
-	testProjectHistory(t, testClient, docPId.String())
+	testProjectSnapshot(t, testClient, docPId.String(), 2)
 
-	testProjectHistoryMetadata(t, testClient, docPId.String())
+	testProjectHistory(t, testClient, docPId.String())
 
 	testRollbackProject(t, testClient, docPId.String(), 1)
 }
@@ -340,12 +352,73 @@ func testLatestProjectSnapshot(t *testing.T, e *httpexpect.Expect, projectId str
 	}
 }
 
-func testProjectHistory(t *testing.T, e *httpexpect.Expect, projectId string) {
-	query := `query($projectId: ID!) {
-		projectHistory(projectId: $projectId) {
+func testProjectSnapshot(t *testing.T, e *httpexpect.Expect, projectId string, version int) {
+	query := `query($projectId: ID!, $version: Int!) {
+		projectSnapshot(projectId: $projectId, version: $version) {
 			timestamp
 			updates
 			version
+		}
+	}`
+
+	variables := fmt.Sprintf(`{
+		"projectId": "%s",
+		"version": %d
+	}`, projectId, version)
+
+	var variablesMap map[string]any
+	err := json.Unmarshal([]byte(variables), &variablesMap)
+	assert.NoError(t, err)
+
+	request := GraphQLRequest{
+		Query:     query,
+		Variables: variablesMap,
+	}
+	jsonData, err := json.Marshal(request)
+	assert.NoError(t, err)
+
+	resp := e.POST("/api/graphql").
+		WithHeader("authorization", "Bearer test").
+		WithHeader("Content-Type", "application/json").
+		WithHeader("X-Reearth-Debug-User", docUId.String()).
+		WithBytes(jsonData).
+		Expect().Status(http.StatusOK)
+
+	var result struct {
+		Data struct {
+			ProjectSnapshot []struct {
+				Timestamp time.Time `json:"timestamp"`
+				Updates   []int     `json:"updates"`
+				Version   int       `json:"version"`
+			} `json:"projectSnapshot"`
+		} `json:"data"`
+		Errors []map[string]interface{} `json:"errors"`
+	}
+
+	err = json.Unmarshal([]byte(resp.Body().Raw()), &result)
+	assert.NoError(t, err)
+
+	if len(result.Errors) > 0 {
+		t.Fatalf("GraphQL errors: %v", result.Errors)
+	}
+
+	snapshots := result.Data.ProjectSnapshot
+	assert.NotNil(t, snapshots, "snapshots should not be nil")
+	assert.Equal(t, 1, len(snapshots), "should return 1 snapshot")
+
+	if len(snapshots) > 0 {
+		snapshot := snapshots[0]
+		assert.Equal(t, version, snapshot.Version)
+		assert.Equal(t, []int{1, 2, 3}, snapshot.Updates)
+		assert.WithinDuration(t, time.Date(2023, 1, 20, 14, 0, 0, 0, time.UTC), snapshot.Timestamp, time.Second)
+	}
+}
+
+func testProjectHistory(t *testing.T, e *httpexpect.Expect, projectId string) {
+	query := `query($projectId: ID!) {
+		projectHistory(projectId: $projectId) {
+			version
+			timestamp
 		}
 	}`
 
@@ -374,9 +447,8 @@ func testProjectHistory(t *testing.T, e *httpexpect.Expect, projectId string) {
 	var result struct {
 		Data struct {
 			ProjectHistory []struct {
-				Timestamp time.Time `json:"timestamp"`
-				Updates   []int     `json:"updates"`
 				Version   int       `json:"version"`
+				Timestamp time.Time `json:"timestamp"`
 			} `json:"projectHistory"`
 		} `json:"data"`
 		Errors []map[string]interface{} `json:"errors"`
@@ -395,15 +467,12 @@ func testProjectHistory(t *testing.T, e *httpexpect.Expect, projectId string) {
 
 	if len(history) >= 3 {
 		assert.Equal(t, 1, history[0].Version)
-		assert.Equal(t, []int{1}, history[0].Updates)
 		assert.WithinDuration(t, time.Date(2023, 1, 15, 9, 0, 0, 0, time.UTC), history[0].Timestamp, time.Second)
 
 		assert.Equal(t, 2, history[1].Version)
-		assert.Equal(t, []int{1, 2, 3}, history[1].Updates)
 		assert.WithinDuration(t, time.Date(2023, 1, 20, 14, 0, 0, 0, time.UTC), history[1].Timestamp, time.Second)
 
 		assert.Equal(t, 3, history[2].Version)
-		assert.Equal(t, []int{1, 2, 3, 4, 5}, history[2].Updates)
 		assert.WithinDuration(t, time.Date(2023, 2, 1, 10, 0, 0, 0, time.UTC), history[2].Timestamp, time.Second)
 	}
 }

--- a/server/api/gql/document.graphql
+++ b/server/api/gql/document.graphql
@@ -31,4 +31,5 @@ extend type Query {
 
 extend type Mutation {
   rollbackProject(projectId: ID!, version: Int!): ProjectDocument
+  flushProjectToGcs(projectId: ID!): Boolean
 }

--- a/server/api/gql/document.graphql
+++ b/server/api/gql/document.graphql
@@ -23,8 +23,8 @@ type ProjectSnapshotMetadata {
 
 extend type Query {
   latestProjectSnapshot(projectId: ID!): ProjectDocument
-  projectHistory(projectId: ID!): [ProjectSnapshot!]!
-  projectHistoryMetadata(projectId: ID!): [ProjectSnapshotMetadata!]!
+  projectSnapshot(projectId: ID!, version: Int!): [ProjectSnapshot!]!
+  projectHistory(projectId: ID!): [ProjectSnapshotMetadata!]!
 }
 
 # Mutation

--- a/server/api/internal/adapter/gql/generated.go
+++ b/server/api/internal/adapter/gql/generated.go
@@ -290,25 +290,25 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Assets                 func(childComplexity int, workspaceID gqlmodel.ID, keyword *string, sort *gqlmodel.AssetSortType, pagination gqlmodel.PageBasedPagination) int
-		DeploymentByVersion    func(childComplexity int, input gqlmodel.GetByVersionInput) int
-		DeploymentHead         func(childComplexity int, input gqlmodel.GetHeadInput) int
-		DeploymentVersions     func(childComplexity int, workspaceID gqlmodel.ID, projectID *gqlmodel.ID) int
-		Deployments            func(childComplexity int, workspaceID gqlmodel.ID, pagination gqlmodel.PageBasedPagination) int
-		Job                    func(childComplexity int, id gqlmodel.ID) int
-		Jobs                   func(childComplexity int, workspaceID gqlmodel.ID, pagination gqlmodel.PageBasedPagination) int
-		LatestProjectSnapshot  func(childComplexity int, projectID gqlmodel.ID) int
-		Me                     func(childComplexity int) int
-		Node                   func(childComplexity int, id gqlmodel.ID, typeArg gqlmodel.NodeType) int
-		NodeExecution          func(childComplexity int, jobID gqlmodel.ID, nodeID string) int
-		Nodes                  func(childComplexity int, id []gqlmodel.ID, typeArg gqlmodel.NodeType) int
-		ProjectHistory         func(childComplexity int, projectID gqlmodel.ID) int
-		ProjectHistoryMetadata func(childComplexity int, projectID gqlmodel.ID) int
-		ProjectSharingInfo     func(childComplexity int, projectID gqlmodel.ID) int
-		Projects               func(childComplexity int, workspaceID gqlmodel.ID, includeArchived *bool, pagination gqlmodel.PageBasedPagination) int
-		SearchUser             func(childComplexity int, nameOrEmail string) int
-		SharedProject          func(childComplexity int, token string) int
-		Triggers               func(childComplexity int, workspaceID gqlmodel.ID, pagination gqlmodel.PageBasedPagination) int
+		Assets                func(childComplexity int, workspaceID gqlmodel.ID, keyword *string, sort *gqlmodel.AssetSortType, pagination gqlmodel.PageBasedPagination) int
+		DeploymentByVersion   func(childComplexity int, input gqlmodel.GetByVersionInput) int
+		DeploymentHead        func(childComplexity int, input gqlmodel.GetHeadInput) int
+		DeploymentVersions    func(childComplexity int, workspaceID gqlmodel.ID, projectID *gqlmodel.ID) int
+		Deployments           func(childComplexity int, workspaceID gqlmodel.ID, pagination gqlmodel.PageBasedPagination) int
+		Job                   func(childComplexity int, id gqlmodel.ID) int
+		Jobs                  func(childComplexity int, workspaceID gqlmodel.ID, pagination gqlmodel.PageBasedPagination) int
+		LatestProjectSnapshot func(childComplexity int, projectID gqlmodel.ID) int
+		Me                    func(childComplexity int) int
+		Node                  func(childComplexity int, id gqlmodel.ID, typeArg gqlmodel.NodeType) int
+		NodeExecution         func(childComplexity int, jobID gqlmodel.ID, nodeID string) int
+		Nodes                 func(childComplexity int, id []gqlmodel.ID, typeArg gqlmodel.NodeType) int
+		ProjectHistory        func(childComplexity int, projectID gqlmodel.ID) int
+		ProjectSharingInfo    func(childComplexity int, projectID gqlmodel.ID) int
+		ProjectSnapshot       func(childComplexity int, projectID gqlmodel.ID, version int) int
+		Projects              func(childComplexity int, workspaceID gqlmodel.ID, includeArchived *bool, pagination gqlmodel.PageBasedPagination) int
+		SearchUser            func(childComplexity int, nameOrEmail string) int
+		SharedProject         func(childComplexity int, token string) int
+		Triggers              func(childComplexity int, workspaceID gqlmodel.ID, pagination gqlmodel.PageBasedPagination) int
 	}
 
 	RemoveAssetPayload struct {
@@ -472,8 +472,8 @@ type QueryResolver interface {
 	DeploymentHead(ctx context.Context, input gqlmodel.GetHeadInput) (*gqlmodel.Deployment, error)
 	DeploymentVersions(ctx context.Context, workspaceID gqlmodel.ID, projectID *gqlmodel.ID) ([]*gqlmodel.Deployment, error)
 	LatestProjectSnapshot(ctx context.Context, projectID gqlmodel.ID) (*gqlmodel.ProjectDocument, error)
-	ProjectHistory(ctx context.Context, projectID gqlmodel.ID) ([]*gqlmodel.ProjectSnapshot, error)
-	ProjectHistoryMetadata(ctx context.Context, projectID gqlmodel.ID) ([]*gqlmodel.ProjectSnapshotMetadata, error)
+	ProjectSnapshot(ctx context.Context, projectID gqlmodel.ID, version int) ([]*gqlmodel.ProjectSnapshot, error)
+	ProjectHistory(ctx context.Context, projectID gqlmodel.ID) ([]*gqlmodel.ProjectSnapshotMetadata, error)
 	Jobs(ctx context.Context, workspaceID gqlmodel.ID, pagination gqlmodel.PageBasedPagination) (*gqlmodel.JobConnection, error)
 	Job(ctx context.Context, id gqlmodel.ID) (*gqlmodel.Job, error)
 	NodeExecution(ctx context.Context, jobID gqlmodel.ID, nodeID string) (*gqlmodel.NodeExecution, error)
@@ -1840,18 +1840,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.ProjectHistory(childComplexity, args["projectId"].(gqlmodel.ID)), true
 
-	case "Query.projectHistoryMetadata":
-		if e.complexity.Query.ProjectHistoryMetadata == nil {
-			break
-		}
-
-		args, err := ec.field_Query_projectHistoryMetadata_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.ProjectHistoryMetadata(childComplexity, args["projectId"].(gqlmodel.ID)), true
-
 	case "Query.projectSharingInfo":
 		if e.complexity.Query.ProjectSharingInfo == nil {
 			break
@@ -1863,6 +1851,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.ProjectSharingInfo(childComplexity, args["projectId"].(gqlmodel.ID)), true
+
+	case "Query.projectSnapshot":
+		if e.complexity.Query.ProjectSnapshot == nil {
+			break
+		}
+
+		args, err := ec.field_Query_projectSnapshot_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ProjectSnapshot(childComplexity, args["projectId"].(gqlmodel.ID), args["version"].(int)), true
 
 	case "Query.projects":
 		if e.complexity.Query.Projects == nil {
@@ -2635,8 +2635,8 @@ type ProjectSnapshotMetadata {
 
 extend type Query {
   latestProjectSnapshot(projectId: ID!): ProjectDocument
-  projectHistory(projectId: ID!): [ProjectSnapshot!]!
-  projectHistoryMetadata(projectId: ID!): [ProjectSnapshotMetadata!]!
+  projectSnapshot(projectId: ID!, version: Int!): [ProjectSnapshot!]!
+  projectHistory(projectId: ID!): [ProjectSnapshotMetadata!]!
 }
 
 # Mutation
@@ -3980,21 +3980,6 @@ func (ec *executionContext) field_Query_nodes_args(ctx context.Context, rawArgs 
 	return args, nil
 }
 
-func (ec *executionContext) field_Query_projectHistoryMetadata_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 gqlmodel.ID
-	if tmp, ok := rawArgs["projectId"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectId"))
-		arg0, err = ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["projectId"] = arg0
-	return args, nil
-}
-
 func (ec *executionContext) field_Query_projectHistory_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -4022,6 +4007,30 @@ func (ec *executionContext) field_Query_projectSharingInfo_args(ctx context.Cont
 		}
 	}
 	args["projectId"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_projectSnapshot_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 gqlmodel.ID
+	if tmp, ok := rawArgs["projectId"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectId"))
+		arg0, err = ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["projectId"] = arg0
+	var arg1 int
+	if tmp, ok := rawArgs["version"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("version"))
+		arg1, err = ec.unmarshalNInt2int(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["version"] = arg1
 	return args, nil
 }
 
@@ -12030,6 +12039,69 @@ func (ec *executionContext) fieldContext_Query_latestProjectSnapshot(ctx context
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_projectSnapshot(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_projectSnapshot(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ProjectSnapshot(rctx, fc.Args["projectId"].(gqlmodel.ID), fc.Args["version"].(int))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*gqlmodel.ProjectSnapshot)
+	fc.Result = res
+	return ec.marshalNProjectSnapshot2ᚕᚖgithubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectSnapshotᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_projectSnapshot(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "timestamp":
+				return ec.fieldContext_ProjectSnapshot_timestamp(ctx, field)
+			case "updates":
+				return ec.fieldContext_ProjectSnapshot_updates(ctx, field)
+			case "version":
+				return ec.fieldContext_ProjectSnapshot_version(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ProjectSnapshot", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_projectSnapshot_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_projectHistory(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_projectHistory(ctx, field)
 	if err != nil {
@@ -12056,75 +12128,12 @@ func (ec *executionContext) _Query_projectHistory(ctx context.Context, field gra
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*gqlmodel.ProjectSnapshot)
-	fc.Result = res
-	return ec.marshalNProjectSnapshot2ᚕᚖgithubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectSnapshotᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_projectHistory(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "timestamp":
-				return ec.fieldContext_ProjectSnapshot_timestamp(ctx, field)
-			case "updates":
-				return ec.fieldContext_ProjectSnapshot_updates(ctx, field)
-			case "version":
-				return ec.fieldContext_ProjectSnapshot_version(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type ProjectSnapshot", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_projectHistory_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return fc, err
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_projectHistoryMetadata(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_projectHistoryMetadata(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().ProjectHistoryMetadata(rctx, fc.Args["projectId"].(gqlmodel.ID))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
 	res := resTmp.([]*gqlmodel.ProjectSnapshotMetadata)
 	fc.Result = res
 	return ec.marshalNProjectSnapshotMetadata2ᚕᚖgithubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectSnapshotMetadataᚄ(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) fieldContext_Query_projectHistoryMetadata(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Query_projectHistory(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Query",
 		Field:      field,
@@ -12147,7 +12156,7 @@ func (ec *executionContext) fieldContext_Query_projectHistoryMetadata(ctx contex
 		}
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_projectHistoryMetadata_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+	if fc.Args, err = ec.field_Query_projectHistory_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -20410,7 +20419,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "projectHistory":
+		case "projectSnapshot":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -20419,7 +20428,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_projectHistory(ctx, field)
+				res = ec._Query_projectSnapshot(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -20432,7 +20441,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
-		case "projectHistoryMetadata":
+		case "projectHistory":
 			field := field
 
 			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
@@ -20441,7 +20450,7 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
-				res = ec._Query_projectHistoryMetadata(ctx, field)
+				res = ec._Query_projectHistory(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/server/api/internal/adapter/gql/resolver_document.go
+++ b/server/api/internal/adapter/gql/resolver_document.go
@@ -70,6 +70,15 @@ func (r *mutationResolver) RollbackProject(ctx context.Context, projectId gqlmod
 	}, nil
 }
 
+func (r *mutationResolver) FlushProjectToGcs(ctx context.Context, projectId gqlmodel.ID) (*bool, error) {
+	err := interactor.FlushToGCS(ctx, string(projectId))
+	if err != nil {
+		return nil, err
+	}
+	result := true
+	return &result, nil
+}
+
 type projectDocumentResolver struct{ *Resolver }
 
 func (r *Resolver) ProjectDocument() ProjectDocumentResolver {

--- a/server/api/internal/adapter/gql/resolver_document.go
+++ b/server/api/internal/adapter/gql/resolver_document.go
@@ -22,24 +22,21 @@ func (r *queryResolver) LatestProjectSnapshot(ctx context.Context, projectId gql
 }
 
 func (r *queryResolver) ProjectSnapshot(ctx context.Context, projectId gqlmodel.ID, version int) ([]*gqlmodel.ProjectSnapshot, error) {
-	history, err := interactor.GetHistory(ctx, string(projectId))
+	history, err := interactor.GetHistoryByVersion(ctx, string(projectId), version)
 	if err != nil {
 		return nil, err
 	}
 
-	var filteredHistory []*gqlmodel.ProjectSnapshot
-	for _, h := range history {
-		if h.Version == version {
-			filteredHistory = append(filteredHistory, &gqlmodel.ProjectSnapshot{
-				Updates:   h.Updates,
-				Version:   h.Version,
-				Timestamp: h.Timestamp,
-			})
-			break
+	snapshots := make([]*gqlmodel.ProjectSnapshot, len(history))
+	for i, h := range history {
+		snapshots[i] = &gqlmodel.ProjectSnapshot{
+			Updates:   h.Updates,
+			Version:   h.Version,
+			Timestamp: h.Timestamp,
 		}
 	}
 
-	return filteredHistory, nil
+	return snapshots, nil
 }
 
 func (r *queryResolver) ProjectHistory(ctx context.Context, projectId gqlmodel.ID) ([]*gqlmodel.ProjectSnapshotMetadata, error) {

--- a/server/api/internal/adapter/gql/resolver_document.go
+++ b/server/api/internal/adapter/gql/resolver_document.go
@@ -21,25 +21,28 @@ func (r *queryResolver) LatestProjectSnapshot(ctx context.Context, projectId gql
 	}, nil
 }
 
-func (r *queryResolver) ProjectHistory(ctx context.Context, projectId gqlmodel.ID) ([]*gqlmodel.ProjectSnapshot, error) {
+func (r *queryResolver) ProjectSnapshot(ctx context.Context, projectId gqlmodel.ID, version int) ([]*gqlmodel.ProjectSnapshot, error) {
 	history, err := interactor.GetHistory(ctx, string(projectId))
 	if err != nil {
 		return nil, err
 	}
 
-	nodes := make([]*gqlmodel.ProjectSnapshot, len(history))
-	for i, h := range history {
-		nodes[i] = &gqlmodel.ProjectSnapshot{
-			Updates:   h.Updates,
-			Version:   h.Version,
-			Timestamp: h.Timestamp,
+	var filteredHistory []*gqlmodel.ProjectSnapshot
+	for _, h := range history {
+		if h.Version == version {
+			filteredHistory = append(filteredHistory, &gqlmodel.ProjectSnapshot{
+				Updates:   h.Updates,
+				Version:   h.Version,
+				Timestamp: h.Timestamp,
+			})
+			break
 		}
 	}
 
-	return nodes, nil
+	return filteredHistory, nil
 }
 
-func (r *queryResolver) ProjectHistoryMetadata(ctx context.Context, projectId gqlmodel.ID) ([]*gqlmodel.ProjectSnapshotMetadata, error) {
+func (r *queryResolver) ProjectHistory(ctx context.Context, projectId gqlmodel.ID) ([]*gqlmodel.ProjectSnapshotMetadata, error) {
 	metadata, err := interactor.GetHistoryMetadata(ctx, string(projectId))
 	if err != nil {
 		return nil, err

--- a/server/api/internal/infrastructure/websocket/client.go
+++ b/server/api/internal/infrastructure/websocket/client.go
@@ -317,3 +317,30 @@ func (c *Client) Rollback(ctx context.Context, id string, version int) (*websock
 		Timestamp: timestamp,
 	}, nil
 }
+
+func (c *Client) FlushToGCS(ctx context.Context, id string) error {
+	url := fmt.Sprintf("%s/api/document/%s/flush", c.config.ServerURL, id)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to flush document to GCS: %w", err)
+	}
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+			log.Warnf("failed to close response body: %v", err)
+		}
+	}(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("server returned non-200 status: %d %s", resp.StatusCode, body)
+	}
+
+	return nil
+}

--- a/server/api/internal/usecase/interactor/websocket.go
+++ b/server/api/internal/usecase/interactor/websocket.go
@@ -54,6 +54,14 @@ func GetHistory(ctx context.Context, id string) ([]*ws.History, error) {
 	return client.GetHistory(ctx, id)
 }
 
+func GetHistoryByVersion(ctx context.Context, id string, version int) ([]*ws.History, error) {
+	client := getDefaultWebsocketClient()
+	if client == nil {
+		return nil, fmt.Errorf("websocket client is not initialized")
+	}
+	return client.GetHistoryByVersion(ctx, id, version)
+}
+
 func GetHistoryMetadata(ctx context.Context, id string) ([]*ws.HistoryMetadata, error) {
 	client := getDefaultWebsocketClient()
 	if client == nil {

--- a/server/api/internal/usecase/interactor/websocket.go
+++ b/server/api/internal/usecase/interactor/websocket.go
@@ -77,3 +77,11 @@ func Rollback(ctx context.Context, id string, version int) (*ws.Document, error)
 	}
 	return client.Rollback(ctx, id, version)
 }
+
+func FlushToGCS(ctx context.Context, id string) error {
+	client := getDefaultWebsocketClient()
+	if client == nil {
+		return fmt.Errorf("websocket client is not initialized")
+	}
+	return client.FlushToGCS(ctx, id)
+}

--- a/server/api/internal/usecase/interfaces/websocket.go
+++ b/server/api/internal/usecase/interfaces/websocket.go
@@ -12,6 +12,7 @@ type WebsocketClient interface {
 	GetHistoryByVersion(ctx context.Context, docID string, version int) ([]*websocket.History, error)
 	GetHistoryMetadata(ctx context.Context, docID string) ([]*websocket.HistoryMetadata, error)
 	Rollback(ctx context.Context, id string, version int) (*websocket.Document, error)
+	FlushToGCS(ctx context.Context, id string) error
 
 	Close() error
 }

--- a/server/api/internal/usecase/interfaces/websocket.go
+++ b/server/api/internal/usecase/interfaces/websocket.go
@@ -9,6 +9,7 @@ import (
 type WebsocketClient interface {
 	GetLatest(ctx context.Context, docID string) (*websocket.Document, error)
 	GetHistory(ctx context.Context, docID string) ([]*websocket.History, error)
+	GetHistoryByVersion(ctx context.Context, docID string, version int) ([]*websocket.History, error)
 	GetHistoryMetadata(ctx context.Context, docID string) ([]*websocket.HistoryMetadata, error)
 	Rollback(ctx context.Context, id string, version int) (*websocket.Document, error)
 

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -40,7 +40,6 @@ pub struct BroadcastGroup {
     storage: Option<Arc<GcsStore>>,
     redis_store: Option<Arc<RedisStore>>,
     doc_name: Option<String>,
-    redis_ttl: Option<usize>,
     redis_subscriber_task: Option<JoinHandle<()>>,
     redis_consumer_name: Option<String>,
     redis_group_name: Option<String>,
@@ -55,7 +54,6 @@ impl std::fmt::Debug for BroadcastGroup {
             .field("connections", &self.connections)
             .field("awareness_ref", &self.awareness_ref)
             .field("doc_name", &self.doc_name)
-            .field("redis_ttl", &self.redis_ttl)
             .finish()
     }
 }
@@ -164,7 +162,6 @@ impl BroadcastGroup {
             storage: None,
             redis_store: None,
             doc_name: None,
-            redis_ttl: None,
             redis_subscriber_task: None,
             redis_consumer_name: None,
             redis_group_name: None,
@@ -190,8 +187,6 @@ impl BroadcastGroup {
         let mut group = Self::new(awareness, buffer_capacity).await?;
 
         let doc_name = config.doc_name.clone().unwrap_or_default();
-
-        let redis_ttl = Some(redis_store.get_config().ttl as usize);
 
         Self::load_from_storage(&store, &doc_name, &group.awareness_ref).await;
 
@@ -289,7 +284,6 @@ impl BroadcastGroup {
 
         group.storage = Some(store);
         group.doc_name = Some(doc_name.clone());
-        group.redis_ttl = redis_ttl;
 
         if let Some(redis_store) = &group.redis_store {
             let redis_store_clone = redis_store.clone();

--- a/server/websocket/src/doc/handler.rs
+++ b/server/websocket/src/doc/handler.rs
@@ -32,49 +32,42 @@ impl DocumentHandler {
 
         let storage = state.pool.get_store();
         let doc = Doc::new();
-        let doc_id_clone = doc_id.clone();
 
-        let result = tokio::task::block_in_place(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap();
+        let result = async {
+            let mut txn = doc.transact_mut();
+            let load_result = storage.load_doc(&doc_id, &mut txn).await;
 
-            rt.block_on(async move {
-                let mut txn = doc.transact_mut();
-                let load_result = storage.load_doc(&doc_id_clone, &mut txn).await;
+            match load_result {
+                Ok(true) => {
+                    drop(txn);
+                    let read_txn = doc.transact();
+                    let state = read_txn.encode_diff_v1(&StateVector::default());
+                    drop(read_txn);
 
-                match load_result {
-                    Ok(true) => {
-                        drop(txn);
-                        let read_txn = doc.transact();
-                        let state = read_txn.encode_diff_v1(&StateVector::default());
-                        drop(read_txn);
+                    let metadata = storage.get_latest_update_metadata(&doc_id).await?;
 
-                        let metadata = storage.get_latest_update_metadata(&doc_id_clone).await?;
+                    let latest_clock = metadata.map(|(clock, _)| clock).unwrap_or(0);
+                    let timestamp = if let Some((_, ts)) = metadata {
+                        chrono::DateTime::from_timestamp(ts.unix_timestamp(), 0)
+                            .unwrap_or(Utc::now())
+                    } else {
+                        Utc::now()
+                    };
 
-                        let latest_clock = metadata.map(|(clock, _)| clock).unwrap_or(0);
-                        let timestamp = if let Some((_, ts)) = metadata {
-                            chrono::DateTime::from_timestamp(ts.unix_timestamp(), 0)
-                                .unwrap_or(Utc::now())
-                        } else {
-                            Utc::now()
-                        };
+                    let document = Document {
+                        id: doc_id.clone(),
+                        version: latest_clock as u64,
+                        timestamp,
+                        updates: state,
+                    };
 
-                        let document = Document {
-                            id: doc_id_clone,
-                            version: latest_clock as u64,
-                            timestamp,
-                            updates: state,
-                        };
-
-                        Ok::<_, anyhow::Error>(document)
-                    }
-                    Ok(false) => Err(anyhow::anyhow!("Document not found: {}", doc_id_clone)),
-                    Err(e) => Err(anyhow::anyhow!("Failed to load document: {}", e)),
+                    Ok::<_, anyhow::Error>(document)
                 }
-            })
-        });
+                Ok(false) => Err(anyhow::anyhow!("Document not found: {}", doc_id)),
+                Err(e) => Err(anyhow::anyhow!("Failed to load document: {}", e)),
+            }
+        }
+        .await;
 
         match result {
             Ok(doc) => Json(DocumentResponse {
@@ -105,32 +98,26 @@ impl DocumentHandler {
         debug!("Handling GetHistory request for document: {}", doc_id);
 
         let storage = state.pool.get_store();
-        let doc_id_clone = doc_id.clone();
-        let result = tokio::task::block_in_place(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap();
 
-            rt.block_on(async move {
-                let updates = storage.get_updates(&doc_id_clone).await?;
+        let result = async {
+            let updates = storage.get_updates(&doc_id).await?;
 
-                let history_items: Vec<HistoryItem> = updates
-                    .iter()
-                    .map(|update_info| HistoryItem {
-                        version: update_info.clock as u64,
-                        updates: update_info.update.encode_v1(),
-                        timestamp: chrono::DateTime::from_timestamp(
-                            update_info.timestamp.unix_timestamp(),
-                            0,
-                        )
-                        .unwrap_or(Utc::now()),
-                    })
-                    .collect();
+            let history_items: Vec<HistoryItem> = updates
+                .iter()
+                .map(|update_info| HistoryItem {
+                    version: update_info.clock as u64,
+                    updates: update_info.update.encode_v1(),
+                    timestamp: chrono::DateTime::from_timestamp(
+                        update_info.timestamp.unix_timestamp(),
+                        0,
+                    )
+                    .unwrap_or(Utc::now()),
+                })
+                .collect();
 
-                Ok::<_, anyhow::Error>(history_items)
-            })
-        });
+            Ok::<_, anyhow::Error>(history_items)
+        }
+        .await;
 
         match result {
             Ok(history_items) => {
@@ -170,29 +157,22 @@ impl DocumentHandler {
         );
 
         let storage = state.pool.get_store();
-        let doc_id_clone = doc_id.clone();
         let version = request.version;
 
-        let rollback_result = tokio::task::block_in_place(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap();
+        let rollback_result = async {
+            let doc = storage.rollback_to(&doc_id, version as u32).await?;
 
-            rt.block_on(async move {
-                let doc = storage.rollback_to(&doc_id_clone, version as u32).await?;
+            let read_txn = doc.transact();
+            let state = read_txn.encode_state_as_update_v1(&StateVector::default());
 
-                let read_txn = doc.transact();
-                let state = read_txn.encode_state_as_update_v1(&StateVector::default());
-
-                Ok::<_, anyhow::Error>(Document {
-                    id: doc_id_clone,
-                    version,
-                    timestamp: Utc::now(),
-                    updates: state,
-                })
+            Ok::<_, anyhow::Error>(Document {
+                id: doc_id.clone(),
+                version,
+                timestamp: Utc::now(),
+                updates: state,
             })
-        });
+        }
+        .await;
 
         match rollback_result {
             Ok(doc) => Json(DocumentResponse {
@@ -231,18 +211,12 @@ impl DocumentHandler {
         );
 
         let storage = state.pool.get_store();
-        let doc_id_clone = doc_id.clone();
-        let result = tokio::task::block_in_place(move || {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap();
 
-            rt.block_on(async move {
-                let metadata = storage.get_updates_metadata(&doc_id_clone).await?;
-                Ok::<_, anyhow::Error>(metadata)
-            })
-        });
+        let result = async {
+            let metadata = storage.get_updates_metadata(&doc_id).await?;
+            Ok::<_, anyhow::Error>(metadata)
+        }
+        .await;
 
         match result {
             Ok(metadata) => {
@@ -262,6 +236,68 @@ impl DocumentHandler {
                 error!(
                     "Failed to get history metadata for document {}: {}",
                     doc_id, err
+                );
+
+                let status_code = if err.to_string().contains("not found") {
+                    StatusCode::NOT_FOUND
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                };
+
+                (status_code, format!("Error: {}", err)).into_response()
+            }
+        }
+    }
+
+    pub async fn get_history_by_version(
+        Path((doc_id, version)): Path<(String, u64)>,
+        State(state): State<Arc<AppState>>,
+    ) -> Response {
+        debug!(
+            "Handling GetHistoryByVersion request for document: {} version: {}",
+            doc_id, version
+        );
+
+        let storage = state.pool.get_store();
+        let version_u32 = version as u32;
+
+        let result = async {
+            let updates = storage.get_updates_by_version(&doc_id, version_u32).await?;
+
+            let history_items: Vec<HistoryItem> = updates
+                .iter()
+                .map(|update_info| HistoryItem {
+                    version: update_info.clock as u64,
+                    updates: update_info.update.encode_v1(),
+                    timestamp: chrono::DateTime::from_timestamp(
+                        update_info.timestamp.unix_timestamp(),
+                        0,
+                    )
+                    .unwrap_or(Utc::now()),
+                })
+                .collect();
+
+            Ok::<_, anyhow::Error>(history_items)
+        }
+        .await;
+
+        match result {
+            Ok(history_items) => {
+                let history: Vec<HistoryResponse> = history_items
+                    .into_iter()
+                    .map(|item| HistoryResponse {
+                        updates: item.updates,
+                        version: item.version,
+                        timestamp: item.timestamp.to_rfc3339(),
+                    })
+                    .collect();
+
+                Json(history).into_response()
+            }
+            Err(err) => {
+                error!(
+                    "Failed to get history for document {} version {}: {}",
+                    doc_id, version, err
                 );
 
                 let status_code = if err.to_string().contains("not found") {

--- a/server/websocket/src/doc/handler.rs
+++ b/server/websocket/src/doc/handler.rs
@@ -310,4 +310,19 @@ impl DocumentHandler {
             }
         }
     }
+
+    pub async fn flush_to_gcs(
+        Path(doc_id): Path<String>,
+        State(state): State<Arc<AppState>>,
+    ) -> Response {
+        info!("Manually flushing document {} to GCS", doc_id);
+
+        match state.pool.flush_to_gcs(&doc_id).await {
+            Ok(_) => StatusCode::OK.into_response(),
+            Err(err) => {
+                error!("Failed to flush document {} to GCS: {}", doc_id, err);
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
+        }
+    }
 }

--- a/server/websocket/src/doc/route.rs
+++ b/server/websocket/src/doc/route.rs
@@ -26,4 +26,8 @@ pub fn document_routes() -> Router<Arc<AppState>> {
             "/document/{doc_id}/rollback",
             post(DocumentHandler::rollback),
         )
+        .route(
+            "/document/{doc_id}/flush",
+            post(DocumentHandler::flush_to_gcs),
+        )
 }

--- a/server/websocket/src/doc/route.rs
+++ b/server/websocket/src/doc/route.rs
@@ -19,6 +19,10 @@ pub fn document_routes() -> Router<Arc<AppState>> {
             get(DocumentHandler::get_history_metadata),
         )
         .route(
+            "/document/{doc_id}/history/version/{version}",
+            get(DocumentHandler::get_history_by_version),
+        )
+        .route(
             "/document/{doc_id}/rollback",
             post(DocumentHandler::rollback),
         )

--- a/ui/src/lib/gql/document/queries.graphql
+++ b/ui/src/lib/gql/document/queries.graphql
@@ -23,7 +23,3 @@ mutation RollbackProject($projectId: ID!, $version: Int!) {
     version
   }
 }
-
-mutation FlushProjectToGcs($projectId: ID!) {
-  flushProjectToGcs(projectId: $projectId)
-}

--- a/ui/src/lib/gql/document/queries.graphql
+++ b/ui/src/lib/gql/document/queries.graphql
@@ -23,3 +23,7 @@ mutation RollbackProject($projectId: ID!, $version: Int!) {
     version
   }
 }
+
+mutation FlushProjectToGcs($projectId: ID!) {
+  flushProjectToGcs(projectId: $projectId)
+}


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API route that lets users retrieve document history by specifying a version, enabling precise access to historical snapshots.
  - Added a mutation to flush project data to Google Cloud Storage (GCS).
  - Enhanced GraphQL queries to support version-specific requests that now return streamlined project metadata.
  - Upgraded WebSocket functionality to offer targeted document update history based on a chosen version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->