### PR TITLE
fix(engine): update examples in README

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -215,7 +215,7 @@ $ cargo run --package reearth-flow-cli -- run --workflow ${workflow_path}
 
 ### Run example
 
-See example [README](runtime/examples/README.md).
+See examples [README](runtime/examples/README.md).
 
 ### Run generate graphviz
 


### PR DESCRIPTION
# Overview

Currently, the example section in `/engine/README.md` refers to an `attribute_reader` example which has been removed. This may lead to confusions to new users who try the engine for the first time. 

## What I've done

Since currently there is an independent `/engine/runtime/examples/README.md` titled "Re:Earth Flow Examples",
I removed the obsolete example usage and created a link to the examples package.

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo

This is just a quick fix as my first commit to this project. Probably in the future we need a proper way to document examples.