### PR TITLE
feat(engine): add CityGML geometry support, fix decimal precision for Clipper action

### DIFF
--- a/engine/runtime/action-processor/src/geometry/clipper.rs
+++ b/engine/runtime/action-processor/src/geometry/clipper.rs
@@ -14,7 +14,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory},
 };
-use reearth_flow_types::{Feature, Geometry, GeometryValue};
+use reearth_flow_types::{CityGmlGeometry, Feature, Geometry, GeometryValue};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -102,9 +102,13 @@ impl Processor for Clipper {
                     }
                 }
             }
-            GeometryValue::CityGmlGeometry(_) => {
-                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()))
-            }
+            GeometryValue::CityGmlGeometry(_) => match &ctx.port {
+                port if port == &*CLIPPER_PORT => self.clippers.push(feature.clone()),
+                port if port == &*CANDIDATE_PORT => self.candidates.push(feature.clone()),
+                _ => {
+                    fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+                }
+            },
         }
         Ok(())
     }
@@ -125,6 +129,8 @@ impl Processor for Clipper {
                 _ => None,
             })
             .collect_vec();
+
+        // Extract 3D clip regions from both FlowGeometry3D and CityGmlGeometry
         let clip_regions3d = self
             .clippers
             .iter()
@@ -133,13 +139,34 @@ impl Processor for Clipper {
                 _ => None,
             })
             .collect_vec();
-        let clip_regions3d = clip_regions3d
+        let clip_regions3d_from_flow = clip_regions3d
             .iter()
             .flat_map(|g| match g {
                 Geometry3D::Polygon(poly) => Some(poly.clone()),
                 _ => None,
             })
             .collect_vec();
+
+        // Extract polygons from CityGML geometries for clipping
+        let clip_regions3d_from_citygml = self
+            .clippers
+            .iter()
+            .filter_map(|g| match &g.geometry.value {
+                GeometryValue::CityGmlGeometry(citygml) => Some(citygml),
+                _ => None,
+            })
+            .flat_map(|citygml| {
+                citygml
+                    .gml_geometries
+                    .iter()
+                    .flat_map(|gml| gml.polygons.clone())
+            })
+            .collect_vec();
+
+        let clip_regions3d: Vec<Polygon3D<f64>> = clip_regions3d_from_flow
+            .into_iter()
+            .chain(clip_regions3d_from_citygml)
+            .collect();
         if clip_regions2d.is_empty() && clip_regions3d.is_empty() {
             for candidate in &self.candidates {
                 fw.send(ExecutorContext::new_with_node_context_feature_and_port(
@@ -173,6 +200,16 @@ impl Processor for Clipper {
                 GeometryValue::FlowGeometry3D(geos) => {
                     handle_3d_geometry(
                         &geos,
+                        &clip_regions3d,
+                        candidate,
+                        &candidate.geometry,
+                        &ctx,
+                        fw,
+                    );
+                }
+                GeometryValue::CityGmlGeometry(citygml) => {
+                    handle_citygml_geometry(
+                        &citygml,
                         &clip_regions3d,
                         candidate,
                         &candidate.geometry,
@@ -357,6 +394,24 @@ fn clip_mpolygon2d(
     )
 }
 
+/// Clips a 3D polygon against multiple clip regions.
+///
+/// IMPORTANT: This implementation performs surface-level clipping on 3D polygons,
+/// not true volumetric boolean operations. The underlying Clipper2 library
+/// processes polygons in 2D space while preserving Z-coordinates.
+///
+/// Limitations:
+/// - This is essentially 2.5D clipping (2D operations with Z preservation)
+/// - Does NOT perform true 3D solid/volume intersections
+/// - Suitable for clipping polygon surfaces in 3D space
+/// - Not suitable for CSG (Constructive Solid Geometry) operations on 3D solids
+///
+/// Use cases:
+/// - Clipping building facades against boundary polygons
+/// - Extracting portions of 3D surfaces within a region
+/// - Filtering 3D polygons by spatial boundaries
+///
+/// For true 3D volumetric operations, a different library would be required.
 fn clip_polygon3d(
     polygon: &Polygon3D<f64>,
     clip_regions: &[Polygon3D<f64>],
@@ -373,6 +428,10 @@ fn clip_polygon3d(
     )
 }
 
+/// Clips a 3D multi-polygon against multiple clip regions.
+///
+/// See `clip_polygon3d` for important limitations regarding 3D clipping.
+/// This function applies the same 2.5D clipping approach to multiple polygons.
 fn clip_mpolygon3d(
     mpolygon: &MultiPolygon3D<f64>,
     clip_regions: &[Polygon3D<f64>],
@@ -387,4 +446,905 @@ fn clip_mpolygon3d(
         inside.iter().cloned().collect(),
         outside.iter().cloned().collect(),
     )
+}
+
+fn process_gml_geometry(
+    gml_geometry: &reearth_flow_types::GmlGeometry,
+    clip_regions: &[Polygon3D<f64>],
+    inside_gml_geometries: &mut Vec<reearth_flow_types::GmlGeometry>,
+    outside_gml_geometries: &mut Vec<reearth_flow_types::GmlGeometry>,
+) {
+    let mut inside_polygons = Vec::new();
+    let mut outside_polygons = Vec::new();
+
+    // Clip each polygon in the GML geometry
+    for polygon in &gml_geometry.polygons {
+        let (insides, outsides) = clip_polygon3d(polygon, clip_regions);
+        inside_polygons.extend(insides);
+        outside_polygons.extend(outsides);
+    }
+
+    // Process line_strings if they exist (for Curve type geometries)
+    // Note: Line strings cannot be clipped in the same way as polygons,
+    // so we keep them as-is
+    let line_strings = gml_geometry.line_strings.clone();
+
+    // Process composite surfaces recursively
+    let mut inside_composite_surfaces = Vec::new();
+    let mut outside_composite_surfaces = Vec::new();
+
+    for composite_surface in &gml_geometry.composite_surfaces {
+        let mut temp_inside = Vec::new();
+        let mut temp_outside = Vec::new();
+        process_gml_geometry(
+            composite_surface,
+            clip_regions,
+            &mut temp_inside,
+            &mut temp_outside,
+        );
+        inside_composite_surfaces.extend(temp_inside);
+        outside_composite_surfaces.extend(temp_outside);
+    }
+
+    // Check if we have Curve type with line_strings but no polygons
+    let is_curve_without_polygons = gml_geometry.ty == reearth_flow_types::GeometryType::Curve
+        && inside_polygons.is_empty()
+        && outside_polygons.is_empty()
+        && !line_strings.is_empty();
+
+    // Create new GML geometries for inside results
+    if !inside_polygons.is_empty()
+        || !inside_composite_surfaces.is_empty()
+        || is_curve_without_polygons
+    {
+        let mut inside_gml = gml_geometry.clone();
+        inside_gml.polygons = inside_polygons;
+        inside_gml.composite_surfaces = inside_composite_surfaces;
+        // Keep line_strings as-is for Curve type geometries
+        if gml_geometry.ty == reearth_flow_types::GeometryType::Curve {
+            inside_gml.line_strings = line_strings.clone();
+        }
+        inside_gml_geometries.push(inside_gml);
+    }
+
+    // Create new GML geometries for outside results
+    if !outside_polygons.is_empty() || !outside_composite_surfaces.is_empty() {
+        let mut outside_gml = gml_geometry.clone();
+        outside_gml.polygons = outside_polygons;
+        outside_gml.composite_surfaces = outside_composite_surfaces;
+        // Line strings are not included in outside results for non-Curve types
+        if is_curve_without_polygons {
+            outside_gml.line_strings = line_strings;
+        } else {
+            outside_gml.line_strings = vec![];
+        }
+        outside_gml_geometries.push(outside_gml);
+    }
+}
+
+fn handle_citygml_geometry(
+    citygml: &CityGmlGeometry,
+    clip_regions: &[Polygon3D<f64>],
+    feature: &Feature,
+    geometry: &Geometry,
+    ctx: &NodeContext,
+    fw: &ProcessorChannelForwarder,
+) {
+    // Process each GML geometry in the CityGML
+    let mut inside_gml_geometries = Vec::new();
+    let mut outside_gml_geometries = Vec::new();
+
+    for gml_geometry in &citygml.gml_geometries {
+        process_gml_geometry(
+            gml_geometry,
+            clip_regions,
+            &mut inside_gml_geometries,
+            &mut outside_gml_geometries,
+        );
+    }
+
+    // Send inside CityGML features
+    if !inside_gml_geometries.is_empty() {
+        let mut feature = feature.clone();
+        let mut geometry = geometry.clone();
+        let inside_citygml = CityGmlGeometry {
+            gml_geometries: inside_gml_geometries,
+            materials: citygml.materials.clone(),
+            textures: citygml.textures.clone(),
+            polygon_materials: citygml.polygon_materials.clone(),
+            polygon_textures: citygml.polygon_textures.clone(),
+            polygon_uvs: citygml.polygon_uvs.clone(),
+        };
+        geometry.value = GeometryValue::CityGmlGeometry(inside_citygml);
+        feature.geometry = geometry;
+        fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+            ctx,
+            feature,
+            INSIDE_PORT.clone(),
+        ));
+    }
+
+    // Send outside CityGML features
+    if !outside_gml_geometries.is_empty() {
+        let mut feature = feature.clone();
+        let mut geometry = geometry.clone();
+        let outside_citygml = CityGmlGeometry {
+            gml_geometries: outside_gml_geometries,
+            materials: citygml.materials.clone(),
+            textures: citygml.textures.clone(),
+            polygon_materials: citygml.polygon_materials.clone(),
+            polygon_textures: citygml.polygon_textures.clone(),
+            polygon_uvs: citygml.polygon_uvs.clone(),
+        };
+        geometry.value = GeometryValue::CityGmlGeometry(outside_citygml);
+        feature.geometry = geometry;
+        fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+            ctx,
+            feature,
+            OUTSIDE_PORT.clone(),
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reearth_flow_geometry::types::coordinate::Coordinate2D;
+    use reearth_flow_geometry::types::line_string::{LineString2D, LineString3D};
+    use reearth_flow_geometry::types::no_value::NoValue;
+    use reearth_flow_geometry::types::point::Point2D;
+    use reearth_flow_runtime::executor_operation::NodeContext;
+    use reearth_flow_runtime::forwarder::NoopChannelForwarder;
+
+    use crate::tests::utils::create_default_execute_context;
+
+    fn create_test_polygon_2d() -> Polygon2D<f64> {
+        let exterior = LineString2D::new(vec![
+            Coordinate2D::new_(0.0, 0.0),
+            Coordinate2D::new_(10.0, 0.0),
+            Coordinate2D::new_(10.0, 10.0),
+            Coordinate2D::new_(0.0, 10.0),
+            Coordinate2D::new_(0.0, 0.0),
+        ]);
+        Polygon2D::new(exterior, vec![])
+    }
+
+    fn create_clipper_polygon_2d() -> Polygon2D<f64> {
+        let exterior = LineString2D::new(vec![
+            Coordinate2D::new_(5.0, 5.0),
+            Coordinate2D::new_(15.0, 5.0),
+            Coordinate2D::new_(15.0, 15.0),
+            Coordinate2D::new_(5.0, 15.0),
+            Coordinate2D::new_(5.0, 5.0),
+        ]);
+        Polygon2D::new(exterior, vec![])
+    }
+
+    fn create_test_polygon_3d() -> Polygon3D<f64> {
+        let exterior = LineString3D::new(vec![
+            (0.0, 0.0, 0.0).into(),
+            (10.0, 0.0, 0.0).into(),
+            (10.0, 10.0, 0.0).into(),
+            (0.0, 10.0, 0.0).into(),
+            (0.0, 0.0, 0.0).into(),
+        ]);
+        Polygon3D::new(exterior, vec![])
+    }
+
+    fn create_clipper_polygon_3d() -> Polygon3D<f64> {
+        let exterior = LineString3D::new(vec![
+            (5.0, 5.0, 0.0).into(),
+            (15.0, 5.0, 0.0).into(),
+            (15.0, 15.0, 0.0).into(),
+            (5.0, 15.0, 0.0).into(),
+            (5.0, 5.0, 0.0).into(),
+        ]);
+        Polygon3D::new(exterior, vec![])
+    }
+
+    #[test]
+    fn test_clipper_with_empty_geometry() {
+        let mut clipper = Clipper {
+            clippers: Vec::new(),
+            candidates: Vec::new(),
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+
+        let feature = Feature::default();
+        let ctx = create_default_execute_context(&feature);
+
+        let result = clipper.process(ctx, &fw);
+        assert!(result.is_ok());
+
+        if let ProcessorChannelForwarder::Noop(noop) = fw {
+            let ports = noop.send_ports.lock().unwrap();
+            assert_eq!(ports.len(), 1);
+            assert_eq!(ports[0], *REJECTED_PORT);
+        }
+    }
+
+    #[test]
+    fn test_clipper_adds_features_to_correct_lists() {
+        let mut clipper = Clipper {
+            clippers: Vec::new(),
+            candidates: Vec::new(),
+        };
+
+        let polygon = create_test_polygon_2d();
+        let clipper_feature = Feature {
+            geometry: Geometry {
+                value: GeometryValue::FlowGeometry2D(Geometry2D::Polygon(polygon.clone())),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let candidate_feature = Feature {
+            geometry: Geometry {
+                value: GeometryValue::FlowGeometry2D(Geometry2D::Polygon(polygon.clone())),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // Process clipper feature
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let mut ctx = create_default_execute_context(&clipper_feature);
+        ctx.port = CLIPPER_PORT.clone();
+
+        let result = clipper.process(ctx, &fw);
+        assert!(result.is_ok());
+        assert_eq!(clipper.clippers.len(), 1);
+        assert_eq!(clipper.candidates.len(), 0);
+
+        // Process candidate feature
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let mut ctx = create_default_execute_context(&candidate_feature);
+        ctx.port = CANDIDATE_PORT.clone();
+
+        let result = clipper.process(ctx, &fw);
+        assert!(result.is_ok());
+        assert_eq!(clipper.clippers.len(), 1);
+        assert_eq!(clipper.candidates.len(), 1);
+    }
+
+    #[test]
+    fn test_clipper_finish_with_no_clippers() {
+        let clipper = Clipper {
+            clippers: Vec::new(),
+            candidates: vec![Feature::default()],
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let ctx = NodeContext::default();
+
+        let result = clipper.finish(ctx, &fw);
+        assert!(result.is_ok());
+
+        if let ProcessorChannelForwarder::Noop(noop) = fw {
+            let ports = noop.send_ports.lock().unwrap();
+            assert_eq!(ports.len(), 1);
+            assert_eq!(ports[0], *REJECTED_PORT);
+        }
+    }
+
+    #[test]
+    fn test_clip_polygon2d_basic() {
+        let polygon = create_test_polygon_2d();
+        let clip_region = create_clipper_polygon_2d();
+
+        let (insides, outsides) = clip_polygon2d(&polygon, &[clip_region]);
+
+        // Should have both inside and outside results
+        assert!(!insides.is_empty(), "Should have inside polygons");
+        assert!(!outsides.is_empty(), "Should have outside polygons");
+    }
+
+    #[test]
+    fn test_clip_polygon3d_basic() {
+        let polygon = create_test_polygon_3d();
+        let clip_region = create_clipper_polygon_3d();
+
+        let (insides, outsides) = clip_polygon3d(&polygon, &[clip_region]);
+
+        // Should have both inside and outside results
+        assert!(!insides.is_empty(), "Should have inside polygons");
+        assert!(!outsides.is_empty(), "Should have outside polygons");
+    }
+
+    #[test]
+    fn test_clip_mpolygon2d() {
+        let polygon = create_test_polygon_2d();
+        let mpolygon = MultiPolygon2D::new(vec![polygon]);
+        let clip_region = create_clipper_polygon_2d();
+
+        let (insides, outsides) = clip_mpolygon2d(&mpolygon, &[clip_region]);
+
+        assert!(!insides.is_empty(), "Should have inside polygons");
+        assert!(!outsides.is_empty(), "Should have outside polygons");
+    }
+
+    #[test]
+    fn test_clip_mpolygon3d() {
+        let polygon = create_test_polygon_3d();
+        let mpolygon = MultiPolygon3D::new(vec![polygon]);
+        let clip_region = create_clipper_polygon_3d();
+
+        let (insides, outsides) = clip_mpolygon3d(&mpolygon, &[clip_region]);
+
+        assert!(!insides.is_empty(), "Should have inside polygons");
+        assert!(!outsides.is_empty(), "Should have outside polygons");
+    }
+
+    #[test]
+    fn test_clipper_finish_with_2d_geometries() {
+        let polygon = create_test_polygon_2d();
+        let clip_polygon = create_clipper_polygon_2d();
+
+        let clipper = Clipper {
+            clippers: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry2D(Geometry2D::Polygon(clip_polygon)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            candidates: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry2D(Geometry2D::Polygon(polygon)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let ctx = NodeContext::default();
+
+        let result = clipper.finish(ctx, &fw);
+        assert!(result.is_ok());
+
+        if let ProcessorChannelForwarder::Noop(noop) = fw {
+            let ports = noop.send_ports.lock().unwrap();
+            // Should have sent features to both inside and outside ports
+            assert!(ports.contains(&*INSIDE_PORT));
+            assert!(ports.contains(&*OUTSIDE_PORT));
+        }
+    }
+
+    #[test]
+    fn test_clipper_finish_with_3d_geometries() {
+        let polygon = create_test_polygon_3d();
+        let clip_polygon = create_clipper_polygon_3d();
+
+        let clipper = Clipper {
+            clippers: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry3D(Geometry3D::Polygon(clip_polygon)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            candidates: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry3D(Geometry3D::Polygon(polygon)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let ctx = NodeContext::default();
+
+        let result = clipper.finish(ctx, &fw);
+        assert!(result.is_ok());
+
+        if let ProcessorChannelForwarder::Noop(noop) = fw {
+            let ports = noop.send_ports.lock().unwrap();
+            // Should have sent features to both inside and outside ports
+            assert!(ports.contains(&*INSIDE_PORT));
+            assert!(ports.contains(&*OUTSIDE_PORT));
+        }
+    }
+
+    #[test]
+    fn test_clipper_with_multiple_clip_regions() {
+        let polygon = create_test_polygon_2d();
+
+        // Create two overlapping clip regions
+        let clip_region1 = create_clipper_polygon_2d();
+        let exterior2 = LineString2D::new(vec![
+            Coordinate2D::new_(2.0, 2.0),
+            Coordinate2D::new_(8.0, 2.0),
+            Coordinate2D::new_(8.0, 8.0),
+            Coordinate2D::new_(2.0, 8.0),
+            Coordinate2D::new_(2.0, 2.0),
+        ]);
+        let clip_region2 = Polygon2D::new(exterior2, vec![]);
+
+        let (insides, outsides) = clip_polygon2d(&polygon, &[clip_region1, clip_region2]);
+
+        // With multiple clip regions, the result should be their intersection
+        assert!(
+            !insides.is_empty() || !outsides.is_empty(),
+            "Should have some results"
+        );
+    }
+
+    #[test]
+    fn test_clipper_with_non_polygon_geometry() {
+        let mut clipper = Clipper {
+            clippers: Vec::new(),
+            candidates: Vec::new(),
+        };
+
+        // Create a point geometry (non-polygon)
+        let point_feature = Feature {
+            geometry: Geometry {
+                value: GeometryValue::FlowGeometry2D(Geometry2D::Point(Point2D::new_(
+                    5.0, 5.0, NoValue,
+                ))),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let mut ctx = create_default_execute_context(&point_feature);
+        ctx.port = CANDIDATE_PORT.clone();
+
+        let result = clipper.process(ctx, &fw);
+        assert!(result.is_ok());
+        // Non-polygon geometries should still be added to the list
+        assert_eq!(clipper.candidates.len(), 1);
+    }
+
+    #[test]
+    fn test_clipper_finish_with_non_polygon_candidate() {
+        let clip_polygon = create_clipper_polygon_2d();
+
+        let clipper = Clipper {
+            clippers: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry2D(Geometry2D::Polygon(clip_polygon)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            candidates: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry2D(Geometry2D::Point(Point2D::new_(
+                        5.0, 5.0, NoValue,
+                    ))),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let ctx = NodeContext::default();
+
+        let result = clipper.finish(ctx, &fw);
+        assert!(result.is_ok());
+
+        if let ProcessorChannelForwarder::Noop(noop) = fw {
+            let ports = noop.send_ports.lock().unwrap();
+            // Non-polygon candidates should be rejected
+            assert!(ports.contains(&*REJECTED_PORT));
+        }
+    }
+
+    #[test]
+    fn test_clipper_with_citygml_geometry() {
+        use reearth_flow_types::{GeometryType, GmlGeometry};
+
+        let polygon = create_test_polygon_3d();
+        let clip_polygon = create_clipper_polygon_3d();
+
+        // Create a CityGML geometry with a polygon
+        let gml_geometry = GmlGeometry {
+            id: Some("test_gml".to_string()),
+            ty: GeometryType::Surface,
+            lod: Some(2),
+            pos: 0,
+            len: 1,
+            polygons: vec![polygon.clone()],
+            line_strings: vec![],
+            feature_id: Some("feature1".to_string()),
+            feature_type: Some("Building".to_string()),
+            composite_surfaces: vec![],
+        };
+
+        let citygml = CityGmlGeometry {
+            gml_geometries: vec![gml_geometry],
+            materials: vec![],
+            textures: vec![],
+            polygon_materials: vec![],
+            polygon_textures: vec![],
+            polygon_uvs: Default::default(),
+        };
+
+        let clipper = Clipper {
+            clippers: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry3D(Geometry3D::Polygon(clip_polygon)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            candidates: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::CityGmlGeometry(citygml),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let ctx = NodeContext::default();
+
+        let result = clipper.finish(ctx, &fw);
+        assert!(result.is_ok());
+
+        if let ProcessorChannelForwarder::Noop(noop) = fw {
+            let ports = noop.send_ports.lock().unwrap();
+            // Should have sent features to both inside and outside ports
+            assert!(ports.contains(&*INSIDE_PORT));
+            assert!(ports.contains(&*OUTSIDE_PORT));
+        }
+    }
+
+    #[test]
+    fn test_clipper_with_citygml_as_clipper() {
+        use reearth_flow_types::{GeometryType, GmlGeometry};
+
+        let polygon = create_test_polygon_3d();
+        let clip_polygon = create_clipper_polygon_3d();
+
+        // Create a CityGML geometry as the clipper
+        let gml_clipper = GmlGeometry {
+            id: Some("clipper_gml".to_string()),
+            ty: GeometryType::Surface,
+            lod: Some(2),
+            pos: 0,
+            len: 1,
+            polygons: vec![clip_polygon.clone()],
+            line_strings: vec![],
+            feature_id: Some("clipper1".to_string()),
+            feature_type: Some("Building".to_string()),
+            composite_surfaces: vec![],
+        };
+
+        let citygml_clipper = CityGmlGeometry {
+            gml_geometries: vec![gml_clipper],
+            materials: vec![],
+            textures: vec![],
+            polygon_materials: vec![],
+            polygon_textures: vec![],
+            polygon_uvs: Default::default(),
+        };
+
+        let clipper = Clipper {
+            clippers: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::CityGmlGeometry(citygml_clipper),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            candidates: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry3D(Geometry3D::Polygon(polygon)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let ctx = NodeContext::default();
+
+        let result = clipper.finish(ctx, &fw);
+        assert!(result.is_ok());
+
+        if let ProcessorChannelForwarder::Noop(noop) = fw {
+            let ports = noop.send_ports.lock().unwrap();
+            // Should have sent features to both inside and outside ports
+            assert!(ports.contains(&*INSIDE_PORT));
+            assert!(ports.contains(&*OUTSIDE_PORT));
+        }
+    }
+
+    #[test]
+    fn test_clipper_with_citygml_composite_surfaces() {
+        use reearth_flow_types::{GeometryType, GmlGeometry};
+
+        let polygon1 = create_test_polygon_3d();
+        let polygon2 = create_clipper_polygon_3d();
+        let clip_polygon = create_clipper_polygon_3d();
+
+        // Create a nested GML geometry (composite surface)
+        let nested_gml = GmlGeometry {
+            id: Some("nested_surface".to_string()),
+            ty: GeometryType::Surface,
+            lod: Some(2),
+            pos: 0,
+            len: 1,
+            polygons: vec![polygon1.clone()],
+            line_strings: vec![],
+            feature_id: Some("nested_feature".to_string()),
+            feature_type: Some("Wall".to_string()),
+            composite_surfaces: vec![],
+        };
+
+        // Create a parent GML geometry with composite surfaces
+        let parent_gml = GmlGeometry {
+            id: Some("parent_solid".to_string()),
+            ty: GeometryType::Solid,
+            lod: Some(2),
+            pos: 0,
+            len: 2,
+            polygons: vec![polygon2.clone()],
+            line_strings: vec![],
+            feature_id: Some("parent_feature".to_string()),
+            feature_type: Some("Building".to_string()),
+            composite_surfaces: vec![nested_gml],
+        };
+
+        let citygml = CityGmlGeometry {
+            gml_geometries: vec![parent_gml],
+            materials: vec![],
+            textures: vec![],
+            polygon_materials: vec![],
+            polygon_textures: vec![],
+            polygon_uvs: Default::default(),
+        };
+
+        let clipper = Clipper {
+            clippers: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry3D(Geometry3D::Polygon(clip_polygon)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            candidates: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::CityGmlGeometry(citygml),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let ctx = NodeContext::default();
+
+        let result = clipper.finish(ctx, &fw);
+        assert!(result.is_ok());
+
+        if let ProcessorChannelForwarder::Noop(noop) = fw {
+            let ports = noop.send_ports.lock().unwrap();
+            // Should have sent features to both inside and outside ports
+            assert!(ports.contains(&*INSIDE_PORT));
+            assert!(ports.contains(&*OUTSIDE_PORT));
+        }
+    }
+
+    #[test]
+    fn test_clipper_with_citygml_curve_geometry() {
+        use reearth_flow_geometry::types::line_string::LineString3D;
+        use reearth_flow_types::{GeometryType, GmlGeometry};
+
+        let clip_polygon = create_clipper_polygon_3d();
+
+        // Create a line string for Curve geometry
+        let line_string = LineString3D::new(vec![
+            (0.0, 0.0, 0.0).into(),
+            (10.0, 10.0, 0.0).into(),
+            (20.0, 20.0, 0.0).into(),
+        ]);
+
+        // Create a Curve type GML geometry
+        let curve_gml = GmlGeometry {
+            id: Some("curve_gml".to_string()),
+            ty: GeometryType::Curve,
+            lod: Some(2),
+            pos: 0,
+            len: 1,
+            polygons: vec![], // Curves don't have polygons
+            line_strings: vec![line_string],
+            feature_id: Some("curve_feature".to_string()),
+            feature_type: Some("Road".to_string()),
+            composite_surfaces: vec![],
+        };
+
+        let citygml = CityGmlGeometry {
+            gml_geometries: vec![curve_gml],
+            materials: vec![],
+            textures: vec![],
+            polygon_materials: vec![],
+            polygon_textures: vec![],
+            polygon_uvs: Default::default(),
+        };
+
+        let clipper = Clipper {
+            clippers: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry3D(Geometry3D::Polygon(clip_polygon)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            candidates: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::CityGmlGeometry(citygml),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let ctx = NodeContext::default();
+
+        let result = clipper.finish(ctx, &fw);
+        assert!(result.is_ok());
+
+        if let ProcessorChannelForwarder::Noop(noop) = fw {
+            let ports = noop.send_ports.lock().unwrap();
+            // Curve geometry with line_strings should be sent to inside port as-is
+            // since we can't clip line strings the same way as polygons
+            assert!(ports.contains(&*INSIDE_PORT));
+        }
+    }
+
+    #[test]
+    fn test_clipper_with_citygml_solid_with_nested_surfaces() {
+        use reearth_flow_types::{GeometryType, GmlGeometry};
+
+        let polygon1 = create_test_polygon_3d();
+        let polygon2 = create_clipper_polygon_3d();
+
+        // Create nested surface geometries (representing walls, roof, etc.)
+        let wall1 = GmlGeometry {
+            id: Some("wall1".to_string()),
+            ty: GeometryType::Surface,
+            lod: Some(2),
+            pos: 0,
+            len: 1,
+            polygons: vec![polygon1.clone()],
+            line_strings: vec![],
+            feature_id: Some("wall1_feature".to_string()),
+            feature_type: Some("WallSurface".to_string()),
+            composite_surfaces: vec![],
+        };
+
+        let wall2 = GmlGeometry {
+            id: Some("wall2".to_string()),
+            ty: GeometryType::Surface,
+            lod: Some(2),
+            pos: 1,
+            len: 1,
+            polygons: vec![polygon2.clone()],
+            line_strings: vec![],
+            feature_id: Some("wall2_feature".to_string()),
+            feature_type: Some("WallSurface".to_string()),
+            composite_surfaces: vec![],
+        };
+
+        // Create a Solid with composite surfaces
+        let solid = GmlGeometry {
+            id: Some("building_solid".to_string()),
+            ty: GeometryType::Solid,
+            lod: Some(2),
+            pos: 0,
+            len: 2,
+            polygons: vec![], // Solid might not have direct polygons
+            line_strings: vec![],
+            feature_id: Some("building".to_string()),
+            feature_type: Some("Building".to_string()),
+            composite_surfaces: vec![wall1, wall2],
+        };
+
+        let citygml = CityGmlGeometry {
+            gml_geometries: vec![solid],
+            materials: vec![],
+            textures: vec![],
+            polygon_materials: vec![],
+            polygon_textures: vec![],
+            polygon_uvs: Default::default(),
+        };
+
+        let clip_polygon = create_clipper_polygon_3d();
+
+        let clipper = Clipper {
+            clippers: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry3D(Geometry3D::Polygon(clip_polygon)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            candidates: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::CityGmlGeometry(citygml),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let ctx = NodeContext::default();
+
+        let result = clipper.finish(ctx, &fw);
+        assert!(result.is_ok());
+
+        if let ProcessorChannelForwarder::Noop(noop) = fw {
+            let ports = noop.send_ports.lock().unwrap();
+            // Should process nested surfaces and send results
+            assert!(ports.contains(&*INSIDE_PORT));
+            assert!(ports.contains(&*OUTSIDE_PORT));
+        }
+    }
+
+    #[test]
+    fn test_clipper_with_geometry_collection() {
+        let polygon1 = create_test_polygon_2d();
+        let polygon2 = create_clipper_polygon_2d();
+        let collection = Geometry2D::GeometryCollection(vec![
+            Geometry2D::Polygon(polygon1.clone()),
+            Geometry2D::Polygon(polygon2.clone()),
+        ]);
+
+        let clip_polygon = create_clipper_polygon_2d();
+
+        let clipper = Clipper {
+            clippers: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry2D(Geometry2D::Polygon(clip_polygon)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+            candidates: vec![Feature {
+                geometry: Geometry {
+                    value: GeometryValue::FlowGeometry2D(collection),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }],
+        };
+
+        let noop = NoopChannelForwarder::default();
+        let fw = ProcessorChannelForwarder::Noop(noop);
+        let ctx = NodeContext::default();
+
+        let result = clipper.finish(ctx, &fw);
+        assert!(result.is_ok());
+
+        if let ProcessorChannelForwarder::Noop(noop) = fw {
+            let ports = noop.send_ports.lock().unwrap();
+            // GeometryCollection should process each geometry individually
+            assert!(!ports.is_empty());
+        }
+    }
 }

--- a/engine/runtime/action-processor/src/geometry/clipper.rs
+++ b/engine/runtime/action-processor/src/geometry/clipper.rs
@@ -365,18 +365,18 @@ fn forward_polygon3d(
 /// The scaling factor used to preserve decimal precision in Clipper operations.
 /// Clipper library internally uses integer arithmetic, so we scale up coordinates
 /// to preserve decimal places, then scale back down after processing.
-/// 
+///
 /// Current setting: 10^8 preserves 8 decimal places of precision.
-/// 
+///
 /// Precision vs Range tradeoff:
 /// - 10^5 (100,000): 5 decimal places, safe for any coordinate range
 /// - 10^8 (100,000,000): 8 decimal places, safe for geographic coordinates (±180/±90)
 /// - 10^10: 10 decimal places, may overflow for large coordinates
-/// 
+///
 /// Note: Clipper uses 64-bit integers internally, so:
 /// max_coordinate * scale_factor < 2^63 (9.2×10^18)
 /// For geographic coords (±180): 180 * 10^8 = 1.8×10^10 << 9.2×10^18 ✓
-/// 
+///
 /// This does NOT provide full f64 (double) precision (~15-17 significant digits),
 /// but is sufficient for most geospatial applications where 8 decimal places
 /// (~1.1mm precision at equator) is more than adequate.
@@ -774,14 +774,14 @@ mod tests {
         // Create polygon with decimal coordinates (similar to real-world usage)
         // These coordinates have the same integer part but differ in decimal places
         let exterior = LineString2D::new(vec![
-            Coordinate2D::new_(139.7456, 35.6821),  // Real coordinates like in Tokyo
+            Coordinate2D::new_(139.7456, 35.6821), // Real coordinates like in Tokyo
             Coordinate2D::new_(139.7458, 35.6821),
             Coordinate2D::new_(139.7458, 35.6823),
             Coordinate2D::new_(139.7456, 35.6823),
             Coordinate2D::new_(139.7456, 35.6821),
         ]);
         let polygon = Polygon2D::new(exterior, vec![]);
-        
+
         // Create clipper with decimal coordinates
         let clip_exterior = LineString2D::new(vec![
             Coordinate2D::new_(139.7457, 35.6822),
@@ -791,15 +791,21 @@ mod tests {
             Coordinate2D::new_(139.7457, 35.6822),
         ]);
         let clip_region = Polygon2D::new(clip_exterior, vec![]);
-        
+
         let (insides, outsides) = clip_polygon2d(&polygon, &[clip_region]);
-        
+
         // This test will likely fail due to the decimal truncation issue
-        println!("Decimal test - Insides: {:?}, Outsides: {:?}", insides.len(), outsides.len());
-        assert!(!insides.is_empty() || !outsides.is_empty(), 
-                "Should have some results with decimal coordinates");
+        println!(
+            "Decimal test - Insides: {:?}, Outsides: {:?}",
+            insides.len(),
+            outsides.len()
+        );
+        assert!(
+            !insides.is_empty() || !outsides.is_empty(),
+            "Should have some results with decimal coordinates"
+        );
     }
-    
+
     #[test]
     fn test_clip_polygon2d_with_small_decimal_differences() {
         // Test with very small differences (only in decimal places)
@@ -811,7 +817,7 @@ mod tests {
             Coordinate2D::new_(0.0001, 0.0001),
         ]);
         let polygon = Polygon2D::new(exterior, vec![]);
-        
+
         let clip_exterior = LineString2D::new(vec![
             Coordinate2D::new_(0.0002, 0.0002),
             Coordinate2D::new_(0.0004, 0.0002),
@@ -820,15 +826,21 @@ mod tests {
             Coordinate2D::new_(0.0002, 0.0002),
         ]);
         let clip_region = Polygon2D::new(clip_exterior, vec![]);
-        
+
         let (insides, outsides) = clip_polygon2d(&polygon, &[clip_region]);
-        
+
         // This will demonstrate the problem - decimal truncation
-        println!("Small decimal test - Insides: {:?}, Outsides: {:?}", insides.len(), outsides.len());
-        
+        println!(
+            "Small decimal test - Insides: {:?}, Outsides: {:?}",
+            insides.len(),
+            outsides.len()
+        );
+
         // This assertion will likely fail
-        assert!(!insides.is_empty() || !outsides.is_empty(), 
-                "Should handle small decimal differences correctly");
+        assert!(
+            !insides.is_empty() || !outsides.is_empty(),
+            "Should handle small decimal differences correctly"
+        );
     }
 
     #[test]
@@ -842,7 +854,7 @@ mod tests {
             Coordinate2D::new_(139.74561234, 35.68211234),
         ]);
         let polygon = Polygon2D::new(exterior, vec![]);
-        
+
         let clip_exterior = LineString2D::new(vec![
             Coordinate2D::new_(139.74571234, 35.68221234),
             Coordinate2D::new_(139.74591234, 35.68221234),
@@ -851,17 +863,26 @@ mod tests {
             Coordinate2D::new_(139.74571234, 35.68221234),
         ]);
         let clip_region = Polygon2D::new(clip_exterior, vec![]);
-        
+
         let (insides, outsides) = clip_polygon2d(&polygon, &[clip_region]);
-        
-        println!("High precision test - Insides: {:?}, Outsides: {:?}", insides.len(), outsides.len());
-        assert!(!insides.is_empty() || !outsides.is_empty(), 
-                "Should handle 8 decimal places with 10^8 scaling");
-        
+
+        println!(
+            "High precision test - Insides: {:?}, Outsides: {:?}",
+            insides.len(),
+            outsides.len()
+        );
+        assert!(
+            !insides.is_empty() || !outsides.is_empty(),
+            "Should handle 8 decimal places with 10^8 scaling"
+        );
+
         // Check if coordinates maintain precision (within rounding errors)
         if !insides.is_empty() {
             let first_coord = insides[0].exterior().0[0];
-            println!("Resulting coordinate precision: x={:.10}, y={:.10}", first_coord.x, first_coord.y);
+            println!(
+                "Resulting coordinate precision: x={:.10}, y={:.10}",
+                first_coord.x, first_coord.y
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- Add full CityGML geometry support to the Clipper action
- Support composite surfaces (MultiSurface) with recursive processing
- Handle line strings (Curve type geometries) appropriately

## Changes
- Enable CityGML geometries as both clipper and candidate inputs
- Extract 3D polygons from CityGML for clipping operations
- Add recursive processing for composite surfaces (nested GML geometries)
- Handle line strings for Curve type geometries (preserved as-is since they cannot be clipped)
- Preserve CityGML metadata (materials, textures, UV coordinates) after clipping
- Add comprehensive tests for all CityGML geometry types (Solid, Surface, Curve, composite surfaces)
- Add documentation comments about 3D clipping limitations (2.5D surface clipping, not volumetric)

## Test Coverage
Added 18 tests covering:
- Basic 2D/3D polygon clipping
- CityGML as candidate geometry
- CityGML as clipper geometry  
- Composite surfaces (nested MultiSurface)
- Curve type with line strings
- Solid type with nested surfaces
- Geometry collections

All tests passing ✅

## Notes
- The 3D clipping is surface-level (2.5D), not true volumetric operations, as documented in code comments
- Line strings in Curve geometries are preserved as-is since they cannot be clipped like polygons