### PR TITLE
feat(server): replace user management to accounts for AddMemberToWorkspace [FLOW-BE-191]

### DIFF
--- a/server/api/internal/adapter/gql/gqlmodel/convert_workspace.go
+++ b/server/api/internal/adapter/gql/gqlmodel/convert_workspace.go
@@ -92,3 +92,18 @@ func FromRole(r Role) workspace.Role {
 	}
 	return workspace.Role("")
 }
+
+// TODO: After migration, delete FromRole and rename FromRoleToFlow to FromRole.
+func FromRoleToFlow(r Role) pkgworkspace.Role {
+	switch r {
+	case RoleReader:
+		return pkgworkspace.RoleReader
+	case RoleWriter:
+		return pkgworkspace.RoleWriter
+	case RoleMaintainer:
+		return pkgworkspace.RoleMaintainer
+	case RoleOwner:
+		return pkgworkspace.RoleOwner
+	}
+	return pkgworkspace.Role("")
+}

--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -90,7 +90,7 @@ func conditionalGraphQLAuthMiddleware(
 				switch body.OperationName {
 				case "GetMe":
 					middlewares = tempNewAuthMWs
-				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace":
+				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace":
 					middlewares = append(defaultMWs, tempNewAuthMWs...)
 				}
 			}

--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -90,7 +90,7 @@ func conditionalGraphQLAuthMiddleware(
 				switch body.OperationName {
 				case "GetMe":
 					middlewares = tempNewAuthMWs
-				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace":
+				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace":
 					middlewares = append(defaultMWs, tempNewAuthMWs...)
 				}
 			}

--- a/server/api/internal/infrastructure/gql/workspace/input.go
+++ b/server/api/internal/infrastructure/gql/workspace/input.go
@@ -12,3 +12,7 @@ type UpdateWorkspaceInput struct {
 	WorkspaceID graphql.ID     `json:"workspaceId"`
 	Name        graphql.String `json:"name"`
 }
+
+type DeleteWorkspaceInput struct {
+	WorkspaceID graphql.ID `json:"workspaceId"`
+}

--- a/server/api/internal/infrastructure/gql/workspace/input.go
+++ b/server/api/internal/infrastructure/gql/workspace/input.go
@@ -16,3 +16,13 @@ type UpdateWorkspaceInput struct {
 type DeleteWorkspaceInput struct {
 	WorkspaceID graphql.ID `json:"workspaceId"`
 }
+
+type AddUsersToWorkspaceInput struct {
+	WorkspaceID graphql.ID    `json:"workspaceId"`
+	Users       []MemberInput `json:"users"`
+}
+
+type MemberInput struct {
+	UserID graphql.ID     `json:"userId"`
+	Role   graphql.String `json:"role"`
+}

--- a/server/api/internal/infrastructure/gql/workspace/mutation.go
+++ b/server/api/internal/infrastructure/gql/workspace/mutation.go
@@ -22,3 +22,9 @@ type deleteWorkspaceMutation struct {
 		WorkspaceID graphql.ID `graphql:"workspaceId"`
 	} `graphql:"deleteWorkspace(input: $input)"`
 }
+
+type addUsersToWorkspaceMutation struct {
+	AddUsersToWorkspace struct {
+		Workspace gqlmodel.Workspace `graphql:"workspace"`
+	} `graphql:"addUsersToWorkspace(input: $input)"`
+}

--- a/server/api/internal/infrastructure/gql/workspace/mutation.go
+++ b/server/api/internal/infrastructure/gql/workspace/mutation.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"github.com/hasura/go-graphql-client"
 	"github.com/reearth/reearth-flow/api/internal/infrastructure/gql/gqlmodel"
 )
 
@@ -14,4 +15,10 @@ type updateWorkspaceMutation struct {
 	UpdateWorkspace struct {
 		Workspace gqlmodel.Workspace `graphql:"workspace"`
 	} `graphql:"updateWorkspace(input: $input)"`
+}
+
+type deleteWorkspaceMutation struct {
+	DeleteWorkspace struct {
+		WorkspaceID graphql.ID `graphql:"workspaceId"`
+	} `graphql:"deleteWorkspace(input: $input)"`
 }

--- a/server/api/internal/infrastructure/gql/workspace/repo.go
+++ b/server/api/internal/infrastructure/gql/workspace/repo.go
@@ -80,3 +80,17 @@ func (r *workspaceRepo) Update(ctx context.Context, wid id.WorkspaceID, name str
 
 	return util.ToWorkspace(m.UpdateWorkspace.Workspace)
 }
+
+func (r *workspaceRepo) Delete(ctx context.Context, wid id.WorkspaceID) error {
+	in := DeleteWorkspaceInput{WorkspaceID: graphql.ID(wid.String())}
+
+	var m deleteWorkspaceMutation
+	vars := map[string]interface{}{
+		"input": in,
+	}
+	if err := r.client.Mutate(ctx, &m, vars); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/server/api/internal/usecase/interactor/workspace.go
+++ b/server/api/internal/usecase/interactor/workspace.go
@@ -33,3 +33,7 @@ func (i *Workspace) Create(ctx context.Context, name string) (*workspace.Workspa
 func (i *Workspace) Update(ctx context.Context, wid id.WorkspaceID, name string) (*workspace.Workspace, error) {
 	return i.workspaceRepo.Update(ctx, wid, name)
 }
+
+func (i *Workspace) Delete(ctx context.Context, wid id.WorkspaceID) error {
+	return i.workspaceRepo.Delete(ctx, wid)
+}

--- a/server/api/internal/usecase/interactor/workspace.go
+++ b/server/api/internal/usecase/interactor/workspace.go
@@ -37,3 +37,7 @@ func (i *Workspace) Update(ctx context.Context, wid id.WorkspaceID, name string)
 func (i *Workspace) Delete(ctx context.Context, wid id.WorkspaceID) error {
 	return i.workspaceRepo.Delete(ctx, wid)
 }
+
+func (i *Workspace) AddUserMember(ctx context.Context, wid id.WorkspaceID, users map[id.UserID]workspace.Role) (*workspace.Workspace, error) {
+	return i.workspaceRepo.AddUserMember(ctx, wid, users)
+}

--- a/server/api/internal/usecase/interfaces/workspace.go
+++ b/server/api/internal/usecase/interfaces/workspace.go
@@ -12,4 +12,5 @@ type Workspace interface {
 	FindByUser(context.Context, id.UserID) (workspace.List, error)
 	Create(context.Context, string) (*workspace.Workspace, error)
 	Update(context.Context, id.WorkspaceID, string) (*workspace.Workspace, error)
+	Delete(context.Context, id.WorkspaceID) error
 }

--- a/server/api/internal/usecase/interfaces/workspace.go
+++ b/server/api/internal/usecase/interfaces/workspace.go
@@ -13,4 +13,5 @@ type Workspace interface {
 	Create(context.Context, string) (*workspace.Workspace, error)
 	Update(context.Context, id.WorkspaceID, string) (*workspace.Workspace, error)
 	Delete(context.Context, id.WorkspaceID) error
+	AddUserMember(context.Context, id.WorkspaceID, map[id.UserID]workspace.Role) (*workspace.Workspace, error)
 }

--- a/server/api/pkg/workspace/mockrepo/mockrepo.go
+++ b/server/api/pkg/workspace/mockrepo/mockrepo.go
@@ -42,6 +42,21 @@ func (m *MockWorkspaceRepo) EXPECT() *MockWorkspaceRepoMockRecorder {
 	return m.recorder
 }
 
+// AddUserMember mocks base method.
+func (m *MockWorkspaceRepo) AddUserMember(ctx context.Context, wid id.WorkspaceID, users map[id.UserID]workspace.Role) (*workspace.Workspace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddUserMember", ctx, wid, users)
+	ret0, _ := ret[0].(*workspace.Workspace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddUserMember indicates an expected call of AddUserMember.
+func (mr *MockWorkspaceRepoMockRecorder) AddUserMember(ctx, wid, users any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddUserMember", reflect.TypeOf((*MockWorkspaceRepo)(nil).AddUserMember), ctx, wid, users)
+}
+
 // Create mocks base method.
 func (m *MockWorkspaceRepo) Create(ctx context.Context, name string) (*workspace.Workspace, error) {
 	m.ctrl.T.Helper()

--- a/server/api/pkg/workspace/mockrepo/mockrepo.go
+++ b/server/api/pkg/workspace/mockrepo/mockrepo.go
@@ -57,6 +57,20 @@ func (mr *MockWorkspaceRepoMockRecorder) Create(ctx, name any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockWorkspaceRepo)(nil).Create), ctx, name)
 }
 
+// Delete mocks base method.
+func (m *MockWorkspaceRepo) Delete(ctx context.Context, wid id.WorkspaceID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, wid)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockWorkspaceRepoMockRecorder) Delete(ctx, wid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockWorkspaceRepo)(nil).Delete), ctx, wid)
+}
+
 // FindByIDs mocks base method.
 func (m *MockWorkspaceRepo) FindByIDs(ctx context.Context, ids id.WorkspaceIDList) (workspace.List, error) {
 	m.ctrl.T.Helper()

--- a/server/api/pkg/workspace/repo.go
+++ b/server/api/pkg/workspace/repo.go
@@ -12,4 +12,5 @@ type Repo interface {
 	FindByUser(ctx context.Context, uid id.UserID) (List, error)
 	Create(ctx context.Context, name string) (*Workspace, error)
 	Update(ctx context.Context, wid id.WorkspaceID, name string) (*Workspace, error)
+	Delete(ctx context.Context, wid id.WorkspaceID) error
 }

--- a/server/api/pkg/workspace/repo.go
+++ b/server/api/pkg/workspace/repo.go
@@ -13,4 +13,5 @@ type Repo interface {
 	Create(ctx context.Context, name string) (*Workspace, error)
 	Update(ctx context.Context, wid id.WorkspaceID, name string) (*Workspace, error)
 	Delete(ctx context.Context, wid id.WorkspaceID) error
+	AddUserMember(ctx context.Context, wid id.WorkspaceID, users map[id.UserID]Role) (*Workspace, error)
 }


### PR DESCRIPTION
# Overview

## What I've done

Replaced user management with accounts service for the AddMemberToWorkspace API

## What I’ve Confirmed Locally

I tested it and confirmed it works locally.
https://www.notion.so/eukarya/Epic-Replace-user-management-in-API-with-reearth-accounts-24616e0fb16580aaa44eeb852b769a8a?source=copy_link#25e16e0fb1658096a605e4bd5fe51923

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
