### PR TITLE
chore(ui): attribution for react flow and cesium

### DIFF
--- a/ui/src/components/visualizations/Cesium/index.tsx
+++ b/ui/src/components/visualizations/Cesium/index.tsx
@@ -7,8 +7,6 @@ import { SupportedDataTypes } from "@flow/utils/fetchAndReadGeoData";
 
 import GeoJsonData from "./GeoJson";
 
-const dummyCredit = document.createElement("div");
-
 const defaultCesiumProps: Partial<ViewerProps> = {
   // timeline: false,
   // baseLayerPicker: false,
@@ -19,7 +17,7 @@ const defaultCesiumProps: Partial<ViewerProps> = {
   geocoder: false,
   animation: false,
   navigationHelpButton: false,
-  creditContainer: dummyCredit,
+  creditContainer: undefined,
 };
 
 type Props = {

--- a/ui/src/features/Canvas/index.tsx
+++ b/ui/src/features/Canvas/index.tsx
@@ -29,7 +29,7 @@ const gridSize = 16.5;
 
 const snapGrid: SnapGrid = [gridSize, gridSize];
 
-const proOptions: ProOptions = { hideAttribution: true };
+const proOptions: ProOptions = { hideAttribution: false };
 
 type Props = {
   readonly?: boolean;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -199,6 +199,11 @@
   /* pulse 1.5s infinite; */
 }
 
+/* Allows for react flow logo to displayed without style conflicts */
+.react-flow__attribution {
+  background: none !important;
+}
+
 /* Animation for queued node - shadow */
 @keyframes cycleColorsShadow {
   0% {


### PR DESCRIPTION
# Overview

- Adds attribution for Cesium and React Flow

## What I've done

- Added acknowledgements for Cesium and React Flow in a similar vein to how Maplibre was done.  

## What I haven't done

## How I tested

## Screenshot
![react-flow-attribution](https://github.com/user-attachments/assets/a54745de-50ae-41fc-8219-e417753b95bf)
![cesium attribution](https://github.com/user-attachments/assets/643f092b-a115-4814-9145-4f982293d907)
![maplibre attribution](https://github.com/user-attachments/assets/d021985c-599b-4237-92b9-fe80b24fefe1)


## Which point I want you to review particularly

## Memo
