### PR TITLE
fix(websocket): allow empty nodes in map json value validation

### DIFF
--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -526,8 +526,7 @@ impl BroadcastGroup {
                 if let Some(main) = map_json_value["main"].as_object() {
                     if let Some(nodes) = main["nodes"].as_object() {
                         if nodes.is_empty() {
-                            debug!("No nodes found");
-                            return false;
+                            return true;
                         }
 
                         for (_, node) in nodes {


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
