### PR TITLE
feat(server): replace user management to accounts for UpdateMemberOfWorkspace [FLOW-BE-191]

### DIFF
--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -90,7 +90,7 @@ func conditionalGraphQLAuthMiddleware(
 				switch body.OperationName {
 				case "GetMe":
 					middlewares = tempNewAuthMWs
-				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace":
+				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace", "UpdateMemberOfWorkspace":
 					middlewares = append(defaultMWs, tempNewAuthMWs...)
 				}
 			}

--- a/server/api/internal/infrastructure/gql/workspace/input.go
+++ b/server/api/internal/infrastructure/gql/workspace/input.go
@@ -22,6 +22,12 @@ type AddUsersToWorkspaceInput struct {
 	Users       []MemberInput `json:"users"`
 }
 
+type UpdateUserOfWorkspaceInput struct {
+	WorkspaceID graphql.ID     `json:"workspaceId"`
+	UserID      graphql.ID     `json:"userId"`
+	Role        graphql.String `json:"role"`
+}
+
 type MemberInput struct {
 	UserID graphql.ID     `json:"userId"`
 	Role   graphql.String `json:"role"`

--- a/server/api/internal/infrastructure/gql/workspace/mutation.go
+++ b/server/api/internal/infrastructure/gql/workspace/mutation.go
@@ -28,3 +28,9 @@ type addUsersToWorkspaceMutation struct {
 		Workspace gqlmodel.Workspace `graphql:"workspace"`
 	} `graphql:"addUsersToWorkspace(input: $input)"`
 }
+
+type updateUserOfWorkspaceMutation struct {
+	UpdateUserOfWorkspace struct {
+		Workspace gqlmodel.Workspace `graphql:"workspace"`
+	} `graphql:"updateUserOfWorkspace(input: $input)"`
+}

--- a/server/api/internal/infrastructure/gql/workspace/repo.go
+++ b/server/api/internal/infrastructure/gql/workspace/repo.go
@@ -118,3 +118,21 @@ func (r *workspaceRepo) AddUserMember(ctx context.Context, wid id.WorkspaceID, u
 
 	return util.ToWorkspace(m.AddUsersToWorkspace.Workspace)
 }
+
+func (r *workspaceRepo) UpdateUserMember(ctx context.Context, wid id.WorkspaceID, uid id.UserID, role workspace.Role) (*workspace.Workspace, error) {
+	in := UpdateUserOfWorkspaceInput{
+		WorkspaceID: graphql.ID(wid.String()),
+		UserID:      graphql.ID(uid.String()),
+		Role:        graphql.String(role),
+	}
+
+	var m updateUserOfWorkspaceMutation
+	vars := map[string]interface{}{
+		"input": in,
+	}
+	if err := r.client.Mutate(ctx, &m, vars); err != nil {
+		return nil, err
+	}
+
+	return util.ToWorkspace(m.UpdateUserOfWorkspace.Workspace)
+}

--- a/server/api/internal/usecase/interactor/workspace.go
+++ b/server/api/internal/usecase/interactor/workspace.go
@@ -41,3 +41,7 @@ func (i *Workspace) Delete(ctx context.Context, wid id.WorkspaceID) error {
 func (i *Workspace) AddUserMember(ctx context.Context, wid id.WorkspaceID, users map[id.UserID]workspace.Role) (*workspace.Workspace, error) {
 	return i.workspaceRepo.AddUserMember(ctx, wid, users)
 }
+
+func (i *Workspace) UpdateUserMember(ctx context.Context, wid id.WorkspaceID, uid id.UserID, role workspace.Role) (*workspace.Workspace, error) {
+	return i.workspaceRepo.UpdateUserMember(ctx, wid, uid, role)
+}

--- a/server/api/internal/usecase/interfaces/workspace.go
+++ b/server/api/internal/usecase/interfaces/workspace.go
@@ -14,4 +14,5 @@ type Workspace interface {
 	Update(context.Context, id.WorkspaceID, string) (*workspace.Workspace, error)
 	Delete(context.Context, id.WorkspaceID) error
 	AddUserMember(context.Context, id.WorkspaceID, map[id.UserID]workspace.Role) (*workspace.Workspace, error)
+	UpdateUserMember(context.Context, id.WorkspaceID, id.UserID, workspace.Role) (*workspace.Workspace, error)
 }

--- a/server/api/pkg/workspace/mockrepo/mockrepo.go
+++ b/server/api/pkg/workspace/mockrepo/mockrepo.go
@@ -130,3 +130,18 @@ func (mr *MockWorkspaceRepoMockRecorder) Update(ctx, wid, name any) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockWorkspaceRepo)(nil).Update), ctx, wid, name)
 }
+
+// UpdateUserMember mocks base method.
+func (m *MockWorkspaceRepo) UpdateUserMember(ctx context.Context, wid id.WorkspaceID, uid id.UserID, role workspace.Role) (*workspace.Workspace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUserMember", ctx, wid, uid, role)
+	ret0, _ := ret[0].(*workspace.Workspace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateUserMember indicates an expected call of UpdateUserMember.
+func (mr *MockWorkspaceRepoMockRecorder) UpdateUserMember(ctx, wid, uid, role any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserMember", reflect.TypeOf((*MockWorkspaceRepo)(nil).UpdateUserMember), ctx, wid, uid, role)
+}

--- a/server/api/pkg/workspace/repo.go
+++ b/server/api/pkg/workspace/repo.go
@@ -14,4 +14,5 @@ type Repo interface {
 	Update(ctx context.Context, wid id.WorkspaceID, name string) (*Workspace, error)
 	Delete(ctx context.Context, wid id.WorkspaceID) error
 	AddUserMember(ctx context.Context, wid id.WorkspaceID, users map[id.UserID]Role) (*Workspace, error)
+	UpdateUserMember(ctx context.Context, wid id.WorkspaceID, uid id.UserID, role Role) (*Workspace, error)
 }


### PR DESCRIPTION
# Overview

**The target branch is feat/replace-user-management-for-addmembertoworkspace**

## What I've done

Replaced user management with accounts service for the UpdateMemberOfWorkspace API

## What I’ve Confirmed Locally

I tested it and confirmed it works locally.
https://www.notion.so/eukarya/Epic-Replace-user-management-in-API-with-reearth-accounts-24616e0fb16580aaa44eeb852b769a8a?source=copy_link#26116e0fb1658016a92ada972d472f98

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
