### PR TITLE
fix(api): Add handling for Cloud Batch status SCHEDULED in conversion [FLOW-BE-96]

### DIFF
--- a/server/api/internal/infrastructure/gcpbatch/batch.go
+++ b/server/api/internal/infrastructure/gcpbatch/batch.go
@@ -307,6 +307,8 @@ func convertGCPStatusToGatewayStatus(gcpStatus batchpb.JobStatus_State) gateway.
 		return gateway.JobStatusUnknown
 	case batchpb.JobStatus_QUEUED:
 		return gateway.JobStatusPending
+	case batchpb.JobStatus_SCHEDULED:
+		return gateway.JobStatusPending
 	case batchpb.JobStatus_RUNNING:
 		return gateway.JobStatusRunning
 	case batchpb.JobStatus_SUCCEEDED:

--- a/server/api/internal/infrastructure/gcpbatch/batch_test.go
+++ b/server/api/internal/infrastructure/gcpbatch/batch_test.go
@@ -131,6 +131,7 @@ func TestConvertGCPStatusToGatewayStatus(t *testing.T) {
 	}{
 		{"Unspecified", batchpb.JobStatus_STATE_UNSPECIFIED, gateway.JobStatusUnknown},
 		{"Queued", batchpb.JobStatus_QUEUED, gateway.JobStatusPending},
+		{"Scheduled", batchpb.JobStatus_SCHEDULED, gateway.JobStatusPending},
 		{"Running", batchpb.JobStatus_RUNNING, gateway.JobStatusRunning},
 		{"Succeeded", batchpb.JobStatus_SUCCEEDED, gateway.JobStatusCompleted},
 		{"Failed", batchpb.JobStatus_FAILED, gateway.JobStatusFailed},


### PR DESCRIPTION
# Overview
This pull request includes changes to the `convertGCPStatusToGatewayStatus` function and its associated test to ensure that the `SCHEDULED` status is correctly mapped to `JobStatusPending`.

Mapping GCP status to gateway status:

* [`server/api/internal/infrastructure/gcpbatch/batch.go`](diffhunk://#diff-0abacb41ff875a4bc1135ba9a9434ec0d2ffc3a79eac8df992f349776a605a7fR310-R311): Added a case for `batchpb.JobStatus_SCHEDULED` to return `gateway.JobStatusPending`.

Updating tests:

* [`server/api/internal/infrastructure/gcpbatch/batch_test.go`](diffhunk://#diff-a9c63fd4b957da7b6bf881b68bdb518115547440506958323901fcaafe5b1795R134): Added a test case to verify that `batchpb.JobStatus_SCHEDULED` maps to `gateway.JobStatusPending`.
## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced job status classification: Scheduled jobs are now displayed as pending, ensuring a clearer and more consistent view of job progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->