### PR TITLE
fix(ui): added support for triangle and rectangle

### DIFF
--- a/ui/src/utils/jsonl/transformIntermediateData.test.ts
+++ b/ui/src/utils/jsonl/transformIntermediateData.test.ts
@@ -392,6 +392,79 @@ describe("intermediateDataTransform", () => {
       expect(intermediateDataTransform(data)).toEqual(expected);
     });
 
+    it("should transform triangle geometry correctly", () => {
+      const data = {
+        id: "123",
+        attributes: { name: "Test Triangle" },
+        geometry: {
+          value: {
+            flowGeometry2D: {
+              triangle: [
+                { x: 0, y: 0 },
+                { x: 10, y: 0 },
+                { x: 5, y: 10 },
+              ],
+            },
+          },
+        },
+      };
+
+      const expected = {
+        id: "123",
+        type: "Feature",
+        properties: { name: "Test Triangle" },
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [0, 0],
+              [10, 0],
+              [5, 10],
+            ],
+          ],
+        },
+      };
+
+      expect(intermediateDataTransform(data)).toEqual(expected);
+    });
+
+    it("should transform rectangle geometry correctly", () => {
+      const data = {
+        id: "123",
+        attributes: { name: "Test Rectangle" },
+        geometry: {
+          value: {
+            flowGeometry2D: {
+              rectangle: {
+                min: { x: 0, y: 0 },
+                max: { x: 10, y: 20 },
+              },
+            },
+          },
+        },
+      };
+
+      const expected = {
+        id: "123",
+        type: "Feature",
+        properties: { name: "Test Rectangle" },
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [0, 0],
+              [10, 0],
+              [10, 20],
+              [0, 20],
+              [0, 0],
+            ],
+          ],
+        },
+      };
+
+      expect(intermediateDataTransform(data)).toEqual(expected);
+    });
+
     it("should return the original geometry if no recognized type is found", () => {
       const unknownGeometry = {
         unknownType: {

--- a/ui/src/utils/jsonl/transformIntermediateData.ts
+++ b/ui/src/utils/jsonl/transformIntermediateData.ts
@@ -99,5 +99,30 @@ function handle2DGeometry(geometry: any) {
       coordinates,
     };
   }
+  if ("triangle" in geometry) {
+    const coordinates = [
+      geometry.triangle.map((point: any) => [point.x, point.y]),
+    ];
+    return {
+      type: "Polygon",
+      coordinates,
+    };
+  }
+  if ("rectangle" in geometry) {
+    const { min, max } = geometry.rectangle;
+    const coordinates = [
+      [
+        [min.x, min.y],
+        [max.x, min.y],
+        [max.x, max.y],
+        [min.x, max.y],
+        [min.x, min.y],
+      ],
+    ];
+    return {
+      type: "Polygon",
+      coordinates,
+    };
+  }
   return geometry;
 }


### PR DESCRIPTION
# Overview
We support in the engine rectangle and triangle geometry and need to convert this into GeoJSON to allow it to be displayed as intermediate data in the frontend.
## What I've done

- Added support for rectangle and triangle conversion into polygon to allow intermediate data to be displayed
- Added tests for rectangle and triangle conversion

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
