### PR TITLE
feat(websocket): node deletion persistence issue where deleted nodes would reappear after page reload

### DIFF
--- a/server/websocket/.env.local
+++ b/server/websocket/.env.local
@@ -1,0 +1,5 @@
+# Local testing environment
+REEARTH_FLOW_REDIS_URL=redis://127.0.0.1:6379
+REEARTH_FLOW_GCS_BUCKET_NAME=test-bucket
+REEARTH_FLOW_GCS_ENDPOINT=http://localhost:4443
+RUST_LOG=websocket=debug,info

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -609,8 +609,13 @@ impl BroadcastGroup {
                         debug!("Skipping GCS save: not all nodes have position data");
                     } else {
                         // Get the last stream ID before saving
-                        let last_stream_id = self.redis_store.get_stream_last_id(&self.doc_name).await.ok().flatten();
-                        
+                        let last_stream_id = self
+                            .redis_store
+                            .get_stream_last_id(&self.doc_name)
+                            .await
+                            .ok()
+                            .flatten();
+
                         let gcs_doc = Doc::new();
                         let mut gcs_txn = gcs_doc.transact_mut();
 
@@ -649,8 +654,15 @@ impl BroadcastGroup {
                                 // Successfully saved to GCS, trim the Redis stream
                                 // Remove all entries up to the last one we incorporated
                                 if let Some(last_id) = last_stream_id {
-                                    tracing::info!("Document saved to GCS, trimming Redis stream up to ID: {}", last_id);
-                                    if let Err(e) = self.redis_store.trim_stream_before(&self.doc_name, &last_id).await {
+                                    tracing::info!(
+                                        "Document saved to GCS, trimming Redis stream up to ID: {}",
+                                        last_id
+                                    );
+                                    if let Err(e) = self
+                                        .redis_store
+                                        .trim_stream_before(&self.doc_name, &last_id)
+                                        .await
+                                    {
                                         warn!("Failed to trim Redis stream after GCS save: {}", e);
                                     }
                                 }

--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -526,6 +526,11 @@ impl BroadcastGroup {
             Ok(map_json_value) => {
                 if let Some(main) = map_json_value["main"].as_object() {
                     if let Some(nodes) = main["nodes"].as_object() {
+                        if nodes.is_empty() {
+                            debug!("No nodes found");
+                            return false;
+                        }
+
                         for (_, node) in nodes {
                             if let Some(position) = node["position"].as_object() {
                                 if let (Some(x), Some(y)) = (position.get("x"), position.get("y")) {
@@ -539,7 +544,7 @@ impl BroadcastGroup {
                         return true;
                     }
                 }
-                true
+                false
             }
             Err(e) => {
                 tracing::error!("Error parsing map_json: {:?}", e);
@@ -599,11 +604,10 @@ impl BroadcastGroup {
                     let awareness = self.awareness_ref.write().await;
                     let awareness_doc = awareness.doc();
 
-                    tracing::info!("Saving document to GCS");
-
-                    if self.all_nodes_have_position(awareness_doc) {
-                        tracing::info!("All nodes have position data");
-                        
+                    // Check if all nodes have position data before saving to GCS
+                    if !self.all_nodes_have_position(awareness_doc) {
+                        debug!("Skipping GCS save: not all nodes have position data");
+                    } else {
                         // Get the last stream ID before saving
                         let last_stream_id = self.redis_store.get_stream_last_id(&self.doc_name).await.ok().flatten();
                         
@@ -617,39 +621,46 @@ impl BroadcastGroup {
                         let gcs_state = gcs_txn.state_vector();
 
                         let awareness_txn = awareness_doc.transact();
+                        let awareness_state = awareness_txn.state_vector();
 
                         let update = awareness_txn.encode_diff_v1(&gcs_state);
                         let update_bytes = Bytes::from(update);
 
-                        tracing::info!("Updating document in storage");
-                        let update_future = self.storage.push_update(
-                            &self.doc_name,
-                            &update_bytes,
-                            &self.redis_store,
-                        );
-                        let flush_future =
-                            self.storage.flush_doc_v2(&self.doc_name, &awareness_txn);
+                        if !(update_bytes.is_empty()
+                            || (update_bytes.len() == 2
+                                && update_bytes[0] == 0
+                                && update_bytes[1] == 0)
+                            || awareness_state == gcs_state)
+                        {
+                            let update_future = self.storage.push_update(
+                                &self.doc_name,
+                                &update_bytes,
+                                &self.redis_store,
+                            );
+                            let flush_future =
+                                self.storage.flush_doc_v2(&self.doc_name, &awareness_txn);
 
-                        let (update_result, flush_result) =
-                            tokio::join!(update_future, flush_future);
+                            let (update_result, flush_result) =
+                                tokio::join!(update_future, flush_future);
 
-                        if let Err(e) = flush_result {
-                            warn!("Failed to flush document directly to storage: {}", e);
-                        } else if flush_result.is_ok() {
-                            // Successfully saved to GCS, trim the Redis stream
-                            // Remove all entries up to the last one we incorporated
-                            if let Some(last_id) = last_stream_id {
-                                tracing::info!("Document saved to GCS, trimming Redis stream up to ID: {}", last_id);
-                                if let Err(e) = self.redis_store.trim_stream_before(&self.doc_name, &last_id).await {
-                                    warn!("Failed to trim Redis stream after GCS save: {}", e);
+                            if let Err(e) = flush_result {
+                                warn!("Failed to flush document directly to storage: {}", e);
+                            } else {
+                                // Successfully saved to GCS, trim the Redis stream
+                                // Remove all entries up to the last one we incorporated
+                                if let Some(last_id) = last_stream_id {
+                                    tracing::info!("Document saved to GCS, trimming Redis stream up to ID: {}", last_id);
+                                    if let Err(e) = self.redis_store.trim_stream_before(&self.doc_name, &last_id).await {
+                                        warn!("Failed to trim Redis stream after GCS save: {}", e);
+                                    }
                                 }
                             }
-                        }
 
-                        if let Err(e) = update_result {
-                            warn!("Failed to update document in storage: {}", e);
+                            if let Err(e) = update_result {
+                                warn!("Failed to update document in storage: {}", e);
+                            }
                         }
-                    }
+                    } // Close the else block for position check
                 }
 
                 if let Err(e) = self

--- a/server/websocket/src/storage/redis/mod.rs
+++ b/server/websocket/src/storage/redis/mod.rs
@@ -231,7 +231,7 @@ impl RedisStore {
         instance_id: &str,
         last_read_id: &Arc<Mutex<String>>,
     ) -> Result<Vec<Bytes>> {
-        let block_ms = 1600;
+        let block_ms = 1000;
 
         let read_id = {
             let last_id = last_read_id.lock().await;

--- a/server/websocket/src/ws.rs
+++ b/server/websocket/src/ws.rs
@@ -16,7 +16,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::sync::mpsc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 use yrs::sync::Error;
 
 #[cfg(feature = "auth")]
@@ -115,17 +115,13 @@ impl Stream for WarpStream {
                                 if let Err(e) = tx.send(pong_msg).await {
                                     warn!("Failed to send pong message: {}", e);
                                 } else {
-                                    info!("Pong response sent");
+                                    debug!("Pong response sent");
                                 }
                             });
                         }
-                        cx.waker().wake_by_ref();
-                        Poll::Pending
+                        self.poll_next(cx)
                     }
-                    Message::Pong(_) | Message::Text(_) => {
-                        cx.waker().wake_by_ref();
-                        Poll::Pending
-                    }
+                    Message::Pong(_) | Message::Text(_) => self.poll_next(cx),
                     Message::Close(_) => Poll::Ready(None),
                 },
                 Err(e) => Poll::Ready(Some(Err(Error::Other(e.into())))),
@@ -208,16 +204,20 @@ async fn handle_socket(
         error!("Failed to increment connections: {}", e);
     }
 
-    // tracing::info!("WebSocket connection established for document '{}'", doc_id);
+    let connection_result = tokio::select! {
+        result = conn => result,
+        _ = tokio::time::sleep(tokio::time::Duration::from_secs(86400)) => {
+            warn!("Connection timeout for document '{}' - possible stale connection", doc_id);
+            Err(yrs::sync::Error::Other("Connection timeout".into()))
+        }
+    };
 
-    if let Err(e) = conn.await {
+    if let Err(e) = connection_result {
         error!(
             "WebSocket connection error for document '{}': {}",
             doc_id, e
         );
     }
-
-    // tracing::info!("WebSocket connection closed for document '{}'", doc_id);
 
     let _ = bcast.decrement_connections().await;
 


### PR DESCRIPTION
# Overview
Fixed node deletion persistence issue in WebSocket server where deleted nodes would reappear after page reload due to Redis stream replay.

## What I've done

1. Root Cause Analysis
- Identified that the WebSocket server was replaying ALL Redis stream updates when loading documents
- Found that deleted nodes were recreated because old creation events in Redis stream were being replayed on top of the saved GCS state

2. Implemented Proper Fix
- Added get_stream_last_id() method to capture the last Redis stream entry before GCS save
- Added trim_stream_before() method to remove Redis entries that have been incorporated into GCS
- Modified GCS save logic to trim Redis stream after successful save, keeping only new updates

3. Reverted Problematic Changes
- Reverted commit a08d6d757 that removed empty nodes validation check
- Restored the original all_nodes_have_position() logic that was working in stable version c6b12a0c6

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
