### PR TITLE
refactor(api): update ProjectSnapshot query and related resolver logic to return a single snapshot instead of a list[FLOW-BE-117]

### DIFF
--- a/server/api/gql/document.graphql
+++ b/server/api/gql/document.graphql
@@ -23,7 +23,7 @@ type ProjectSnapshotMetadata {
 
 extend type Query {
   latestProjectSnapshot(projectId: ID!): ProjectDocument
-  projectSnapshot(projectId: ID!, version: Int!): [ProjectSnapshot!]!
+  projectSnapshot(projectId: ID!, version: Int!): ProjectSnapshot!
   projectHistory(projectId: ID!): [ProjectSnapshotMetadata!]!
 }
 

--- a/server/api/internal/adapter/gql/generated.go
+++ b/server/api/internal/adapter/gql/generated.go
@@ -474,7 +474,7 @@ type QueryResolver interface {
 	DeploymentHead(ctx context.Context, input gqlmodel.GetHeadInput) (*gqlmodel.Deployment, error)
 	DeploymentVersions(ctx context.Context, workspaceID gqlmodel.ID, projectID *gqlmodel.ID) ([]*gqlmodel.Deployment, error)
 	LatestProjectSnapshot(ctx context.Context, projectID gqlmodel.ID) (*gqlmodel.ProjectDocument, error)
-	ProjectSnapshot(ctx context.Context, projectID gqlmodel.ID, version int) ([]*gqlmodel.ProjectSnapshot, error)
+	ProjectSnapshot(ctx context.Context, projectID gqlmodel.ID, version int) (*gqlmodel.ProjectSnapshot, error)
 	ProjectHistory(ctx context.Context, projectID gqlmodel.ID) ([]*gqlmodel.ProjectSnapshotMetadata, error)
 	Jobs(ctx context.Context, workspaceID gqlmodel.ID, pagination gqlmodel.PageBasedPagination) (*gqlmodel.JobConnection, error)
 	Job(ctx context.Context, id gqlmodel.ID) (*gqlmodel.Job, error)
@@ -2649,7 +2649,7 @@ type ProjectSnapshotMetadata {
 
 extend type Query {
   latestProjectSnapshot(projectId: ID!): ProjectDocument
-  projectSnapshot(projectId: ID!, version: Int!): [ProjectSnapshot!]!
+  projectSnapshot(projectId: ID!, version: Int!): ProjectSnapshot!
   projectHistory(projectId: ID!): [ProjectSnapshotMetadata!]!
 }
 
@@ -12147,9 +12147,9 @@ func (ec *executionContext) _Query_projectSnapshot(ctx context.Context, field gr
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*gqlmodel.ProjectSnapshot)
+	res := resTmp.(*gqlmodel.ProjectSnapshot)
 	fc.Result = res
-	return ec.marshalNProjectSnapshot2ᚕᚖgithubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectSnapshotᚄ(ctx, field.Selections, res)
+	return ec.marshalNProjectSnapshot2ᚖgithubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectSnapshot(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_projectSnapshot(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -22719,48 +22719,8 @@ func (ec *executionContext) marshalNProjectSharingInfoPayload2ᚖgithubᚗcomᚋ
 	return ec._ProjectSharingInfoPayload(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNProjectSnapshot2ᚕᚖgithubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectSnapshotᚄ(ctx context.Context, sel ast.SelectionSet, v []*gqlmodel.ProjectSnapshot) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNProjectSnapshot2ᚖgithubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectSnapshot(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
+func (ec *executionContext) marshalNProjectSnapshot2githubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectSnapshot(ctx context.Context, sel ast.SelectionSet, v gqlmodel.ProjectSnapshot) graphql.Marshaler {
+	return ec._ProjectSnapshot(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNProjectSnapshot2ᚖgithubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐProjectSnapshot(ctx context.Context, sel ast.SelectionSet, v *gqlmodel.ProjectSnapshot) graphql.Marshaler {

--- a/server/api/internal/adapter/gql/resolver_document.go
+++ b/server/api/internal/adapter/gql/resolver_document.go
@@ -21,22 +21,17 @@ func (r *queryResolver) LatestProjectSnapshot(ctx context.Context, projectId gql
 	}, nil
 }
 
-func (r *queryResolver) ProjectSnapshot(ctx context.Context, projectId gqlmodel.ID, version int) ([]*gqlmodel.ProjectSnapshot, error) {
+func (r *queryResolver) ProjectSnapshot(ctx context.Context, projectId gqlmodel.ID, version int) (*gqlmodel.ProjectSnapshot, error) {
 	history, err := interactor.GetHistoryByVersion(ctx, string(projectId), version)
 	if err != nil {
 		return nil, err
 	}
 
-	snapshots := make([]*gqlmodel.ProjectSnapshot, len(history))
-	for i, h := range history {
-		snapshots[i] = &gqlmodel.ProjectSnapshot{
-			Updates:   h.Updates,
-			Version:   h.Version,
-			Timestamp: h.Timestamp,
-		}
-	}
-
-	return snapshots, nil
+	return &gqlmodel.ProjectSnapshot{
+		Updates:   history.Updates,
+		Version:   history.Version,
+		Timestamp: history.Timestamp,
+	}, nil
 }
 
 func (r *queryResolver) ProjectHistory(ctx context.Context, projectId gqlmodel.ID) ([]*gqlmodel.ProjectSnapshotMetadata, error) {

--- a/server/api/internal/infrastructure/websocket/client.go
+++ b/server/api/internal/infrastructure/websocket/client.go
@@ -208,7 +208,7 @@ func (c *Client) GetHistoryMetadata(ctx context.Context, docID string) ([]*webso
 	return metadata, nil
 }
 
-func (c *Client) GetHistoryByVersion(ctx context.Context, docID string, version int) ([]*websocket.History, error) {
+func (c *Client) GetHistoryByVersion(ctx context.Context, docID string, version int) (*websocket.History, error) {
 	url := fmt.Sprintf("%s/api/document/%s/history/version/%d", c.config.ServerURL, docID, version)
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -231,32 +231,27 @@ func (c *Client) GetHistoryByVersion(ctx context.Context, docID string, version 
 		return nil, fmt.Errorf("server returned non-200 status: %d %s", resp.StatusCode, body)
 	}
 
-	var historyResp []historyResponse
+	var historyResp historyResponse
 	if err := json.NewDecoder(resp.Body).Decode(&historyResp); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	history := make([]*websocket.History, len(historyResp))
-	for i, item := range historyResp {
-		timestamp, err := time.Parse(time.RFC3339, item.Timestamp)
-		if err != nil {
-			log.Warnf("failed to parse timestamp: %v, using current time", err)
-			timestamp = time.Now()
-		}
-
-		updates := make([]int, len(item.Updates))
-		for j, update := range item.Updates {
-			updates[j] = int(update)
-		}
-
-		history[i] = &websocket.History{
-			Updates:   updates,
-			Version:   int(item.Version),
-			Timestamp: timestamp,
-		}
+	timestamp, err := time.Parse(time.RFC3339, historyResp.Timestamp)
+	if err != nil {
+		log.Warnf("failed to parse timestamp: %v, using current time", err)
+		timestamp = time.Now()
 	}
 
-	return history, nil
+	updates := make([]int, len(historyResp.Updates))
+	for j, update := range historyResp.Updates {
+		updates[j] = int(update)
+	}
+
+	return &websocket.History{
+		Version:   int(historyResp.Version),
+		Timestamp: timestamp,
+		Updates:   updates,
+	}, nil
 }
 
 func (c *Client) Rollback(ctx context.Context, id string, version int) (*websocket.Document, error) {

--- a/server/api/internal/usecase/interactor/websocket.go
+++ b/server/api/internal/usecase/interactor/websocket.go
@@ -54,7 +54,7 @@ func GetHistory(ctx context.Context, id string) ([]*ws.History, error) {
 	return client.GetHistory(ctx, id)
 }
 
-func GetHistoryByVersion(ctx context.Context, id string, version int) ([]*ws.History, error) {
+func GetHistoryByVersion(ctx context.Context, id string, version int) (*ws.History, error) {
 	client := getDefaultWebsocketClient()
 	if client == nil {
 		return nil, fmt.Errorf("websocket client is not initialized")

--- a/server/api/internal/usecase/interfaces/websocket.go
+++ b/server/api/internal/usecase/interfaces/websocket.go
@@ -9,7 +9,7 @@ import (
 type WebsocketClient interface {
 	GetLatest(ctx context.Context, docID string) (*websocket.Document, error)
 	GetHistory(ctx context.Context, docID string) ([]*websocket.History, error)
-	GetHistoryByVersion(ctx context.Context, docID string, version int) ([]*websocket.History, error)
+	GetHistoryByVersion(ctx context.Context, docID string, version int) (*websocket.History, error)
 	GetHistoryMetadata(ctx context.Context, docID string) ([]*websocket.HistoryMetadata, error)
 	Rollback(ctx context.Context, id string, version int) (*websocket.Document, error)
 	FlushToGCS(ctx context.Context, id string) error

--- a/server/websocket/src/storage/redis/mod.rs
+++ b/server/websocket/src/storage/redis/mod.rs
@@ -487,7 +487,6 @@ impl RedisStore {
         count: usize,
     ) -> Result<Vec<Bytes>, anyhow::Error> {
         let stream_key = format!("yjs:stream:{}", doc_id);
-
         let mut conn = self.pool.get().await?;
         let block_ms = 2000;
         let script = redis::Script::new(
@@ -538,7 +537,6 @@ impl RedisStore {
             .arg(block_ms)
             .invoke_async(&mut *conn)
             .await?;
-            
         Ok(updates)
     }
       

--- a/server/websocket/src/storage/redis/mod.rs
+++ b/server/websocket/src/storage/redis/mod.rs
@@ -489,9 +489,7 @@ impl RedisStore {
         let stream_key = format!("yjs:stream:{}", doc_id);
 
         let mut conn = self.pool.get().await?;
-        
         let block_ms = 2000;
-    
         let script = redis::Script::new(
             r#"
             local stream_key = KEYS[1]
@@ -540,10 +538,9 @@ impl RedisStore {
             .arg(block_ms)
             .invoke_async(&mut *conn)
             .await?;
-
+            
         Ok(updates)
     }
-
       
     pub async fn delete_stream(&self, doc_id: &str) -> Result<(), anyhow::Error> {
         let stream_key = format!("yjs:stream:{}", doc_id);

--- a/server/websocket/src/storage/redis/mod.rs
+++ b/server/websocket/src/storage/redis/mod.rs
@@ -539,7 +539,7 @@ impl RedisStore {
             .await?;
         Ok(updates)
     }
-      
+
     pub async fn delete_stream(&self, doc_id: &str) -> Result<(), anyhow::Error> {
         let stream_key = format!("yjs:stream:{}", doc_id);
         if let Ok(mut conn) = self.pool.get().await {

--- a/server/websocket/src/storage/redis/mod.rs
+++ b/server/websocket/src/storage/redis/mod.rs
@@ -487,7 +487,7 @@ impl RedisStore {
         count: usize,
     ) -> Result<Vec<Bytes>, anyhow::Error> {
         let stream_key = format!("yjs:stream:{}", doc_id);
-    
+
         let mut conn = self.pool.get().await?;
         
         let block_ms = 2000;
@@ -531,7 +531,7 @@ impl RedisStore {
             return updates
             "#,
         );
-    
+
         let updates = script
             .key(stream_key)
             .arg(group_name)
@@ -540,7 +540,7 @@ impl RedisStore {
             .arg(block_ms)
             .invoke_async(&mut *conn)
             .await?;
-    
+
         Ok(updates)
     }
 


### PR DESCRIPTION
…c to return a single snapshot instead of a list[FLOW-BE-117]

# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Adjusted the GraphQL snapshot query to return a single snapshot rather than a list, ensuring a more targeted response.
  - Streamlined history retrieval via the websocket API so that fetching by version now delivers a single history record, simplifying client handling.
  - Enhanced the `read_and_ack` method to allow for a configurable blocking time when waiting for messages, improving responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->