### PR TITLE
feat(websocket): introduce Publish struct to manage Redis updates and optimize message handling in BroadcastGroup and PING/PONG logic [FLOW-BE-129]

### DIFF
--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -113,8 +113,8 @@ impl BroadcastGroup {
             changed.extend_from_slice(updated);
             changed.extend_from_slice(removed);
 
-            if tx.send(changed).is_err() {
-                warn!("failed to send awareness update");
+            if let Err(e) = tx.send(changed) {
+                warn!("failed to send awareness update: {}", e);
             }
         });
         drop(lock);

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -132,10 +132,10 @@ impl BroadcastGroup {
                                 if let Some(awareness) = awareness_c.upgrade() {
                                     let awareness = awareness.read().await;
                                     if let Ok(update) = awareness.update_with_clients(changed_clients) {
-                                        let msg_bytes = Bytes::from(Message::Awareness(update).encode_v1());
-                                        if sink.send(msg_bytes).is_err() {
-                                            warn!("couldn't broadcast awareness update");
-                                            return;
+                                            let msg_bytes = Bytes::from(Message::Awareness(update).encode_v1());
+                                            if sink.send(msg_bytes).is_err() {
+                                                warn!("couldn't broadcast awareness update");
+                                                return;
                                         }
                                     }
                                 } else {
@@ -205,10 +205,10 @@ impl BroadcastGroup {
             .await?;
 
         let awareness_for_sub = group.awareness_ref.clone();
-        let sender_for_sub = group.sender.clone();
         let doc_name_for_sub = doc_name.clone();
         let redis_store_for_sub = redis_store.clone();
         let last_read_id_for_sub = group.last_read_id.clone();
+        let instance_id_for_sub = group.instance_id.clone();
 
         let (heartbeat_shutdown_tx, mut heartbeat_shutdown_rx) = tokio::sync::mpsc::channel(1);
         let instance_id = group.instance_id.clone();
@@ -267,18 +267,19 @@ impl BroadcastGroup {
                             .await;
 
                         match result {
-                            Ok(updates) => {
+                            Ok((updates, origins)) => {
                                 let update_count = updates.len();
                                 let mut decoded_updates = Vec::with_capacity(update_count);
 
-                                for update in &updates {
+                                for (i, update) in updates.iter().enumerate() {
+                                    if i < origins.len() && origins[i] == instance_id_for_sub {
+                                        continue;
+                                    }
+
                                     if let Ok(decoded) = Update::decode_v1(update) {
                                         decoded_updates.push(decoded);
                                     }
 
-                                    if sender_for_sub.send(update.clone()).is_err() {
-                                        debug!("Failed to broadcast Redis update to clients for '{}'", stream_key);
-                                    }
                                 }
 
                                 if !decoded_updates.is_empty() {
@@ -410,7 +411,8 @@ impl BroadcastGroup {
             let redis_store = self.redis_store.clone();
             let doc_name = self.doc_name.clone();
             let stream_key = format!("yjs:stream:{}", doc_name);
-            let mut publish = Publish::new(redis_store, stream_key);
+            let instance_id = self.instance_id.clone();
+            let mut publish = Publish::new(redis_store, stream_key, instance_id);
             tokio::spawn(async move {
                 while let Some(res) = stream.next().await {
                     let data = match res.map_err(anyhow::Error::from) {

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -135,6 +135,7 @@ impl BroadcastGroup {
                                         let msg_bytes = Bytes::from(Message::Awareness(update).encode_v1());
                                         if sink.send(msg_bytes).is_err() {
                                             warn!("couldn't broadcast awareness update");
+                                            return;
                                         }
                                     }
                                 } else {

--- a/server/websocket/src/broadcast/mod.rs
+++ b/server/websocket/src/broadcast/mod.rs
@@ -1,4 +1,7 @@
 pub mod group;
 pub mod pool;
+mod publish;
 pub mod tasks;
 pub mod types;
+
+use publish::Publish;

--- a/server/websocket/src/broadcast/publish.rs
+++ b/server/websocket/src/broadcast/publish.rs
@@ -1,0 +1,55 @@
+use crate::storage::redis::RedisStore;
+use anyhow::Result;
+use bytes::Bytes;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use yrs::{updates::decoder::Decode, Doc, ReadTxn, StateVector, Transact, Update};
+
+pub struct Publish {
+    redis_store: Arc<RedisStore>,
+    stream_key: String,
+    count: u32,
+    doc: Doc,
+    last_flush: Option<Instant>,
+}
+
+impl Publish {
+    pub fn new(redis_store: Arc<RedisStore>, stream_key: String) -> Self {
+        Self {
+            redis_store,
+            stream_key,
+            count: 0,
+            doc: Doc::new(),
+            last_flush: None,
+        }
+    }
+
+    pub async fn insert(&mut self, bytes: Bytes) -> Result<()> {
+        let update = Update::decode_v1(&bytes)?;
+
+        self.doc.transact_mut().apply_update(update)?;
+        self.count += 1;
+        let time_since_last_flush = self
+            .last_flush
+            .map_or(Duration::from_secs(0), |t| t.elapsed());
+
+        if time_since_last_flush > Duration::from_millis(20) || self.count >= 4 {
+            self.flush().await?;
+        }
+        Ok(())
+    }
+
+    pub async fn flush(&mut self) -> Result<()> {
+        let update = {
+            let txn = self.doc.transact_mut();
+            txn.encode_state_as_update_v1(&StateVector::default())
+        };
+        self.redis_store
+            .publish_update(&self.stream_key, &update)
+            .await?;
+        self.doc = Doc::new();
+        self.last_flush = Some(Instant::now());
+        self.count = 0;
+        Ok(())
+    }
+}

--- a/server/websocket/src/broadcast/publish.rs
+++ b/server/websocket/src/broadcast/publish.rs
@@ -28,7 +28,7 @@ impl Publish {
         let (flush_sender, mut flush_receiver) = mpsc::channel(32);
 
         let timer_task = tokio::spawn(async move {
-            let mut interval = interval(Duration::from_millis(20));
+            let mut interval = interval(Duration::from_millis(22));
 
             loop {
                 tokio::select! {
@@ -90,7 +90,7 @@ impl Publish {
             let mut count = self.count.lock().await;
             *count += 1;
 
-            if *count > 4 {
+            if *count > 5 {
                 let _ = self.flush_sender.send(()).await;
             }
         }

--- a/server/websocket/src/broadcast/publish.rs
+++ b/server/websocket/src/broadcast/publish.rs
@@ -33,7 +33,7 @@ impl Publish {
             .last_flush
             .map_or(Duration::from_secs(0), |t| t.elapsed());
 
-        if time_since_last_flush > Duration::from_millis(20) || self.count >= 4 {
+        if time_since_last_flush > Duration::from_millis(20) || self.count > 4 {
             self.flush().await?;
         }
         Ok(())

--- a/server/websocket/src/broadcast/publish.rs
+++ b/server/websocket/src/broadcast/publish.rs
@@ -17,13 +17,14 @@ pub struct Publish {
 }
 
 impl Publish {
-    pub fn new(redis_store: Arc<RedisStore>, stream_key: String) -> Self {
+    pub fn new(redis_store: Arc<RedisStore>, stream_key: String, instance_id: String) -> Self {
         let doc = Arc::new(Mutex::new(Doc::new()));
         let doc_clone = doc.clone();
         let redis_clone = redis_store.clone();
         let stream_key_clone = stream_key.clone();
         let count = Arc::new(Mutex::new(0));
         let count_clone = count.clone();
+        let instance_id_clone = instance_id.clone();
 
         let (flush_sender, mut flush_receiver) = mpsc::channel(32);
 
@@ -40,7 +41,7 @@ impl Publish {
                                 txn.encode_state_as_update_v1(&StateVector::default())
                             };
 
-                            if let Err(e) = redis_clone.publish_update(&stream_key_clone, &update).await {
+                            if let Err(e) = redis_clone.publish_update_with_origin(&stream_key_clone, &update, &instance_id_clone).await {
                                 warn!("Failed to flush document: {}", e);
                             }
 
@@ -57,7 +58,7 @@ impl Publish {
                                 txn.encode_state_as_update_v1(&StateVector::default())
                             };
 
-                            if let Err(e) = redis_clone.publish_update(&stream_key_clone, &update).await {
+                            if let Err(e) = redis_clone.publish_update_with_origin(&stream_key_clone, &update, &instance_id_clone).await {
                                 warn!("Failed to flush document: {}", e);
                             }
 

--- a/server/websocket/src/conn.rs
+++ b/server/websocket/src/conn.rs
@@ -80,7 +80,6 @@ impl<Sink, Stream> Future for Connection<Sink, Stream> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.completion_future.is_none() {
             if let Some(sub) = self.broadcast_sub.take() {
-                tracing::info!("Creating completion future from subscription");
                 self.completion_future = Some(Box::pin(sub.completed()));
             }
         }
@@ -89,10 +88,10 @@ impl<Sink, Stream> Future for Connection<Sink, Stream> {
             let poll_result = fut.as_mut().poll(cx);
             match &poll_result {
                 Poll::Ready(result) => {
-                    tracing::info!("Connection future completed with result: {:?}", result);
+                    tracing::debug!("Connection future completed with result: {:?}", result);
                 }
                 Poll::Pending => {
-                    tracing::info!("Connection future is pending");
+                    tracing::debug!("Connection future is pending");
                 }
             }
             poll_result

--- a/server/websocket/src/conn.rs
+++ b/server/websocket/src/conn.rs
@@ -7,6 +7,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio::time::{interval, Duration};
 use yrs::sync::Error;
 
 use crate::group::{BroadcastGroup, Subscription};
@@ -17,6 +19,8 @@ pub struct Connection<Sink, Stream> {
     broadcast_sub: Option<Subscription>,
     completion_future: Option<CompletionFuture>,
     user_token: Option<String>,
+    ping_interval: Duration,
+    ping_task: Option<JoinHandle<()>>,
     _sink: PhantomData<Sink>,
     _stream: PhantomData<Stream>,
 }
@@ -36,17 +40,37 @@ where
         let sink = Arc::new(Mutex::new(sink));
         let broadcast_sub = Some(
             broadcast_group
-                .subscribe(sink, stream, user_token.clone())
+                .subscribe(sink.clone(), stream, user_token.clone())
                 .await,
         );
+
+        let ping_interval = Duration::from_secs(15);
+        let ping_task = Some(Self::start_ping_task(sink, ping_interval));
 
         Connection {
             broadcast_sub,
             completion_future: None,
             user_token,
+            ping_interval,
+            ping_task,
             _sink: PhantomData,
             _stream: PhantomData,
         }
+    }
+
+    fn start_ping_task(sink: Arc<Mutex<Sink>>, ping_interval: Duration) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut interval = interval(ping_interval);
+            loop {
+                interval.tick().await;
+                let ping_message = Bytes::from("ping");
+                let mut sink_lock = sink.lock().await;
+                if let Err(e) = sink_lock.send(ping_message).await {
+                    tracing::warn!("Failed to send ping: {:?}", e);
+                    break;
+                }
+            }
+        })
     }
 }
 
@@ -56,12 +80,22 @@ impl<Sink, Stream> Future for Connection<Sink, Stream> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.completion_future.is_none() {
             if let Some(sub) = self.broadcast_sub.take() {
+                tracing::info!("Creating completion future from subscription");
                 self.completion_future = Some(Box::pin(sub.completed()));
             }
         }
 
         if let Some(fut) = self.completion_future.as_mut() {
-            fut.as_mut().poll(cx)
+            let poll_result = fut.as_mut().poll(cx);
+            match &poll_result {
+                Poll::Ready(result) => {
+                    tracing::info!("Connection future completed with result: {:?}", result);
+                }
+                Poll::Pending => {
+                    tracing::info!("Connection future is pending");
+                }
+            }
+            poll_result
         } else {
             Poll::Ready(Ok(()))
         }
@@ -72,6 +106,10 @@ impl<Sink, Stream> Drop for Connection<Sink, Stream> {
     fn drop(&mut self) {
         if let Some(sub) = self.broadcast_sub.take() {
             drop(sub);
+        }
+
+        if let Some(task) = self.ping_task.take() {
+            task.abort();
         }
     }
 }

--- a/server/websocket/src/ws.rs
+++ b/server/websocket/src/ws.rs
@@ -15,7 +15,8 @@ use futures_util::{Stream, StreamExt};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tracing::{debug, error};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, warn};
 use yrs::sync::Error;
 
 #[cfg(feature = "auth")]
@@ -76,17 +77,23 @@ impl futures_util::Sink<Bytes> for WarpSink {
 }
 
 #[derive(Debug)]
-pub struct WarpStream(SplitStream<WebSocket>);
+pub struct WarpStream(SplitStream<WebSocket>, Option<mpsc::Sender<Message>>);
 
 impl From<SplitStream<WebSocket>> for WarpStream {
     fn from(stream: SplitStream<WebSocket>) -> Self {
-        WarpStream(stream)
+        WarpStream(stream, None)
     }
 }
 
 impl From<WarpStream> for SplitStream<WebSocket> {
     fn from(val: WarpStream) -> Self {
         val.0
+    }
+}
+
+impl WarpStream {
+    pub fn with_pong_sender(stream: SplitStream<WebSocket>, sender: mpsc::Sender<Message>) -> Self {
+        WarpStream(stream, Some(sender))
     }
 }
 
@@ -100,7 +107,22 @@ impl Stream for WarpStream {
             Poll::Ready(Some(res)) => match res {
                 Ok(msg) => match msg {
                     Message::Binary(data) => Poll::Ready(Some(Ok(data))),
-                    Message::Ping(_) | Message::Pong(_) | Message::Text(_) => {
+                    Message::Ping(ping_data) => {
+                        if let Some(sender) = &self.1 {
+                            let pong_msg = Message::Pong(ping_data.clone());
+                            let tx = sender.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = tx.send(pong_msg).await {
+                                    warn!("Failed to send pong message: {}", e);
+                                } else {
+                                    info!("Pong response sent");
+                                }
+                            });
+                        }
+                        cx.waker().wake_by_ref();
+                        Poll::Pending
+                    }
+                    Message::Pong(_) | Message::Text(_) => {
                         cx.waker().wake_by_ref();
                         Poll::Pending
                     }
@@ -175,37 +197,37 @@ async fn handle_socket(
 ) {
     let (sender, receiver) = socket.split();
 
-    let conn = crate::conn::Connection::new(
-        bcast.clone(),
-        WarpSink(sender),
-        WarpStream(receiver),
-        user_token,
-    )
-    .await;
+    let (pong_tx, _pong_rx) = mpsc::channel::<Message>(32);
+
+    let sink = WarpSink(sender);
+    let stream = WarpStream::with_pong_sender(receiver, pong_tx);
+
+    let conn = crate::conn::Connection::new(bcast.clone(), sink, stream, user_token).await;
 
     if let Err(e) = bcast.increment_connections().await {
         error!("Failed to increment connections: {}", e);
     }
 
-    // tracing::info!("WebSocket connection established for document '{}'", doc_id);
+    tracing::info!("WebSocket connection established for document '{}'", doc_id);
 
-    let result = conn.await;
-    if let Err(e) = result {
-        error!("WebSocket connection error: {}", e);
+    if let Err(e) = conn.await {
+        error!(
+            "WebSocket connection error for document '{}': {}",
+            doc_id, e
+        );
     }
-    // tracing::info!("WebSocket connection closed for document '{}'", doc_id);
+
+    tracing::info!("WebSocket connection closed for document '{}'", doc_id);
 
     let _ = bcast.decrement_connections().await;
 
     let count = bcast.connection_count();
 
     if count == 0 {
-        if let Err(e) = pool.cleanup_empty_group(&doc_id, bcast).await {
+        if let Err(e) = pool.cleanup_empty_group(&doc_id).await {
             error!("Failed to cleanup empty group for {}: {}", doc_id, e);
         }
     }
-
-    debug!("Connection decreased for document '{}'", doc_id);
 }
 
 fn normalize_doc_id(doc_id: &str) -> String {

--- a/server/websocket/src/ws.rs
+++ b/server/websocket/src/ws.rs
@@ -208,7 +208,7 @@ async fn handle_socket(
         error!("Failed to increment connections: {}", e);
     }
 
-    tracing::info!("WebSocket connection established for document '{}'", doc_id);
+    // tracing::info!("WebSocket connection established for document '{}'", doc_id);
 
     if let Err(e) = conn.await {
         error!(
@@ -217,7 +217,7 @@ async fn handle_socket(
         );
     }
 
-    tracing::info!("WebSocket connection closed for document '{}'", doc_id);
+    // tracing::info!("WebSocket connection closed for document '{}'", doc_id);
 
     let _ = bcast.decrement_connections().await;
 

--- a/server/websocket/src/ws.rs
+++ b/server/websocket/src/ws.rs
@@ -208,7 +208,7 @@ async fn handle_socket(
         error!("Failed to increment connections: {}", e);
     }
 
-    // tracing::info!("WebSocket connection established for document '{}'", doc_id);
+    tracing::info!("WebSocket connection established for document '{}'", doc_id);
 
     if let Err(e) = conn.await {
         error!(
@@ -217,7 +217,7 @@ async fn handle_socket(
         );
     }
 
-    // tracing::info!("WebSocket connection closed for document '{}'", doc_id);
+    tracing::info!("WebSocket connection closed for document '{}'", doc_id);
 
     let _ = bcast.decrement_connections().await;
 


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new publishing mechanism for managing document updates and publishing them to a Redis store, enhancing real-time update delivery.
  - Added a ping mechanism to maintain connection health with periodic pings.
  - Implemented graceful shutdown handling for the server, improving termination processes.
  - Enhanced WebSocket functionality to automatically respond to ping messages with pong messages.

- **Refactor**
  - Streamlined the internal update processing for faster and more reliable communication during live sessions.
  - Simplified the cleanup process for empty broadcast groups, improving responsiveness.
  - Updated method signatures and internal logic for better management of broadcast groups and connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->