### PR TITLE
refactor(websocket): increase buffer size and add sleep duration in BroadcastGroup for improved message handling

### DIFF
--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -330,7 +330,7 @@ impl BroadcastGroup {
                         }
 
                         tokio::task::yield_now().await;
-                        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+                        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
                     } => {}
                 }
             }

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -330,7 +330,7 @@ impl BroadcastGroup {
                         }
 
                         tokio::task::yield_now().await;
-                        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+                        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
                     } => {}
                 }
             }

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -285,7 +285,7 @@ impl BroadcastGroup {
                                 &stream_key,
                                 &group_name_clone,
                                 &consumer_name_clone,
-                                50,
+                                256,
                             )
                             .await;
 
@@ -330,6 +330,7 @@ impl BroadcastGroup {
                         }
 
                         tokio::task::yield_now().await;
+                        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
                     } => {}
                 }
             }


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved backend message processing to better accommodate higher message volumes and enhance operational stability.
	- Introduced a brief pause in message processing to optimize timing and efficiency, with adjustments based on message count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->