### PR TITLE
feat(websocket): add create_empty_stream_with_ttl method for stream initialization and TTL management[FLOW-BE-127]

### DIFF
--- a/server/websocket/Cargo.lock
+++ b/server/websocket/Cargo.lock
@@ -151,9 +151,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
  "axum-core",
  "base64 0.22.1",
@@ -188,12 +188,12 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "http-body-util",
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1090,6 +1090,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1506,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
@@ -2179,9 +2180,9 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -22,7 +22,7 @@ auth = []
 
 [dependencies]
 yrs = { version = "0.23.0", features = ["sync"] }
-axum = { version = "0.8.1", features = ["ws"] }
+axum = { version = "0.8.3", features = ["ws"] }
 futures-util = "0.3"
 tokio = { version = "1.44", features = ["full"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/server/websocket/src/auth/mod.rs
+++ b/server/websocket/src/auth/mod.rs
@@ -23,8 +23,7 @@ pub struct TokenVerifyResponse {
 
 impl AuthService {
     pub async fn new(config: AuthConfig) -> Result<Self> {
-        let client = reqwest::ClientBuilder::new()
-            .build()?;
+        let client = reqwest::ClientBuilder::new().build()?;
         Ok(Self {
             client,
             url: config.url,

--- a/server/websocket/src/auth/mod.rs
+++ b/server/websocket/src/auth/mod.rs
@@ -3,7 +3,6 @@ use anyhow::{anyhow, Result};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::time::{SystemTime, UNIX_EPOCH};
-use tracing::debug;
 
 #[derive(Debug, Clone)]
 pub struct AuthService {

--- a/server/websocket/src/auth/mod.rs
+++ b/server/websocket/src/auth/mod.rs
@@ -23,13 +23,7 @@ pub struct TokenVerifyResponse {
 
 impl AuthService {
     pub async fn new(config: AuthConfig) -> Result<Self> {
-        debug!("Connecting to auth service at: {}", config.url);
         let client = reqwest::ClientBuilder::new()
-            .no_deflate()
-            .no_brotli()
-            .no_gzip()
-            .tcp_keepalive(None)
-            .pool_max_idle_per_host(0)
             .build()?;
         Ok(Self {
             client,
@@ -38,8 +32,6 @@ impl AuthService {
     }
 
     pub async fn verify_token(&self, token: &str) -> Result<bool> {
-        debug!("Verifying token");
-
         let request = TokenVerifyRequest {
             token: token.to_string(),
         };
@@ -64,12 +56,10 @@ impl AuthService {
 
         if !response.status().is_success() {
             let error_text = response.text().await?;
-            debug!("Token verification failed: {}", error_text);
             return Err(anyhow!("Token verification failed: {}", error_text));
         }
 
         let verify_response = response.json::<TokenVerifyResponse>().await?;
-        debug!("Token verification result: {}", verify_response.authorized);
 
         if !verify_response.authorized {
             return Err(anyhow!("Token verification failed: unauthorized"));

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -483,12 +483,10 @@ impl BroadcastGroup {
                 };
 
                 if !update_bytes.is_empty() {
-                    if let Err(e) = redis_store
+                    redis_store
                         .publish_update(stream_key, &update_bytes, conn)
                         .await
-                    {
-                        error!("Redis Stream update failed: {}", e);
-                    }
+                        .map_err(|e| Error::Other(e.into()))?;
                 }
 
                 match msg {

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -184,7 +184,7 @@ impl BroadcastGroup {
             doc_name,
             shutdown_complete: AtomicBool::new(false),
             instance_id,
-            last_read_id: Arc::new(tokio::sync::Mutex::new("0".to_string())),
+            last_read_id: Arc::new(Mutex::new("0".to_string())),
         };
 
         Ok(result)
@@ -669,7 +669,7 @@ impl Drop for BroadcastGroup {
         }
 
         self.shutdown_complete
-            .store(true, std::sync::atomic::Ordering::SeqCst);
+            .store(true, Ordering::SeqCst);
 
         let background_tasks = self.background_tasks.clone();
         tokio::spawn(async move {

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -645,13 +645,9 @@ impl BroadcastGroup {
             background_tasks.stop_all();
         }
 
-        if let Err(e) = self
-            .redis_store
+        self.redis_store
             .safe_delete_stream(&self.doc_name, &self.instance_id)
-            .await
-        {
-            warn!("Failed to delete Redis stream: {}", e);
-        }
+            .await?;
 
         Ok(())
     }

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -302,9 +302,9 @@ impl BroadcastGroup {
                                     }
                                 }
 
-                                if update_count == 1  {
-                                    tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
-                                }
+                                // if update_count == 1  {
+                                //     tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+                                // }
 
                             },
                             Err(e) => {

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -303,7 +303,7 @@ impl BroadcastGroup {
                                 }
 
                                 if update_count == 1  {
-                                    tokio::time::sleep(tokio::time::Duration::from_millis(22)).await;
+                                    tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
                                 }
 
                             },

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -212,7 +212,7 @@ impl BroadcastGroup {
         .await?;
 
         redis_store
-            .create_empty_stream_with_ttl(&doc_name, 7200)
+            .create_empty_stream_with_ttl(&doc_name, 86400)
             .await?;
 
         let awareness_for_sub = group.awareness_ref.clone();

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -528,8 +528,7 @@ impl BroadcastGroup {
     }
 
     pub async fn shutdown(&self) -> Result<()> {
-        self.shutdown_complete
-            .store(true, Ordering::SeqCst);
+        self.shutdown_complete.store(true, Ordering::SeqCst);
 
         if self.connection_count() == 0 {
             if let Err(e) = self
@@ -668,8 +667,7 @@ impl Drop for BroadcastGroup {
             drop(sub);
         }
 
-        self.shutdown_complete
-            .store(true, Ordering::SeqCst);
+        self.shutdown_complete.store(true, Ordering::SeqCst);
 
         let background_tasks = self.background_tasks.clone();
         tokio::spawn(async move {

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -529,7 +529,7 @@ impl BroadcastGroup {
 
     pub async fn shutdown(&self) -> Result<()> {
         self.shutdown_complete
-            .store(true, std::sync::atomic::Ordering::SeqCst);
+            .store(true, Ordering::SeqCst);
 
         if self.connection_count() == 0 {
             if let Err(e) = self

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -271,7 +271,7 @@ impl BroadcastGroup {
                             .read_and_ack_dedicated(
                                 &mut conn,
                                 &stream_key,
-                                512,
+                                1024,
                                 &last_read_id_for_sub,
                             )
                             .await;

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -211,6 +211,10 @@ impl BroadcastGroup {
         )
         .await?;
 
+        redis_store
+            .create_empty_stream_with_ttl(&doc_name, 7200)
+            .await?;
+
         let awareness_for_sub = group.awareness_ref.clone();
         let sender_for_sub = group.sender.clone();
         let doc_name_for_sub = doc_name.clone();

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -677,8 +677,6 @@ impl Subscription {
             let _ = sync_complete.await;
         }
 
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
         let res = select! {
             r1 = self.sink_task => r1,
             r2 = self.stream_task => r2,

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -591,7 +591,6 @@ impl BroadcastGroup {
                 if lock_acquired.is_some() {
                     let awareness = self.awareness_ref.write().await;
                     let awareness_doc = awareness.doc();
-                    let _awareness_state = awareness_doc.transact().state_vector();
 
                     let gcs_doc = Doc::new();
                     let mut gcs_txn = gcs_doc.transact_mut();

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -40,7 +40,7 @@ pub struct BroadcastGroup {
     doc_name: String,
     shutdown_complete: AtomicBool,
     instance_id: String,
-    last_read_id: Arc<tokio::sync::Mutex<String>>,
+    last_read_id: Arc<Mutex<String>>,
 }
 
 impl std::fmt::Debug for BroadcastGroup {

--- a/server/websocket/src/broadcast/pool.rs
+++ b/server/websocket/src/broadcast/pool.rs
@@ -9,7 +9,7 @@ use dashmap::DashMap;
 use rand;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 use yrs::sync::Awareness;
 use yrs::updates::decoder::Decode;
 use yrs::{Doc, ReadTxn, StateVector, Transact, Update};
@@ -237,11 +237,6 @@ impl BroadcastPool {
                     .await
                 {
                     Ok(updates) if !updates.is_empty() => {
-                        info!(
-                            "Found {} updates in Redis stream for '{}', applying before GCS flush",
-                            updates.len(),
-                            doc_id
-                        );
                         let awareness = group.awareness().write().await;
                         let mut txn = awareness.doc().transact_mut();
 

--- a/server/websocket/src/broadcast/pool.rs
+++ b/server/websocket/src/broadcast/pool.rs
@@ -44,7 +44,7 @@ impl BroadcastGroupManager {
 
                 let doc_name = group_clone.get_doc_name();
                 let valid =
-                    (self.redis_store.check_stream_exists(&doc_name).await).unwrap_or(false);
+                    self.redis_store.check_stream_exists(&doc_name).await.unwrap_or(false);
 
                 if !valid {
                     self.doc_to_id_map.remove(doc_id);
@@ -99,7 +99,7 @@ impl BroadcastGroupManager {
             let awareness_clone = Arc::clone(&awareness);
             let redis_store_clone = Arc::clone(&self.redis_store);
             tokio::spawn(async move {
-                tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+                tokio::time::sleep(Duration::from_secs(1)).await;
 
                 let awareness_guard = awareness_clone.read().await;
                 let doc = awareness_guard.doc();

--- a/server/websocket/src/broadcast/pool.rs
+++ b/server/websocket/src/broadcast/pool.rs
@@ -166,7 +166,7 @@ impl BroadcastPool {
                     let group = entry.value().clone();
 
                     if group.connection_count() == 0 {
-                        tokio::time::sleep(Duration::from_secs(2)).await;
+                        tokio::time::sleep(Duration::from_secs(1)).await;
                         if group.connection_count() == 0 {
                             empty_groups.push((doc_id, group));
                         }

--- a/server/websocket/src/broadcast/pool.rs
+++ b/server/websocket/src/broadcast/pool.rs
@@ -317,9 +317,7 @@ impl BroadcastPool {
                     }
 
                     if let Some((redis, lock_id, instance_id)) = lock_acquired {
-                        if let Err(e) = redis.release_doc_lock(&lock_id, &instance_id).await {
-                            warn!("Failed to release GCS lock: {}", e);
-                        }
+                        redis.release_doc_lock(&lock_id, &instance_id).await?;
                     }
                 }
             }

--- a/server/websocket/src/broadcast/pool.rs
+++ b/server/websocket/src/broadcast/pool.rs
@@ -43,8 +43,11 @@ impl BroadcastGroupManager {
                 drop(entry);
 
                 let doc_name = group_clone.get_doc_name();
-                let valid =
-                    self.redis_store.check_stream_exists(&doc_name).await.unwrap_or(false);
+                let valid = self
+                    .redis_store
+                    .check_stream_exists(&doc_name)
+                    .await
+                    .unwrap_or(false);
 
                 if !valid {
                     self.doc_to_id_map.remove(doc_id);

--- a/server/websocket/src/broadcast/types.rs
+++ b/server/websocket/src/broadcast/types.rs
@@ -1,14 +1,5 @@
-use std::sync::Arc;
-
-use crate::BroadcastGroup;
-
 #[derive(Debug, Clone)]
 pub struct BroadcastConfig {
     pub storage_enabled: bool,
     pub doc_name: Option<String>,
-}
-
-#[derive(Debug)]
-pub struct BroadcastGroupContext {
-    pub group: Arc<BroadcastGroup>,
 }

--- a/server/websocket/src/doc/handler.rs
+++ b/server/websocket/src/doc/handler.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use chrono::Utc;
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::error;
 use yrs::updates::encoder::Encode;
 use yrs::{Doc, ReadTxn, StateVector, Transact};
 
@@ -147,11 +147,6 @@ impl DocumentHandler {
         State(state): State<Arc<AppState>>,
         Json(request): Json<RollbackRequest>,
     ) -> Response {
-        info!(
-            "Rolling back document {} to version {}",
-            doc_id, request.version
-        );
-
         let storage = state.pool.get_store();
         let version = request.version;
 

--- a/server/websocket/src/doc/types.rs
+++ b/server/websocket/src/doc/types.rs
@@ -1,4 +1,7 @@
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use yrs::updates::encoder::Encode;
+use crate::storage::gcs::UpdateInfo;
 
 #[derive(Debug, Clone)]
 pub struct Document {
@@ -13,6 +16,20 @@ pub struct HistoryItem {
     pub version: u64,
     pub updates: Vec<u8>,
     pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<UpdateInfo> for HistoryItem {
+    fn from(info: UpdateInfo) -> Self {
+        HistoryItem {
+            version: info.clock as u64,
+            updates: info.update.encode_v1(),
+            timestamp: chrono::DateTime::from_timestamp(
+                info.timestamp.unix_timestamp(),
+                0,
+            )
+            .unwrap_or(Utc::now()),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize)]

--- a/server/websocket/src/doc/types.rs
+++ b/server/websocket/src/doc/types.rs
@@ -1,21 +1,21 @@
+use crate::storage::gcs::UpdateInfo;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use yrs::updates::encoder::Encode;
-use crate::storage::gcs::UpdateInfo;
 
 #[derive(Debug, Clone)]
 pub struct Document {
     pub id: String,
     pub updates: Vec<u8>,
     pub version: u64,
-    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub timestamp: chrono::DateTime<Utc>,
 }
 
 #[derive(Debug, Clone)]
 pub struct HistoryItem {
     pub version: u64,
     pub updates: Vec<u8>,
-    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub timestamp: chrono::DateTime<Utc>,
 }
 
 impl From<UpdateInfo> for HistoryItem {
@@ -23,11 +23,8 @@ impl From<UpdateInfo> for HistoryItem {
         HistoryItem {
             version: info.clock as u64,
             updates: info.update.encode_v1(),
-            timestamp: chrono::DateTime::from_timestamp(
-                info.timestamp.unix_timestamp(),
-                0,
-            )
-            .unwrap_or(Utc::now()),
+            timestamp: chrono::DateTime::from_timestamp(info.timestamp.unix_timestamp(), 0)
+                .unwrap_or(Utc::now()),
         }
     }
 }

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -19,6 +19,7 @@ use tracing::info;
 #[cfg(feature = "auth")]
 use crate::AuthQuery;
 use crate::{doc::document_routes, AppState};
+use anyhow::Result;
 #[cfg(feature = "auth")]
 use axum::extract::Query;
 
@@ -27,7 +28,7 @@ struct ServerState {
     app_state: Arc<AppState>,
 }
 
-pub async fn ensure_bucket(client: &Client, bucket_name: &str) -> Result<(), anyhow::Error> {
+pub async fn ensure_bucket(client: &Client, bucket_name: &str) -> Result<()> {
     let bucket = BucketCreationConfig {
         location: "US".to_string(),
         ..Default::default()
@@ -45,7 +46,7 @@ pub async fn ensure_bucket(client: &Client, bucket_name: &str) -> Result<(), any
     }
 }
 
-pub async fn start_server(state: Arc<AppState>, port: &str) -> Result<(), anyhow::Error> {
+pub async fn start_server(state: Arc<AppState>, port: &str) -> Result<()> {
     let addr = format!("0.0.0.0:{}", port);
     let listener = TcpListener::bind(&addr).await?;
 

--- a/server/websocket/src/storage/gcs/mod.rs
+++ b/server/websocket/src/storage/gcs/mod.rs
@@ -152,7 +152,7 @@ impl GcsStore {
             if let Ok(update) = Update::decode_v1(&data) {
                 if let Ok(key_bytes) = hex::decode(&obj.name) {
                     if key_bytes.len() >= 12 {
-                        let clock_bytes: [u8; 4] = key_bytes[7..11].try_into().unwrap();
+                        let clock_bytes: [u8; 4] = key_bytes[7..11].try_into()?;
                         let clock = u32::from_be_bytes(clock_bytes);
 
                         let timestamp = obj.updated.unwrap_or_else(OffsetDateTime::now_utc);
@@ -282,7 +282,7 @@ impl GcsStore {
                 continue;
             }
 
-            let clock_bytes: [u8; 4] = key_bytes[7..11].try_into().unwrap();
+            let clock_bytes: [u8; 4] = key_bytes[7..11].try_into()?;
             let clock = u32::from_be_bytes(clock_bytes);
 
             if clock <= target_clock {
@@ -381,7 +381,7 @@ impl GcsStore {
         for obj in objects {
             if let Ok(key_bytes) = hex::decode(&obj.name) {
                 if key_bytes.len() >= 12 {
-                    let clock_bytes: [u8; 4] = key_bytes[7..11].try_into().unwrap();
+                    let clock_bytes: [u8; 4] = key_bytes[7..11].try_into()?;
                     let clock = u32::from_be_bytes(clock_bytes);
 
                     if clock > latest_clock {
@@ -435,7 +435,7 @@ impl GcsStore {
         for obj in all_objects {
             if let Ok(key_bytes) = hex::decode(&obj.name) {
                 if key_bytes.len() >= 12 {
-                    let clock_bytes: [u8; 4] = key_bytes[7..11].try_into().unwrap();
+                    let clock_bytes: [u8; 4] = key_bytes[7..11].try_into()?;
                     let clock = u32::from_be_bytes(clock_bytes);
                     let timestamp = obj.updated.unwrap_or_else(OffsetDateTime::now_utc);
 

--- a/server/websocket/src/storage/gcs/mod.rs
+++ b/server/websocket/src/storage/gcs/mod.rs
@@ -467,12 +467,14 @@ impl KVStore for GcsStore {
             ..Default::default()
         };
 
-        let data = self
+        match self
             .client
             .download_object(&request, &Range::default())
-            .await?;
-
-        Ok(Some(data))
+            .await
+        {
+            Ok(data) => Ok(Some(data)),
+            Err(_) => Ok(None),
+        }
     }
 
     async fn upsert(&self, key: &[u8], value: &[u8]) -> Result<(), Self::Error> {

--- a/server/websocket/src/storage/kv/mod.rs
+++ b/server/websocket/src/storage/kv/mod.rs
@@ -513,7 +513,7 @@ where
     }
 
     let mut lock_value = None;
-    let max_retries = 5;
+    let max_retries = 10;
     let retry_delay_ms = 500;
 
     for attempt in 0..max_retries {
@@ -581,8 +581,6 @@ where
         (last_oid_key.as_ref(), &new_oid_bytes[..]),
     ];
     db.batch_upsert(&batch).await?;
-
-    tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
     let _ = redis.release_oid_lock(&lock_value).await;
 

--- a/server/websocket/src/storage/redis/mod.rs
+++ b/server/websocket/src/storage/redis/mod.rs
@@ -136,25 +136,6 @@ impl RedisStore {
         Ok(result)
     }
 
-    pub async fn set_nx_with_expiry(
-        &self,
-        key: &str,
-        value: &str,
-        ttl_seconds: u64,
-    ) -> Result<bool> {
-        let mut conn = self.pool.get().await?;
-        let result: Option<String> = redis::cmd("SET")
-            .arg(key)
-            .arg(value)
-            .arg("NX")
-            .arg("EX")
-            .arg(ttl_seconds)
-            .query_async(&mut *conn)
-            .await?;
-
-        Ok(result.is_some())
-    }
-
     pub async fn del(&self, key: &str) -> Result<()> {
         let mut conn = self.pool.get().await?;
         let _: () = redis::cmd("DEL").arg(key).query_async(&mut *conn).await?;

--- a/server/websocket/src/ws.rs
+++ b/server/websocket/src/ws.rs
@@ -180,10 +180,13 @@ async fn handle_socket(
     )
     .await;
 
+    // tracing::info!("WebSocket connection established for document '{}'", doc_id);
+
     let result = conn.await;
     if let Err(e) = result {
         error!("WebSocket connection error: {}", e);
     }
+    // tracing::info!("WebSocket connection closed for document '{}'", doc_id);
 
     let _ = bcast.decrement_connections().await;
     debug!("Connection decreased for document '{}'", doc_id);


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced automated data stream handling that initiates streams with a scheduled expiration, ensuring timely cleanup of broadcast data.
	- Added a new asynchronous method for creating Redis streams with a specified expiration time.

- **Bug Fixes**
	- Improved resource lock management by increasing retry attempts for a more reliable connection.
	- Removed an unnecessary delay after data updates to enhance overall responsiveness.
	- Enhanced error handling and reduced logging verbosity in update and rollback methods.
	- Simplified connection management for Redis subscribers.
	- Added logging for WebSocket connection events to provide better context.

- **Chores**
	- Updated the `axum` dependency to the latest version for potential improvements and bug fixes.
	- Streamlined method return types across several services for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->