### PR TITLE
fix(ui): workflow tab name update

### DIFF
--- a/ui/src/features/Editor/components/ParamsPanel/components/ParamEditor/index.tsx
+++ b/ui/src/features/Editor/components/ParamsPanel/components/ParamEditor/index.tsx
@@ -30,7 +30,7 @@ type Props = {
     data: any,
     type: "params" | "customizations",
   ) => Promise<void>;
-  onWorkflowRename: (id: string, name: string) => void;
+  onWorkflowRename?: (id: string, name: string) => void;
 };
 
 const ParamEditor: React.FC<Props> = ({
@@ -83,7 +83,7 @@ const ParamEditor: React.FC<Props> = ({
       onUpdate(nodeId, updatedParams, "params");
     } else if (nodeType === "subworkflow" && nodeMeta.subworkflowId) {
       onUpdate(nodeId, updatedCustomization, "customizations");
-      onWorkflowRename(
+      onWorkflowRename?.(
         nodeMeta?.subworkflowId,
         updatedCustomization?.customName || nodeMeta?.officialName,
       );

--- a/ui/src/features/Editor/components/ParamsPanel/components/ParamEditor/index.tsx
+++ b/ui/src/features/Editor/components/ParamsPanel/components/ParamEditor/index.tsx
@@ -30,6 +30,7 @@ type Props = {
     data: any,
     type: "params" | "customizations",
   ) => Promise<void>;
+  onWorkflowRename: (id: string, name: string) => void;
 };
 
 const ParamEditor: React.FC<Props> = ({
@@ -38,6 +39,7 @@ const ParamEditor: React.FC<Props> = ({
   nodeType,
   // nodeParameters = [{ id: "param1", name: "Param 1", value: "Value 1", type: "string"}],
   onUpdate,
+  onWorkflowRename,
 }) => {
   const t = useT();
   const { useGetActionById } = useAction(i18n.language);
@@ -79,6 +81,12 @@ const ParamEditor: React.FC<Props> = ({
   const handleUpdate = () => {
     if (activeTab === "params") {
       onUpdate(nodeId, updatedParams, "params");
+    } else if (nodeType === "subworkflow" && nodeMeta.subworkflowId) {
+      onUpdate(nodeId, updatedCustomization, "customizations");
+      onWorkflowRename(
+        nodeMeta?.subworkflowId,
+        updatedCustomization?.customName || nodeMeta?.officialName,
+      );
     } else {
       onUpdate(nodeId, updatedCustomization, "customizations");
     }

--- a/ui/src/features/Editor/components/ParamsPanel/index.tsx
+++ b/ui/src/features/Editor/components/ParamsPanel/index.tsx
@@ -19,9 +19,14 @@ type Props = {
     dataField: "params" | "customizations",
     updatedValue: any,
   ) => void;
+  onWorkflowRename: (id: string, name: string) => void;
 };
 
-const ParamsPanel: React.FC<Props> = ({ selected, onDataSubmit }) => {
+const ParamsPanel: React.FC<Props> = ({
+  selected,
+  onDataSubmit,
+  onWorkflowRename,
+}) => {
   const t = useT();
   // This is a little hacky, but it works. We need to dispatch a click event to the react-flow__pane
   // to unlock the node when user wants to close the right panel. - @KaWaite
@@ -76,6 +81,7 @@ const ParamsPanel: React.FC<Props> = ({ selected, onDataSubmit }) => {
             nodeMeta={selected.data}
             nodeType={selected.type}
             onUpdate={handleUpdate}
+            onWorkflowRename={onWorkflowRename}
           />
         )}
       </DialogContent>

--- a/ui/src/features/Editor/components/ParamsPanel/index.tsx
+++ b/ui/src/features/Editor/components/ParamsPanel/index.tsx
@@ -19,7 +19,7 @@ type Props = {
     dataField: "params" | "customizations",
     updatedValue: any,
   ) => void;
-  onWorkflowRename: (id: string, name: string) => void;
+  onWorkflowRename?: (id: string, name: string) => void;
 };
 
 const ParamsPanel: React.FC<Props> = ({

--- a/ui/src/features/Editor/components/TopBar/index.tsx
+++ b/ui/src/features/Editor/components/TopBar/index.tsx
@@ -21,7 +21,6 @@ type Props = {
   onDebugRunStop: () => Promise<void>;
   onWorkflowClose: (workflowId: string) => void;
   onWorkflowChange: (workflowId?: string) => void;
-  onWorkflowRename: (id: string, name: string) => void;
 };
 
 const TopBar: React.FC<Props> = ({
@@ -35,7 +34,6 @@ const TopBar: React.FC<Props> = ({
   onDebugRunStop,
   onWorkflowClose,
   onWorkflowChange,
-  onWorkflowRename,
 }) => {
   return (
     <div className="flex shrink-0 justify-between gap-2 bg-secondary w-[100vw]">
@@ -55,7 +53,6 @@ const TopBar: React.FC<Props> = ({
           openWorkflows={openWorkflows}
           onWorkflowClose={onWorkflowClose}
           onWorkflowChange={onWorkflowChange}
-          onWorkflowRename={onWorkflowRename}
         />
       </div>
       <div className="flex select-none items-center h-full justify-center gap-2 self-center p-1">

--- a/ui/src/features/Editor/components/WorkflowTabs/WorkflowTab.tsx
+++ b/ui/src/features/Editor/components/WorkflowTabs/WorkflowTab.tsx
@@ -2,16 +2,12 @@ import { Graph, X } from "@phosphor-icons/react";
 
 type Props = {
   currentWorkflowId?: string;
-  editId?: string;
   id: string;
   name?: string;
-  setName: (name: string) => void;
   onWorkflowChange: (workflowId?: string) => void;
   onWorkflowClose: (
     workflowId: string,
   ) => (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
-  onDoubleClick?: (workflowId: string, name: string | undefined) => void;
-  onSubmit: () => void;
 };
 
 const WorkflowTab: React.FC<Props> = ({
@@ -20,13 +16,11 @@ const WorkflowTab: React.FC<Props> = ({
   name,
   onWorkflowChange,
   onWorkflowClose,
-  onDoubleClick,
 }) => {
   return (
     <div
       className={`relative rounded-t flex h-4/5 w-[150px] shrink-0 items-end justify-center transition-colors ${currentWorkflowId === id ? "bg-node-subworkflow" : "bg-node-subworkflow/50 hover:bg-node-subworkflow"} group cursor-pointer`}
       onClick={() => onWorkflowChange(id)}
-      onDoubleClick={() => onDoubleClick?.(id, name)}
       key={id}>
       <div
         className={`h-full flex gap-2 items-center justify-center ml-[15px] mr-[19px] group-hover:text-white dark:font-extralight ${currentWorkflowId !== id && "text-accent-foreground"}`}>

--- a/ui/src/features/Editor/components/WorkflowTabs/WorkflowTab.tsx
+++ b/ui/src/features/Editor/components/WorkflowTabs/WorkflowTab.tsx
@@ -19,13 +19,17 @@ const WorkflowTab: React.FC<Props> = ({
 }) => {
   return (
     <div
-      className={`relative rounded-t flex h-4/5 w-[150px] shrink-0 items-end justify-center transition-colors ${currentWorkflowId === id ? "bg-node-subworkflow" : "bg-node-subworkflow/50 hover:bg-node-subworkflow"} group cursor-pointer`}
+      className={`relative rounded-t flex h-4/5 w-[150px] gap-1 shrink-0 items-end transition-colors ${currentWorkflowId === id ? "bg-node-subworkflow" : "bg-node-subworkflow/50 hover:bg-node-subworkflow"} group cursor-pointer`}
       onClick={() => onWorkflowChange(id)}
       key={id}>
       <div
-        className={`h-full flex gap-2 items-center justify-center ml-[15px] mr-[19px] group-hover:text-white dark:font-extralight ${currentWorkflowId !== id && "text-accent-foreground"}`}>
+        className={`h-full flex gap-2 items-center ml-[8px] group-hover:text-white dark:font-extralight ${currentWorkflowId !== id && "text-accent-foreground"}`}>
         <Graph weight="light" />
-        <p className="select-none truncate text-center text-xs">{name}</p>
+      </div>
+      <div className="flex justify-center items-center text-center w-[100px] h-full overflow-hidden">
+        <p className="select-none truncate text-center text-xs w-full">
+          {name}
+        </p>
       </div>
       <div className="bg-secondary h-full w-[35px] absolute right-0 flex group-hover:delay-200 group-hover:opacity-100 opacity-0 delay-0 transition-all shadow-[-8px_0_8px_rgba(0,0,0,0.1)]">
         <div className="bg-node-entrance/60 w-full flex items-center justify-center rounded-tr">

--- a/ui/src/features/Editor/components/WorkflowTabs/index.tsx
+++ b/ui/src/features/Editor/components/WorkflowTabs/index.tsx
@@ -1,7 +1,6 @@
-import { memo, useState } from "react";
+import { memo } from "react";
 
 import { ScrollArea } from "@flow/components";
-import { useToast } from "@flow/features/NotificationSystem/useToast";
 import { useT } from "@flow/lib/i18n";
 import { Workflow } from "@flow/types";
 
@@ -15,7 +14,6 @@ type Props = {
   }[];
   onWorkflowClose: (workflowId: string) => void;
   onWorkflowChange: (workflowId?: string) => void;
-  onWorkflowRename?: (id: string, name: string) => void;
 };
 
 const WorkflowTabs: React.FC<Props> = ({
@@ -23,13 +21,8 @@ const WorkflowTabs: React.FC<Props> = ({
   openWorkflows,
   onWorkflowClose,
   onWorkflowChange,
-  onWorkflowRename,
 }) => {
   const t = useT();
-  const { toast } = useToast();
-
-  const [name, setName] = useState<string | undefined>();
-  const [editId, setEditId] = useState<string | undefined>();
 
   const mainWorkflow = openWorkflows?.[0];
 
@@ -41,35 +34,6 @@ const WorkflowTabs: React.FC<Props> = ({
       e.stopPropagation();
       onWorkflowClose(workflowId);
     };
-
-  const handleDoubleClick = onWorkflowRename
-    ? (workflowId: string, name: string | undefined) => {
-        setEditId(workflowId);
-        setName(name);
-      }
-    : undefined;
-
-  const handleSubmit = () => {
-    if (!name || !editId) {
-      setEditId(undefined);
-      setName(undefined);
-      return;
-    }
-    const trimmedName = name?.trim();
-    if (!trimmedName || trimmedName.length < 1) return;
-
-    try {
-      onWorkflowRename?.(editId, trimmedName);
-    } catch {
-      toast({
-        title: t("Unable to rename workflow"),
-        description: t("Renaming workflow failed. Please try again later."),
-        variant: "destructive",
-      });
-    }
-    setEditId(undefined);
-    setName(undefined);
-  };
 
   return (
     <div className="flex gap-1 h-full flex-1 items-end w-full overflow-hidden">
@@ -88,15 +52,11 @@ const WorkflowTabs: React.FC<Props> = ({
             subWorkflows.map((sw) => (
               <WorkflowTab
                 currentWorkflowId={currentWorkflowId}
-                editId={editId}
                 id={sw.id}
                 key={sw.id}
                 name={sw.name}
-                setName={setName}
                 onWorkflowChange={onWorkflowChange}
                 onWorkflowClose={handleWorkflowClose}
-                onDoubleClick={handleDoubleClick}
-                onSubmit={handleSubmit}
               />
             ))}
         </div>

--- a/ui/src/features/Editor/hooks.ts
+++ b/ui/src/features/Editor/hooks.ts
@@ -139,6 +139,7 @@ export default ({
     handleWorkflowOpen,
     handleWorkflowClose,
     handleCurrentWorkflowIdChange,
+    setWorkflowsNames,
   } = useWorkflowTabs({
     currentWorkflowId,
     rawWorkflows,
@@ -279,6 +280,16 @@ export default ({
     // },
   ]);
 
+  const handleWorkflowRename = useCallback(
+    (id: string, newName: string) => {
+      handleYWorkflowRename(id, newName);
+      setWorkflowsNames((prevNames) =>
+        prevNames.map((w) => (w.id === id ? { ...w, name: newName } : w)),
+      );
+    },
+    [handleYWorkflowRename, setWorkflowsNames],
+  );
+
   return {
     isSubworkflow,
     currentWorkflowId,
@@ -305,7 +316,7 @@ export default ({
     handleWorkflowChange: handleCurrentWorkflowIdChange,
     handleWorkflowRedo: handleYWorkflowRedo,
     handleWorkflowUndo: handleYWorkflowUndo,
-    handleWorkflowRename: handleYWorkflowRename,
+    handleWorkflowRename,
     handleLayoutChange,
     handleNodesAdd: handleYNodesAdd,
     handleNodesChange: handleYNodesChange,

--- a/ui/src/features/Editor/index.tsx
+++ b/ui/src/features/Editor/index.tsx
@@ -89,7 +89,6 @@ export default function Editor({
           onWorkflowDeployment={handleWorkflowDeployment}
           onWorkflowClose={handleWorkflowClose}
           onWorkflowChange={handleWorkflowChange}
-          onWorkflowRename={handleWorkflowRename}
           onDebugRunStart={handleDebugRunStart}
           onDebugRunStop={handleDebugRunStop}
         />
@@ -137,6 +136,7 @@ export default function Editor({
           <ParamsPanel
             selected={locallyLockedNode}
             onDataSubmit={handleNodeDataUpdate}
+            onWorkflowRename={handleWorkflowRename}
           />
         </div>
       </EditorProvider>

--- a/ui/src/lib/i18n/locales/en.json
+++ b/ui/src/lib/i18n/locales/en.json
@@ -146,8 +146,6 @@
   "Deployments": "",
   "Triggers": "",
   "Jobs": "",
-  "Unable to rename workflow": "Unable to rename workflow",
-  "Renaming workflow failed. Please try again later.": "Renaming workflow failed. Please try again later.",
   "Main Workflow": "",
   "Reader node cannot be copied": "",
   "Only one reader can be present in any project.": "",

--- a/ui/src/lib/i18n/locales/es.json
+++ b/ui/src/lib/i18n/locales/es.json
@@ -146,8 +146,6 @@
   "Deployments": "Despliegues",
   "Triggers": "Disparadores",
   "Jobs": "Trabajos",
-  "Unable to rename workflow": "No se puede renombrar el flujo de trabajo",
-  "Renaming workflow failed. Please try again later.": "Renombrar el flujo de trabajo falló. Por favor, inténtalo de nuevo más tarde.",
   "Main Workflow": "Flujo de trabajo principal",
   "Reader node cannot be copied": "El nodo lector no se puede copiar",
   "Only one reader can be present in any project.": "Solo puede haber un lector en cualquier proyecto.",

--- a/ui/src/lib/i18n/locales/fr.json
+++ b/ui/src/lib/i18n/locales/fr.json
@@ -146,8 +146,6 @@
   "Deployments": "Déploiements",
   "Triggers": "Déclencheurs",
   "Jobs": "Emplois",
-  "Unable to rename workflow": "Impossible de renommer le flux de travail",
-  "Renaming workflow failed. Please try again later.": "Échec du renommage du flux de travail. Veuillez réessayer plus tard.",
   "Main Workflow": "Flux de travail principal",
   "Reader node cannot be copied": "",
   "Only one reader can be present in any project.": "",

--- a/ui/src/lib/i18n/locales/ja.json
+++ b/ui/src/lib/i18n/locales/ja.json
@@ -146,8 +146,6 @@
   "Deployments": "デプロイ",
   "Triggers": "トリガー",
   "Jobs": "ジョブ",
-  "Unable to rename workflow": "ワークフローの名前を変更できません",
-  "Renaming workflow failed. Please try again later.": "ワークフローの名前変更に失敗しました。後でもう一度お試しください。",
   "Main Workflow": "メインワークフロー",
   "Reader node cannot be copied": "リーダーノードはコピーできません",
   "Only one reader can be present in any project.": "プロジェクトには1つのリーダーしか存在できません。",

--- a/ui/src/lib/i18n/locales/zh.json
+++ b/ui/src/lib/i18n/locales/zh.json
@@ -146,8 +146,6 @@
   "Deployments": "部署",
   "Triggers": "触发器",
   "Jobs": "任务",
-  "Unable to rename workflow": "无法重命名工作流",
-  "Renaming workflow failed. Please try again later.": "重命名工作流失败。请稍后再试。",
   "Main Workflow": "主工作流",
   "Reader node cannot be copied": "读者节点无法复制",
   "Only one reader can be present in any project.": "任何项目中只能存在一个读者。",

--- a/ui/src/lib/yjs/useWorkflowTabs.ts
+++ b/ui/src/lib/yjs/useWorkflowTabs.ts
@@ -21,6 +21,7 @@ export default ({
   const [workflowNames, setWorkflowsNames] = useState(
     rawWorkflows.map((w) => ({ id: w.id, name: w.name })),
   );
+  // Length check is used to for adding and removing workflows.
   // This works as a semi-static base for the rest of the state in this hook.
   // Without this state (aka using rawWorkflows directly), performance drops
   // due to the state updating on every change to a node (which is a lot)

--- a/ui/src/lib/yjs/useWorkflowTabs.ts
+++ b/ui/src/lib/yjs/useWorkflowTabs.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { DEFAULT_ENTRY_GRAPH_ID } from "@flow/global-constants";
 import { Workflow } from "@flow/types";
@@ -18,22 +18,24 @@ export default ({
     [currentWorkflowId],
   );
 
-  const workflowName = useMemo(
-    () => rawWorkflows.map((w) => w.name),
-    [rawWorkflows],
+  const [workflowNames, setWorkflowsNames] = useState(
+    rawWorkflows.map((w) => ({ id: w.id, name: w.name })),
   );
-
   // This works as a semi-static base for the rest of the state in this hook.
   // Without this state (aka using rawWorkflows directly), performance drops
   // due to the state updating on every change to a node (which is a lot)
-  const workflows = useMemo(
-    () =>
-      rawWorkflows.filter(isDefined).map((w2) => ({
-        id: w2.id as string,
-        name: w2.name as string,
-      })),
-    [rawWorkflows.length, workflowName], // eslint-disable-line react-hooks/exhaustive-deps
-  );
+  useEffect(() => {
+    if (rawWorkflows.length !== workflowNames.length) {
+      setWorkflowsNames(rawWorkflows.map((w) => ({ id: w.id, name: w.name })));
+    }
+  }, [rawWorkflows.length, workflowNames.length]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const workflows = useMemo(() => {
+    return workflowNames.filter(isDefined).map((w2) => ({
+      id: w2.id as string,
+      name: w2.name as string,
+    }));
+  }, [workflowNames]);
 
   const handleCurrentWorkflowIdChange = useCallback(
     (id?: string) => {
@@ -95,5 +97,7 @@ export default ({
     handleWorkflowOpen,
     handleWorkflowClose,
     handleCurrentWorkflowIdChange,
+    setWorkflowsNames,
+    workflowNames,
   };
 };

--- a/ui/src/lib/yjs/useWorkflowTabs.ts
+++ b/ui/src/lib/yjs/useWorkflowTabs.ts
@@ -18,6 +18,11 @@ export default ({
     [currentWorkflowId],
   );
 
+  const workflowName = useMemo(
+    () => rawWorkflows.map((w) => w.name),
+    [rawWorkflows],
+  );
+
   // This works as a semi-static base for the rest of the state in this hook.
   // Without this state (aka using rawWorkflows directly), performance drops
   // due to the state updating on every change to a node (which is a lot)
@@ -27,7 +32,7 @@ export default ({
         id: w2.id as string,
         name: w2.name as string,
       })),
-    [rawWorkflows.length], // eslint-disable-line react-hooks/exhaustive-deps
+    [rawWorkflows.length, workflowName], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   const handleCurrentWorkflowIdChange = useCallback(

--- a/ui/src/lib/yjs/useYWorkflow.ts
+++ b/ui/src/lib/yjs/useYWorkflow.ts
@@ -329,23 +329,11 @@ export default ({
         if (!name.trim()) {
           throw new Error("Workflow name cannot be empty");
         }
-
-        // Update subworkflow node in main workflow if this is a subworkflow
-        const mainWorkflow = yWorkflows.get(DEFAULT_ENTRY_GRAPH_ID);
-        const mainWorkflowNodes = mainWorkflow?.get("nodes") as YNodesMap;
-
-        mainWorkflowNodes.forEach((node) => {
-          // Get the id from the YNode
-          const nodeId = (node.get("id") as Y.Text).toString();
-
-          if (nodeId === id) {
-            // Get existing data as YMap
-            const nodeData = node.get("data") as Y.Map<unknown>;
-
-            if (nodeData.get("customName")?.toString() === name) return;
-            nodeData.set("customName", name);
-          }
-        });
+        const yWorkflow = yWorkflows.get(id);
+        if (!yWorkflow) return;
+        const yName = new Y.Text();
+        yName.insert(0, name.trim());
+        yWorkflow.set("name", yName);
       }),
     [undoTrackerActionWrapper, yWorkflows],
   );


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workflow renaming is now triggered from the parameters panel for subworkflow nodes when customizations are updated.

- **Refactor**
  - Workflow renaming logic and related callbacks were removed from the top bar and workflow tabs, streamlining the interface and simplifying workflow tab interactions.
  - Simplified internal workflow renaming logic to directly update workflow names.
  - Updated workflow names state management for improved synchronization.
  - Shifted workflow rename event handling from the top bar to the parameters panel within the editor.

- **Style**
  - Removed unused translation strings related to workflow renaming errors from all supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->