### PR TITLE
fix(worker): add python3.11 and other dependencies to worker to support py2wasm

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5203,7 +5203,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.75"
+version = "0.0.76"
 dependencies = [
  "directories",
  "log",
@@ -5868,7 +5868,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "futures",
  "once_cell",
@@ -5888,7 +5888,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "approx",
  "async-trait",
@@ -5930,7 +5930,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "Inflector",
  "approx",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6039,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-wasm-processor"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "chrono",
  "indexmap 2.10.0",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "bytes",
  "clap",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6176,7 +6176,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "chrono",
  "futures",
@@ -6190,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "approx",
  "bytes",
@@ -6245,7 +6245,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "ahash 0.8.12",
  "byteorder",
@@ -6273,7 +6273,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6282,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6312,7 +6312,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6345,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -6362,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "bytes",
  "reearth-flow-common",
@@ -6388,7 +6388,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "bytes",
  "futures",
@@ -6406,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -6420,7 +6420,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "bytes",
  "directories",
@@ -6449,7 +6449,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -6486,7 +6486,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.78"
+version = "0.0.79"
 dependencies = [
  "async-trait",
  "bytes",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.85" # Remember to update clippy.toml as well
-version = "0.0.78"
+version = "0.0.79"
 
 [profile.dev]
 opt-level = 0

--- a/engine/containers/worker/Dockerfile
+++ b/engine/containers/worker/Dockerfile
@@ -49,8 +49,13 @@ RUN \
     apt-get update && \
     apt-get install -y \
     ca-certificates \
-    libxml2 && \
+    libxml2 \
+    python3.11 \
+    python3.11-distutils \
+    python3-pip && \
     rm -rf /var/lib/apt/lists/*
+
+RUN python3.11 -m pip install --upgrade pip && pip install py2wasm
 
 COPY --chmod=0755 --from=builder /tmp/reearth-flow-worker /bin
 

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.75"
+version = "0.0.76"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/runtime/action-wasm-processor/src/runtime_executor.rs
+++ b/engine/runtime/action-wasm-processor/src/runtime_executor.rs
@@ -186,9 +186,6 @@ impl WasmRuntimeExecutorFactory {
                 binary
             }
         };
-        
-        // Explicitly drop the temporary file holder after py2wasm execution
-        drop(_temp_py_file_holder);
 
         Ok(wasm_binary)
     }

--- a/engine/runtime/action-wasm-processor/src/runtime_executor.rs
+++ b/engine/runtime/action-wasm-processor/src/runtime_executor.rs
@@ -186,6 +186,9 @@ impl WasmRuntimeExecutorFactory {
                 binary
             }
         };
+        
+        // Explicitly drop the temporary file holder after py2wasm execution
+        drop(_temp_py_file_holder);
 
         Ok(wasm_binary)
     }


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
