### PR TITLE
docs: add comprehensive CLAUDE.md documentation for monorepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,154 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Architecture Overview
+
+Re:Earth Flow is a **monorepo** containing a comprehensive geospatial workflow platform with three main components:
+
+- **Engine** (`engine/`) - Rust-based DAG workflow execution engine for geospatial data processing
+- **Server** (`server/`) - Go-based GraphQL API backend with real-time collaboration
+- **UI** (`ui/`) - React/TypeScript frontend with visual workflow builder
+
+## Development Commands
+
+### Engine (Rust)
+```bash
+cd engine/
+cargo install cargo-make
+cargo make format      # Format code
+cargo make check       # Compilation check
+cargo make clippy      # Linting
+cargo make test        # Run tests
+cargo make doc         # Generate docs
+
+# Run CLI
+cargo run --package reearth-flow-cli -- run --workflow path/to/workflow.yml
+```
+
+### Server (Go)
+```bash
+cd server/api/
+make run-app          # Start API server
+make run-db           # Start MongoDB
+make test             # Run tests
+make e2e              # End-to-end tests
+make gql              # Generate GraphQL code
+```
+
+### UI (React/TypeScript)
+```bash
+cd ui/
+yarn                  # Install dependencies
+yarn start            # Development server
+yarn build            # Production build
+yarn test             # Unit tests
+yarn gql              # Generate GraphQL code
+yarn lint             # ESLint
+```
+
+## Project Structure
+
+### Engine - Workflow Execution
+- **Languages**: Rust with cargo-make for build management
+- **Core**: DAG-based workflow execution with multi-threading
+- **Data Model**: Feature-centric geospatial data processing
+- **Actions**: Source/Processor/Sink pattern for data operations
+- **Storage**: OpenDAL multi-backend abstraction (GCS, S3, local)
+- **Expressions**: Rhai scripting for dynamic parameters
+
+**For detailed engine architecture, development patterns, and debugging guidance, see `engine/CLAUDE.md`.**
+
+### Server - API Backend
+- **Languages**: Go with GraphQL (gqlgen)
+- **Architecture**: Clean Architecture with DDD patterns
+- **Database**: MongoDB with Redis for caching
+- **Authentication**: JWT with Auth0/Cognito support
+- **Cloud**: Google Cloud Batch/Storage/Pub-Sub integration
+- **Real-time**: Rust WebSocket server for collaboration
+
+Key services:
+- `api/` - Main GraphQL API server
+- `websocket/` - Real-time collaboration (Rust)
+- `subscriber/` - Log processing service
+
+### UI - Frontend Application
+- **Framework**: React 19 with TypeScript, Vite build
+- **UI**: Tailwind CSS + Radix UI components
+- **State**: Jotai atoms + TanStack Query + Yjs collaboration
+- **Routing**: TanStack Router with file-based routes
+- **Editor**: ReactFlow for visual workflow building
+- **Maps**: Cesium 3D + MapLibre 2D geospatial visualization
+
+Key features:
+- Visual workflow editor with real-time collaboration
+- Multi-tenant workspace management
+- Geospatial data visualization
+- Job monitoring and deployment management
+
+## Technology Integration
+
+### Collaborative Editing
+- **UI**: Yjs for document synchronization
+- **Server**: Rust WebSocket server (`server/websocket/`)
+- **Protocol**: Y-WebSocket for real-time updates
+
+### Workflow Execution
+- **Definition**: YAML/JSON workflows created in UI
+- **Storage**: MongoDB via GraphQL API
+- **Execution**: Engine processes workflows via Server coordination
+- **Monitoring**: Real-time job status through WebSocket + GraphQL subscriptions
+
+### Data Flow
+1. UI creates workflows with visual editor
+2. Server stores definitions in MongoDB
+3. Engine executes workflows on GCP Batch
+4. Results stored in cloud storage
+5. Real-time updates via WebSocket/GraphQL
+
+## Environment Configuration
+
+### Engine
+- `FLOW_RUNTIME_*` variables control execution behavior
+- `FLOW_VAR_*` variables inject into workflow context
+- See `engine/CLAUDE.md` for detailed configuration
+
+### Server
+- Google Cloud credentials for batch processing
+- MongoDB and Redis connection strings
+- Auth provider configuration (Auth0, Cognito)
+
+### UI
+- Auth0 configuration for authentication
+- API endpoint configuration
+- Feature flags for development
+
+## Multi-Service Development
+
+When working across components:
+1. **Database changes** - Update server GraphQL schema and UI types
+2. **New actions** - Add to engine, update server action registry
+3. **UI features** - Consider real-time collaboration impact
+4. **Testing** - Each component has its own test suite
+
+## Common Workflows
+
+### Adding New Workflow Actions
+1. Implement in `engine/runtime/action-*/`
+2. Register in engine mapping files
+3. Update server action schemas
+4. Add UI components for action configuration
+
+### Frontend Development
+- Use Storybook for component development
+- Real-time features require WebSocket testing
+- Geospatial features need sample data
+
+### Backend API Changes
+- Update GraphQL schema in `server/api/gql/`
+- Run `make gql` to regenerate code
+- Update UI with `yarn gql` for TypeScript types
+
+## Git Commit Guidelines
+
+When creating git commits, do not include Claude Code attribution or "Generated with Claude Code" messages in commit messages. Keep commit messages clean and focused on the actual changes made.

--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -1,0 +1,166 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Building and Testing
+```bash
+# Install required tools
+cargo install cargo-make
+cargo install cargo-watch
+
+# Format code
+cargo make format
+
+# Check code (basic compilation check)
+cargo make check
+
+# Run linting with clippy
+cargo make clippy
+
+# Run tests
+cargo make test
+
+# Generate documentation
+cargo make doc
+
+# Run specific CLI commands
+cargo run --package reearth-flow-cli -- run --workflow path/to/workflow.yml
+cargo run --package reearth-flow-cli -- schema-action
+cargo run --package reearth-flow-cli -- doc-action
+```
+
+### Development Dependencies
+- **Linux/Debian**: `libxml2-dev`, `pkg-config`
+- **macOS**: `brew install libxml2 pkg-config`
+- **Windows**: vcpkg with libxml2
+- **Optional WASM support**: Python 3.11 + `pip install py2wasm`
+
+## Architecture Overview
+
+This is a **DAG-based geospatial workflow execution engine** with the following key components:
+
+### Core Workflow System
+- **Workflows** are defined in YAML/JSON with nodes (actions) connected by edges (data flow)
+- **Three node types**: Sources (data input), Processors (transformation), Sinks (output)
+- **Multi-threaded execution**: Each node runs in its own thread with channel-based communication
+- **Feature-centric**: Primary data unit is a `Feature` with attributes, geometry, and metadata
+
+### Key Directories
+- `runtime/runtime/` - Core execution engine, DAG construction, thread orchestration
+- `runtime/types/` - Core data structures (Feature, Geometry, Workflow definitions)
+- `runtime/action-*` - Action implementations (source, processor, sink, plateau-specific)
+- `runtime/geometry/` - Comprehensive 2D/3D geometry operations
+- `runtime/eval-expr/` - Rhai-based expression evaluation system
+- `cli/` - Command-line interface
+- `worker/` - Distributed execution worker component
+
+### Action System
+Actions are implemented using factory patterns with three traits:
+- `SourceFactory` - Data ingestion (files, databases, synthetic data)
+- `ProcessorFactory` - Data transformation (geometry ops, attribute manipulation)  
+- `SinkFactory` - Data export (various file formats, 3D tiles, vector tiles)
+
+Each action defines input/output ports, JSON schema for validation, and parameter handling.
+
+### Expression System
+- Uses **Rhai scripting language** for dynamic parameter evaluation
+- Available in action parameters and workflow variables
+- Built-in modules for file ops, JSON processing, string manipulation
+- Feature context provides access to attributes, metadata, geometry
+
+### Environment Variables
+Runtime behavior controlled by `FLOW_RUNTIME_*` variables:
+- `FLOW_RUNTIME_THREAD_POOL_SIZE` - Worker thread count (default: 30)
+- `FLOW_RUNTIME_CHANNEL_BUFFER_SIZE` - Inter-node channel buffer (default: 256)
+- `FLOW_RUNTIME_FEATURE_FLUSH_THRESHOLD` - Sink flush threshold (default: 512)
+
+Workflow variables use `FLOW_VAR_*` prefix for environment injection.
+
+## Specialized Components
+
+### PLATEAU Processing
+`action-plateau-processor/` contains specialized processors for Japanese PLATEAU 3D city model standard:
+- CityGML validation and attribute extraction
+- LOD (Level of Detail) processing
+- Domain validation for Japanese urban data
+
+### Storage Abstraction
+Multi-backend storage system built on **OpenDAL** supports:
+- Local filesystem (`file://`)
+- Google Cloud Storage (`gs://`) with emulator support
+- HTTP endpoints (`http://`, `https://`)
+- In-memory storage (`ram://`) for testing
+- Built-in layers: timeout, retry with jitter, logging, metrics
+
+## Common Development Patterns
+
+### Adding New Actions
+1. Create factory struct implementing appropriate trait (`SourceFactory`, `ProcessorFactory`, `SinkFactory`)
+2. Define parameter struct with serde + schemars derives
+3. Implement `build()` method returning action instance
+4. Register in appropriate mapping file
+5. Add i18n entries in `schema/i18n/actions/`
+6. Run `cargo make doc-action` to update schemas
+
+### Testing
+- Integration tests in `runtime/tests/` with YAML workflow fixtures
+- Unit tests alongside implementation files
+- Use `pretty_assertions` for better diff output
+
+### Error Handling
+- Use `thiserror` for custom error types
+- Propagate errors through `Result<T, E>` patterns
+- Event system captures and broadcasts execution errors
+
+## Intermediate Data & Caching for Debugging
+
+### Working Directory Structure
+```
+<working_directory>/
+├── projects/<project_key>/
+│   ├── jobs/<job_id>/
+│   │   ├── feature-store/        # Feature data streams by edge ID
+│   │   ├── action-log/           # Action execution logs
+│   │   └── temp/                 # Job-specific temporary files
+│   └── temp/<temp_id>/           # Project-level temporary files
+```
+
+### Feature Store - Intermediate Data Capture
+- **All intermediate feature data** is automatically captured as features flow between nodes
+- **File format**: JSON Lines (`.jsonl`) - one feature per line, organized by edge ID
+- **Location**: `<job_id>/feature-store/<edge_id>.jsonl`
+- **Critical for debugging**: Examine exact data transformations between workflow nodes
+
+### Environment Variables for Data Handling
+- **`FLOW_RUNTIME_WORKING_DIRECTORY`**: Override default cache directory location
+  - Default: macOS `$HOME/Library/Caches/<project_path>`, Linux `$HOME/.cache/<project_path>`
+- **`FLOW_RUNTIME_FEATURE_WRITER_DISABLE`**: Set to "true" to disable intermediate data capture (impacts debugging)
+- **`FLOW_RUNTIME_FEATURE_FLUSH_THRESHOLD`**: Buffer size before writing to disk (default: 512)
+
+### Debugging Workflow Issues
+**View intermediate data**:
+```bash
+# Examine feature data for specific workflow edge
+cat <working_dir>/projects/<project>/jobs/<job_id>/feature-store/<edge_id>.jsonl
+
+# Check action execution logs
+ls <working_dir>/projects/<project>/jobs/<job_id>/action-log/
+```
+
+**Event system provides real-time monitoring**:
+- Node status changes (Starting, Processing, Completed, Failed)
+- Edge completion events (data flow tracking)
+- Structured logging with node context
+
+### State Persistence
+- **Key-Value Store**: Runtime state shared across workflow nodes
+- **Object Storage**: JSON/JSONL persistence through State API
+- **Temporary Files**: Automatic cleanup of job-specific temporary data
+
+**Note**: Keep feature writing enabled during development - intermediate data is essential for debugging complex workflow issues.
+
+## Git Commit Guidelines
+
+When creating git commits, do not include Claude Code attribution or "Generated with Claude Code" messages in commit messages. Keep commit messages clean and focused on the actual changes made.

--- a/engine/README.md
+++ b/engine/README.md
@@ -157,8 +157,53 @@ export FLOW_VAR_targetPackages='["bldg", "fld"]'
 | FLOW_RUNTIME_ASYNC_WORKER_NUM                 | Tokio Worker number                                                | cpu num |
 | FLOW_RUNTIME_FEATURE_WRITER_DISABLE           | Whether to disable the ability to export data to the feature store | false   |
 | FLOW_RUNTIME_SLOW_ACTION_THRESHOLD            | Threshold for writing slow action logs(ms)                         | 300     |
-| FLOW_RUNTIME_WORKING_DIRECTORY                | working directory                                                  | mac: $HOMELibrary/Caches/<project_path>, linux: $HOME/.cache/<project_path>  |
+| FLOW_RUNTIME_WORKING_DIRECTORY                | working directory                                                  | macOS: `$HOME/Library/Caches/<project_path>`, Linux: `$HOME/.cache/<project_path>`, Windows: `%LOCALAPPDATA%\<project_path>` |
 | FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS | Delay (ms) to ensure node status events propagate                  | 500     |
+
+## Intermediate Data & Cache
+
+The workflow engine automatically captures intermediate data for debugging and analysis purposes.
+
+### Cache Directory Location
+
+By default, the engine stores intermediate data in the following locations:
+
+- **macOS**: `$HOME/Library/Caches/reearth/flow/<project_key>/`
+- **Linux**: `$HOME/.cache/reearth/flow/<project_key>/`
+- **Windows**: `%LOCALAPPDATA%\reearth\flow\<project_key>\`
+
+You can override this location by setting the `FLOW_RUNTIME_WORKING_DIRECTORY` environment variable.
+
+### Directory Structure
+
+```
+<cache_directory>/
+├── projects/<project_key>/
+│   ├── jobs/<job_id>/
+│   │   ├── feature-store/        # Feature data streams (JSONL format)
+│   │   │   ├── <edge_id>.jsonl   # Features flowing through each edge
+│   │   │   └── ...
+│   │   ├── action-log/           # Action execution logs
+│   │   └── temp/                 # Temporary files for this job
+│   └── temp/<temp_id>/           # Project-level temporary files
+```
+
+### Accessing Intermediate Data
+
+The intermediate feature data is stored in JSON Lines format and can be examined for debugging:
+
+```bash
+# View features flowing through a specific edge
+cat <cache_directory>/projects/<project>/jobs/<job_id>/feature-store/<edge_id>.jsonl
+
+# List available job data
+ls <cache_directory>/projects/<project>/jobs/<job_id>/
+```
+
+### Configuration
+
+- Set `FLOW_RUNTIME_FEATURE_WRITER_DISABLE=true` to disable intermediate data capture (not recommended for debugging)
+- Adjust `FLOW_RUNTIME_FEATURE_FLUSH_THRESHOLD` to control buffering behavior (default: 512)
 
 ## Usage
 

--- a/engine/runtime/examples/fixture/workflow/requirement/plateau4/a009-4/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/requirement/plateau4/a009-4/workflow.yml
@@ -37,7 +37,7 @@ graphs:
         with:
           format: csv
           output: |
-            file::join_path(env.get("currentPath"), "a009-1.csv")
+            file::join_path(env.get("currentPath"), "a009-4.csv")
 
     edges:
       - id: c064cf52-705f-443a-b2de-6795266c540d


### PR DESCRIPTION
## Summary
- Add root CLAUDE.md with monorepo overview and development commands
- Add engine/CLAUDE.md with detailed workflow engine architecture
- Update engine/README.md with improved cache directory documentation
- Fix workflow fixture output filename in a009-4 example