### PR TITLE
fix(ui): added condition to check whether confirmaiton dialog is open…

### DIFF
--- a/ui/src/features/Editor/components/TopBar/components/ActionBar/components/Version/VersionDialog.tsx
+++ b/ui/src/features/Editor/components/TopBar/components/ActionBar/components/Version/VersionDialog.tsx
@@ -51,7 +51,8 @@ const VersionDialog: React.FC<Props> = ({ project, yDoc, onDialogClose }) => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
         dialogRef.current &&
-        !dialogRef.current.contains(event.target as Node)
+        !dialogRef.current.contains(event.target as Node) &&
+        !openVersionConfirmationDialog
       ) {
         handleCloseDialog();
       }
@@ -59,7 +60,7 @@ const VersionDialog: React.FC<Props> = ({ project, yDoc, onDialogClose }) => {
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [handleCloseDialog]);
+  }, [handleCloseDialog, openVersionConfirmationDialog]);
 
   return (
     <div


### PR DESCRIPTION
# Overview
Original handleCloseDialog would everything even the confirmation dialog.
## What I've done
Added !openVersionConfirmationDialog check inside the handleClickOutside function
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
