### PR TITLE
feat(engine): Add stdout log event publishing

### DIFF
--- a/engine/.gitignore
+++ b/engine/.gitignore
@@ -26,3 +26,4 @@ sample.xlsx
 metadata.json
 
 tmp/
+example.yml

--- a/engine/compose.yml
+++ b/engine/compose.yml
@@ -18,7 +18,7 @@ services:
     restart: always
     environment:
       - PROJECT_ID=local-project
-      - TOPIC_IDS=flow-edge-pass-through-topic,flow-log-stream-topic,flow-job-complete-topic # Corresponding pull-type subscriptions({TOPIC}-sub) will be created automatically
+      - TOPIC_IDS=flow-edge-pass-through-topic,flow-log-stream-topic,flow-job-complete-topic,flow-worker-stdout-log-topic,flow-node-status-topic # Corresponding pull-type subscriptions({TOPIC}-sub) will be created automatically
     ports:
       - 8085:8085
     networks:

--- a/engine/worker/README.md
+++ b/engine/worker/README.md
@@ -103,4 +103,5 @@ graphs:
 | FLOW_WORKER_LOG_STREAM_TOPIC              | Topic name of the event that occurs when the log comes into the log stream     | flow-log-stream-topic         |
 | FLOW_WORKER_JOB_COMPLETE_TOPIC            | Topic name of the event that will occur when the job is completed              | flow-job-complete-topic       |
 | FLOW_WORKER_NODE_STATUS_TOPIC             | Topic name of the event that will occur when each when Feature passes the node | flow-node-status-topic        |
+| FLOW_WORKER_STDOUT_LOG_TOPIC              | Topic name for the stdout/stderr log stream event                              | flow-worker-stdout-log-topic  |
 | FLOW_WORKER_ENABLE_JSON_LOG               | Enable log format to JSON format                                               | false                        |

--- a/engine/worker/src/command.rs
+++ b/engine/worker/src/command.rs
@@ -13,13 +13,15 @@ use crate::{
     asset::download_asset,
     event_handler::{EventHandler, NodeFailureHandler},
     factory::ALL_ACTION_FACTORIES,
-    logger::enable_file_logging,
+    logger::{enable_file_logging, set_pubsub_context},
     pubsub::{backend::PubSubBackend, publisher::Publisher},
     types::{
         job_complete_event::{JobCompleteEvent, JobResult},
         metadata::Metadata,
     },
 };
+
+use tokio::runtime::Handle;
 
 const WORKER_ASSET_GLOBAL_PARAMETER_VARIABLE: &str = "workerAssetPath";
 const WORKER_ARTIFACT_GLOBAL_PARAMETER_VARIABLE: &str = "workerArtifactPath";
@@ -145,18 +147,24 @@ impl RunWorkerCommand {
         let storage_resolver = Arc::new(resolve::StorageResolver::new());
         let (workflow, state, logger_factory, meta) = self.prepare(&storage_resolver).await?;
         enable_file_logging(meta.job_id)?;
+
         let pubsub = PubSubBackend::try_from(self.pubsub_backend.as_str())
             .await
             .map_err(crate::errors::Error::init)?;
 
-        let handler: Arc<dyn reearth_flow_runtime::event::EventHandler> = match pubsub {
-            PubSubBackend::Google(pubsub) => {
-                Arc::new(EventHandler::new(workflow.id, meta.job_id, pubsub))
+        let handle = Handle::current();
+
+        set_pubsub_context(pubsub.clone(), workflow.id, meta.job_id, handle);
+
+        let handler: Arc<dyn reearth_flow_runtime::event::EventHandler> = match &pubsub {
+            PubSubBackend::Google(p) => {
+                Arc::new(EventHandler::new(workflow.id, meta.job_id, p.clone()))
             }
-            PubSubBackend::Noop(pubsub) => {
-                Arc::new(EventHandler::new(workflow.id, meta.job_id, pubsub))
+            PubSubBackend::Noop(p) => {
+                Arc::new(EventHandler::new(workflow.id, meta.job_id, p.clone()))
             }
         };
+
         let workflow_id = workflow.id;
         let node_failure_handler = Arc::new(NodeFailureHandler::new());
         let result = AsyncRunner::run_with_event_handler(
@@ -181,11 +189,11 @@ impl RunWorkerCommand {
             Err(_) => JobResult::Failed,
         };
         self.cleanup(&meta, &storage_resolver).await?;
-        let pubsub = PubSubBackend::try_from(self.pubsub_backend.as_str())
+        let final_pubsub = PubSubBackend::try_from(self.pubsub_backend.as_str())
             .await
             .map_err(crate::errors::Error::init)?;
-        match pubsub {
-            PubSubBackend::Google(pubsub) => pubsub
+        match final_pubsub {
+            PubSubBackend::Google(p) => p
                 .publish(JobCompleteEvent::new(
                     workflow_id,
                     meta.job_id,
@@ -193,7 +201,14 @@ impl RunWorkerCommand {
                 ))
                 .await
                 .map_err(crate::errors::Error::run),
-            PubSubBackend::Noop(_) => Ok(()),
+            PubSubBackend::Noop(p) => p
+                .publish(JobCompleteEvent::new(
+                    workflow_id,
+                    meta.job_id,
+                    job_result.clone(),
+                ))
+                .await
+                .map_err(|e| crate::errors::Error::run(format!("{:?}", e))),
         }?;
         tracing::info!(
             "Job completed with workflow_id: {:?}, job_id: {:?} result: {:?}",

--- a/engine/worker/src/logger.rs
+++ b/engine/worker/src/logger.rs
@@ -5,12 +5,23 @@ use std::{
 };
 
 use crate::errors::Error;
+use crate::pubsub::backend::PubSubBackend;
+use crate::pubsub::publisher::Publisher;
+use crate::types::stdout_log_event::StdoutLogEvent;
 use once_cell::sync::Lazy;
+use parking_lot::RwLock as ParkingRwLock;
+use tokio::runtime::Handle;
+use tracing::field::{Field, Visit};
 use tracing::Level;
+use tracing::{Event, Subscriber};
 use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::fmt::time::UtcTime;
+use tracing_subscriber::layer::Context;
 use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Layer;
+use uuid::Uuid;
 
 static ENABLE_JSON_LOG: Lazy<bool> = Lazy::new(|| {
     env::var("FLOW_WORKER_ENABLE_JSON_LOG")
@@ -21,6 +32,123 @@ static ENABLE_JSON_LOG: Lazy<bool> = Lazy::new(|| {
 
 static WORKER_FILE_WRITER: Lazy<RwLock<Option<NonBlocking>>> = Lazy::new(|| RwLock::new(None));
 static WORKER_FILE_GUARD: Lazy<RwLock<Option<WorkerGuard>>> = Lazy::new(|| RwLock::new(None));
+
+static PUBSUB_PUBLISHER: Lazy<ParkingRwLock<Option<PubSubBackend>>> =
+    Lazy::new(|| ParkingRwLock::new(None));
+static WORKFLOW_ID: Lazy<ParkingRwLock<Option<Uuid>>> = Lazy::new(|| ParkingRwLock::new(None));
+static JOB_ID: Lazy<ParkingRwLock<Option<Uuid>>> = Lazy::new(|| ParkingRwLock::new(None));
+static TOKIO_RUNTIME_HANDLE: Lazy<ParkingRwLock<Option<Handle>>> =
+    Lazy::new(|| ParkingRwLock::new(None));
+
+pub fn set_pubsub_context(
+    publisher: PubSubBackend,
+    workflow_id: Uuid,
+    job_id: Uuid,
+    handle: Handle,
+) {
+    *PUBSUB_PUBLISHER.write() = Some(publisher);
+    *WORKFLOW_ID.write() = Some(workflow_id);
+    *JOB_ID.write() = Some(job_id);
+    *TOKIO_RUNTIME_HANDLE.write() = Some(handle);
+    tracing::info!("Pub/Sub context and Tokio handle set for stdout log publishing.");
+}
+
+#[derive(Default)]
+struct MessageExtractor(Option<String>);
+
+impl Visit for MessageExtractor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.0 = Some(value.to_string());
+        }
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            if self.0.is_none() {
+                self.0 = Some(format!("{:?}", value));
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+struct StdoutLogPublishLayer;
+
+impl<S> Layer<S> for StdoutLogPublishLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a> + Send + Sync,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let handle_guard = TOKIO_RUNTIME_HANDLE.read();
+        let handle = match handle_guard.as_ref() {
+            Some(h) => h.clone(),
+            None => return,
+        };
+        drop(handle_guard);
+        let publisher_guard = PUBSUB_PUBLISHER.read();
+        if publisher_guard.is_none() {
+            return;
+        }
+        let maybe_publisher = publisher_guard.clone();
+        drop(publisher_guard);
+        let workflow_id_guard = WORKFLOW_ID.read();
+        let workflow_id = match workflow_id_guard.as_ref() {
+            Some(id) => *id,
+            None => return,
+        };
+        drop(workflow_id_guard);
+        let job_id_guard = JOB_ID.read();
+        let job_id = match job_id_guard.as_ref() {
+            Some(id) => *id,
+            None => return,
+        };
+        drop(job_id_guard);
+
+        if let Some(publisher) = maybe_publisher {
+            let meta = event.metadata();
+            let level = meta.level();
+            let target = meta.target();
+            let event_timestamp = chrono::Utc::now();
+
+            let timestamp_str = event_timestamp.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+
+            let mut extractor = MessageExtractor::default();
+            event.record(&mut extractor);
+            let core_message = extractor.0.unwrap_or_else(|| "".to_string());
+
+            let message = format!(
+                "{}  {} {}: {}",
+                timestamp_str,
+                level,
+                target,
+                core_message
+            );
+
+            let log_event = StdoutLogEvent {
+                workflow_id,
+                job_id,
+                timestamp: event_timestamp,
+                level: level.to_string(),
+                message,
+                target: target.to_string(),
+            };
+
+            handle.spawn(async move {
+                let result = match publisher {
+                    PubSubBackend::Google(p) => {
+                        p.publish(log_event).await.map_err(|e| e.to_string())
+                    }
+                    PubSubBackend::Noop(p) => {
+                        p.publish(log_event).await.map_err(|e| format!("{:?}", e))
+                    }
+                };
+                if let Err(e) = result {
+                    eprintln!("Failed to publish stdout log event: {}", e);
+                }
+            });
+        }
+    }
+}
 
 #[derive(Clone)]
 struct DynamicFileWriter;
@@ -51,7 +179,10 @@ pub fn setup_logging_and_tracing() -> crate::errors::Result<()> {
         )
         .map_err(crate::errors::Error::init)?,
     );
-    let registry = tracing_subscriber::registry();
+
+    let registry = tracing_subscriber::registry().with(env_filter);
+    let pubsub_layer = StdoutLogPublishLayer;
+
     if *ENABLE_JSON_LOG {
         let mut console_layer = json_subscriber::JsonLayer::stdout();
         console_layer.with_flattened_event();
@@ -66,30 +197,30 @@ pub fn setup_logging_and_tracing() -> crate::errors::Result<()> {
         file_layer.with_timer("time", time_format);
 
         registry
-            .with(env_filter)
             .with(console_layer)
             .with(file_layer)
+            .with(pubsub_layer)
             .try_init()
             .map_err(Error::init)
     } else {
-        let event_format = tracing_subscriber::fmt::format()
+        let file_event_format = tracing_subscriber::fmt::format()
             .with_target(true)
-            .with_timer(time_format.clone());
+            .with_timer(time_format.clone())
+            .with_ansi(false);
 
         let console_layer = tracing_subscriber::fmt::layer()
-            .event_format(event_format)
+            .event_format(file_event_format.clone())
             .with_ansi(true)
             .with_writer(std::io::stdout);
 
         let file_layer = tracing_subscriber::fmt::layer()
-            .with_timer(time_format)
-            .with_ansi(false)
+            .event_format(file_event_format.clone())
             .with_writer(DynamicFileWriter);
 
         registry
-            .with(env_filter)
             .with(console_layer)
             .with(file_layer)
+            .with(pubsub_layer)
             .try_init()
             .map_err(Error::init)
     }

--- a/engine/worker/src/pubsub/backend.rs
+++ b/engine/worker/src/pubsub/backend.rs
@@ -17,6 +17,7 @@ impl PubSubBackendError {
     }
 }
 
+#[derive(Clone)]
 pub(crate) enum PubSubBackend {
     Google(google::CloudPubSub),
     Noop(noop::NoopPubSub),

--- a/engine/worker/src/pubsub/backend/google.rs
+++ b/engine/worker/src/pubsub/backend/google.rs
@@ -23,6 +23,7 @@ impl CloudPubSubError {
     }
 }
 
+#[derive(Clone)]
 pub struct CloudPubSub {
     pub(crate) client: Client,
     pub(crate) publishers: Arc<parking_lot::RwLock<HashMap<Topic, Arc<Publisher>>>>,
@@ -48,15 +49,24 @@ impl crate::pubsub::publisher::Publisher for CloudPubSub {
             if let Some(publisher) = publishers.get(&topic) {
                 publisher.clone()
             } else {
-                let pubsub_topic = self.client.topic(message.topic().to_string().as_str());
+                let pubsub_topic = self.client.topic(topic.as_ref());
                 let publisher = Arc::new(pubsub_topic.new_publisher(None));
-                publishers.insert(topic, publisher.clone());
+                publishers.insert(topic.clone(), publisher.clone());
                 publisher
             }
         };
-        let data = message.encode().map_err(CloudPubSubError::encode)?;
+        let validated_data = message.encode().map_err(CloudPubSubError::encode)?;
+
+        let message_id = validated_data.id.to_string();
+        let timestamp = validated_data.timestamp;
+        let data_bytes = validated_data.data;
+
         let pubsub_msg = PubsubMessage {
-            data: data.data.into(),
+            message_id,
+            publish_time: Some(std::time::SystemTime::from(timestamp).into()),
+            data: data_bytes.to_vec(),
+            attributes: HashMap::new(),
+            ordering_key: String::new(),
             ..Default::default()
         };
         let awaiter = publisher.publish(pubsub_msg).await;
@@ -65,19 +75,14 @@ impl crate::pubsub::publisher::Publisher for CloudPubSub {
     }
 
     async fn shutdown(&self) {
-        let publishers = self.publishers.read().clone();
-        let mut handles = vec![];
-
-        for publisher in publishers.values() {
-            let publisher = Arc::clone(publisher);
-            handles.push(tokio::spawn(async move {
-                if let Ok(mut publisher) = Arc::try_unwrap(publisher) {
-                    publisher.shutdown().await;
-                }
-            }));
+        tracing::debug!("CloudPubSub::shutdown called. Clearing publishers map.");
+        let mut guard = self.publishers.write();
+        if !guard.is_empty() {
+            tracing::info!("Clearing {} cached publishers.", guard.len());
+            guard.clear();
+        } else {
+            tracing::debug!("Publishers map already empty.");
         }
-        for handle in handles {
-            let _ = handle.await;
-        }
+        tracing::info!("CloudPubSub shutdown logic finished (map cleared).");
     }
 }

--- a/engine/worker/src/pubsub/backend/noop.rs
+++ b/engine/worker/src/pubsub/backend/noop.rs
@@ -3,6 +3,7 @@ use crate::pubsub::message::EncodableMessage;
 #[derive(thiserror::Error, Debug)]
 pub enum NoopPubSubError {}
 
+#[derive(Clone)]
 pub struct NoopPubSub {}
 
 #[async_trait::async_trait]

--- a/engine/worker/src/types.rs
+++ b/engine/worker/src/types.rs
@@ -3,3 +3,4 @@ pub(crate) mod job_complete_event;
 pub(crate) mod log_stream_event;
 pub(crate) mod metadata;
 pub(crate) mod node_status_event;
+pub(crate) mod stdout_log_event;

--- a/engine/worker/src/types/stdout_log_event.rs
+++ b/engine/worker/src/types/stdout_log_event.rs
@@ -1,0 +1,45 @@
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use std::env;
+use uuid::Uuid;
+
+use crate::pubsub::{
+    message::{EncodableMessage, ValidatedMessage},
+    topic::Topic,
+};
+
+#[derive(Serialize, Debug, Clone)]
+pub struct StdoutLogEvent {
+    #[serde(rename = "workflowId")]
+    pub workflow_id: Uuid,
+    #[serde(rename = "jobId")]
+    pub job_id: Uuid,
+    pub timestamp: DateTime<Utc>,
+    #[serde(rename = "logLevel")]
+    pub level: String,
+    pub message: String,
+    pub target: String,
+}
+
+impl EncodableMessage for StdoutLogEvent {
+    type Error = String;
+
+    fn topic(&self) -> Topic {
+        let topic_name = env::var("FLOW_WORKER_STDOUT_LOG_TOPIC")
+            .unwrap_or_else(|_| "flow-worker-stdout-log-topic".to_string());
+        Topic::new(topic_name)
+    }
+
+    fn encode(&self) -> Result<ValidatedMessage<Bytes>, Self::Error> {
+        let data = serde_json::to_vec(self).map_err(|e| {
+            eprintln!("Failed to serialize StdoutLogEvent: {}", e);
+            e.to_string()
+        })?;
+        Ok(ValidatedMessage::new(
+            Uuid::new_v4(),
+            self.timestamp,
+            Bytes::from(data),
+        ))
+    }
+}


### PR DESCRIPTION
# Overview
This pull request introduces significant changes to enhance logging and Pub/Sub functionality in the worker service. Key updates include the addition of a new `StdoutLogEvent` for structured logging, integration of a Pub/Sub layer for publishing logs, and updates to the Pub/Sub backend to support cloning and improved shutdown handling. It also updates configuration files and documentation to reflect the new `flow-worker-stdout-log-topic`.

### Logging Enhancements:
* Introduced a new `StdoutLogEvent` struct for structured stdout/stderr logging, including fields for workflow ID, job ID, timestamp, log level, message, and target (`engine/worker/src/types/stdout_log_event.rs`).
* Added a `StdoutLogPublishLayer` to publish log events to Pub/Sub, with context management for workflow and job IDs (`engine/worker/src/logger.rs`). [[1]](diffhunk://#diff-b23fbfd0550ed82fd1f9dd61c1efc7f52abd6b5c86adfb8ffc7c49f6ad058ed7R36-R152) [[2]](diffhunk://#diff-b23fbfd0550ed82fd1f9dd61c1efc7f52abd6b5c86adfb8ffc7c49f6ad058ed7L54-R185) [[3]](diffhunk://#diff-b23fbfd0550ed82fd1f9dd61c1efc7f52abd6b5c86adfb8ffc7c49f6ad058ed7L69-R223)

### Pub/Sub Backend Improvements:
* Made `PubSubBackend`, `CloudPubSub`, and `NoopPubSub` structs clonable to facilitate their use in asynchronous logging contexts (`engine/worker/src/pubsub/backend.rs`, `engine/worker/src/pubsub/backend/google.rs`, `engine/worker/src/pubsub/backend/noop.rs`). [[1]](diffhunk://#diff-b280b8b5d6d586c4b4b622d2e60aac948c457c8048698ad0a5930244f0cda1f6R20) [[2]](diffhunk://#diff-a264fa65d305e8455907b2f0bc46f773b7ed28de41c001343671eadca843b963R26) [[3]](diffhunk://#diff-4c704ff4f9823272a3789d85d20ca7b22174a7e45195709acd8e17e7b572188eR6)
* Enhanced the `CloudPubSub` shutdown process by clearing cached publishers and logging debug information (`engine/worker/src/pubsub/backend/google.rs`).

### Configuration and Documentation Updates:
* Added `flow-worker-stdout-log-topic` and `flow-node-status-topic` to the `TOPIC_IDS` environment variable in `compose.yml` and updated the corresponding documentation (`engine/compose.yml`, `engine/worker/README.md`). [[1]](diffhunk://#diff-a7eb4cb35382bcd99c39769500c8a68dffe6d9cd2716f74d37f7c59dd7e3589aL21-R21) [[2]](diffhunk://#diff-42a4635be30ad4763b936ed6cc3119afea2eaea8958aae923e7896e3326dafd1R106)

### Codebase Modifications:
* Added a `set_pubsub_context` function to manage Pub/Sub context and integrated it into the worker command execution flow (`engine/worker/src/command.rs`). [[1]](diffhunk://#diff-b76379618575e6337dfe5e8e3653b74bde84b2d8a8ad9836ae52da1afdf7fac9L16-R25) [[2]](diffhunk://#diff-b76379618575e6337dfe5e8e3653b74bde84b2d8a8ad9836ae52da1afdf7fac9R150-R167) [[3]](diffhunk://#diff-b76379618575e6337dfe5e8e3653b74bde84b2d8a8ad9836ae52da1afdf7fac9L184-R211)
* Updated the `CloudPubSub` publisher to include additional metadata (e.g., message ID and timestamp) in published messages (`engine/worker/src/pubsub/backend/google.rs`).

### Miscellaneous:
* Updated `.gitignore` to include `example.yml` for better repository hygiene (`engine/.gitignore`).
## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
