### PR TITLE
chore(ui): changed all phosphor icons to updated names [FLOW-FE-206]

### DIFF
--- a/ui/src/components/DateTimePicker/index.tsx
+++ b/ui/src/components/DateTimePicker/index.tsx
@@ -1,4 +1,4 @@
-import { Calendar } from "@phosphor-icons/react";
+import { CalendarIcon } from "@phosphor-icons/react";
 import { enUS, ja, es, fr, zhCN, Locale } from "date-fns/locale";
 import { useEffect, useState } from "react";
 import DatePicker, { registerLocale } from "react-datepicker";
@@ -50,7 +50,7 @@ const DateTimePicker: React.FC<Props> = ({ className }) => {
       showTimeSelect
       showIcon
       toggleCalendarOnIconClick
-      icon={<Calendar />}
+      icon={<CalendarIcon />}
       locale={currentLang}
       showPopperArrow={false}
       onChange={(date) => date && setStartDate(date)}

--- a/ui/src/components/FileTree/index.tsx
+++ b/ui/src/components/FileTree/index.tsx
@@ -1,4 +1,4 @@
-import { CaretRight, Icon } from "@phosphor-icons/react";
+import { CaretRightIcon, Icon } from "@phosphor-icons/react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 import { XYPosition } from "@xyflow/react";
 import { forwardRef, useCallback, useMemo, useState } from "react";
@@ -262,7 +262,7 @@ const AccordionTrigger = forwardRef<
       )}
       {...props}>
       {children}
-      <CaretRight className="ml-auto size-4 shrink-0 transition-transform duration-200" />
+      <CaretRightIcon className="ml-auto size-4 shrink-0 transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
 ));

--- a/ui/src/components/LogsTable/index.tsx
+++ b/ui/src/components/LogsTable/index.tsx
@@ -1,4 +1,4 @@
-import { Bug } from "@phosphor-icons/react";
+import { BugIcon } from "@phosphor-icons/react";
 import {
   CaretSortIcon,
   ClockIcon,
@@ -146,7 +146,7 @@ const LogsTable = ({
             variant={getStatusValue === "DEBUG" ? "default" : "outline"}
             tooltipText={t("Debug")}
             onClick={() => handleStatusChange(LogLevel.Debug)}
-            icon={<Bug />}
+            icon={<BugIcon />}
           />
           <IconButton
             size="icon"

--- a/ui/src/components/Pagination/index.tsx
+++ b/ui/src/components/Pagination/index.tsx
@@ -1,8 +1,8 @@
 import {
-  CaretDoubleLeft,
-  CaretDoubleRight,
-  CaretLeft,
-  CaretRight,
+  CaretDoubleLeftIcon,
+  CaretDoubleRightIcon,
+  CaretLeftIcon,
+  CaretRightIcon,
 } from "@phosphor-icons/react";
 import * as React from "react";
 
@@ -23,7 +23,7 @@ const Pagination: React.FC<PaginationProps> = ({
       <div className="flex gap-1">
         <IconButton
           variant="outline"
-          icon={<CaretDoubleLeft />}
+          icon={<CaretDoubleLeftIcon />}
           onClick={() => {
             if (currentPage > 1) {
               setCurrentPage?.(1);
@@ -34,7 +34,7 @@ const Pagination: React.FC<PaginationProps> = ({
         />
         <IconButton
           variant="outline"
-          icon={<CaretLeft />}
+          icon={<CaretLeftIcon />}
           onClick={() => {
             if (currentPage > 1) {
               setCurrentPage?.(currentPage - 1);
@@ -50,7 +50,7 @@ const Pagination: React.FC<PaginationProps> = ({
         </div>
         <IconButton
           className="rounded border p-1"
-          icon={<CaretRight />}
+          icon={<CaretRightIcon />}
           onClick={() => {
             if (currentPage < totalPages) {
               setCurrentPage?.(currentPage + 1);
@@ -62,7 +62,7 @@ const Pagination: React.FC<PaginationProps> = ({
 
         <IconButton
           className="rounded border p-1"
-          icon={<CaretDoubleRight />}
+          icon={<CaretDoubleRightIcon />}
           onClick={() => {
             if (currentPage < totalPages) {
               setCurrentPage?.(totalPages);

--- a/ui/src/components/SchemaForm/index.stories.tsx
+++ b/ui/src/components/SchemaForm/index.stories.tsx
@@ -1,4 +1,4 @@
-import { Copy } from "@phosphor-icons/react";
+import { CopyIcon } from "@phosphor-icons/react";
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
@@ -148,7 +148,7 @@ export const Default = () => {
             onClick={() => {
               navigator.clipboard.writeText(JSON.stringify(schema, null, 2));
             }}>
-            <Copy />
+            <CopyIcon />
           </Button>
         </pre>
       )}

--- a/ui/src/features/Canvas/components/CanvasContextMenu/index.tsx
+++ b/ui/src/features/Canvas/components/CanvasContextMenu/index.tsx
@@ -1,10 +1,10 @@
 import {
-  Clipboard,
-  Copy,
-  GearFine,
-  Graph,
-  Scissors,
-  Trash,
+  ClipboardIcon,
+  CopyIcon,
+  GearFineIcon,
+  GraphIcon,
+  ScissorsIcon,
+  TrashIcon,
 } from "@phosphor-icons/react";
 import { EdgeChange, XYPosition } from "@xyflow/react";
 import { useCallback, useMemo } from "react";
@@ -100,7 +100,7 @@ const CanvasContextMenu: React.FC<Props> = ({
         type: "action",
         props: {
           label: t("Copy"),
-          icon: <Copy weight="light" />,
+          icon: <CopyIcon weight="light" />,
           shortcut: (
             <ContextMenuShortcut keyBinding={{ key: "c", commandKey: true }} />
           ),
@@ -112,7 +112,7 @@ const CanvasContextMenu: React.FC<Props> = ({
         type: "action",
         props: {
           label: t("Cut"),
-          icon: <Scissors weight="light" />,
+          icon: <ScissorsIcon weight="light" />,
           shortcut: (
             <ContextMenuShortcut keyBinding={{ key: "x", commandKey: true }} />
           ),
@@ -124,7 +124,7 @@ const CanvasContextMenu: React.FC<Props> = ({
         type: "action",
         props: {
           label: t("Paste"),
-          icon: <Clipboard weight="light" />,
+          icon: <ClipboardIcon weight="light" />,
           shortcut: (
             <ContextMenuShortcut keyBinding={{ key: "v", commandKey: true }} />
           ),
@@ -138,7 +138,7 @@ const CanvasContextMenu: React.FC<Props> = ({
               type: "action" as const,
               props: {
                 label: t("Open Subworkflow"),
-                icon: <Graph weight="light" />,
+                icon: <GraphIcon weight="light" />,
                 onCallback: wrapWithClose(() => handleSubworkflowOpen(node)),
               },
             },
@@ -150,7 +150,7 @@ const CanvasContextMenu: React.FC<Props> = ({
               type: "action" as const,
               props: {
                 label: t("Node Settings"),
-                icon: <GearFine weight="light" />,
+                icon: <GearFineIcon weight="light" />,
                 onCallback: wrapWithClose(() => handleNodeSettingsOpen(node)),
               },
             },
@@ -170,7 +170,7 @@ const CanvasContextMenu: React.FC<Props> = ({
               type: "action" as const,
               props: {
                 label: node ? t("Delete Node") : t("Delete Selection"),
-                icon: <Trash weight="light" />,
+                icon: <TrashIcon weight="light" />,
                 destructive: true,
                 disabled: !onNodesChange || !onEdgesChange,
 

--- a/ui/src/features/Editor/components/LeftPanel/components/Actions/Action.tsx
+++ b/ui/src/features/Editor/components/LeftPanel/components/Actions/Action.tsx
@@ -1,4 +1,4 @@
-import { Lightning } from "@phosphor-icons/react";
+import { LightningIcon } from "@phosphor-icons/react";
 import { type DragEvent, memo } from "react";
 import { createRoot } from "react-dom/client";
 
@@ -41,7 +41,7 @@ const ActionComponent: React.FC<Props> = ({
       <div className="flex size-12 rounded bg-secondary">
         <div
           className={`flex w-full justify-center rounded align-middle  ${type === "reader" ? "bg-node-reader/60" : type === "writer" ? "bg-node-writer/60" : "bg-node-transformer/60"}`}>
-          <Lightning className="self-center" />
+          <LightningIcon className="self-center" />
         </div>
       </div>,
     );

--- a/ui/src/features/Editor/components/LeftPanel/components/Resources.tsx
+++ b/ui/src/features/Editor/components/LeftPanel/components/Resources.tsx
@@ -1,22 +1,22 @@
-import { HardDrive } from "@phosphor-icons/react";
+import { HardDriveIcon } from "@phosphor-icons/react";
 
 const Resources: React.FC = () => {
   return (
     <div className="flex flex-col gap-2 px-1">
       <div className="flex items-center gap-2">
-        <HardDrive className="size-[15px]" weight="thin" />
+        <HardDriveIcon className="size-[15px]" weight="thin" />
         <p className="text-sm dark:font-extralight">resource</p>
       </div>
       <div className="flex items-center gap-2">
-        <HardDrive className="size-[15px]" weight="thin" />
+        <HardDriveIcon className="size-[15px]" weight="thin" />
         <p className="text-sm dark:font-extralight">resource</p>
       </div>
       <div className="flex items-center gap-2">
-        <HardDrive className="size-[15px]" weight="thin" />
+        <HardDriveIcon className="size-[15px]" weight="thin" />
         <p className="text-sm dark:font-extralight">resource</p>
       </div>
       <div className="flex items-center gap-2">
-        <HardDrive className="size-[15px]" weight="thin" />
+        <HardDriveIcon className="size-[15px]" weight="thin" />
         <p className="text-sm dark:font-extralight">resource</p>
       </div>
     </div>

--- a/ui/src/features/Editor/components/LeftPanel/index.tsx
+++ b/ui/src/features/Editor/components/LeftPanel/index.tsx
@@ -1,11 +1,11 @@
 import {
-  Database,
-  Disc,
-  Graph,
+  DatabaseIcon,
+  DiscIcon,
+  GraphIcon,
   Icon,
-  Lightning,
-  RectangleDashed,
-  TreeView,
+  LightningIcon,
+  RectangleDashedIcon,
+  TreeViewIcon,
 } from "@phosphor-icons/react";
 import { memo, useCallback, useEffect, useState } from "react";
 
@@ -74,17 +74,21 @@ const LeftPanel: React.FC<Props> = ({
   );
 
   const treeContent: TreeDataItem[] = [
-    ...(createTreeDataItem("reader", Database, nodes) || []),
-    ...(createTreeDataItem("writer", Disc, nodes) || []),
+    ...(createTreeDataItem("reader", DatabaseIcon, nodes) || []),
+    ...(createTreeDataItem("writer", DiscIcon, nodes) || []),
     ...(createTreeDataItem(
       "transformer",
-      Lightning,
+      LightningIcon,
       nodes,
       t("Transformers"),
     ) || []),
-    ...(createTreeDataItem("subworkflow", Graph, nodes, t("Subworkflows")) ||
-      []),
-    ...(createTreeDataItem("batch", RectangleDashed, nodes, t("Batches")) ||
+    ...(createTreeDataItem(
+      "subworkflow",
+      GraphIcon,
+      nodes,
+      t("Subworkflows"),
+    ) || []),
+    ...(createTreeDataItem("batch", RectangleDashedIcon, nodes, t("Batches")) ||
       []),
   ];
 
@@ -97,7 +101,7 @@ const LeftPanel: React.FC<Props> = ({
     {
       id: "navigator",
       title: t("Canvas Navigation"),
-      icon: <TreeView className="size-5" weight="thin" />,
+      icon: <TreeViewIcon className="size-5" weight="thin" />,
       component:
         nodes.length !== 0 ? (
           <Tree
@@ -123,7 +127,7 @@ const LeftPanel: React.FC<Props> = ({
     {
       id: "actions-list",
       title: t("Actions list"),
-      icon: <Lightning className="size-5" weight="thin" />,
+      icon: <LightningIcon className="size-5" weight="thin" />,
       component: (
         <ActionsList
           nodes={nodes}

--- a/ui/src/features/Editor/components/OverlayUI/components/CanvasActionbar/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/CanvasActionbar/index.tsx
@@ -1,9 +1,9 @@
 import {
-  CornersIn,
-  CornersOut,
-  FrameCorners,
-  MagnifyingGlassMinus,
-  MagnifyingGlassPlus,
+  CornersInIcon,
+  CornersOutIcon,
+  FrameCornersIcon,
+  MagnifyingGlassMinusIcon,
+  MagnifyingGlassPlusIcon,
 } from "@phosphor-icons/react";
 import { useReactFlow } from "@xyflow/react";
 import { memo } from "react";
@@ -28,7 +28,7 @@ const CanvasActionBar = () => {
             tooltipText={t("Zoom in")}
             tooltipPosition="left"
             tooltipOffset={tooltipOffset}
-            icon={<MagnifyingGlassPlus weight="thin" size={16} />}
+            icon={<MagnifyingGlassPlusIcon weight="thin" size={16} />}
             onClick={() => zoomIn({ duration: 400 })}
           />
           <IconButton
@@ -36,7 +36,7 @@ const CanvasActionBar = () => {
             tooltipText={t("Zoom out")}
             tooltipOffset={tooltipOffset}
             tooltipPosition="left"
-            icon={<MagnifyingGlassMinus weight="thin" size={16} />}
+            icon={<MagnifyingGlassMinusIcon weight="thin" size={16} />}
             onClick={() => zoomOut({ duration: 400 })}
           />
           <IconButton
@@ -44,7 +44,7 @@ const CanvasActionBar = () => {
             tooltipText={t("All nodes in viewport")}
             tooltipOffset={tooltipOffset}
             tooltipPosition="left"
-            icon={<FrameCorners weight="thin" size={16} />}
+            icon={<FrameCornersIcon weight="thin" size={16} />}
             onClick={() => fitView({ duration: 400, padding: 0.5 })}
           />
           <IconButton
@@ -56,9 +56,9 @@ const CanvasActionBar = () => {
             tooltipPosition="left"
             icon={
               isFullscreen ? (
-                <CornersIn weight="thin" size={16} />
+                <CornersInIcon weight="thin" size={16} />
               ) : (
-                <CornersOut weight="thin" size={16} />
+                <CornersOutIcon weight="thin" size={16} />
               )
             }
             onClick={handleFullscreenToggle}

--- a/ui/src/features/Editor/components/OverlayUI/components/DebugLogs/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/DebugLogs/index.tsx
@@ -1,4 +1,9 @@
-import { CaretUp, CaretDown, Minus, Terminal } from "@phosphor-icons/react";
+import {
+  CaretUpIcon,
+  CaretDownIcon,
+  MinusIcon,
+  TerminalIcon,
+} from "@phosphor-icons/react";
 import { memo } from "react";
 
 import LogsConsole from "@flow/features/LogsConsole";
@@ -16,21 +21,25 @@ const DebugLogs: React.FC = () => {
       className={`pointer-events-auto w-[45vw] min-w-[700px] cursor-pointer rounded-md bg-secondary transition-all shadow-md shadow-secondary ${minimized ? "h-[36px]" : expanded ? "h-[90vh]" : "h-[350px]"}`}>
       <div className="flex items-center p-1" onClick={handleExpand}>
         <div className="flex flex-1 items-center justify-center gap-2">
-          <Terminal />
+          <TerminalIcon />
           <p className="select-none text-sm font-thin">{t("Workflow Logs")}</p>
         </div>
         <div className="flex items-center gap-2">
           <div
             className="rounded p-1 hover:bg-primary"
             onClick={handleMinimize}>
-            {minimized ? <CaretUp weight="light" /> : <Minus weight="light" />}
+            {minimized ? (
+              <CaretUpIcon weight="light" />
+            ) : (
+              <MinusIcon weight="light" />
+            )}
           </div>
           {!minimized && (
             <div className="rounded p-1 hover:bg-primary">
               {expanded ? (
-                <CaretDown weight="light" />
+                <CaretDownIcon weight="light" />
               ) : (
-                <CaretUp weight="light" />
+                <CaretUpIcon weight="light" />
               )}
             </div>
           )}

--- a/ui/src/features/Editor/components/OverlayUI/components/DebugPreview/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/DebugPreview/index.tsx
@@ -1,11 +1,11 @@
 import {
-  CaretUp,
-  CornersIn,
-  CornersOut,
-  Globe,
-  GridNine,
-  Minus,
-  Warning,
+  CaretUpIcon,
+  CornersInIcon,
+  CornersOutIcon,
+  GlobeIcon,
+  GridNineIcon,
+  MinusIcon,
+  WarningIcon,
 } from "@phosphor-icons/react";
 import { memo } from "react";
 
@@ -81,7 +81,7 @@ const DebugPreview: React.FC = () => {
               className="gap-1 bg-card font-thin"
               value="data-viewer"
               onClick={handleTabChange}>
-              <GridNine />
+              <GridNineIcon />
               <p className="select-none text-sm font-thin">
                 {t("Table Viewer")}
               </p>
@@ -90,7 +90,7 @@ const DebugPreview: React.FC = () => {
               className="gap-1 bg-card"
               value="3d-viewer"
               onClick={handleTabChange}>
-              <Globe />
+              <GlobeIcon />
               <p className="select-none text-sm font-thin">{t("3D Viewer")}</p>
             </TabsTrigger>
           </TabsList>
@@ -99,16 +99,20 @@ const DebugPreview: React.FC = () => {
           <div
             className="cursor-pointer rounded p-1 hover:bg-primary"
             onClick={handleMinimize}>
-            {minimized ? <CaretUp weight="light" /> : <Minus weight="light" />}
+            {minimized ? (
+              <CaretUpIcon weight="light" />
+            ) : (
+              <MinusIcon weight="light" />
+            )}
           </div>
           {!minimized && (
             <div
               className="cursor-pointer rounded p-1 hover:bg-primary"
               onClick={handleExpand}>
               {expanded ? (
-                <CornersIn weight="light" />
+                <CornersInIcon weight="light" />
               ) : (
-                <CornersOut weight="light" />
+                <CornersOutIcon weight="light" />
               )}
             </div>
           )}
@@ -136,7 +140,7 @@ const DebugPreview: React.FC = () => {
       <DialogContent size="sm" hideCloseButton>
         <DialogHeader className="text-warning">
           <DialogTitle className="flex justify-center gap-1">
-            <Warning weight="light" />
+            <WarningIcon weight="light" />
             {t("Warning")}
           </DialogTitle>
         </DialogHeader>

--- a/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
@@ -1,13 +1,13 @@
 import {
-  ArrowArcLeft,
-  ArrowArcRight,
-  Database,
-  Disc,
-  Graph,
-  Layout,
-  Lightning,
-  Note,
-  RectangleDashed,
+  ArrowArcLeftIcon,
+  ArrowArcRightIcon,
+  DatabaseIcon,
+  DiscIcon,
+  GraphIcon,
+  LayoutIcon,
+  LightningIcon,
+  NoteIcon,
+  RectangleDashedIcon,
 } from "@phosphor-icons/react";
 import { memo, type DragEvent } from "react";
 import { createRoot } from "react-dom/client";
@@ -55,36 +55,40 @@ const Toolbox: React.FC<Props> = ({
     {
       id: "reader" as const,
       name: t("Reader Node"),
-      icon: <Database weight="thin" size={16} />,
+      icon: <DatabaseIcon weight="thin" size={16} />,
       disabled: !isMainWorkflow || hasReader,
     },
     {
       id: "transformer" as const,
       name: t("Transformer Node"),
-      icon: <Lightning weight="thin" size={16} />,
+      icon: <LightningIcon weight="thin" size={16} />,
     },
     {
       id: "writer" as const,
       name: t("Writer Node"),
-      icon: <Disc weight="thin" size={16} />,
+      icon: <DiscIcon weight="thin" size={16} />,
       disabled: !isMainWorkflow,
     },
     {
       id: "note" as const,
       name: t("Note"),
-      icon: <Note weight="thin" size={16} />,
+      icon: <NoteIcon weight="thin" size={16} />,
     },
     {
       id: "batch" as const,
       name: t("Batch Node"),
       icon: (
-        <RectangleDashed className="fill-orange-400" weight="thin" size={16} />
+        <RectangleDashedIcon
+          className="fill-orange-400"
+          weight="thin"
+          size={16}
+        />
       ),
     },
     {
       id: "subworkflow" as const,
       name: t("Subworkflow Node"),
-      icon: <Graph weight="thin" size={16} />,
+      icon: <GraphIcon weight="thin" size={16} />,
     },
   ];
 
@@ -92,21 +96,21 @@ const Toolbox: React.FC<Props> = ({
     {
       id: "layout",
       name: t("Auto layout"),
-      icon: <Layout weight="thin" size={16} />,
+      icon: <LayoutIcon weight="thin" size={16} />,
       onClick: onLayoutChange,
     },
     { id: "break" },
     {
       id: "undo",
       name: t("Undo last action"),
-      icon: <ArrowArcLeft weight="thin" size={16} />,
+      icon: <ArrowArcLeftIcon weight="thin" size={16} />,
       disabled: !canUndo,
       onClick: onUndo,
     },
     {
       id: "redo",
       name: t("Redo action"),
-      icon: <ArrowArcRight weight="thin" size={16} />,
+      icon: <ArrowArcRightIcon weight="thin" size={16} />,
       disabled: !canRedo,
       onClick: onRedo,
     },
@@ -140,17 +144,17 @@ const Toolbox: React.FC<Props> = ({
                     : "bg-node-transformer/60"
           }`}>
           {nodeType === "reader" ? (
-            <Database className="self-center" />
+            <DatabaseIcon className="self-center" />
           ) : nodeType === "writer" ? (
-            <Disc className="self-center" />
+            <DiscIcon className="self-center" />
           ) : nodeType === "subworkflow" ? (
-            <Graph className="self-center" />
+            <GraphIcon className="self-center" />
           ) : nodeType === "batch" ? (
-            <RectangleDashed className="self-center" />
+            <RectangleDashedIcon className="self-center" />
           ) : nodeType === "note" ? (
-            <Note className="self-center" />
+            <NoteIcon className="self-center" />
           ) : (
-            <Lightning className="self-center" />
+            <LightningIcon className="self-center" />
           )}
         </div>
       </div>,

--- a/ui/src/features/Editor/components/ParamsPanel/components/ParamEditor/index.tsx
+++ b/ui/src/features/Editor/components/ParamsPanel/components/ParamEditor/index.tsx
@@ -1,4 +1,4 @@
-import { Info, Nut, PuzzlePiece } from "@phosphor-icons/react";
+import { InfoIcon, NutIcon, PuzzlePieceIcon } from "@phosphor-icons/react";
 import { RJSFSchema } from "@rjsf/utils";
 import { JSONSchema7Definition } from "json-schema";
 import { memo, useMemo, useState } from "react";
@@ -106,20 +106,20 @@ const ParamEditor: React.FC<Props> = ({
               <TabsTrigger
                 className="w-full gap-2 h-[30px] justify-start"
                 value="params">
-                <PuzzlePiece className="shrink-0" />
+                <PuzzlePieceIcon className="shrink-0" />
                 <p>{t("Parameters")}</p>
               </TabsTrigger>
             )}
             <TabsTrigger
               className="w-full gap-2 h-[30px] justify-start"
               value="customizations">
-              <Nut className="shrink-0" />
+              <NutIcon className="shrink-0" />
               <p>{t("Customizations")}</p>
             </TabsTrigger>
             <TabsTrigger
               className="w-full gap-2 h-[30px] justify-start"
               value="details">
-              <Info className="shrink-0" />
+              <InfoIcon className="shrink-0" />
               <p>{t("Details")}</p>
             </TabsTrigger>
           </TabsList>

--- a/ui/src/features/Editor/components/TopBar/components/ActionBar/components/DeployDialog.tsx
+++ b/ui/src/features/Editor/components/TopBar/components/ActionBar/components/DeployDialog.tsx
@@ -1,5 +1,4 @@
-// import { CaretRight } from "@phosphor-icons/react";
-import { CaretRight } from "@phosphor-icons/react";
+import { CaretRightIcon } from "@phosphor-icons/react";
 import { useCallback, useMemo, useState } from "react";
 
 import {
@@ -77,7 +76,7 @@ const DeployDialog: React.FC<Props> = ({
             <Label>{t("Deployment Version: ")}</Label>
             <div className="flex items-center gap-2">
               <p className="dark:font-thin">{currentVersion}</p>
-              <CaretRight />
+              <CaretRightIcon />
               <p className="font-semibold">
                 {currentVersion ? currentVersion + 1 : 1}
               </p>

--- a/ui/src/features/Editor/components/TopBar/components/ActionBar/components/SharePopover.tsx
+++ b/ui/src/features/Editor/components/TopBar/components/ActionBar/components/SharePopover.tsx
@@ -1,4 +1,4 @@
-import { Paperclip } from "@phosphor-icons/react";
+import { PaperclipIcon } from "@phosphor-icons/react";
 import { debounce } from "lodash-es";
 import { useEffect, useRef, useState } from "react";
 
@@ -85,7 +85,7 @@ const SharePopover: React.FC<Props> = ({ onProjectShare }) => {
           variant="outline"
           disabled={!currentProject?.sharedToken}
           onClick={handleCopyUrl}>
-          <Paperclip weight="thin" />
+          <PaperclipIcon weight="thin" />
           <p className="text-xs dark:font-light">{t("Copy URL")}</p>
         </Button>
       </div>

--- a/ui/src/features/Editor/components/TopBar/components/ActionBar/index.tsx
+++ b/ui/src/features/Editor/components/TopBar/components/ActionBar/index.tsx
@@ -1,9 +1,9 @@
 import {
-  ClockCounterClockwise,
-  DotsThreeVertical,
-  Export,
-  PaperPlaneTilt,
-  Rocket,
+  ClockCounterClockwiseIcon,
+  DotsThreeVerticalIcon,
+  ExportIcon,
+  PaperPlaneTiltIcon,
+  RocketIcon,
 } from "@phosphor-icons/react";
 import { memo } from "react";
 import { Doc } from "yjs";
@@ -63,7 +63,7 @@ const ActionBar: React.FC<Props> = ({
           <IconButton
             tooltipText={t("Deploy project's workflow")}
             tooltipOffset={tooltipOffset}
-            icon={<Rocket weight="thin" size={18} />}
+            icon={<RocketIcon weight="thin" size={18} />}
             onClick={handleShowDeployDialog}
           />
           <Popover
@@ -75,7 +75,7 @@ const ActionBar: React.FC<Props> = ({
               <IconButton
                 tooltipText={t("Share Project")}
                 tooltipOffset={tooltipOffset}
-                icon={<PaperPlaneTilt weight="thin" size={18} />}
+                icon={<PaperPlaneTiltIcon weight="thin" size={18} />}
                 onClick={handleShowSharePopover}
               />
             </PopoverTrigger>
@@ -91,7 +91,7 @@ const ActionBar: React.FC<Props> = ({
                 className="w-[25px]"
                 tooltipText={t("Additional actions")}
                 tooltipOffset={tooltipOffset}
-                icon={<DotsThreeVertical size={18} />}
+                icon={<DotsThreeVerticalIcon size={18} />}
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent
@@ -103,13 +103,13 @@ const ActionBar: React.FC<Props> = ({
                 className="flex justify-between gap-4"
                 onClick={onProjectExport}>
                 <p>{t("Export Project")}</p>
-                <Export weight="thin" size={18} />
+                <ExportIcon weight="thin" size={18} />
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="flex justify-between gap-4"
                 onClick={handleShowVersionDialog}>
                 <p>{t("Version History")}</p>
-                <ClockCounterClockwise weight="thin" size={18} />
+                <ClockCounterClockwiseIcon weight="thin" size={18} />
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/ui/src/features/Editor/components/TopBar/components/Breadcrumb/index.tsx
+++ b/ui/src/features/Editor/components/TopBar/components/Breadcrumb/index.tsx
@@ -1,4 +1,4 @@
-import { SquaresFour, UsersThree } from "@phosphor-icons/react";
+import { SquaresFourIcon, UsersThreeIcon } from "@phosphor-icons/react";
 import { memo, useEffect, useState } from "react";
 
 import { useCurrentProject, useCurrentWorkspace } from "@flow/stores";
@@ -19,14 +19,14 @@ const Breadcrumb: React.FC = () => {
     <div
       className="flex cursor-default select-none items-center gap-2"
       onMouseLeave={() => setIsHovered(undefined)}>
-      <UsersThree weight="thin" size={18} />
+      <UsersThreeIcon weight="thin" size={18} />
       <p
         className={`max-w-[200px] truncate transition-all delay-0 duration-500 text-sm dark:font-thin ${isHovered?.includes("workspace") ? "max-w-[50vw] select-text delay-500" : undefined}`}
         onMouseEnter={() => setIsHovered((h) => [...(h ?? []), "workspace"])}>
         {currentWorkspace?.name}
       </p>
       <p className="text-sm font-thin text-accent-foreground">{"/"}</p>
-      <SquaresFour weight="thin" size={18} />
+      <SquaresFourIcon weight="thin" size={18} />
       <p
         className={`max-w-[200px] truncate transition-all delay-0 duration-500 text-sm dark:font-thin ${isHovered?.includes("project") ? "max-w-[50vw] select-text delay-500" : undefined}`}
         onMouseEnter={() => setIsHovered((h) => [...(h ?? []), "project"])}>

--- a/ui/src/features/Editor/components/TopBar/components/DebugActionBar/index.tsx
+++ b/ui/src/features/Editor/components/TopBar/components/DebugActionBar/index.tsx
@@ -1,4 +1,4 @@
-import { Broom, Play, Stop } from "@phosphor-icons/react";
+import { BroomIcon, PlayIcon, StopIcon } from "@phosphor-icons/react";
 import { memo } from "react";
 
 import { IconButton } from "@flow/components";
@@ -43,7 +43,7 @@ const DebugActionBar: React.FC<Props> = ({
               jobStatus === "running" ||
               jobStatus === "queued"
             }
-            icon={<Play weight="thin" size={18} />}
+            icon={<PlayIcon weight="thin" size={18} />}
             onClick={handleDebugRunStart}
           />
           <IconButton
@@ -52,7 +52,7 @@ const DebugActionBar: React.FC<Props> = ({
             disabled={
               !jobStatus || (jobStatus !== "running" && jobStatus !== "queued")
             }
-            icon={<Stop weight="thin" size={18} />}
+            icon={<StopIcon weight="thin" size={18} />}
             onClick={handleShowDebugStopDialog}
           />
           <IconButton
@@ -64,7 +64,7 @@ const DebugActionBar: React.FC<Props> = ({
               jobStatus === "running" ||
               jobStatus === "queued"
             }
-            icon={<Broom weight="thin" size={18} />}
+            icon={<BroomIcon weight="thin" size={18} />}
             onClick={handleDebugRunReset}
           />
         </div>

--- a/ui/src/features/Editor/components/TopBar/components/HomeMenu/index.tsx
+++ b/ui/src/features/Editor/components/TopBar/components/HomeMenu/index.tsx
@@ -1,13 +1,13 @@
 import {
-  ArrowSquareOut,
-  Broadcast,
-  CaretDown,
-  Keyboard,
-  Rocket,
-  SignOut,
-  SneakerMove,
-  SquaresFour,
-  User,
+  ArrowSquareOutIcon,
+  BroadcastIcon,
+  CaretDownIcon,
+  KeyboardIcon,
+  RocketIcon,
+  SignOutIcon,
+  SneakerMoveIcon,
+  SquaresFourIcon,
+  UserIcon,
 } from "@phosphor-icons/react";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { useCallback, useState } from "react";
@@ -79,7 +79,7 @@ const HomeMenu: React.FC<Props> = ({
         <DropdownMenuTrigger asChild>
           <div className="self-start h-full flex gap-2 items-center pl-4 pr-2 group cursor-pointer hover:bg-primary">
             <FlowLogo className="size-6 transition-all group-hover:text-[#46ce7c]" />
-            <CaretDown weight="thin" />
+            <CaretDownIcon weight="thin" />
           </div>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -94,25 +94,25 @@ const HomeMenu: React.FC<Props> = ({
             <DropdownMenuItem
               className="gap-3"
               onClick={handleNavigationToDashboard("projects")}>
-              <SquaresFour weight="light" />
+              <SquaresFourIcon weight="light" />
               <p>{t("Projects")}</p>
             </DropdownMenuItem>
             <DropdownMenuItem
               className="gap-3"
               onClick={handleNavigationToDashboard("deployments")}>
-              <Rocket weight="light" />
+              <RocketIcon weight="light" />
               <p>{t("Deployments")}</p>
             </DropdownMenuItem>
             <DropdownMenuItem
               className="gap-3"
               onClick={handleNavigationToDashboard("triggers")}>
-              <Broadcast weight="light" />
+              <BroadcastIcon weight="light" />
               <p>{t("Triggers")}</p>
             </DropdownMenuItem>
             <DropdownMenuItem
               className="gap-3"
               onClick={handleNavigationToDashboard("jobs")}>
-              <SneakerMove weight="light" />
+              <SneakerMoveIcon weight="light" />
               <p>{t("Jobs")}</p>
             </DropdownMenuItem>
           </DropdownMenuGroup>
@@ -120,19 +120,19 @@ const HomeMenu: React.FC<Props> = ({
           <DropdownMenuItem
             className="gap-3"
             onClick={() => setOpenAccountUpdateDialog(true)}>
-            <User weight="light" />
+            <UserIcon weight="light" />
             <p>{t("Account Settings")}</p>
           </DropdownMenuItem>
           <DropdownMenuItem
             className="gap-3"
             onClick={() => setOpenShortcutDialog(true)}>
-            <Keyboard weight="light" />
+            <KeyboardIcon weight="light" />
             <p>{t("Keyboard Shortcuts")}</p>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           {tosUrl && (
             <DropdownMenuItem className="gap-3" onClick={handleTosPageOpen}>
-              <ArrowSquareOut weight="light" />
+              <ArrowSquareOutIcon weight="light" />
               <p>{t("Terms of Service")}</p>
             </DropdownMenuItem>
           )}
@@ -140,7 +140,7 @@ const HomeMenu: React.FC<Props> = ({
             <DropdownMenuItem
               className="gap-3"
               onClick={handleDocumentationPageOpen}>
-              <ArrowSquareOut weight="light" />
+              <ArrowSquareOutIcon weight="light" />
               <p>{t("Documentation")}</p>
             </DropdownMenuItem>
           )}
@@ -149,7 +149,7 @@ const HomeMenu: React.FC<Props> = ({
           <DropdownMenuItem
             className="gap-3 text-warning"
             onClick={handleLogout}>
-            <SignOut weight="light" />
+            <SignOutIcon weight="light" />
             <p>{t("Log Out")}</p>
           </DropdownMenuItem>
         </DropdownMenuContent>

--- a/ui/src/features/Editor/components/WorkflowTabs/WorkflowTab.tsx
+++ b/ui/src/features/Editor/components/WorkflowTabs/WorkflowTab.tsx
@@ -1,4 +1,4 @@
-import { Graph, X } from "@phosphor-icons/react";
+import { GraphIcon, XIcon } from "@phosphor-icons/react";
 
 type Props = {
   currentWorkflowId?: string;
@@ -24,7 +24,7 @@ const WorkflowTab: React.FC<Props> = ({
       key={id}>
       <div
         className={`h-full flex gap-2 items-center ml-[8px] group-hover:text-white dark:font-extralight ${currentWorkflowId !== id && "text-accent-foreground"}`}>
-        <Graph weight="light" />
+        <GraphIcon weight="light" />
       </div>
       <div className="flex justify-center items-center text-center w-[100px] h-full overflow-hidden">
         <p className="select-none truncate text-center text-xs w-full">
@@ -36,7 +36,7 @@ const WorkflowTab: React.FC<Props> = ({
           <div
             className="transition-all p-1 rounded hover:bg-node-entrance/40"
             onClick={onWorkflowClose(id)}>
-            <X />
+            <XIcon />
           </div>
         </div>
       </div>

--- a/ui/src/features/KeyboardShortcutDialog/index.tsx
+++ b/ui/src/features/KeyboardShortcutDialog/index.tsx
@@ -1,4 +1,4 @@
-import { X } from "@phosphor-icons/react";
+import { XIcon } from "@phosphor-icons/react";
 import { ReactNode, useCallback, useEffect, useState } from "react";
 import ReactDOM from "react-dom";
 
@@ -45,7 +45,7 @@ const KeyboardShortcutDialog: React.FC<Props> = ({ isOpen, onOpenChange }) => {
         onClick={(e) => e.stopPropagation()}>
         <div className="relative flex h-[40px] items-center justify-center rounded-t-lg border-y border-b-primary">
           <p>{title}</p>
-          <X
+          <XIcon
             className="absolute right-3 cursor-pointer"
             onClick={handlePortalClose}
           />

--- a/ui/src/features/SharedCanvas/components/SharedCanvasTopBar/index.tsx
+++ b/ui/src/features/SharedCanvas/components/SharedCanvasTopBar/index.tsx
@@ -1,9 +1,9 @@
 import {
-  DotsThreeVertical,
-  Export,
-  PaperPlaneTilt,
-  Question,
-  SquaresFour,
+  DotsThreeVerticalIcon,
+  ExportIcon,
+  PaperPlaneTiltIcon,
+  QuestionIcon,
+  SquaresFourIcon,
 } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
 import { memo } from "react";
@@ -75,18 +75,18 @@ const SharedCanvasTopBar: React.FC<Props> = ({
           <FlowLogo className="size-6 transition-all cursor-pointer" />
         </div>
         <div className="flex items-center gap-2 border border-logo/50 py-0.5 px-2 rounded">
-          <PaperPlaneTilt weight="thin" size={18} />
+          <PaperPlaneTiltIcon weight="thin" size={18} />
           <p className="text-accent-foreground font-light select-none">
             {t("Shared Project")}
           </p>
           <Tooltip delayDuration={0}>
             <TooltipTrigger>
-              <Question weight="thin" size={16} />
+              <QuestionIcon weight="thin" size={16} />
             </TooltipTrigger>
             <TooltipContent className="max-w-[200px]" sideOffset={18}>
               <div className="flex flex-col gap-2">
                 <div className="flex items-center gap-1">
-                  <Question size={12} />
+                  <QuestionIcon size={12} />
                   <p>{t("Shared project")}</p>
                 </div>
                 <p>
@@ -101,7 +101,7 @@ const SharedCanvasTopBar: React.FC<Props> = ({
       </div>
       <div className="flex items-center pr-4 pl-2">
         <p className="flex items-center gap-2 max-w-[200px] truncate transition-all delay-0 duration-500 text-sm dark:font-thin">
-          <SquaresFour weight="thin" size={18} />
+          <SquaresFourIcon weight="thin" size={18} />
           {project?.name}
         </p>
       </div>
@@ -120,7 +120,7 @@ const SharedCanvasTopBar: React.FC<Props> = ({
               className="w-[25px]"
               tooltipText={t("Additional actions")}
               tooltipOffset={6}
-              icon={<DotsThreeVertical size={18} />}
+              icon={<DotsThreeVerticalIcon size={18} />}
             />
           </DropdownMenuTrigger>
           <DropdownMenuContent
@@ -132,7 +132,7 @@ const SharedCanvasTopBar: React.FC<Props> = ({
               className="flex justify-between gap-4"
               onClick={handleSharedProjectExport}>
               <p>{t("Export Project")}</p>
-              <Export weight="thin" size={18} />
+              <ExportIcon weight="thin" size={18} />
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>

--- a/ui/src/features/WorkspaceDeployments/components/DeploymentDetails/index.tsx
+++ b/ui/src/features/WorkspaceDeployments/components/DeploymentDetails/index.tsx
@@ -1,4 +1,9 @@
-import { CaretLeft, PencilLine, Play, Trash } from "@phosphor-icons/react";
+import {
+  CaretLeftIcon,
+  PencilLineIcon,
+  PlayIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
 
 import { Button } from "@flow/components";
 import { DetailsBox } from "@flow/features/common";
@@ -34,14 +39,14 @@ const DeploymentDetails: React.FC<Props> = ({
       <div className="flex flex-1 flex-col gap-4 px-6 pb-2 pt-6">
         <div className="flex justify-between">
           <Button size="icon" variant="ghost" onClick={handleBack}>
-            <CaretLeft />
+            <CaretLeftIcon />
           </Button>
           <div className="flex gap-2">
             <Button
               variant="default"
               size="sm"
               onClick={() => onDeploymentRun(selectedDeployment)}>
-              <Play />
+              <PlayIcon />
               {t("Run")}
             </Button>
             <Button
@@ -49,14 +54,14 @@ const DeploymentDetails: React.FC<Props> = ({
               size="sm"
               disabled={!selectedDeployment}
               onClick={() => setOpenDeploymentEditDialog(true)}>
-              <PencilLine />
+              <PencilLineIcon />
               {t("Edit Deployment")}
             </Button>
             <Button
               variant="destructive"
               size="sm"
               onClick={() => setDeploymentToBeDeleted(selectedDeployment)}>
-              <Trash />
+              <TrashIcon />
               {t("Delete")}
             </Button>
           </div>

--- a/ui/src/features/WorkspaceDeployments/index.tsx
+++ b/ui/src/features/WorkspaceDeployments/index.tsx
@@ -1,4 +1,9 @@
-import { PencilLine, Play, Plus, Trash } from "@phosphor-icons/react";
+import {
+  PencilLineIcon,
+  PlayIcon,
+  PlusIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
 import { ColumnDef } from "@tanstack/react-table";
 
 import {
@@ -72,21 +77,21 @@ const DeploymentManager: React.FC = () => {
             size="icon"
             tooltipText={t("Run Deployment")}
             onClick={() => handleDeploymentRun(row.row.original)}>
-            <Play />
+            <PlayIcon />
           </ButtonWithTooltip>
           <ButtonWithTooltip
             variant="outline"
             size="icon"
             tooltipText={t("Edit Deployment")}
             onClick={() => setDeploymentToBeEdited(row.row.original)}>
-            <PencilLine />
+            <PencilLineIcon />
           </ButtonWithTooltip>
           <ButtonWithTooltip
             variant="destructive"
             size="icon"
             tooltipText={t("Delete Deployment")}
             onClick={() => setDeploymentToBeDeleted(row.row.original)}>
-            <Trash />
+            <TrashIcon />
           </ButtonWithTooltip>
         </div>
       ),
@@ -111,7 +116,7 @@ const DeploymentManager: React.FC = () => {
               <Button
                 className="flex gap-2"
                 onClick={() => setOpenDeploymentAddDialog(true)}>
-                <Plus weight="thin" />
+                <PlusIcon weight="thin" />
                 <p className="text-xs dark:font-light">{t("New Deployment")}</p>
               </Button>
             </div>

--- a/ui/src/features/WorkspaceJobs/components/JobDetails/index.tsx
+++ b/ui/src/features/WorkspaceJobs/components/JobDetails/index.tsx
@@ -1,4 +1,4 @@
-import { CaretLeft, XCircle } from "@phosphor-icons/react";
+import { CaretLeftIcon, XCircleIcon } from "@phosphor-icons/react";
 
 import { Button } from "@flow/components";
 import { DetailsBox } from "@flow/features/common";
@@ -27,11 +27,11 @@ const JobDetails: React.FC<Props> = ({ jobId, accessToken }) => {
       <div className="flex flex-1 flex-col gap-4 px-6 pb-2 pt-6">
         <div className="flex justify-between">
           <Button size="icon" variant="ghost" onClick={handleBack}>
-            <CaretLeft />
+            <CaretLeftIcon />
           </Button>
           {(jobStatus === "queued" || jobStatus === "running") && (
             <Button variant="destructive" size="sm" onClick={handleCancelJob}>
-              <XCircle />
+              <XCircleIcon />
               {t("Cancel Job")}
             </Button>
           )}

--- a/ui/src/features/WorkspaceLeftPanel/components/BottomSection/components/WorkspaceSettings.tsx
+++ b/ui/src/features/WorkspaceLeftPanel/components/BottomSection/components/WorkspaceSettings.tsx
@@ -1,4 +1,4 @@
-import { Toolbox, UsersThree } from "@phosphor-icons/react";
+import { ToolboxIcon, UsersThreeIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { RouteOption } from "@flow/features/WorkspaceLeftPanel";
@@ -23,7 +23,7 @@ const WorkspaceSettings: React.FC<Props> = ({ selected }) => {
             to: `/workspaces/${currentWorkspace?.id}/settings/general`,
           })
         }>
-        <Toolbox weight="light" />
+        <ToolboxIcon weight="light" />
         <p className="text-sm dark:font-extralight">{t("General Settings")}</p>
       </div>
       <div
@@ -33,7 +33,7 @@ const WorkspaceSettings: React.FC<Props> = ({ selected }) => {
             to: `/workspaces/${currentWorkspace?.id}/settings/members`,
           })
         }>
-        <UsersThree weight="light" />
+        <UsersThreeIcon weight="light" />
         <p className="text-sm dark:font-extralight">{t("Member Settings")}</p>
       </div>
       {/* <div

--- a/ui/src/features/WorkspaceLeftPanel/components/TopSection/components/DeploymentManager.tsx
+++ b/ui/src/features/WorkspaceLeftPanel/components/TopSection/components/DeploymentManager.tsx
@@ -1,4 +1,4 @@
-import { Rocket } from "@phosphor-icons/react";
+import { RocketIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { useT } from "@flow/lib/i18n";
@@ -23,7 +23,7 @@ const DeploymentManager: React.FC<Props> = ({ selected }) => {
       <div
         className={`-mx-2 flex flex-1 cursor-pointer items-center gap-2 rounded px-2 py-1 ${selected && "bg-accent"} hover:bg-accent`}
         onClick={handleNavigation}>
-        <Rocket weight="light" />
+        <RocketIcon weight="light" />
         <p className="text-sm dark:font-extralight">{t("Deployments")}</p>
       </div>
     </div>

--- a/ui/src/features/WorkspaceLeftPanel/components/TopSection/components/JobManager.tsx
+++ b/ui/src/features/WorkspaceLeftPanel/components/TopSection/components/JobManager.tsx
@@ -1,4 +1,4 @@
-import { SneakerMove } from "@phosphor-icons/react";
+import { SneakerMoveIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { useT } from "@flow/lib/i18n";
@@ -20,7 +20,7 @@ const JobManager: React.FC<Props> = ({ selected }) => {
         onClick={() =>
           navigate({ to: `/workspaces/${currentWorkspace?.id}/jobs` })
         }>
-        <SneakerMove weight="light" />
+        <SneakerMoveIcon weight="light" />
         <p className="text-sm dark:font-extralight">{t("Jobs")}</p>
       </div>
     </div>

--- a/ui/src/features/WorkspaceLeftPanel/components/TopSection/components/ProjectManager.tsx
+++ b/ui/src/features/WorkspaceLeftPanel/components/TopSection/components/ProjectManager.tsx
@@ -1,4 +1,4 @@
-import { SquaresFour } from "@phosphor-icons/react";
+import { SquaresFourIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { useT } from "@flow/lib/i18n";
@@ -23,7 +23,7 @@ const ProjectManager: React.FC<Props> = ({ selected }) => {
       <div
         className={`-mx-2 flex flex-1 cursor-pointer items-center gap-2 rounded px-2 py-1 ${selected && "bg-accent"} hover:bg-accent`}
         onClick={handleNavigation}>
-        <SquaresFour weight="light" />
+        <SquaresFourIcon weight="light" />
         <p className="text-sm dark:font-extralight">{t("Projects")}</p>
       </div>
     </div>

--- a/ui/src/features/WorkspaceLeftPanel/components/TopSection/components/TriggerManager.tsx
+++ b/ui/src/features/WorkspaceLeftPanel/components/TopSection/components/TriggerManager.tsx
@@ -1,4 +1,4 @@
-import { Broadcast } from "@phosphor-icons/react";
+import { BroadcastIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { useT } from "@flow/lib/i18n";
@@ -23,7 +23,7 @@ const TriggerManager: React.FC<Props> = ({ selected }) => {
       <div
         className={`-mx-2 flex flex-1 cursor-pointer items-center gap-2 rounded px-2 py-1 ${selected && "bg-accent"} hover:bg-accent`}
         onClick={handleNavigation}>
-        <Broadcast weight="light" />
+        <BroadcastIcon weight="light" />
         <p className="text-sm dark:font-extralight">{t("Triggers")}</p>
       </div>
     </div>

--- a/ui/src/features/WorkspaceProjects/components/ProjectCard.tsx
+++ b/ui/src/features/WorkspaceProjects/components/ProjectCard.tsx
@@ -1,11 +1,11 @@
 import {
-  ClipboardText,
-  Copy,
-  DotsThreeVertical,
-  Export,
-  PencilSimple,
-  PaperPlaneTilt,
-  Trash,
+  ClipboardTextIcon,
+  CopyIcon,
+  DotsThreeVerticalIcon,
+  ExportIcon,
+  PencilSimpleIcon,
+  PaperPlaneTiltIcon,
+  TrashIcon,
 } from "@phosphor-icons/react";
 import { MouseEvent, useState } from "react";
 
@@ -124,7 +124,7 @@ const ProjectCard: React.FC<Props> = ({
             <DropdownMenuTrigger
               className="flex h-full w-[30px] items-center justify-center rounded-br-lg hover:bg-primary"
               onClick={(e) => e.stopPropagation()}>
-              <DotsThreeVertical className="size-[24px]" />
+              <DotsThreeVerticalIcon className="size-[24px]" />
             </DropdownMenuTrigger>
             <DropdownMenuContent
               align="end"
@@ -133,27 +133,27 @@ const ProjectCard: React.FC<Props> = ({
                 className="justify-between gap-2 text-warning"
                 onClick={() => setEditProject({ ...project })}>
                 {t("Edit Details")}
-                <PencilSimple />
+                <PencilSimpleIcon />
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 className="justify-between gap-2"
                 onClick={handleProjectExportFromCard}>
                 {t("Export Project")}
-                <Export weight="light" />
+                <ExportIcon weight="light" />
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="justify-between gap-2"
                 onClick={() => setDuplicateProject({ ...project })}>
                 {t("Duplicate Project")}
-                <Copy weight="light" />
+                <CopyIcon weight="light" />
               </DropdownMenuItem>
               <DropdownMenuItem
                 className="justify-between gap-2"
                 disabled={!sharedUrl}
                 onClick={handleCopyURLToClipBoard}>
                 {t("Copy Share URL")}
-                <ClipboardText weight="light" />
+                <ClipboardTextIcon weight="light" />
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -163,7 +163,7 @@ const ProjectCard: React.FC<Props> = ({
                   setProjectToBeDeleted(id);
                 }}>
                 {t("Delete Project")}
-                <Trash weight="light" />
+                <TrashIcon weight="light" />
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -175,7 +175,7 @@ const ProjectCard: React.FC<Props> = ({
           <TooltipTrigger
             className="absolute right-1 top-1 rounded p-1 text-muted-foreground hover:bg-primary group-hover:text-white"
             onClick={handleOpenSharedProject}>
-            <PaperPlaneTilt />
+            <PaperPlaneTiltIcon />
           </TooltipTrigger>
           <TooltipContent>{t("Public Read Access")}</TooltipContent>
         </Tooltip>

--- a/ui/src/features/WorkspaceProjects/index.tsx
+++ b/ui/src/features/WorkspaceProjects/index.tsx
@@ -1,4 +1,8 @@
-import { ArrowSquareIn, CaretDown, Plus } from "@phosphor-icons/react";
+import {
+  ArrowSquareInIcon,
+  CaretDownIcon,
+  PlusIcon,
+} from "@phosphor-icons/react";
 
 import {
   Button,
@@ -89,12 +93,12 @@ const ProjectsManager: React.FC = () => {
           <div className="flex gap-2">
             <DropdownMenu>
               <DropdownMenuTrigger className="flex items-center gap-1 rounded-md p-2 hover:bg-primary">
-                <ArrowSquareIn weight="thin" />
+                <ArrowSquareInIcon weight="thin" />
                 <p className="line-clamp-2 text-xs font-extralight">
                   {t("Import")}
                 </p>
                 <div className="shrink-0">
-                  <CaretDown size="12px" weight="thin" />
+                  <CaretDownIcon size="12px" weight="thin" />
                 </div>
               </DropdownMenuTrigger>
               <DropdownMenuContent>
@@ -118,7 +122,7 @@ const ProjectsManager: React.FC = () => {
               className="flex gap-2"
               variant="default"
               onClick={() => setOpenProjectAddDialog(true)}>
-              <Plus weight="thin" />
+              <PlusIcon weight="thin" />
               <p className="text-xs dark:font-light">{t("New Project")}</p>
             </Button>
           </div>

--- a/ui/src/features/WorkspaceSettings/components/MembersSettings/index.tsx
+++ b/ui/src/features/WorkspaceSettings/components/MembersSettings/index.tsx
@@ -1,4 +1,4 @@
-import { CaretDown, Plus, User } from "@phosphor-icons/react";
+import { CaretDownIcon, PlusIcon, UserIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 
 import {
@@ -117,7 +117,7 @@ const MembersSettings: React.FC = () => {
           <Button
             className="flex gap-2"
             onClick={() => setOpenMemberAddDialog(true)}>
-            <Plus weight="thin" />
+            <PlusIcon weight="thin" />
             <p className="text-xs dark:font-light"> {t("Add Member")}</p>
           </Button>
         )}
@@ -136,7 +136,7 @@ const MembersSettings: React.FC = () => {
                 <DropdownMenu>
                   <DropdownMenuTrigger className="flex items-center gap-2">
                     <p>{filters.find((f) => f.id === currentFilter)?.title}</p>
-                    <CaretDown className="size-3" />
+                    <CaretDownIcon className="size-3" />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent className="min-w-[70px]">
                     {filters.map((filter, idx) => (
@@ -152,7 +152,7 @@ const MembersSettings: React.FC = () => {
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <User weight="thin" />
+              <UserIcon weight="thin" />
               <p>{`${members?.length} ${t("Members")}`}</p>
             </div>
           </div>
@@ -168,7 +168,7 @@ const MembersSettings: React.FC = () => {
                     disabled={m.userId === me?.id}
                     className={`flex flex-1 items-center gap-1 ${m.userId === me?.id ? "opacity-50" : ""}`}>
                     <p className="text-sm">{t("Change role")}</p>
-                    <CaretDown className="size-2" />
+                    <CaretDownIcon className="size-2" />
                   </DropdownMenuTrigger>
                   <DropdownMenuContent className="min-w-[70px]">
                     {roles.map((role, idx) => (

--- a/ui/src/features/WorkspaceSettings/index.tsx
+++ b/ui/src/features/WorkspaceSettings/index.tsx
@@ -1,4 +1,4 @@
-import { Toolbox, UsersThree } from "@phosphor-icons/react";
+import { ToolboxIcon, UsersThreeIcon } from "@phosphor-icons/react";
 import { useRouterState } from "@tanstack/react-router";
 
 import { useT } from "@flow/lib/i18n";
@@ -30,13 +30,13 @@ const WorkspaceSettings: React.FC = () => {
     {
       id: "general",
       name: t("General"),
-      icon: <Toolbox weight="light" />,
+      icon: <ToolboxIcon weight="light" />,
       component: <GeneralSettings />,
     },
     {
       id: "members",
       name: t("Members"),
-      icon: <UsersThree weight="light" />,
+      icon: <UsersThreeIcon weight="light" />,
       component: <MembersSettings />,
     },
   ];

--- a/ui/src/features/WorkspaceTriggers/components/TriggerDetails.tsx
+++ b/ui/src/features/WorkspaceTriggers/components/TriggerDetails.tsx
@@ -1,4 +1,8 @@
-import { CaretLeft, PencilLine, Trash } from "@phosphor-icons/react";
+import {
+  CaretLeftIcon,
+  PencilLineIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
 import { useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo, useState } from "react";
 
@@ -111,7 +115,7 @@ const TriggerDetails: React.FC<Props> = ({
       <div className="flex flex-1 flex-col gap-4 px-6 pb-2 pt-6">
         <div className="flex justify-between">
           <Button size="icon" variant="ghost" onClick={handleBack}>
-            <CaretLeft />
+            <CaretLeftIcon />
           </Button>
           <div className="flex gap-2">
             <Button
@@ -119,14 +123,14 @@ const TriggerDetails: React.FC<Props> = ({
               size="sm"
               disabled={!selectedTrigger}
               onClick={() => setOpenTriggerEditDialog(true)}>
-              <PencilLine />
+              <PencilLineIcon />
               {t("Update Trigger")}
             </Button>
             <Button
               variant="destructive"
               size="sm"
               onClick={() => setTriggerToBeDeleted(selectedTrigger)}>
-              <Trash />
+              <TrashIcon />
               {t("Delete")}
             </Button>
           </div>

--- a/ui/src/features/WorkspaceTriggers/index.tsx
+++ b/ui/src/features/WorkspaceTriggers/index.tsx
@@ -1,4 +1,4 @@
-import { PencilLine, Plus, Trash } from "@phosphor-icons/react";
+import { PencilLineIcon, PlusIcon, TrashIcon } from "@phosphor-icons/react";
 import { ColumnDef } from "@tanstack/react-table";
 
 import {
@@ -70,14 +70,14 @@ const TriggerManager: React.FC = () => {
             size="icon"
             tooltipText={t("Update Trigger")}
             onClick={() => setTriggerToBeEdited(row.row.original)}>
-            <PencilLine />
+            <PencilLineIcon />
           </ButtonWithTooltip>
           <ButtonWithTooltip
             variant="destructive"
             size="icon"
             tooltipText={t("Delete Trigger")}
             onClick={() => setTriggerToBeDeleted(row.row.original)}>
-            <Trash />
+            <TrashIcon />
           </ButtonWithTooltip>
         </div>
       ),
@@ -101,7 +101,7 @@ const TriggerManager: React.FC = () => {
               <Button
                 className="flex gap-2"
                 onClick={() => setOpenTriggerAddDialog(true)}>
-                <Plus weight="thin" />
+                <PlusIcon weight="thin" />
                 <p className="text-xs dark:font-light">{t("New Trigger")}</p>
               </Button>
             </div>

--- a/ui/src/features/common/DetailsBox.tsx
+++ b/ui/src/features/common/DetailsBox.tsx
@@ -1,4 +1,8 @@
-import { CaretDown, CaretUp, Download } from "@phosphor-icons/react";
+import {
+  CaretDownIcon,
+  CaretUpIcon,
+  DownloadIcon,
+} from "@phosphor-icons/react";
 import { useState } from "react";
 
 import { Button } from "@flow/components";
@@ -69,7 +73,7 @@ const DetailsBox: React.FC<Props> = ({ title, content, collapsible }) => {
         onClick={() => collapsible && setCollapsed(!collapsed)}>
         <div className="flex items-center gap-4">
           <p className="text-xl">{title}</p>
-          {collapsible ? collapsed ? <CaretUp /> : <CaretDown /> : null}
+          {collapsible ? collapsed ? <CaretUpIcon /> : <CaretDownIcon /> : null}
         </div>
         <div className="flex items-center gap-2">
           {!collapsed &&
@@ -86,7 +90,7 @@ const DetailsBox: React.FC<Props> = ({ title, content, collapsible }) => {
                       className="flex h-full items-center gap-2 rounded px-4 py-2"
                       href={value}
                       onClick={() => value && handleDownload(value)}>
-                      <Download />
+                      <DownloadIcon />
                       <p className="max-w-[100px] truncate font-light">
                         {value.split("/").pop()}
                       </p>
@@ -107,7 +111,7 @@ const DetailsBox: React.FC<Props> = ({ title, content, collapsible }) => {
                       typeof detail.value === "string" &&
                       handleDownload(detail.value)
                     }>
-                    <Download />
+                    <DownloadIcon />
                     <p className="font-light">{detail.name}</p>
                   </a>
                 </Button>

--- a/ui/src/features/common/UserMenu/index.tsx
+++ b/ui/src/features/common/UserMenu/index.tsx
@@ -1,4 +1,9 @@
-import { ArrowSquareOut, Keyboard, SignOut, User } from "@phosphor-icons/react";
+import {
+  ArrowSquareOutIcon,
+  KeyboardIcon,
+  SignOutIcon,
+  UserIcon,
+} from "@phosphor-icons/react";
 import { useState } from "react";
 
 import {
@@ -79,13 +84,13 @@ const UserMenu: React.FC<Props> = ({
             className="justify-between gap-4"
             onClick={() => setOpenAccountUpdateDialog(true)}>
             <p>{t("Account Settings")}</p>
-            <User weight="light" />
+            <UserIcon weight="light" />
           </DropdownMenuItem>
           <DropdownMenuItem
             className="justify-between gap-4"
             onClick={() => setOpenShortcutDialog(true)}>
             <p>{t("Keyboard Shortcuts")}</p>
-            <Keyboard weight="light" />
+            <KeyboardIcon weight="light" />
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           {tosUrl && (
@@ -93,7 +98,7 @@ const UserMenu: React.FC<Props> = ({
               className="justify-between gap-4"
               onClick={handleTosPageOpen}>
               <p>{t("Terms of Service")}</p>
-              <ArrowSquareOut weight="light" />
+              <ArrowSquareOutIcon weight="light" />
             </DropdownMenuItem>
           )}
           {documentationUrl && (
@@ -101,7 +106,7 @@ const UserMenu: React.FC<Props> = ({
               className="justify-between gap-4"
               onClick={handleDocumentationPageOpen}>
               <p>{t("Documentation")}</p>
-              <ArrowSquareOut weight="light" />
+              <ArrowSquareOutIcon weight="light" />
             </DropdownMenuItem>
           )}
           <DropdownMenuSeparator />
@@ -109,7 +114,7 @@ const UserMenu: React.FC<Props> = ({
             className="justify-between gap-4 text-warning"
             onClick={handleLogout}>
             <p>{t("Log Out")}</p>
-            <SignOut weight="light" />
+            <SignOutIcon weight="light" />
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/ui/src/features/common/WorkspaceMenu/index.tsx
+++ b/ui/src/features/common/WorkspaceMenu/index.tsx
@@ -1,4 +1,4 @@
-import { CaretDown, Plus } from "@phosphor-icons/react";
+import { CaretDownIcon, PlusIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
@@ -50,7 +50,7 @@ const WorkspaceMenu: React.FC = () => {
             {currentWorkspace?.name}
           </p>
           <div className="shrink-0">
-            <CaretDown size="12px" weight="thin" />
+            <CaretDownIcon size="12px" weight="thin" />
           </div>
         </DropdownMenuTrigger>
         <DropdownMenuContent
@@ -95,7 +95,7 @@ const WorkspaceMenu: React.FC = () => {
               setOpenWorkspaceAddDialog(true);
               setOpenDropdown(false);
             }}>
-            <Plus weight="thin" />
+            <PlusIcon weight="thin" />
             <p className="text-xs dark:font-light">{t("New Workspace")}</p>
           </div>
         </DropdownMenuContent>

--- a/ui/src/lib/reactFlow/edgeTypes/DefaultEdge/index.tsx
+++ b/ui/src/lib/reactFlow/edgeTypes/DefaultEdge/index.tsx
@@ -1,4 +1,4 @@
-import { Table, X } from "@phosphor-icons/react";
+import { TableIcon, XIcon } from "@phosphor-icons/react";
 import {
   BaseEdge,
   EdgeLabelRenderer,
@@ -51,7 +51,7 @@ const DefaultEdge: React.FC<CustomEdgeProps> = ({
       <BaseEdge id={id} path={edgePath} />
       <EdgeLabelRenderer>
         {jobStatus === "failed" && (
-          <X
+          <XIcon
             className="nodrag nopan absolute size-[20px] origin-center rounded-full border border-destructive bg-primary fill-destructive p-1"
             weight="bold"
             style={{
@@ -61,7 +61,7 @@ const DefaultEdge: React.FC<CustomEdgeProps> = ({
           />
         )}
         {hasIntermediateData && (
-          <Table
+          <TableIcon
             className={`nodrag nopan absolute size-[25px] origin-center rounded-full border bg-primary p-1 transition-[height,width] hover:size-[40px] hover:fill-success  ${intermediateDataIsSet ? "size-[35px] border-success bg-success fill-white hover:fill-white" : selected ? "border-success fill-success" : "border-slate-400/80 fill-success/80"}`}
             style={{
               pointerEvents: "all",

--- a/ui/src/lib/reactFlow/nodeTypes/BatchNode/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/BatchNode/index.tsx
@@ -1,4 +1,4 @@
-import { RectangleDashed } from "@phosphor-icons/react";
+import { RectangleDashedIcon } from "@phosphor-icons/react";
 import { NodeProps, NodeResizer } from "@xyflow/react";
 import { memo } from "react";
 
@@ -56,7 +56,7 @@ const BatchNode: React.FC<BatchNodeProps> = ({ data, selected, id }) => {
               );
           }}>
           <div className="p-1 rounded-sm bg-primary">
-            <RectangleDashed
+            <RectangleDashedIcon
               className="w-[15px] fill-orange-400/80"
               weight="bold"
             />

--- a/ui/src/lib/reactFlow/nodeTypes/GeneralNode/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/GeneralNode/index.tsx
@@ -1,4 +1,9 @@
-import { Database, Disc, Graph, Lightning } from "@phosphor-icons/react";
+import {
+  DatabaseIcon,
+  DiscIcon,
+  GraphIcon,
+  LightningIcon,
+} from "@phosphor-icons/react";
 import { NodeProps } from "@xyflow/react";
 import { memo } from "react";
 
@@ -37,13 +42,13 @@ const GeneralNode: React.FC<GeneralNodeProps> = ({
         <div
           className={`flex p-1 self-center align-middle justify-center rounded-sm border ${selected ? selectedColor : borderColor} ${selected ? selectedBackgroundColor : className}`}>
           {type === "reader" ? (
-            <Database className={typeIconClasses} />
+            <DatabaseIcon className={typeIconClasses} />
           ) : type === "writer" ? (
-            <Disc className={typeIconClasses} />
+            <DiscIcon className={typeIconClasses} />
           ) : type === "transformer" ? (
-            <Lightning className={typeIconClasses} />
+            <LightningIcon className={typeIconClasses} />
           ) : type === "subworkflow" ? (
-            <Graph className={typeIconClasses} />
+            <GraphIcon className={typeIconClasses} />
           ) : null}
         </div>
         <div className="flex flex-1 items-center justify-between gap-2 truncate rounded-r-sm px-1 leading-none">

--- a/ui/src/lib/reactFlow/nodeTypes/NoteNode/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/NoteNode/index.tsx
@@ -1,4 +1,4 @@
-import { Note } from "@phosphor-icons/react";
+import { NoteIcon } from "@phosphor-icons/react";
 import { NodeProps, NodeResizer } from "@xyflow/react";
 import { memo } from "react";
 
@@ -65,7 +65,7 @@ const NoteNode: React.FC<NoteNodeProps> = ({ id, type, data, ...props }) => {
               );
           }}>
           <div className="p-1 bg-primary/80 rounded-sm">
-            <Note className="w-[15px]" />
+            <NoteIcon className="w-[15px]" />
           </div>
           <p>{data.customizations?.customName ?? data.officialName}</p>
         </div>

--- a/ui/src/utils/getNodeIcon.ts
+++ b/ui/src/utils/getNodeIcon.ts
@@ -1,25 +1,25 @@
 import {
-  Circle,
-  Database,
-  Disc,
-  Graph,
-  Lightning,
-  Note,
+  CircleIcon,
+  DatabaseIcon,
+  DiscIcon,
+  GraphIcon,
+  LightningIcon,
+  NoteIcon,
 } from "@phosphor-icons/react";
 
 export function getNodeIcon(type: string | undefined) {
   switch (type) {
     case "note":
-      return Note;
+      return NoteIcon;
     case "subworkflow":
-      return Graph;
+      return GraphIcon;
     case "transformer":
-      return Lightning;
+      return LightningIcon;
     case "reader":
-      return Database;
+      return DatabaseIcon;
     case "writer":
-      return Disc;
+      return DiscIcon;
     default:
-      return Circle;
+      return CircleIcon;
   }
 }


### PR DESCRIPTION
# Overview
Phosphor Icons have changed their naming conventions for icons. For example, instead of `Calendar` it is now `CalendarIcon`.

This is to avoid components having similar names to icons I presume.
## What I've done

Change all phosphor icons where used to the new naming convention

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
