### PR TITLE
fix(ui): removed console.log and set edges to deselect on paste [FLOW-FE-167]

### DIFF
--- a/ui/src/features/Editor/useCanvasCopyPaste.ts
+++ b/ui/src/features/Editor/useCanvasCopyPaste.ts
@@ -395,8 +395,8 @@ export default ({
         selected: false,
       }));
 
-      const edgeChanges: EdgeChange[] = edges.map((n) => ({
-        id: n.id,
+      const edgeChanges: EdgeChange[] = edges.map((e) => ({
+        id: e.id,
         type: "select",
         selected: false,
       }));

--- a/ui/src/features/Editor/useCanvasCopyPaste.ts
+++ b/ui/src/features/Editor/useCanvasCopyPaste.ts
@@ -299,7 +299,6 @@ export default ({
         if (referencedWorkflows.length === 0) return;
       }
 
-      console.log("TEST", nodesToProcess);
       return {
         nodes: nodesToProcess,
         edges: edgesToProcess,
@@ -396,7 +395,14 @@ export default ({
         selected: false,
       }));
 
+      const edgeChanges: EdgeChange[] = edges.map((n) => ({
+        id: n.id,
+        type: "select",
+        selected: false,
+      }));
+
       handleNodesChange(nodeChanges);
+      handleEdgesChange(edgeChanges);
 
       handleNodesAdd([...processedNewNodes]);
 
@@ -417,11 +423,13 @@ export default ({
     },
     [
       nodes,
+      edges,
       copy,
       paste,
       handleNodesAdd,
       handleNodesChange,
       handleEdgesAdd,
+      handleEdgesChange,
       newNodeCreation,
       newEdgeCreation,
       newWorkflowCreation,


### PR DESCRIPTION
# Overview

## What I've done
Previously selected edges from the copied/cut nodes were not being deselected, therefore added similar logic of hanldeNodesChange for handleEdgesChange
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
