### PR TITLE
fix(ui): added error handling for corrupted project

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -83,6 +83,7 @@
     "react": "19.1.0",
     "react-datepicker": "8.3.0",
     "react-dom": "19.1.0",
+    "react-error-boundary": "6.0.0",
     "react-i18next": "15.5.1",
     "react-resizable-panels": "3.0.2",
     "react-yjs": "2.0.1",

--- a/ui/src/features/Editor/components/TopBar/components/ActionBar/components/Version/VersionDialog.tsx
+++ b/ui/src/features/Editor/components/TopBar/components/ActionBar/components/Version/VersionDialog.tsx
@@ -1,9 +1,16 @@
 import { Cross2Icon } from "@radix-ui/react-icons";
 import { ReactFlowProvider } from "@xyflow/react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import * as Y from "yjs";
 
-import { Button, LoadingSplashscreen, LoadingSkeleton } from "@flow/components";
+import {
+  Button,
+  LoadingSplashscreen,
+  LoadingSkeleton,
+  FlowLogo,
+} from "@flow/components";
+import BasicBoiler from "@flow/components/BasicBoiler";
 import VersionCanvas from "@flow/features/VersionCanvas";
 import { useT } from "@flow/lib/i18n";
 import type { YWorkflow } from "@flow/lib/yjs/types";
@@ -144,6 +151,7 @@ const VersionEditorComponent: React.FC<{
   yDoc: Y.Doc | null;
   previewDocYWorkflows: Y.Map<YWorkflow> | null;
 }> = ({ yDoc, previewDocYWorkflows }) => {
+  const t = useT();
   const yWorkflows = previewDocYWorkflows
     ? previewDocYWorkflows
     : yDoc
@@ -153,9 +161,18 @@ const VersionEditorComponent: React.FC<{
   return (
     <div className="w-full h-full">
       {yWorkflows && (
-        <ReactFlowProvider>
-          <VersionCanvas yWorkflows={yWorkflows} />
-        </ReactFlowProvider>
+        <ErrorBoundary
+          fallback={
+            <BasicBoiler
+              text={t("Selected version is corruputed or not available.")}
+              className="size-4 h-full [&>div>p]:text-md"
+              icon={<FlowLogo className="size-20 text-accent" />}
+            />
+          }>
+          <ReactFlowProvider>
+            <VersionCanvas yWorkflows={yWorkflows} />
+          </ReactFlowProvider>
+        </ErrorBoundary>
       )}
     </div>
   );

--- a/ui/src/lib/i18n/locales/en.json
+++ b/ui/src/lib/i18n/locales/en.json
@@ -131,13 +131,14 @@
   "Project cannot be rollbacked to this version. An error has occured.": "",
   "Version Preview Failed": "",
   "Project Version Preview cannot be viewed. An error has occurred.": "",
-  "Version ": "",
   "Are you sure you want to revert to this version?": "",
   "By clicking continue you will be reverting to version {{version}}.": "",
   "Viewing Version: {{version}}": "",
   "Version History": "",
   "Revert": "",
+  "Selected version is corruputed or not available.": "",
   "Current Version": "",
+  "Version ": "",
   "Deploy project's workflow": "",
   "Additional actions": "",
   "Export Project": "",
@@ -395,5 +396,7 @@
   "There was an error when trying to update the members persmissons.": "",
   "Batch": "",
   "Subworkflow": "",
+  "Project or version is corruputed.": "",
+  "Revert to a previous version": "",
   "Reload": ""
 }

--- a/ui/src/lib/i18n/locales/es.json
+++ b/ui/src/lib/i18n/locales/es.json
@@ -131,13 +131,14 @@
   "Project cannot be rollbacked to this version. An error has occured.": "",
   "Version Preview Failed": "",
   "Project Version Preview cannot be viewed. An error has occurred.": "",
-  "Version ": "Versión ",
   "Are you sure you want to revert to this version?": "¿Estás seguro de que deseas revertir a esta versión?",
   "By clicking continue you will be reverting to version {{version}}.": "Al hacer clic en continuar, volverás a la versión {{version}}.",
   "Viewing Version: {{version}}": "",
   "Version History": "Historial de versiones",
   "Revert": "",
+  "Selected version is corruputed or not available.": "",
   "Current Version": "Versión actual",
+  "Version ": "Versión ",
   "Deploy project's workflow": "Desplegar el flujo de trabajo del proyecto",
   "Additional actions": "Acciones adicionales",
   "Export Project": "Exportar proyecto",
@@ -395,5 +396,7 @@
   "There was an error when trying to update the members persmissons.": "",
   "Batch": "Lote",
   "Subworkflow": "Subflujo de trabajo",
+  "Project or version is corruputed.": "",
+  "Revert to a previous version": "",
   "Reload": "Recargar"
 }

--- a/ui/src/lib/i18n/locales/fr.json
+++ b/ui/src/lib/i18n/locales/fr.json
@@ -131,13 +131,14 @@
   "Project cannot be rollbacked to this version. An error has occured.": "",
   "Version Preview Failed": "",
   "Project Version Preview cannot be viewed. An error has occurred.": "",
-  "Version ": "Version ",
   "Are you sure you want to revert to this version?": "",
   "By clicking continue you will be reverting to version {{version}}.": "",
   "Viewing Version: {{version}}": "",
   "Version History": "Historique des versions",
   "Revert": "",
+  "Selected version is corruputed or not available.": "",
   "Current Version": "Version actuelle",
+  "Version ": "Version ",
   "Deploy project's workflow": "",
   "Additional actions": "Actions supplémentaires",
   "Export Project": "Exporter le projet",
@@ -395,5 +396,7 @@
   "There was an error when trying to update the members persmissons.": "",
   "Batch": "",
   "Subworkflow": "",
+  "Project or version is corruputed.": "",
+  "Revert to a previous version": "",
   "Reload": "Recharger"
 }

--- a/ui/src/lib/i18n/locales/ja.json
+++ b/ui/src/lib/i18n/locales/ja.json
@@ -131,13 +131,14 @@
   "Project cannot be rollbacked to this version. An error has occured.": "プロジェクトはこのバージョンにロールバックできません。エラーが発生しました。",
   "Version Preview Failed": "バージョンプレビューに失敗しました",
   "Project Version Preview cannot be viewed. An error has occurred.": "プロジェクトのバージョンプレビューは表示できません。エラーが発生しました。",
-  "Version ": "バージョン ",
   "Are you sure you want to revert to this version?": "このバージョンに戻しますか？",
   "By clicking continue you will be reverting to version {{version}}.": "続行をクリックすると、バージョン{{version}}に戻ります。",
   "Viewing Version: {{version}}": "バージョン表示: {{version}}",
   "Version History": "バージョン履歴",
   "Revert": "戻す",
+  "Selected version is corruputed or not available.": "選択したバージョンは破損しているか、利用できません。",
   "Current Version": "現在のバージョン",
+  "Version ": "バージョン ",
   "Deploy project's workflow": "プロジェクトのワークフローをデプロイ",
   "Additional actions": "追加アクション",
   "Export Project": "プロジェクトをエクスポート",
@@ -395,5 +396,7 @@
   "There was an error when trying to update the members persmissons.": "メンバーの権限を更新しようとした際にエラーが発生しました。",
   "Batch": "バッチ",
   "Subworkflow": "サブワークフロー",
+  "Project or version is corruputed.": "プロジェクトまたはバージョンが破損しています。",
+  "Revert to a previous version": "以前のバージョンに戻す",
   "Reload": "リロード"
 }

--- a/ui/src/lib/i18n/locales/zh.json
+++ b/ui/src/lib/i18n/locales/zh.json
@@ -131,13 +131,14 @@
   "Project cannot be rollbacked to this version. An error has occured.": "项目无法回滚到此版本。发生错误。",
   "Version Preview Failed": "",
   "Project Version Preview cannot be viewed. An error has occurred.": "",
-  "Version ": "版本 ",
   "Are you sure you want to revert to this version?": "您确定要恢复到此版本吗？",
   "By clicking continue you will be reverting to version {{version}}.": "点击继续，您将恢复到版本{{version}}。",
   "Viewing Version: {{version}}": "",
   "Version History": "版本历史",
   "Revert": "",
+  "Selected version is corruputed or not available.": "",
   "Current Version": "当前版本",
+  "Version ": "版本 ",
   "Deploy project's workflow": "部署项目的工作流",
   "Additional actions": "附加操作",
   "Export Project": "导出项目",
@@ -395,5 +396,7 @@
   "There was an error when trying to update the members persmissons.": "更新成员权限时发生错误。",
   "Batch": "批处理",
   "Subworkflow": "子工作流",
+  "Project or version is corruputed.": "",
+  "Revert to a previous version": "",
   "Reload": "重新加载"
 }

--- a/ui/src/routes/workspaces.$workspaceId_.projects_.$projectId.lazy.tsx
+++ b/ui/src/routes/workspaces.$workspaceId_.projects_.$projectId.lazy.tsx
@@ -2,8 +2,10 @@ import { createLazyFileRoute, useParams } from "@tanstack/react-router";
 import { ReactFlowProvider, useReactFlow } from "@xyflow/react";
 import { useEffect, useMemo, useState } from "react";
 
-import { LoadingSplashscreen } from "@flow/components";
+import { Button, FlowLogo, LoadingSplashscreen } from "@flow/components";
+import BasicBoiler from "@flow/components/BasicBoiler";
 import Editor from "@flow/features/Editor";
+import { VersionDialog } from "@flow/features/Editor/components/TopBar/components/ActionBar/components/Version/VersionDialog";
 import {
   ProjectIdWrapper,
   WorkspaceIdWrapper,
@@ -15,6 +17,7 @@ import {
   useShortcuts,
 } from "@flow/hooks";
 import { useAuth } from "@flow/lib/auth";
+import { useT } from "@flow/lib/i18n";
 import { useIndexedDB } from "@flow/lib/indexedDB";
 import useYjsSetup from "@flow/lib/yjs/useYjsSetup";
 import { useCurrentProject } from "@flow/stores";
@@ -32,6 +35,7 @@ export const Route = createLazyFileRoute(
       </ProjectIdWrapper>
     </WorkspaceIdWrapper>
   ),
+  errorComponent: () => <ErrorComponent />,
 });
 
 const EditorComponent = () => {
@@ -107,5 +111,61 @@ const EditorComponent = () => {
       yDoc={yDocState}
       undoTrackerActionWrapper={undoTrackerActionWrapper}
     />
+  );
+};
+
+const ErrorComponent = () => {
+  const [accessToken, setAccessToken] = useState<string | undefined>(undefined);
+  const [openVersionDialog, setOpenVersionDialog] = useState(false);
+  const { getAccessToken } = useAuth();
+  const t = useT();
+  useEffect(() => {
+    if (!accessToken) {
+      (async () => {
+        const token = await getAccessToken();
+        setAccessToken(token);
+      })();
+    }
+  }, [accessToken, getAccessToken]);
+
+  const { projectId }: { projectId: string } = useParams({
+    strict: false,
+  });
+
+  const [currentProject] = useCurrentProject();
+
+  const { yDocState } = useYjsSetup({
+    isProtected: true,
+    projectId,
+    workflowId: DEFAULT_ENTRY_GRAPH_ID,
+  });
+
+  const handleCloseDialog = () => {
+    setOpenVersionDialog(false);
+  };
+  return (
+    <>
+      <div className="flex flex-col h-screen w-full items-center justify-center">
+        <div className="flex flex-col items-center justify-center gap-8">
+          <BasicBoiler
+            text={t("Project or version is corruputed.")}
+            icon={<FlowLogo className="size-16 text-accent" />}
+          />
+          <Button
+            onClick={() => setOpenVersionDialog(true)}
+            variant="default"
+            className="ml-4">
+            {t("Revert to a previous version")}
+          </Button>
+        </div>
+      </div>
+      {openVersionDialog && (
+        <VersionDialog
+          yDoc={yDocState}
+          project={currentProject}
+          onDialogClose={handleCloseDialog}
+        />
+      )}
+    </>
   );
 };

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4532,6 +4532,7 @@ __metadata:
     react: "npm:19.1.0"
     react-datepicker: "npm:8.3.0"
     react-dom: "npm:19.1.0"
+    react-error-boundary: "npm:6.0.0"
     react-i18next: "npm:15.5.1"
     react-resizable-panels: "npm:3.0.2"
     react-yjs: "npm:2.0.1"
@@ -13067,6 +13068,17 @@ __metadata:
   peerDependencies:
     react: ^19.0.0
   checksum: 10c0/a36ce7ab507b237ae2759c984cdaad4af4096d8199fb65b3815c16825e5cfeb7293da790a3fc2184b52bfba7ba3ff31c058c01947aff6fd1a3701632aabaa6a9
+  languageName: node
+  linkType: hard
+
+"react-error-boundary@npm:6.0.0":
+  version: 6.0.0
+  resolution: "react-error-boundary@npm:6.0.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    react: ">=16.13.1"
+  checksum: 10c0/1914d600dee95a14f14af4afe9867b0d35c26c4f7826d23208800ba2a99728659029aad60a6ef95e13430b4d79c2c4c9b3585f50bf508450478760d2e4e732d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Overview
Added react-error-boundary for handling when project versions are corrupted because they are missing a position on a node.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
