### PR TITLE
feat(server): replace user management to accounts for RemoveMemberFromWorkspace [FLOW-BE-191]

### DIFF
--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -90,7 +90,7 @@ func conditionalGraphQLAuthMiddleware(
 				switch body.OperationName {
 				case "GetMe":
 					middlewares = tempNewAuthMWs
-				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace", "UpdateMemberOfWorkspace":
+				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace", "UpdateMemberOfWorkspace", "RemoveMemberFromWorkspace":
 					middlewares = append(defaultMWs, tempNewAuthMWs...)
 				}
 			}

--- a/server/api/internal/infrastructure/gql/workspace/input.go
+++ b/server/api/internal/infrastructure/gql/workspace/input.go
@@ -28,6 +28,11 @@ type UpdateUserOfWorkspaceInput struct {
 	Role        graphql.String `json:"role"`
 }
 
+type RemoveUserFromWorkspaceInput struct {
+	WorkspaceID graphql.ID `json:"workspaceId"`
+	UserID      graphql.ID `json:"userId"`
+}
+
 type MemberInput struct {
 	UserID graphql.ID     `json:"userId"`
 	Role   graphql.String `json:"role"`

--- a/server/api/internal/infrastructure/gql/workspace/mutation.go
+++ b/server/api/internal/infrastructure/gql/workspace/mutation.go
@@ -34,3 +34,9 @@ type updateUserOfWorkspaceMutation struct {
 		Workspace gqlmodel.Workspace `graphql:"workspace"`
 	} `graphql:"updateUserOfWorkspace(input: $input)"`
 }
+
+type removeUserFromWorkspaceMutation struct {
+	RemoveUserFromWorkspace struct {
+		Workspace gqlmodel.Workspace `graphql:"workspace"`
+	} `graphql:"removeUserFromWorkspace(input: $input)"`
+}

--- a/server/api/internal/infrastructure/gql/workspace/repo.go
+++ b/server/api/internal/infrastructure/gql/workspace/repo.go
@@ -136,3 +136,20 @@ func (r *workspaceRepo) UpdateUserMember(ctx context.Context, wid id.WorkspaceID
 
 	return util.ToWorkspace(m.UpdateUserOfWorkspace.Workspace)
 }
+
+func (r *workspaceRepo) RemoveUserMember(ctx context.Context, wid id.WorkspaceID, uid id.UserID) (*workspace.Workspace, error) {
+	in := RemoveUserFromWorkspaceInput{
+		WorkspaceID: graphql.ID(wid.String()),
+		UserID:      graphql.ID(uid.String()),
+	}
+
+	var m removeUserFromWorkspaceMutation
+	vars := map[string]interface{}{
+		"input": in,
+	}
+	if err := r.client.Mutate(ctx, &m, vars); err != nil {
+		return nil, err
+	}
+
+	return util.ToWorkspace(m.RemoveUserFromWorkspace.Workspace)
+}

--- a/server/api/internal/usecase/interactor/workspace.go
+++ b/server/api/internal/usecase/interactor/workspace.go
@@ -45,3 +45,7 @@ func (i *Workspace) AddUserMember(ctx context.Context, wid id.WorkspaceID, users
 func (i *Workspace) UpdateUserMember(ctx context.Context, wid id.WorkspaceID, uid id.UserID, role workspace.Role) (*workspace.Workspace, error) {
 	return i.workspaceRepo.UpdateUserMember(ctx, wid, uid, role)
 }
+
+func (i *Workspace) RemoveUserMember(ctx context.Context, wid id.WorkspaceID, uid id.UserID) (*workspace.Workspace, error) {
+	return i.workspaceRepo.RemoveUserMember(ctx, wid, uid)
+}

--- a/server/api/internal/usecase/interfaces/workspace.go
+++ b/server/api/internal/usecase/interfaces/workspace.go
@@ -15,4 +15,5 @@ type Workspace interface {
 	Delete(context.Context, id.WorkspaceID) error
 	AddUserMember(context.Context, id.WorkspaceID, map[id.UserID]workspace.Role) (*workspace.Workspace, error)
 	UpdateUserMember(context.Context, id.WorkspaceID, id.UserID, workspace.Role) (*workspace.Workspace, error)
+	RemoveUserMember(context.Context, id.WorkspaceID, id.UserID) (*workspace.Workspace, error)
 }

--- a/server/api/pkg/workspace/mockrepo/mockrepo.go
+++ b/server/api/pkg/workspace/mockrepo/mockrepo.go
@@ -116,6 +116,21 @@ func (mr *MockWorkspaceRepoMockRecorder) FindByUser(ctx, uid any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByUser", reflect.TypeOf((*MockWorkspaceRepo)(nil).FindByUser), ctx, uid)
 }
 
+// RemoveUserMember mocks base method.
+func (m *MockWorkspaceRepo) RemoveUserMember(ctx context.Context, wid id.WorkspaceID, uid id.UserID) (*workspace.Workspace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveUserMember", ctx, wid, uid)
+	ret0, _ := ret[0].(*workspace.Workspace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveUserMember indicates an expected call of RemoveUserMember.
+func (mr *MockWorkspaceRepoMockRecorder) RemoveUserMember(ctx, wid, uid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveUserMember", reflect.TypeOf((*MockWorkspaceRepo)(nil).RemoveUserMember), ctx, wid, uid)
+}
+
 // Update mocks base method.
 func (m *MockWorkspaceRepo) Update(ctx context.Context, wid id.WorkspaceID, name string) (*workspace.Workspace, error) {
 	m.ctrl.T.Helper()

--- a/server/api/pkg/workspace/repo.go
+++ b/server/api/pkg/workspace/repo.go
@@ -15,4 +15,5 @@ type Repo interface {
 	Delete(ctx context.Context, wid id.WorkspaceID) error
 	AddUserMember(ctx context.Context, wid id.WorkspaceID, users map[id.UserID]Role) (*Workspace, error)
 	UpdateUserMember(ctx context.Context, wid id.WorkspaceID, uid id.UserID, role Role) (*Workspace, error)
+	RemoveUserMember(ctx context.Context, wid id.WorkspaceID, uid id.UserID) (*Workspace, error)
 }


### PR DESCRIPTION
# Overview

## What I've done

Replaced user management with accounts service for the RemoveMemberFromWorkspace API

## What I’ve Confirmed Locally

I tested it and confirmed it works locally.
https://www.notion.so/eukarya/Epic-Replace-user-management-in-API-with-reearth-accounts-24616e0fb16580aaa44eeb852b769a8a?source=copy_link#26116e0fb165804bb7aacc945261e438

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
