### PR TITLE
fix(ui): implement overlapping point processing in GeoJsonDataSource [FLOW-FE-236]

### DIFF
--- a/ui/src/components/visualizations/MapLibre/sources/GeoJson/index.tsx
+++ b/ui/src/components/visualizations/MapLibre/sources/GeoJson/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   enableClustering?: boolean;
   selectedFeatureId?: string;
 };
-
+const OVERLAP_OFFSET_DISTANCE = 0.0001;
 const GeoJsonDataSource: React.FC<Props> = ({
   fileType,
   fileContent,
@@ -21,13 +21,8 @@ const GeoJsonDataSource: React.FC<Props> = ({
     (
       featureCollection: GeoJSON.FeatureCollection,
     ): GeoJSON.FeatureCollection => {
-      const pointFeatures = featureCollection.features.filter(
-        (feature) => feature.geometry.type === "Point",
-      );
-
       const coordinateGroups = new Map<string, GeoJSON.Feature[]>();
-
-      pointFeatures.forEach((feature) => {
+      featureCollection.features.forEach((feature) => {
         if (feature.geometry.type === "Point") {
           const [lng, lat] = feature.geometry.coordinates;
           const key = `${lng.toFixed(8)},${lat.toFixed(8)}`;
@@ -43,8 +38,9 @@ const GeoJsonDataSource: React.FC<Props> = ({
       });
 
       const processedFeatures = featureCollection.features.map((feature) => {
-        if (feature.geometry.type !== "Point") return feature;
-
+        if (feature.geometry.type !== "Point") {
+          return feature;
+        }
         const [lng, lat] = feature.geometry.coordinates;
         const key = `${lng.toFixed(8)},${lat.toFixed(8)}`;
         const group = coordinateGroups.get(key);
@@ -52,7 +48,7 @@ const GeoJsonDataSource: React.FC<Props> = ({
         if (!group || group.length === 1) return feature;
 
         const index = group.findIndex((f) => f === feature);
-        const offset = 0.0001;
+        const offset = OVERLAP_OFFSET_DISTANCE;
         const angle = (2 * Math.PI * index) / group.length;
         const offsetLng = lng + offset * Math.cos(angle);
         const offsetLat = lat + offset * Math.sin(angle);


### PR DESCRIPTION
# Overview
Originally overlapping points with the same coordinates would not be easily distinguishable making it hard for a user to see which data point in the 2D viewer they have selected in the table.

## What I've done
- Added a function that calculates if points are overlapping and then offsets them slightly.

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
