### PR TITLE
chore(engine): fix compiler warnings that started appearing with the Rust 1.89 update

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5203,7 +5203,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.83"
+version = "0.0.84"
 dependencies = [
  "directories",
  "log",
@@ -5868,7 +5868,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "futures",
  "once_cell",
@@ -5888,7 +5888,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "approx",
  "async-trait",
@@ -5930,7 +5930,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "Inflector",
  "approx",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6039,7 +6039,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-wasm-processor"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "chrono",
  "indexmap 2.10.0",
@@ -6103,7 +6103,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "bytes",
  "clap",
@@ -6141,7 +6141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6176,7 +6176,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "chrono",
  "futures",
@@ -6190,7 +6190,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "approx",
  "bytes",
@@ -6245,7 +6245,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "ahash 0.8.12",
  "byteorder",
@@ -6273,7 +6273,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6282,7 +6282,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6312,7 +6312,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6345,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -6362,7 +6362,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "bytes",
  "reearth-flow-common",
@@ -6388,7 +6388,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "bytes",
  "futures",
@@ -6406,7 +6406,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -6420,7 +6420,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "bytes",
  "directories",
@@ -6449,7 +6449,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -6486,7 +6486,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.86"
+version = "0.0.87"
 dependencies = [
  "async-trait",
  "bytes",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.85" # Remember to update clippy.toml as well
-version = "0.0.86"
+version = "0.0.87"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -26,7 +26,7 @@ cargo clippy --workspace --all-targets --all-features --exclude plateau-gis-qual
 [tasks.clippy-fix]
 script = ['''
 #!/usr/bin/env bash -eux
-cargo clippy --workspace --all-targets --all-features --exclude plateau-gis-quality-checker --fix ${@}
+cargo clippy --workspace --all-targets --all-features --exclude plateau-gis-quality-checker --fix ${@-}
 ''']
 
 [tasks.test]

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.83"
+version = "0.0.84"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/runtime/action-plateau-processor/src/plateau3/xml_attribute_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau3/xml_attribute_extractor.rs
@@ -72,7 +72,7 @@ impl Attributes {
         }
     }
 
-    fn iter(&self) -> std::collections::hash_map::Iter<String, serde_json::Value> {
+    fn iter(&self) -> std::collections::hash_map::Iter<'_, String, serde_json::Value> {
         self.0.iter()
     }
 }

--- a/engine/runtime/action-processor/src/xml/cache.rs
+++ b/engine/runtime/action-processor/src/xml/cache.rs
@@ -24,6 +24,7 @@ pub trait SchemaCache: Send + Sync {
 }
 
 /// No-op implementation when cache is not available
+#[allow(dead_code)]
 pub struct NoOpSchemaCache;
 
 impl SchemaCache for NoOpSchemaCache {

--- a/engine/runtime/geometry/src/algorithm/relate/geomgraph/geometry_graph.rs
+++ b/engine/runtime/geometry/src/algorithm/relate/geomgraph/geometry_graph.rs
@@ -81,7 +81,7 @@ where
         graph
     }
 
-    pub fn geometry(&self) -> &GeometryCow<T, Z> {
+    pub fn geometry(&self) -> &GeometryCow<'_, T, Z> {
         self.parent_geometry
     }
 

--- a/engine/runtime/geometry/src/algorithm/winding_order.rs
+++ b/engine/runtime/geometry/src/algorithm/winding_order.rs
@@ -71,13 +71,13 @@ pub trait Winding {
         self.winding_order() == Some(WindingOrder::CounterClockwise)
     }
 
-    fn points_cw(&self) -> Points<Self::ScalarXY, Self::ScalarZ>;
+    fn points_cw(&self) -> Points<'_, Self::ScalarXY, Self::ScalarZ>;
 
     /// Iterate over the points in a counter-clockwise order
     ///
     /// The object isn't changed, and the points are returned either in order, or in reverse
     /// order, so that the resultant order makes it appear counter-clockwise
-    fn points_ccw(&self) -> Points<Self::ScalarXY, Self::ScalarZ>;
+    fn points_ccw(&self) -> Points<'_, Self::ScalarXY, Self::ScalarZ>;
 
     /// Change this object's points so they are in clockwise winding order
     fn make_cw_winding(&mut self);
@@ -165,7 +165,7 @@ where
         }
     }
 
-    fn points_cw(&self) -> Points<Self::ScalarXY, Self::ScalarZ> {
+    fn points_cw(&self) -> Points<'_, Self::ScalarXY, Self::ScalarZ> {
         match self.winding_order() {
             Some(WindingOrder::CounterClockwise) => Points(EitherIter::B(self.points().rev())),
             _ => Points(EitherIter::A(self.points())),
@@ -176,7 +176,7 @@ where
     ///
     /// The Linestring isn't changed, and the points are returned either in order, or in reverse
     /// order, so that the resultant order makes it appear counter-clockwise
-    fn points_ccw(&self) -> Points<Self::ScalarXY, Self::ScalarZ> {
+    fn points_ccw(&self) -> Points<'_, Self::ScalarXY, Self::ScalarZ> {
         match self.winding_order() {
             Some(WindingOrder::Clockwise) => Points(EitherIter::B(self.points().rev())),
             _ => Points(EitherIter::A(self.points())),

--- a/engine/runtime/geometry/src/types/line_string.rs
+++ b/engine/runtime/geometry/src/types/line_string.rs
@@ -156,7 +156,7 @@ impl<T: CoordNum, Z: CoordNum> LineString<T, Z> {
         Self(value)
     }
 
-    pub fn points(&self) -> PointsIter<T, Z> {
+    pub fn points(&self) -> PointsIter<'_, T, Z> {
         PointsIter(self.0.iter())
     }
 

--- a/engine/runtime/runtime/src/executor/processor_node.rs
+++ b/engine/runtime/runtime/src/executor/processor_node.rs
@@ -264,7 +264,7 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for ProcessorNode<F> {
         }
     }
 
-    fn receiver_name(&self, index: usize) -> Cow<str> {
+    fn receiver_name(&self, index: usize) -> Cow<'_, str> {
         Cow::Owned(self.node_handles[index].to_string())
     }
 

--- a/engine/runtime/runtime/src/executor/receiver_loop.rs
+++ b/engine/runtime/runtime/src/executor/receiver_loop.rs
@@ -14,7 +14,7 @@ pub trait ReceiverLoop {
     /// Returns input channels to this node. Will be called exactly once in [`receiver_loop`].
     fn receivers(&mut self) -> Vec<Receiver<ExecutorOperation>>;
     /// Returns the name of the receiver at `index`. Used for logging.
-    fn receiver_name(&self, index: usize) -> Cow<str>;
+    fn receiver_name(&self, index: usize) -> Cow<'_, str>;
     /// Responds to `op` from the receiver at `index`.
     fn on_op(&mut self, ctx: ExecutorContext) -> Result<(), ExecutionError>;
     /// Responds to `op` from the receiver at `index`, with failure tracking.
@@ -34,7 +34,7 @@ pub trait ReceiverLoop {
         Self: Sized;
 }
 
-pub(crate) fn init_select(receivers: &Vec<Receiver<ExecutorOperation>>) -> Select {
+pub(crate) fn init_select(receivers: &Vec<Receiver<ExecutorOperation>>) -> Select<'_> {
     let mut sel = Select::new();
     for r in receivers {
         sel.recv(r);

--- a/engine/runtime/runtime/src/executor/sink_node.rs
+++ b/engine/runtime/runtime/src/executor/sink_node.rs
@@ -115,7 +115,7 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for SinkNode<F> {
         result
     }
 
-    fn receiver_name(&self, index: usize) -> Cow<str> {
+    fn receiver_name(&self, index: usize) -> Cow<'_, str> {
         Cow::Owned(self.node_handles[index].to_string())
     }
 

--- a/engine/runtime/sevenz/src/archive.rs
+++ b/engine/runtime/sevenz/src/archive.rs
@@ -157,6 +157,7 @@ impl SevenZArchiveEntry {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Default)]
 pub struct SevenZMethodConfiguration {
     pub method: SevenZMethod,

--- a/engine/runtime/sevenz/src/folder.rs
+++ b/engine/runtime/sevenz/src/folder.rs
@@ -49,7 +49,7 @@ impl Folder {
         self.unpack_sizes.get(index).cloned().unwrap_or_default()
     }
 
-    pub fn ordered_coder_iter(&self) -> OrderedCoderIter {
+    pub fn ordered_coder_iter(&self) -> OrderedCoderIter<'_> {
         OrderedCoderIter::new(self)
     }
 }


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
