### PR TITLE
feat(server): replace user management to accounts for CreateWorkspace [FLOW-BE-191]

### DIFF
--- a/server/api/internal/adapter/gql/gqlmodel/convert_user.go
+++ b/server/api/internal/adapter/gql/gqlmodel/convert_user.go
@@ -22,7 +22,11 @@ func ToUser(u *user.User) *User {
 }
 
 // TODO: After migration, delete ToUser and rename ToUserFromFlow to ToUser.
-func ToUserFromFlow(u pkguser.User) *User {
+func ToUserFromFlow(u *pkguser.User) *User {
+	if u == nil {
+		return nil
+	}
+
 	return &User{
 		ID:    IDFrom(u.ID()),
 		Name:  u.Name(),

--- a/server/api/internal/adapter/gql/gqlmodel/convert_workspace.go
+++ b/server/api/internal/adapter/gql/gqlmodel/convert_workspace.go
@@ -28,7 +28,11 @@ func ToWorkspace(t *workspace.Workspace) *Workspace {
 }
 
 // TODO: After migration, delete ToWorkspace and rename ToWorkspaceFromFlow to ToWorkspace.
-func ToWorkspaceFromFlow(t pkgworkspace.Workspace) *Workspace {
+func ToWorkspaceFromFlow(t *pkgworkspace.Workspace) *Workspace {
+	if t == nil {
+		return nil
+	}
+
 	members := make([]*WorkspaceMember, 0, len(t.Members()))
 
 	for _, member := range t.Members() {

--- a/server/api/internal/adapter/gql/loader_user.go
+++ b/server/api/internal/adapter/gql/loader_user.go
@@ -118,7 +118,7 @@ func (c *UserLoader) searchUserWithTempNewUsecase(ctx context.Context, nameOrEma
 		return nil
 	}
 
-	return gqlmodel.ToUserFromFlow(*res)
+	return gqlmodel.ToUserFromFlow(res)
 }
 
 // data loader

--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -90,7 +90,7 @@ func conditionalGraphQLAuthMiddleware(
 				switch body.OperationName {
 				case "GetMe":
 					middlewares = tempNewAuthMWs
-				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe":
+				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace":
 					middlewares = append(defaultMWs, tempNewAuthMWs...)
 				}
 			}

--- a/server/api/internal/infrastructure/gql/util/converter_user.go
+++ b/server/api/internal/infrastructure/gql/util/converter_user.go
@@ -78,7 +78,7 @@ func ToUsers(gqlUsers []gqlmodel.User) (user.List, error) {
 		if err != nil {
 			return nil, err
 		}
-		users = append(users, *u)
+		users = append(users, u)
 	}
 	return users, nil
 }

--- a/server/api/internal/infrastructure/gql/util/converter_workspace.go
+++ b/server/api/internal/infrastructure/gql/util/converter_workspace.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-func toWorkspace(w gqlmodel.Workspace) (*workspace.Workspace, error) {
+func ToWorkspace(w gqlmodel.Workspace) (*workspace.Workspace, error) {
 	wid, err := workspace.IDFrom(string(w.ID))
 	if err != nil {
 		return nil, err
@@ -35,11 +35,11 @@ func toWorkspace(w gqlmodel.Workspace) (*workspace.Workspace, error) {
 func ToWorkspaces(gqlWorkspaces []gqlmodel.Workspace) (workspace.List, error) {
 	workspaces := make(workspace.List, 0, len(gqlWorkspaces))
 	for _, w := range gqlWorkspaces {
-		ws, err := toWorkspace(w)
+		ws, err := ToWorkspace(w)
 		if err != nil {
 			return nil, err
 		}
-		workspaces = append(workspaces, *ws)
+		workspaces = append(workspaces, ws)
 	}
 	return workspaces, nil
 }

--- a/server/api/internal/infrastructure/gql/workspace/input.go
+++ b/server/api/internal/infrastructure/gql/workspace/input.go
@@ -1,0 +1,9 @@
+package workspace
+
+import (
+	"github.com/hasura/go-graphql-client"
+)
+
+type CreateWorkspaceInput struct {
+	Name graphql.String `json:"name"`
+}

--- a/server/api/internal/infrastructure/gql/workspace/mutation.go
+++ b/server/api/internal/infrastructure/gql/workspace/mutation.go
@@ -1,0 +1,11 @@
+package workspace
+
+import (
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/gql/gqlmodel"
+)
+
+type createWorkspaceMutation struct {
+	CreateWorkspace struct {
+		Workspace gqlmodel.Workspace `graphql:"workspace"`
+	} `graphql:"createWorkspace(input: $input)"`
+}

--- a/server/api/internal/infrastructure/gql/workspace/repo.go
+++ b/server/api/internal/infrastructure/gql/workspace/repo.go
@@ -49,3 +49,17 @@ func (r *workspaceRepo) FindByUser(ctx context.Context, uid id.UserID) (workspac
 
 	return util.ToWorkspaces(q.Workspaces)
 }
+
+func (r *workspaceRepo) Create(ctx context.Context, name string) (*workspace.Workspace, error) {
+	in := CreateWorkspaceInput{Name: graphql.String(name)}
+
+	var m createWorkspaceMutation
+	vars := map[string]interface{}{
+		"input": in,
+	}
+	if err := r.client.Mutate(ctx, &m, vars); err != nil {
+		return nil, err
+	}
+
+	return util.ToWorkspace(m.CreateWorkspace.Workspace)
+}

--- a/server/api/internal/usecase/interactor/workspace.go
+++ b/server/api/internal/usecase/interactor/workspace.go
@@ -25,3 +25,7 @@ func (i *Workspace) FindByIDs(ctx context.Context, ids id.WorkspaceIDList) (work
 func (i *Workspace) FindByUser(ctx context.Context, uid id.UserID) (workspace.List, error) {
 	return i.workspaceRepo.FindByUser(ctx, uid)
 }
+
+func (i *Workspace) Create(ctx context.Context, name string) (*workspace.Workspace, error) {
+	return i.workspaceRepo.Create(ctx, name)
+}

--- a/server/api/internal/usecase/interfaces/workspace.go
+++ b/server/api/internal/usecase/interfaces/workspace.go
@@ -10,4 +10,5 @@ import (
 type Workspace interface {
 	FindByIDs(context.Context, id.WorkspaceIDList) (workspace.List, error)
 	FindByUser(context.Context, id.UserID) (workspace.List, error)
+	Create(context.Context, string) (*workspace.Workspace, error)
 }

--- a/server/api/pkg/user/user.go
+++ b/server/api/pkg/user/user.go
@@ -15,7 +15,7 @@ type User struct {
 	myWorkspace   workspace.Workspace
 }
 
-type List []User
+type List []*User
 
 func (u *User) ID() ID {
 	return u.id

--- a/server/api/pkg/workspace/mockrepo/mockrepo.go
+++ b/server/api/pkg/workspace/mockrepo/mockrepo.go
@@ -42,6 +42,21 @@ func (m *MockWorkspaceRepo) EXPECT() *MockWorkspaceRepoMockRecorder {
 	return m.recorder
 }
 
+// Create mocks base method.
+func (m *MockWorkspaceRepo) Create(ctx context.Context, name string) (*workspace.Workspace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, name)
+	ret0, _ := ret[0].(*workspace.Workspace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockWorkspaceRepoMockRecorder) Create(ctx, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockWorkspaceRepo)(nil).Create), ctx, name)
+}
+
 // FindByIDs mocks base method.
 func (m *MockWorkspaceRepo) FindByIDs(ctx context.Context, ids id.WorkspaceIDList) (workspace.List, error) {
 	m.ctrl.T.Helper()

--- a/server/api/pkg/workspace/repo.go
+++ b/server/api/pkg/workspace/repo.go
@@ -10,4 +10,5 @@ import (
 type Repo interface {
 	FindByIDs(ctx context.Context, ids id.WorkspaceIDList) (List, error)
 	FindByUser(ctx context.Context, uid id.UserID) (List, error)
+	Create(ctx context.Context, name string) (*Workspace, error)
 }

--- a/server/api/pkg/workspace/workspace.go
+++ b/server/api/pkg/workspace/workspace.go
@@ -9,7 +9,7 @@ type Workspace struct {
 	members  []Member
 }
 
-type List []Workspace
+type List []*Workspace
 
 func (w *Workspace) ID() ID {
 	return w.id


### PR DESCRIPTION
# Overview

**The target branch for this pull request is "feat/replace-user-management-for-updateuser".**

## What I've done

Replaced user management with accounts service for the CreateWorkspace API

## What I’ve Confirmed Locally

I tested it and confirmed it works locally.
https://www.notion.so/eukarya/Epic-Replace-user-management-in-API-with-reearth-accounts-24616e0fb16580aaa44eeb852b769a8a?source=copy_link#25b16e0fb16580daa261df3b7c413aac

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
