### PR TITLE
fix(engine): expression fallback

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5203,7 +5203,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.80"
+version = "0.0.81"
 dependencies = [
  "directories",
  "log",
@@ -5868,7 +5868,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "futures",
  "once_cell",
@@ -5888,7 +5888,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "approx",
  "async-trait",
@@ -5930,7 +5930,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "Inflector",
  "approx",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6039,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-wasm-processor"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "chrono",
  "indexmap 2.10.0",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "bytes",
  "clap",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6176,7 +6176,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "chrono",
  "futures",
@@ -6190,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "approx",
  "bytes",
@@ -6245,7 +6245,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "ahash 0.8.12",
  "byteorder",
@@ -6273,7 +6273,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6282,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6312,7 +6312,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6345,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -6362,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "bytes",
  "reearth-flow-common",
@@ -6388,7 +6388,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "bytes",
  "futures",
@@ -6406,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -6420,7 +6420,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "bytes",
  "directories",
@@ -6449,7 +6449,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -6486,7 +6486,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "async-trait",
  "bytes",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.85" # Remember to update clippy.toml as well
-version = "0.0.83"
+version = "0.0.84"
 
 [profile.dev]
 opt-level = 0

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.80"
+version = "0.0.81"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/runtime/action-processor/src/feature/reader.rs
+++ b/engine/runtime/action-processor/src/feature/reader.rs
@@ -78,15 +78,16 @@ impl ProcessorFactory for FeatureReaderFactory {
                 common_param,
                 param,
             } => {
-                let common_param = CompiledCommonReaderParam {
+                let compiled_common_param = CompiledCommonReaderParam {
                     expr: expr_engine
                         .compile(common_param.dataset.as_ref())
                         .map_err(|e| FeatureProcessorError::FileReaderFactory(format!("{e:?}")))?,
+                    original_expr: common_param.dataset.clone(),
                 };
                 let process = FeatureReader {
                     global_params: with,
                     params: CompiledFeatureReaderParam::Csv {
-                        common_param,
+                        common_param: compiled_common_param,
                         param,
                     },
                 };
@@ -96,29 +97,33 @@ impl ProcessorFactory for FeatureReaderFactory {
                 common_param,
                 param,
             } => {
-                let common_param = CompiledCommonReaderParam {
+                let compiled_common_param = CompiledCommonReaderParam {
                     expr: expr_engine
                         .compile(common_param.dataset.as_ref())
                         .map_err(|e| FeatureProcessorError::FileReaderFactory(format!("{e:?}")))?,
+                    original_expr: common_param.dataset.clone(),
                 };
                 let process = FeatureReader {
                     global_params: with,
                     params: CompiledFeatureReaderParam::Tsv {
-                        common_param,
+                        common_param: compiled_common_param,
                         param,
                     },
                 };
                 Ok(Box::new(process))
             }
             FeatureReaderParam::Json { common_param } => {
-                let common_param = CompiledCommonReaderParam {
+                let compiled_common_param = CompiledCommonReaderParam {
                     expr: expr_engine
                         .compile(common_param.dataset.as_ref())
                         .map_err(|e| FeatureProcessorError::FileReaderFactory(format!("{e:?}")))?,
+                    original_expr: common_param.dataset.clone(),
                 };
                 let process = FeatureReader {
                     global_params: with,
-                    params: CompiledFeatureReaderParam::Json { common_param },
+                    params: CompiledFeatureReaderParam::Json {
+                        common_param: compiled_common_param,
+                    },
                 };
                 Ok(Box::new(process))
             }
@@ -181,6 +186,7 @@ enum CompiledFeatureReaderParam {
 #[derive(Debug, Clone)]
 struct CompiledCommonReaderParam {
     expr: rhai::AST,
+    original_expr: reearth_flow_types::Expr,
 }
 
 impl Processor for FeatureReader {

--- a/engine/runtime/action-processor/src/feature/reader/citygml/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml/processor.rs
@@ -71,10 +71,11 @@ impl ProcessorFactory for FeatureCityGmlReaderFactory {
             .into());
         };
         let expr_engine = Arc::clone(&ctx.expr_engine);
-        let params = CompiledFeatureCityGmlReaderParam {
+        let compiled_params = CompiledFeatureCityGmlReaderParam {
             dataset: expr_engine
                 .compile(params.dataset.as_ref())
                 .map_err(|e| FeatureProcessorError::FileCityGmlReaderFactory(format!("{e:?}")))?,
+            original_dataset: params.dataset.clone(),
             flatten: params.flatten,
         };
         let threads_num = {
@@ -91,7 +92,7 @@ impl ProcessorFactory for FeatureCityGmlReaderFactory {
             .unwrap();
         let process = FeatureCityGmlReader {
             global_params: with,
-            params,
+            params: compiled_params,
             join_handles: Vec::new(),
             thread_pool: Arc::new(parking_lot::Mutex::new(pool)),
         };
@@ -121,6 +122,7 @@ pub struct FeatureCityGmlReaderParam {
 #[derive(Debug, Clone)]
 struct CompiledFeatureCityGmlReaderParam {
     dataset: rhai::AST,
+    original_dataset: Expr,
     flatten: Option<bool>,
 }
 
@@ -139,6 +141,7 @@ impl Processor for FeatureCityGmlReader {
         let ctx = ctx.as_context();
         let global_params = self.global_params.clone();
         let dataset = self.params.dataset.clone();
+        let original_dataset = self.params.original_dataset.clone();
         let flatten = self.params.flatten;
         let pool = self.thread_pool.lock();
         let (tx, rx) = std::sync::mpsc::channel();
@@ -150,6 +153,7 @@ impl Processor for FeatureCityGmlReader {
                 fw,
                 feature,
                 dataset,
+                original_dataset,
                 flatten,
                 global_params.clone(),
             );

--- a/engine/runtime/action-processor/src/feature/reader/citygml/reader.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml/reader.rs
@@ -28,17 +28,16 @@ pub(super) fn read_citygml(
     fw: ProcessorChannelForwarder,
     feature: Feature,
     dataset: rhai::AST,
+    original_dataset: reearth_flow_types::Expr,
     flatten: Option<bool>,
     global_params: Option<HashMap<String, serde_json::Value>>,
 ) -> Result<(), crate::feature::errors::FeatureProcessorError> {
     let code_resolver = nusamai_plateau::codelist::Resolver::new();
     let expr_engine = Arc::clone(&ctx.expr_engine);
     let scope = feature.new_scope(expr_engine.clone(), &global_params);
-    let city_gml_path = scope.eval_ast::<String>(&dataset).map_err(|e| {
-        crate::feature::errors::FeatureProcessorError::FileCityGmlReader(format!(
-            "Failed to evaluate expr: {e}"
-        ))
-    })?;
+    let city_gml_path = scope
+        .eval_ast::<String>(&dataset)
+        .unwrap_or_else(|_| original_dataset.to_string());
     let input_path = Uri::from_str(city_gml_path.as_str()).map_err(|e| {
         crate::feature::errors::FeatureProcessorError::FileCityGmlReader(format!("{e:?}"))
     })?;

--- a/engine/runtime/action-processor/src/feature/reader/csv.rs
+++ b/engine/runtime/action-processor/src/feature/reader/csv.rs
@@ -29,9 +29,9 @@ pub(crate) fn read_csv(
     let expr_engine = Arc::clone(&ctx.expr_engine);
     let storage_resolver = &ctx.storage_resolver;
     let scope = feature.new_scope(expr_engine.clone(), global_params);
-    let csv_path = scope.eval_ast::<String>(&params.expr).map_err(|e| {
-        super::errors::FeatureProcessorError::FileCsvReader(format!("Failed to evaluate expr: {e}"))
-    })?;
+    let csv_path = scope
+        .eval_ast::<String>(&params.expr)
+        .unwrap_or_else(|_| params.original_expr.to_string());
     let input_path = Uri::from_str(csv_path.as_str())
         .map_err(|e| super::errors::FeatureProcessorError::FileCsvReader(format!("{e:?}")))?;
     let storage = storage_resolver

--- a/engine/runtime/action-processor/src/feature/reader/json.rs
+++ b/engine/runtime/action-processor/src/feature/reader/json.rs
@@ -18,11 +18,9 @@ pub(crate) fn read_json(
     let expr_engine = Arc::clone(&ctx.expr_engine);
     let storage_resolver = &ctx.storage_resolver;
     let scope = feature.new_scope(expr_engine.clone(), global_params);
-    let json_path = scope.eval_ast::<String>(&params.expr).map_err(|e| {
-        super::errors::FeatureProcessorError::FileJsonReader(format!(
-            "Failed to evaluate expr: {e}"
-        ))
-    })?;
+    let json_path = scope
+        .eval_ast::<String>(&params.expr)
+        .unwrap_or_else(|_| params.original_expr.to_string());
     let input_path = Uri::from_str(json_path.as_str())
         .map_err(|e| super::errors::FeatureProcessorError::FileJsonReader(format!("{e:?}")))?;
     let storage = storage_resolver

--- a/engine/runtime/action-wasm-processor/src/runtime_executor.rs
+++ b/engine/runtime/action-wasm-processor/src/runtime_executor.rs
@@ -102,9 +102,10 @@ impl WasmRuntimeExecutorFactory {
         })?;
 
         let expr_engine = Arc::clone(&ctx.expr_engine);
+        let scope = expr_engine.new_scope();
         let source = expr_engine
-            .eval::<String>(params.source.clone().into_inner().as_str())
-            .map_err(|e| WasmProcessorError::RuntimeExecutorFactory(format!("{e:?}")))?;
+            .eval_scope::<String>(params.source.as_ref(), &scope)
+            .unwrap_or_else(|_| params.source.to_string());
 
         let (local_source_path, _temp_py_file_holder) = if source.starts_with("http://")
             || source.starts_with("https://")


### PR DESCRIPTION
Fix expression evaluation inconsistency for URL/path fields across file reader 
  actions

  Problem

  File reader actions were inconsistently handling unquoted URLs in expression
  fields:
  - FileReader.dataset: https://example.com ✅ (graceful fallback)
  - WasmRuntimeExecutor.source: https://example.com ❌ (hard error)
  - FeatureReader.dataset: https://example.com ❌ (hard error)

  Users had to remember which actions required quotes and which didn't, leading to
   confusing errors.

  Solution

  Standardized all file/URL reader actions to use graceful fallback pattern:
  - If expression evaluation succeeds → use evaluated result
  - If expression evaluation fails → fall back to raw string value

  Changes

  - WasmRuntimeExecutor: Updated to use eval_scope() with unwrap_or_else()
  fallback
  - FeatureReader (CSV/JSON/CityGML): Enhanced to store both compiled AST and
  original expression for fallback
  - Infrastructure: Updated parameter structs to support dual evaluation approach

  Result

  Now all actions consistently handle both:
  - field: "https://example.com" ✅ (evaluated as expression)
  - field: https://example.com ✅ (used as literal string)

  Improves user experience by eliminating the need to remember which actions
  require quoted URLs.
