### PR TITLE
fix(ui): added a generic error page for general errors [FLOW-FE-212]

### DIFF
--- a/ui/src/components/errors/ErrorPage/index.tsx
+++ b/ui/src/components/errors/ErrorPage/index.tsx
@@ -2,7 +2,7 @@ import { Button } from "@flow/components/buttons";
 import { FlowLogo } from "@flow/components/icons";
 import { useT } from "@flow/lib/i18n";
 
-function ErrorPage({ errorMessage }: { errorMessage: string }) {
+function ErrorPage({ errorMessage }: { errorMessage?: string }) {
   const t = useT();
   return (
     <div className="flex h-screen items-center justify-center">
@@ -12,7 +12,9 @@ function ErrorPage({ errorMessage }: { errorMessage: string }) {
             <FlowLogo className="size-[75px]" />
           </div>
         </div>
-        <p className="text-destructive dark:font-extralight">{errorMessage}</p>
+        <p className="text-destructive dark:font-extralight">
+          {errorMessage || t("Something Went Wrong")}
+        </p>
         <Button variant="outline" onClick={() => window.location.reload()}>
           <p className="dark:font-extralight">{t("Reload")}</p>
         </Button>

--- a/ui/src/components/errors/ErrorPage/index.tsx
+++ b/ui/src/components/errors/ErrorPage/index.tsx
@@ -8,7 +8,7 @@ function ErrorPage({ errorMessage }: { errorMessage: string }) {
     <div className="flex h-screen items-center justify-center">
       <div className="flex flex-col items-center gap-10">
         <div className="flex items-center gap-4">
-          <div className="rounded bg-logo p-2">
+          <div className="rounded p-2">
             <FlowLogo className="size-[75px]" />
           </div>
         </div>

--- a/ui/src/components/errors/ErrorPage/index.tsx
+++ b/ui/src/components/errors/ErrorPage/index.tsx
@@ -1,0 +1,24 @@
+import { Button } from "@flow/components/buttons";
+import { FlowLogo } from "@flow/components/icons";
+import { useT } from "@flow/lib/i18n";
+
+function ErrorPage({ errorMessage }: { errorMessage: string }) {
+  const t = useT();
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="flex flex-col items-center gap-10">
+        <div className="flex items-center gap-4">
+          <div className="rounded bg-logo p-2">
+            <FlowLogo className="size-[75px]" />
+          </div>
+        </div>
+        <p className="text-destructive dark:font-extralight">{errorMessage}</p>
+        <Button variant="outline" onClick={() => window.location.reload()}>
+          <p className="dark:font-extralight">{t("Reload")}</p>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default ErrorPage;

--- a/ui/src/components/errors/index.ts
+++ b/ui/src/components/errors/index.ts
@@ -1,0 +1,1 @@
+export * from "./ErrorPage";

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -33,3 +33,4 @@ export * from "./visualizations";
 export * from "./Pagination";
 export * from "./Popover";
 export * from "./Switch";
+export * from "./errors";

--- a/ui/src/errors/index.tsx
+++ b/ui/src/errors/index.tsx
@@ -1,0 +1,8 @@
+class ProjectCorruptionError extends Error {
+  constructor(message = "Project data is corrupted") {
+    super(message);
+    this.name = "ProjectCorruptionError";
+  }
+}
+
+export { ProjectCorruptionError };

--- a/ui/src/lib/i18n/locales/en.json
+++ b/ui/src/lib/i18n/locales/en.json
@@ -5,6 +5,7 @@
   "Columns": "Columns",
   "No Results": "No Results",
   "Time": "",
+  "Something Went Wrong": "",
   "Reload": "",
   "Loading": "Loading",
   "Error": "",
@@ -399,6 +400,7 @@
   "There was an error when trying to update the members persmissons.": "",
   "Batch": "",
   "Subworkflow": "",
+  "Please check the shared URL is correct.": "",
   "Project or version is corrupted.": "",
   "Revert to a previous version": ""
 }

--- a/ui/src/lib/i18n/locales/en.json
+++ b/ui/src/lib/i18n/locales/en.json
@@ -5,6 +5,7 @@
   "Columns": "Columns",
   "No Results": "No Results",
   "Time": "",
+  "Reload": "",
   "Loading": "Loading",
   "Error": "",
   "Warning": "",
@@ -19,6 +20,7 @@
   "Reset": "",
   "Reset Value": "",
   "Submit": "Submit",
+  "Feature Info": "",
   "Copy": "",
   "Cut": "",
   "Paste": "",
@@ -70,7 +72,6 @@
   "Exit fullscreen": "",
   "Enter fullscreen": "",
   "Workflow Logs": "",
-  "Feature Info": "",
   "Output data": "",
   "Select Data to Preview": "",
   "Table Viewer": "",
@@ -399,6 +400,5 @@
   "Batch": "",
   "Subworkflow": "",
   "Project or version is corrupted.": "",
-  "Revert to a previous version": "",
-  "Reload": ""
+  "Revert to a previous version": ""
 }

--- a/ui/src/lib/i18n/locales/es.json
+++ b/ui/src/lib/i18n/locales/es.json
@@ -5,6 +5,7 @@
   "Columns": "Columnas",
   "No Results": "Sin resultados",
   "Time": "Tiempo",
+  "Something Went Wrong": "Algo salió mal",
   "Reload": "Recargar",
   "Loading": "Cargando",
   "Error": "Error",
@@ -399,6 +400,7 @@
   "There was an error when trying to update the members persmissons.": "",
   "Batch": "Lote",
   "Subworkflow": "Subflujo de trabajo",
+  "Please check the shared URL is correct.": "Por favor, verifica que la URL compartida sea correcta.",
   "Project or version is corrupted.": "",
   "Revert to a previous version": ""
 }

--- a/ui/src/lib/i18n/locales/es.json
+++ b/ui/src/lib/i18n/locales/es.json
@@ -5,6 +5,7 @@
   "Columns": "Columnas",
   "No Results": "Sin resultados",
   "Time": "Tiempo",
+  "Reload": "Recargar",
   "Loading": "Cargando",
   "Error": "Error",
   "Warning": "Advertencia",
@@ -19,6 +20,7 @@
   "Reset": "Restablecer",
   "Reset Value": "Restablecer valor",
   "Submit": "Enviar",
+  "Feature Info": "",
   "Copy": "Copiar",
   "Cut": "Cortar",
   "Paste": "Pegar",
@@ -70,7 +72,6 @@
   "Exit fullscreen": "Salir de pantalla completa",
   "Enter fullscreen": "Entrar en pantalla completa",
   "Workflow Logs": "Registros del flujo de trabajo",
-  "Feature Info": "",
   "Output data": "Datos de salida",
   "Select Data to Preview": "Seleccionar datos para previsualizar",
   "Table Viewer": "Visor de tabla",
@@ -399,6 +400,5 @@
   "Batch": "Lote",
   "Subworkflow": "Subflujo de trabajo",
   "Project or version is corrupted.": "",
-  "Revert to a previous version": "",
-  "Reload": "Recargar"
+  "Revert to a previous version": ""
 }

--- a/ui/src/lib/i18n/locales/fr.json
+++ b/ui/src/lib/i18n/locales/fr.json
@@ -5,6 +5,7 @@
   "Columns": "Colonnes",
   "No Results": "Aucun résultat",
   "Time": "Temps",
+  "Something Went Wrong": "Quelque chose s'est mal passé",
   "Reload": "Recharger",
   "Loading": "Chargement",
   "Error": "Erreur",
@@ -399,6 +400,7 @@
   "There was an error when trying to update the members persmissons.": "",
   "Batch": "",
   "Subworkflow": "",
+  "Please check the shared URL is correct.": "Veuillez vérifier que l'URL partagée est correcte.",
   "Project or version is corrupted.": "",
   "Revert to a previous version": ""
 }

--- a/ui/src/lib/i18n/locales/fr.json
+++ b/ui/src/lib/i18n/locales/fr.json
@@ -5,6 +5,7 @@
   "Columns": "Colonnes",
   "No Results": "Aucun résultat",
   "Time": "Temps",
+  "Reload": "Recharger",
   "Loading": "Chargement",
   "Error": "Erreur",
   "Warning": "Avertissement",
@@ -19,6 +20,7 @@
   "Reset": "Réinitialiser",
   "Reset Value": "Réinitialiser la valeur",
   "Submit": "Soumettre",
+  "Feature Info": "",
   "Copy": "Copier",
   "Cut": "Couper",
   "Paste": "Coller",
@@ -70,7 +72,6 @@
   "Exit fullscreen": "Quitter le plein écran",
   "Enter fullscreen": "Passer en plein écran",
   "Workflow Logs": "Journaux du flux de travail",
-  "Feature Info": "",
   "Output data": "Sortie de données",
   "Select Data to Preview": "Sélectionner les données à prévisualiser",
   "Table Viewer": "Tableau de visualisation",
@@ -399,6 +400,5 @@
   "Batch": "",
   "Subworkflow": "",
   "Project or version is corrupted.": "",
-  "Revert to a previous version": "",
-  "Reload": "Recharger"
+  "Revert to a previous version": ""
 }

--- a/ui/src/lib/i18n/locales/ja.json
+++ b/ui/src/lib/i18n/locales/ja.json
@@ -5,6 +5,7 @@
   "Columns": "カラム",
   "No Results": "結果なし",
   "Time": "時間",
+  "Something Went Wrong": "何かがうまくいきませんでした",
   "Reload": "リロード",
   "Loading": "読み込み中",
   "Error": "エラー",
@@ -399,6 +400,7 @@
   "There was an error when trying to update the members persmissons.": "メンバーの権限を更新しようとした際にエラーが発生しました。",
   "Batch": "バッチ",
   "Subworkflow": "サブワークフロー",
+  "Please check the shared URL is correct.": "共有URLが正しいか確認してください。",
   "Project or version is corrupted.": "プロジェクトまたはバージョンが破損しています。",
   "Revert to a previous version": "以前のバージョンに戻す"
 }

--- a/ui/src/lib/i18n/locales/ja.json
+++ b/ui/src/lib/i18n/locales/ja.json
@@ -5,6 +5,7 @@
   "Columns": "カラム",
   "No Results": "結果なし",
   "Time": "時間",
+  "Reload": "リロード",
   "Loading": "読み込み中",
   "Error": "エラー",
   "Warning": "警告",
@@ -19,6 +20,7 @@
   "Reset": "リセット",
   "Reset Value": "値をリセット",
   "Submit": "送信",
+  "Feature Info": "機能情報",
   "Copy": "コピー",
   "Cut": "切り取り",
   "Paste": "貼り付け",
@@ -70,7 +72,6 @@
   "Exit fullscreen": "フルスクリーンを終了",
   "Enter fullscreen": "フルスクリーンに入る",
   "Workflow Logs": "ワークフローログ",
-  "Feature Info": "機能情報",
   "Output data": "出力データ",
   "Select Data to Preview": "プレビューするデータを選択",
   "Table Viewer": "テーブルビューア",
@@ -399,6 +400,5 @@
   "Batch": "バッチ",
   "Subworkflow": "サブワークフロー",
   "Project or version is corrupted.": "プロジェクトまたはバージョンが破損しています。",
-  "Revert to a previous version": "以前のバージョンに戻す",
-  "Reload": "リロード"
+  "Revert to a previous version": "以前のバージョンに戻す"
 }

--- a/ui/src/lib/i18n/locales/zh.json
+++ b/ui/src/lib/i18n/locales/zh.json
@@ -5,6 +5,7 @@
   "Columns": "列",
   "No Results": "没有结果",
   "Time": "时间",
+  "Reload": "重新加载",
   "Loading": "加载中",
   "Error": "错误",
   "Warning": "警告",
@@ -19,6 +20,7 @@
   "Reset": "重置",
   "Reset Value": "重置值",
   "Submit": "提交",
+  "Feature Info": "",
   "Copy": "复制",
   "Cut": "剪切",
   "Paste": "粘贴",
@@ -70,7 +72,6 @@
   "Exit fullscreen": "退出全屏",
   "Enter fullscreen": "进入全屏",
   "Workflow Logs": "工作流日志",
-  "Feature Info": "",
   "Output data": "输出数据",
   "Select Data to Preview": "选择要预览的数据",
   "Table Viewer": "表格查看器",
@@ -399,6 +400,5 @@
   "Batch": "批处理",
   "Subworkflow": "子工作流",
   "Project or version is corrupted.": "",
-  "Revert to a previous version": "",
-  "Reload": "重新加载"
+  "Revert to a previous version": ""
 }

--- a/ui/src/lib/i18n/locales/zh.json
+++ b/ui/src/lib/i18n/locales/zh.json
@@ -5,6 +5,7 @@
   "Columns": "列",
   "No Results": "没有结果",
   "Time": "时间",
+  "Something Went Wrong": "出了点问题",
   "Reload": "重新加载",
   "Loading": "加载中",
   "Error": "错误",
@@ -399,6 +400,7 @@
   "There was an error when trying to update the members persmissons.": "更新成员权限时发生错误。",
   "Batch": "批处理",
   "Subworkflow": "子工作流",
-  "Project or version is corrupted.": "",
-  "Revert to a previous version": ""
+  "Please check the shared URL is correct.": "请检查共享URL是否正确。",
+  "Project or version is corrupted.": "项目或版本已损坏。",
+  "Revert to a previous version": "回滚到先前版本"
 }

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -5,9 +5,14 @@ import loadConfig from "@flow/config";
 import { routeTree } from "@flow/routeTree.gen.ts";
 
 import "@flow/index.css";
+import NotFound from "./features/NotFound";
 import { openDatabase } from "./stores";
 
-const router = createRouter({ routeTree });
+const router = createRouter({
+  routeTree,
+  notFoundMode: "root",
+  defaultNotFoundComponent: () => <NotFound />,
+});
 
 loadConfig().finally(async () => {
   const element = document.getElementById("root");

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -1,9 +1,11 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
 import { LoadingSplashscreen } from "@flow/components";
+import ErrorPage from "@flow/components/errors/ErrorPage";
 
 export const Route = createFileRoute("/")({
   component: () => <LoadingSplashscreen />,
+  errorComponent: () => <ErrorPage errorMessage={"Something Went Wrong"} />,
   loader: () => {
     throw redirect({ to: "/workspaces" });
   },

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -5,7 +5,7 @@ import ErrorPage from "@flow/components/errors/ErrorPage";
 
 export const Route = createFileRoute("/")({
   component: () => <LoadingSplashscreen />,
-  errorComponent: () => <ErrorPage errorMessage={"Something Went Wrong"} />,
+  errorComponent: () => <ErrorPage />,
   loader: () => {
     throw redirect({ to: "/workspaces" });
   },

--- a/ui/src/routes/shared.$sharedToken.lazy.tsx
+++ b/ui/src/routes/shared.$sharedToken.lazy.tsx
@@ -9,7 +9,9 @@ import {
 } from "@flow/components";
 import BasicBoiler from "@flow/components/BasicBoiler";
 import ErrorPage from "@flow/components/errors/ErrorPage";
+import { ProjectCorruptionError } from "@flow/errors";
 import AuthenticationWrapper from "@flow/features/AuthenticationWrapper";
+import NotFound from "@flow/features/NotFound";
 import SharedCanvas from "@flow/features/SharedCanvas";
 import { DEFAULT_ENTRY_GRAPH_ID } from "@flow/global-constants";
 import { useFullscreen, useShortcuts } from "@flow/hooks";
@@ -93,7 +95,7 @@ const EditorComponent = ({ accessToken }: { accessToken?: string }) => {
 
   const { sharedToken } = useParams({ strict: false });
 
-  const { sharedProject } = useGetSharedProject(sharedToken);
+  const { sharedProject, isError } = useGetSharedProject(sharedToken);
 
   const { yWorkflows, yDocState, isSynced, undoTrackerActionWrapper } =
     useYjsSetup({
@@ -101,7 +103,12 @@ const EditorComponent = ({ accessToken }: { accessToken?: string }) => {
       workflowId: DEFAULT_ENTRY_GRAPH_ID,
     });
 
-  return !yWorkflows || !isSynced || !undoTrackerActionWrapper ? (
+  return isError ? (
+    <NotFound />
+  ) : !yWorkflows ||
+    !isSynced ||
+    !undoTrackerActionWrapper ||
+    !sharedProject ? (
     <LoadingSplashscreen />
   ) : (
     <SharedCanvas
@@ -119,7 +126,7 @@ const ErrorComponent = ({ error }: { error: Error }) => {
 
   return (
     <>
-      {error.stack?.includes("reassembleNode") ? (
+      {error instanceof ProjectCorruptionError ? (
         <div className="flex h-screen w-full flex-col items-center justify-center">
           <BasicBoiler
             text={t("Project or version is corrupted.")}

--- a/ui/src/routes/shared.$sharedToken.lazy.tsx
+++ b/ui/src/routes/shared.$sharedToken.lazy.tsx
@@ -8,6 +8,7 @@ import {
   TooltipProvider,
 } from "@flow/components";
 import BasicBoiler from "@flow/components/BasicBoiler";
+import ErrorPage from "@flow/components/errors/ErrorPage";
 import AuthenticationWrapper from "@flow/features/AuthenticationWrapper";
 import SharedCanvas from "@flow/features/SharedCanvas";
 import { DEFAULT_ENTRY_GRAPH_ID } from "@flow/global-constants";
@@ -20,7 +21,7 @@ import useYjsSetup from "@flow/lib/yjs/useYjsSetup";
 
 export const Route = createLazyFileRoute("/shared/$sharedToken")({
   component: () => <SharedRoute />,
-  errorComponent: () => <ErrorComponent />,
+  errorComponent: ({ error }) => <ErrorComponent error={error} />,
 });
 
 const SharedRoute = () => {
@@ -113,15 +114,21 @@ const EditorComponent = ({ accessToken }: { accessToken?: string }) => {
   );
 };
 
-const ErrorComponent = () => {
+const ErrorComponent = ({ error }: { error: Error }) => {
   const t = useT();
 
   return (
-    <div className="flex h-screen w-full flex-col items-center justify-center">
-      <BasicBoiler
-        text={t("Project or version is corrupted.")}
-        icon={<FlowLogo className="size-16 text-accent" />}
-      />
-    </div>
+    <>
+      {error.stack?.includes("reassembleNode") ? (
+        <div className="flex h-screen w-full flex-col items-center justify-center">
+          <BasicBoiler
+            text={t("Project or version is corrupted.")}
+            icon={<FlowLogo className="size-16 text-accent" />}
+          />
+        </div>
+      ) : (
+        <ErrorPage errorMessage={"Something Went Wrong"} />
+      )}
+    </>
   );
 };

--- a/ui/src/routes/shared.$sharedToken.lazy.tsx
+++ b/ui/src/routes/shared.$sharedToken.lazy.tsx
@@ -24,6 +24,7 @@ import useYjsSetup from "@flow/lib/yjs/useYjsSetup";
 export const Route = createLazyFileRoute("/shared/$sharedToken")({
   component: () => <SharedRoute />,
   errorComponent: ({ error }) => <ErrorComponent error={error} />,
+  notFoundComponent: () => <NotFound />,
 });
 
 const SharedRoute = () => {
@@ -70,6 +71,7 @@ const SharedRoute = () => {
 };
 
 const EditorComponent = ({ accessToken }: { accessToken?: string }) => {
+  const t = useT();
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const { handleFullscreenToggle } = useFullscreen();
   useShortcuts([
@@ -104,7 +106,7 @@ const EditorComponent = ({ accessToken }: { accessToken?: string }) => {
     });
 
   return isError ? (
-    <NotFound />
+    <ErrorPage errorMessage={t("Please check the shared URL is correct.")} />
   ) : !yWorkflows ||
     !isSynced ||
     !undoTrackerActionWrapper ||
@@ -134,7 +136,7 @@ const ErrorComponent = ({ error }: { error: Error }) => {
           />
         </div>
       ) : (
-        <ErrorPage errorMessage={"Something Went Wrong"} />
+        <ErrorPage />
       )}
     </>
   );

--- a/ui/src/routes/workspaces.$workspaceId_.projects_.$projectId.lazy.tsx
+++ b/ui/src/routes/workspaces.$workspaceId_.projects_.$projectId.lazy.tsx
@@ -166,7 +166,7 @@ const ErrorComponent = ({
           )}
         </div>
       ) : (
-        <ErrorPage errorMessage={"Something Went Wrong"} />
+        <ErrorPage />
       )}
     </>
   );

--- a/ui/src/routes/workspaces.$workspaceId_.projects_.$projectId.lazy.tsx
+++ b/ui/src/routes/workspaces.$workspaceId_.projects_.$projectId.lazy.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Button, FlowLogo, LoadingSplashscreen } from "@flow/components";
 import BasicBoiler from "@flow/components/BasicBoiler";
 import ErrorPage from "@flow/components/errors/ErrorPage";
+import { ProjectCorruptionError } from "@flow/errors";
 import Editor from "@flow/features/Editor";
 import { VersionDialog } from "@flow/features/Editor/components/TopBar/components/ActionBar/components/Version/VersionDialog";
 import {
@@ -141,7 +142,7 @@ const ErrorComponent = ({
 
   return (
     <>
-      {error.stack?.includes("reassembleNode") ? (
+      {error instanceof ProjectCorruptionError ? (
         <div className="flex h-screen w-full flex-col items-center justify-center">
           <div className="flex flex-col items-center justify-center gap-8">
             <BasicBoiler

--- a/ui/src/routes/workspaces.$workspaceId_.projects_.$projectId.lazy.tsx
+++ b/ui/src/routes/workspaces.$workspaceId_.projects_.$projectId.lazy.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { Button, FlowLogo, LoadingSplashscreen } from "@flow/components";
 import BasicBoiler from "@flow/components/BasicBoiler";
+import ErrorPage from "@flow/components/errors/ErrorPage";
 import Editor from "@flow/features/Editor";
 import { VersionDialog } from "@flow/features/Editor/components/TopBar/components/ActionBar/components/Version/VersionDialog";
 import {
@@ -35,7 +36,9 @@ export const Route = createLazyFileRoute(
       </ProjectIdWrapper>
     </WorkspaceIdWrapper>
   ),
-  errorComponent: ({ reset }) => <ErrorComponent onErrorReset={reset} />,
+  errorComponent: ({ error, reset }) => (
+    <ErrorComponent error={error} onErrorReset={reset} />
+  ),
 });
 
 const EditorComponent = () => {
@@ -114,7 +117,13 @@ const EditorComponent = () => {
   );
 };
 
-const ErrorComponent = ({ onErrorReset }: { onErrorReset: () => void }) => {
+const ErrorComponent = ({
+  error,
+  onErrorReset,
+}: {
+  error: Error;
+  onErrorReset: () => void;
+}) => {
   const [openVersionDialog, setOpenVersionDialog] = useState(false);
   const t = useT();
 
@@ -129,29 +138,34 @@ const ErrorComponent = ({ onErrorReset }: { onErrorReset: () => void }) => {
   const handleCloseDialog = () => {
     setOpenVersionDialog(false);
   };
+
   return (
     <>
-      <div className="flex h-screen w-full flex-col items-center justify-center">
-        <div className="flex flex-col items-center justify-center gap-8">
-          <BasicBoiler
-            text={t("Project or version is corrupted.")}
-            icon={<FlowLogo className="size-16 text-accent" />}
-          />
-          <Button
-            onClick={() => setOpenVersionDialog(true)}
-            variant="default"
-            className="ml-4">
-            {t("Revert to a previous version")}
-          </Button>
+      {error.stack?.includes("reassembleNode") ? (
+        <div className="flex h-screen w-full flex-col items-center justify-center">
+          <div className="flex flex-col items-center justify-center gap-8">
+            <BasicBoiler
+              text={t("Project or version is corrupted.")}
+              icon={<FlowLogo className="size-16 text-accent" />}
+            />
+            <Button
+              onClick={() => setOpenVersionDialog(true)}
+              variant="default"
+              className="ml-4">
+              {t("Revert to a previous version")}
+            </Button>
+          </div>
+          {openVersionDialog && (
+            <VersionDialog
+              yDoc={yDocState}
+              project={currentProject}
+              onDialogClose={handleCloseDialog}
+              onErrorReset={onErrorReset}
+            />
+          )}
         </div>
-      </div>
-      {openVersionDialog && (
-        <VersionDialog
-          yDoc={yDocState}
-          project={currentProject}
-          onDialogClose={handleCloseDialog}
-          onErrorReset={onErrorReset}
-        />
+      ) : (
+        <ErrorPage errorMessage={"Something Went Wrong"} />
       )}
     </>
   );

--- a/ui/src/routes/workspaces.tsx
+++ b/ui/src/routes/workspaces.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from "react";
 import { LoadingSplashscreen } from "@flow/components";
 import ErrorPage from "@flow/components/errors/ErrorPage";
 import AuthenticationWrapper from "@flow/features/AuthenticationWrapper";
+import NotFound from "@flow/features/NotFound";
 import { NotificationSystem } from "@flow/features/NotificationSystem";
 import { useAuth } from "@flow/lib/auth";
 import { GraphQLProvider, useUser } from "@flow/lib/gql";
@@ -22,6 +23,8 @@ export const Route = createFileRoute("/workspaces")({
       <WorkspaceRoute />
     </AuthenticationWrapper>
   ),
+  errorComponent: () => <ErrorPage errorMessage={"Something Went Wrong"} />,
+  notFoundComponent: () => <NotFound />,
 });
 
 const WorkspaceRoute = () => {

--- a/ui/src/routes/workspaces.tsx
+++ b/ui/src/routes/workspaces.tsx
@@ -7,12 +7,13 @@ import {
 } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 
-import { Button, FlowLogo, LoadingSplashscreen } from "@flow/components";
+import { LoadingSplashscreen } from "@flow/components";
+import ErrorPage from "@flow/components/errors/ErrorPage";
 import AuthenticationWrapper from "@flow/features/AuthenticationWrapper";
 import { NotificationSystem } from "@flow/features/NotificationSystem";
 import { useAuth } from "@flow/lib/auth";
 import { GraphQLProvider, useUser } from "@flow/lib/gql";
-import { I18nProvider, useT } from "@flow/lib/i18n";
+import { I18nProvider } from "@flow/lib/i18n";
 import { ThemeProvider } from "@flow/lib/theme";
 
 export const Route = createFileRoute("/workspaces")({
@@ -72,22 +73,3 @@ const WorkspaceNavigation = () => {
     <ErrorPage errorMessage={"Could not fetch user"} />
   ) : null;
 };
-
-function ErrorPage({ errorMessage }: { errorMessage: string }) {
-  const t = useT();
-  return (
-    <div className="flex h-screen items-center justify-center">
-      <div className="flex flex-col items-center gap-10">
-        <div className="flex items-center gap-4">
-          <div className="rounded bg-logo p-2">
-            <FlowLogo className="size-[75px]" />
-          </div>
-        </div>
-        <p className="text-destructive dark:font-extralight">{errorMessage}</p>
-        <Button variant="outline" onClick={() => window.location.reload()}>
-          <p className="dark:font-extralight">{t("Reload")}</p>
-        </Button>
-      </div>
-    </div>
-  );
-}

--- a/ui/src/routes/workspaces.tsx
+++ b/ui/src/routes/workspaces.tsx
@@ -23,7 +23,7 @@ export const Route = createFileRoute("/workspaces")({
       <WorkspaceRoute />
     </AuthenticationWrapper>
   ),
-  errorComponent: () => <ErrorPage errorMessage={"Something Went Wrong"} />,
+  errorComponent: () => <ErrorPage />,
   notFoundComponent: () => <NotFound />,
 });
 


### PR DESCRIPTION
# Overview
For rendering errors there was no generic message or indication to the user there is a problem. Also for any of these types of errors that occurred in the Editor it would prompt the user to revert project when it was unnecessary.

Adds a reusable generic error page and updates routes to distinguish corrupted-project errors from other failures.

- Introduces ErrorPage component under components/errors and exports it.
- Custom Errors for edge cases (ProjectCorruption)
- Fallback at root level to 404 if page route doesnt exist
- Fixed logo being a green square

## What I've done
Added a check for when a project is corrupted by checking the instance of the error to see if it matches the new ProjectCorruptionError if it does we can conclude it is the project corruption error where a position is not found. If this error is not present then we just render a something went wrong page similar to that of the "user not found".

This has all been combined to be in a reusable component and has been added to components under `errors` directory.  
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
