### PR TITLE
feat(server): replace user management to accounts for UpdateWorkspace [FLOW-BE-191]

### DIFF
--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -90,7 +90,7 @@ func conditionalGraphQLAuthMiddleware(
 				switch body.OperationName {
 				case "GetMe":
 					middlewares = tempNewAuthMWs
-				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace":
+				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace":
 					middlewares = append(defaultMWs, tempNewAuthMWs...)
 				}
 			}

--- a/server/api/internal/infrastructure/gql/workspace/input.go
+++ b/server/api/internal/infrastructure/gql/workspace/input.go
@@ -7,3 +7,8 @@ import (
 type CreateWorkspaceInput struct {
 	Name graphql.String `json:"name"`
 }
+
+type UpdateWorkspaceInput struct {
+	WorkspaceID graphql.ID     `json:"workspaceId"`
+	Name        graphql.String `json:"name"`
+}

--- a/server/api/internal/infrastructure/gql/workspace/mutation.go
+++ b/server/api/internal/infrastructure/gql/workspace/mutation.go
@@ -9,3 +9,9 @@ type createWorkspaceMutation struct {
 		Workspace gqlmodel.Workspace `graphql:"workspace"`
 	} `graphql:"createWorkspace(input: $input)"`
 }
+
+type updateWorkspaceMutation struct {
+	UpdateWorkspace struct {
+		Workspace gqlmodel.Workspace `graphql:"workspace"`
+	} `graphql:"updateWorkspace(input: $input)"`
+}

--- a/server/api/internal/infrastructure/gql/workspace/repo.go
+++ b/server/api/internal/infrastructure/gql/workspace/repo.go
@@ -63,3 +63,20 @@ func (r *workspaceRepo) Create(ctx context.Context, name string) (*workspace.Wor
 
 	return util.ToWorkspace(m.CreateWorkspace.Workspace)
 }
+
+func (r *workspaceRepo) Update(ctx context.Context, wid id.WorkspaceID, name string) (*workspace.Workspace, error) {
+	in := UpdateWorkspaceInput{
+		WorkspaceID: graphql.ID(wid.String()),
+		Name:        graphql.String(name),
+	}
+
+	var m updateWorkspaceMutation
+	vars := map[string]interface{}{
+		"input": in,
+	}
+	if err := r.client.Mutate(ctx, &m, vars); err != nil {
+		return nil, err
+	}
+
+	return util.ToWorkspace(m.UpdateWorkspace.Workspace)
+}

--- a/server/api/internal/usecase/interactor/workspace.go
+++ b/server/api/internal/usecase/interactor/workspace.go
@@ -29,3 +29,7 @@ func (i *Workspace) FindByUser(ctx context.Context, uid id.UserID) (workspace.Li
 func (i *Workspace) Create(ctx context.Context, name string) (*workspace.Workspace, error) {
 	return i.workspaceRepo.Create(ctx, name)
 }
+
+func (i *Workspace) Update(ctx context.Context, wid id.WorkspaceID, name string) (*workspace.Workspace, error) {
+	return i.workspaceRepo.Update(ctx, wid, name)
+}

--- a/server/api/internal/usecase/interfaces/workspace.go
+++ b/server/api/internal/usecase/interfaces/workspace.go
@@ -11,4 +11,5 @@ type Workspace interface {
 	FindByIDs(context.Context, id.WorkspaceIDList) (workspace.List, error)
 	FindByUser(context.Context, id.UserID) (workspace.List, error)
 	Create(context.Context, string) (*workspace.Workspace, error)
+	Update(context.Context, id.WorkspaceID, string) (*workspace.Workspace, error)
 }

--- a/server/api/pkg/workspace/mockrepo/mockrepo.go
+++ b/server/api/pkg/workspace/mockrepo/mockrepo.go
@@ -86,3 +86,18 @@ func (mr *MockWorkspaceRepoMockRecorder) FindByUser(ctx, uid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByUser", reflect.TypeOf((*MockWorkspaceRepo)(nil).FindByUser), ctx, uid)
 }
+
+// Update mocks base method.
+func (m *MockWorkspaceRepo) Update(ctx context.Context, wid id.WorkspaceID, name string) (*workspace.Workspace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", ctx, wid, name)
+	ret0, _ := ret[0].(*workspace.Workspace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockWorkspaceRepoMockRecorder) Update(ctx, wid, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockWorkspaceRepo)(nil).Update), ctx, wid, name)
+}

--- a/server/api/pkg/workspace/repo.go
+++ b/server/api/pkg/workspace/repo.go
@@ -11,4 +11,5 @@ type Repo interface {
 	FindByIDs(ctx context.Context, ids id.WorkspaceIDList) (List, error)
 	FindByUser(ctx context.Context, uid id.UserID) (List, error)
 	Create(ctx context.Context, name string) (*Workspace, error)
+	Update(ctx context.Context, wid id.WorkspaceID, name string) (*Workspace, error)
 }


### PR DESCRIPTION
# Overview

## What I've done

Replaced user management with accounts service for the UpdateWorkspace API

## What I’ve Confirmed Locally

I tested it and confirmed it works locally.
https://www.notion.so/eukarya/Epic-Replace-user-management-in-API-with-reearth-accounts-24616e0fb16580aaa44eeb852b769a8a?source=copy_link#25c16e0fb165807dba31f614ccd40d33

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
