### PR TITLE
feat(server): replace user management to accounts for UpdateMe [FLOW-BE-191]

### DIFF
--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -90,7 +90,7 @@ func conditionalGraphQLAuthMiddleware(
 				switch body.OperationName {
 				case "GetMe":
 					middlewares = tempNewAuthMWs
-				case "GetWorkspaceById", "GetWorkspaces", "SearchUser":
+				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe":
 					middlewares = append(defaultMWs, tempNewAuthMWs...)
 				}
 			}

--- a/server/api/internal/infrastructure/gql/user/input.go
+++ b/server/api/internal/infrastructure/gql/user/input.go
@@ -1,0 +1,13 @@
+package user
+
+import (
+	"github.com/hasura/go-graphql-client"
+)
+
+type UpdateMeInput struct {
+	Name                 *graphql.String `json:"name,omitempty"`
+	Email                *graphql.String `json:"email,omitempty"`
+	Lang                 *graphql.String `json:"lang,omitempty"`
+	Password             *graphql.String `json:"password,omitempty"`
+	PasswordConfirmation *graphql.String `json:"passwordConfirmation,omitempty"`
+}

--- a/server/api/internal/infrastructure/gql/user/mutation.go
+++ b/server/api/internal/infrastructure/gql/user/mutation.go
@@ -1,0 +1,11 @@
+package user
+
+import (
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/gql/gqlmodel"
+)
+
+type updateMeMutation struct {
+	UpdateMe struct {
+		Me gqlmodel.Me `graphql:"me"`
+	} `graphql:"updateMe(input: $input)"`
+}

--- a/server/api/internal/infrastructure/gql/user/query.go
+++ b/server/api/internal/infrastructure/gql/user/query.go
@@ -1,6 +1,8 @@
 package user
 
-import "github.com/reearth/reearth-flow/api/internal/infrastructure/gql/gqlmodel"
+import (
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/gql/gqlmodel"
+)
 
 type findMeQuery struct {
 	Me gqlmodel.Me `graphql:"me"`

--- a/server/api/internal/infrastructure/gql/user/repo.go
+++ b/server/api/internal/infrastructure/gql/user/repo.go
@@ -62,3 +62,35 @@ func (r *userRepo) UserByNameOrEmail(ctx context.Context, nameOrEmail string) (*
 
 	return util.ToUserFromSimple(q.User)
 }
+
+func (r *userRepo) UpdateMe(ctx context.Context, a user.UpdateAttrs) (*user.User, error) {
+	in := UpdateMeInput{}
+	if a.Name != nil {
+		s := graphql.String(*a.Name)
+		in.Name = &s
+	}
+	if a.Email != nil {
+		s := graphql.String(*a.Email)
+		in.Email = &s
+	}
+	if a.Lang != nil {
+		langCode := graphql.String(a.Lang.String())
+		in.Lang = &langCode
+	}
+	if a.Password != nil && a.PasswordConfirmation != nil {
+		p := graphql.String(*a.Password)
+		pc := graphql.String(*a.PasswordConfirmation)
+		in.Password = &p
+		in.PasswordConfirmation = &pc
+	}
+
+	var m updateMeMutation
+	vars := map[string]interface{}{
+		"input": in,
+	}
+	if err := r.client.Mutate(ctx, &m, vars); err != nil {
+		return nil, err
+	}
+
+	return util.ToMe(m.UpdateMe.Me)
+}

--- a/server/api/internal/infrastructure/gql/util/converter_common.go
+++ b/server/api/internal/infrastructure/gql/util/converter_common.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"github.com/hasura/go-graphql-client"
+)
+
+func FromPtrToPtr(s *graphql.String) *string {
+	if s == nil {
+		return nil
+	}
+	str := string(*s)
+	return &str
+}
+
+func toStringSlice(gqlSlice []graphql.String) []string {
+	res := make([]string, len(gqlSlice))
+	for i, v := range gqlSlice {
+		res[i] = string(v)
+	}
+	return res
+}

--- a/server/api/internal/infrastructure/gql/util/converter_user.go
+++ b/server/api/internal/infrastructure/gql/util/converter_user.go
@@ -1,0 +1,84 @@
+package util
+
+import (
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/gql/gqlmodel"
+	"github.com/reearth/reearth-flow/api/pkg/user"
+	"github.com/samber/lo"
+)
+
+func ToMe(m gqlmodel.Me) (*user.User, error) {
+	uid, err := user.IDFrom(string(m.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	wid, err := user.WorkspaceIDFrom(string(m.MyWorkspaceID))
+	if err != nil {
+		return nil, err
+	}
+
+	workspaces, err := ToWorkspaces(m.Workspaces)
+	if err != nil {
+		return nil, err
+	}
+
+	return user.New().
+		ID(uid).
+		Name(string(m.Name)).
+		Alias(string(m.Alias)).
+		Email(string(m.Email)).
+		Metadata(toUserMetadata(m.Metadata)).
+		Host(lo.ToPtr(string(m.Host))).
+		MyWorkspaceID(wid).
+		Auths(toStringSlice(m.Auths)).
+		Workspaces(workspaces).
+		Build()
+}
+
+func toUser(u gqlmodel.User) (*user.User, error) {
+	uid, err := user.IDFrom(string(u.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	wid, err := user.WorkspaceIDFrom(string(u.Workspace))
+	if err != nil {
+		return nil, err
+	}
+
+	return user.New().
+		ID(uid).
+		Name(string(u.Name)).
+		Email(string(u.Email)).
+		Host(lo.ToPtr(string(u.Host))).
+		MyWorkspaceID(wid).
+		Auths(toStringSlice(u.Auths)).
+		Metadata(toUserMetadata(u.Metadata)).
+		Build()
+}
+
+func ToUserFromSimple(u gqlmodel.UserSimple) (*user.User, error) {
+	uid, err := user.IDFrom(string(u.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	return user.New().
+		ID(uid).
+		Name(string(u.Name)).
+		Email(string(u.Email)).
+		Host(lo.ToPtr(string(u.Host))).
+		Build()
+}
+
+func ToUsers(gqlUsers []gqlmodel.User) (user.List, error) {
+	users := make(user.List, 0, len(gqlUsers))
+	for _, gu := range gqlUsers {
+		u, err := toUser(gu)
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, *u)
+	}
+	return users, nil
+}

--- a/server/api/internal/infrastructure/gql/util/converter_workspace.go
+++ b/server/api/internal/infrastructure/gql/util/converter_workspace.go
@@ -4,91 +4,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/hasura/go-graphql-client"
 	"github.com/reearth/reearth-flow/api/internal/infrastructure/gql/gqlmodel"
 	"github.com/reearth/reearth-flow/api/pkg/id"
 	"github.com/reearth/reearth-flow/api/pkg/user"
 	"github.com/reearth/reearth-flow/api/pkg/workspace"
-	"github.com/samber/lo"
 	"golang.org/x/text/language"
 )
-
-func ToMe(m gqlmodel.Me) (*user.User, error) {
-	uid, err := user.IDFrom(string(m.ID))
-	if err != nil {
-		return nil, err
-	}
-
-	wid, err := user.WorkspaceIDFrom(string(m.MyWorkspaceID))
-	if err != nil {
-		return nil, err
-	}
-
-	workspaces, err := ToWorkspaces(m.Workspaces)
-	if err != nil {
-		return nil, err
-	}
-
-	return user.New().
-		ID(uid).
-		Name(string(m.Name)).
-		Alias(string(m.Alias)).
-		Email(string(m.Email)).
-		Metadata(toUserMetadata(m.Metadata)).
-		Host(lo.ToPtr(string(m.Host))).
-		MyWorkspaceID(wid).
-		Auths(toStringSlice(m.Auths)).
-		Workspaces(workspaces).
-		Build()
-}
-
-func toUser(u gqlmodel.User) (*user.User, error) {
-	uid, err := user.IDFrom(string(u.ID))
-	if err != nil {
-		return nil, err
-	}
-
-	wid, err := user.WorkspaceIDFrom(string(u.Workspace))
-	if err != nil {
-		return nil, err
-	}
-
-	return user.New().
-		ID(uid).
-		Name(string(u.Name)).
-		Email(string(u.Email)).
-		Host(lo.ToPtr(string(u.Host))).
-		MyWorkspaceID(wid).
-		Auths(toStringSlice(u.Auths)).
-		Metadata(toUserMetadata(u.Metadata)).
-		Build()
-}
-
-func ToUserFromSimple(u gqlmodel.UserSimple) (*user.User, error) {
-	uid, err := user.IDFrom(string(u.ID))
-	if err != nil {
-		return nil, err
-	}
-
-	return user.New().
-		ID(uid).
-		Name(string(u.Name)).
-		Email(string(u.Email)).
-		Host(lo.ToPtr(string(u.Host))).
-		Build()
-}
-
-func ToUsers(gqlUsers []gqlmodel.User) (user.List, error) {
-	users := make(user.List, 0, len(gqlUsers))
-	for _, gu := range gqlUsers {
-		u, err := toUser(gu)
-		if err != nil {
-			return nil, err
-		}
-		users = append(users, *u)
-	}
-	return users, nil
-}
 
 func toWorkspace(w gqlmodel.Workspace) (*workspace.Workspace, error) {
 	wid, err := workspace.IDFrom(string(w.ID))
@@ -235,20 +156,4 @@ func toIntegrationMember(gql gqlmodel.WorkspaceMember) (workspace.IntegrationMem
 		}
 	}
 	return member, nil
-}
-
-func FromPtrToPtr(s *graphql.String) *string {
-	if s == nil {
-		return nil
-	}
-	str := string(*s)
-	return &str
-}
-
-func toStringSlice(gqlSlice []graphql.String) []string {
-	res := make([]string, len(gqlSlice))
-	for i, v := range gqlSlice {
-		res[i] = string(v)
-	}
-	return res
 }

--- a/server/api/internal/usecase/interactor/user.go
+++ b/server/api/internal/usecase/interactor/user.go
@@ -25,3 +25,14 @@ func (i *User) FindByIDs(ctx context.Context, ids id.UserIDList) (user.List, err
 func (i *User) UserByNameOrEmail(ctx context.Context, nameOrEmail string) (*user.User, error) {
 	return i.userRepo.UserByNameOrEmail(ctx, nameOrEmail)
 }
+
+func (i *User) UpdateMe(ctx context.Context, p interfaces.UpdateMeParam) (*user.User, error) {
+	attrs := user.UpdateAttrs{
+		Name:                 p.Name,
+		Email:                p.Email,
+		Lang:                 p.Lang,
+		Password:             p.Password,
+		PasswordConfirmation: p.PasswordConfirmation,
+	}
+	return i.userRepo.UpdateMe(ctx, attrs)
+}

--- a/server/api/internal/usecase/interfaces/user.go
+++ b/server/api/internal/usecase/interfaces/user.go
@@ -5,9 +5,19 @@ import (
 
 	"github.com/reearth/reearth-flow/api/pkg/id"
 	"github.com/reearth/reearth-flow/api/pkg/user"
+	"golang.org/x/text/language"
 )
+
+type UpdateMeParam struct {
+	Name                 *string
+	Email                *string
+	Lang                 *language.Tag
+	Password             *string
+	PasswordConfirmation *string
+}
 
 type User interface {
 	FindByIDs(context.Context, id.UserIDList) (user.List, error)
 	UserByNameOrEmail(context.Context, string) (*user.User, error)
+	UpdateMe(context.Context, UpdateMeParam) (*user.User, error)
 }

--- a/server/api/pkg/user/mockrepo/mockrepo.go
+++ b/server/api/pkg/user/mockrepo/mockrepo.go
@@ -72,6 +72,21 @@ func (mr *MockUserRepoMockRecorder) FindMe(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindMe", reflect.TypeOf((*MockUserRepo)(nil).FindMe), ctx)
 }
 
+// UpdateMe mocks base method.
+func (m *MockUserRepo) UpdateMe(ctx context.Context, attrs user.UpdateAttrs) (*user.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMe", ctx, attrs)
+	ret0, _ := ret[0].(*user.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateMe indicates an expected call of UpdateMe.
+func (mr *MockUserRepoMockRecorder) UpdateMe(ctx, attrs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMe", reflect.TypeOf((*MockUserRepo)(nil).UpdateMe), ctx, attrs)
+}
+
 // UserByNameOrEmail mocks base method.
 func (m *MockUserRepo) UserByNameOrEmail(ctx context.Context, nameOrEmail string) (*user.User, error) {
 	m.ctrl.T.Helper()

--- a/server/api/pkg/user/repo.go
+++ b/server/api/pkg/user/repo.go
@@ -11,4 +11,5 @@ type Repo interface {
 	FindMe(ctx context.Context) (*User, error)
 	FindByIDs(ctx context.Context, ids id.UserIDList) (List, error)
 	UserByNameOrEmail(ctx context.Context, nameOrEmail string) (*User, error)
+	UpdateMe(ctx context.Context, attrs UpdateAttrs) (*User, error)
 }

--- a/server/api/pkg/user/update.go
+++ b/server/api/pkg/user/update.go
@@ -1,0 +1,11 @@
+package user
+
+import "golang.org/x/text/language"
+
+type UpdateAttrs struct {
+	Name                 *string
+	Email                *string
+	Lang                 *language.Tag
+	Password             *string
+	PasswordConfirmation *string
+}


### PR DESCRIPTION
# Overview


## What I've done

Replaced user management with accounts service for the UpdateMe API

## What I’ve Confirmed Locally

I tested it and confirmed it works locally.
https://www.notion.so/eukarya/Epic-Replace-user-management-in-API-with-reearth-accounts-24616e0fb16580aaa44eeb852b769a8a?source=copy_link#25a16e0fb16580e78159ed86b3a1f275

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
