### PR TITLE
feat(server): replace user management to accounts for Signup [FLOW-BE-191]

### DIFF
--- a/server/api/internal/adapter/gql/resolver_mutation_user.go
+++ b/server/api/internal/adapter/gql/resolver_mutation_user.go
@@ -7,11 +7,29 @@ import (
 	"github.com/reearth/reearth-flow/api/internal/adapter"
 	"github.com/reearth/reearth-flow/api/internal/adapter/gql/gqlmodel"
 	"github.com/reearth/reearth-flow/api/internal/usecase/interfaces"
+	"github.com/reearth/reearth-flow/api/pkg/id"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountusecase/accountinterfaces"
 )
 
 func (r *mutationResolver) Signup(ctx context.Context, input gqlmodel.SignupInput) (*gqlmodel.SignupPayload, error) {
+	// TODO: After migration, remove this logic and use the new usecase directly.
+	if usecases(ctx).TempNewUser != nil {
+		flowUser, err := usecases(ctx).TempNewUser.SignupOIDC(ctx, interfaces.SignupOIDCParam{
+			UserID:      gqlmodel.ToIDRef[id.User](input.UserID),
+			Lang:        input.Lang,
+			WorkspaceID: gqlmodel.ToIDRef[id.Workspace](input.WorkspaceID),
+			Secret:      input.Secret,
+		})
+		if err != nil {
+			log.Printf("WARNING:[mutationResolver.signupWithTempNewUsecase] Failed to sign up user: %v", err)
+		} else {
+			log.Printf("DEBUG:[mutationResolver.signupWithTempNewUsecase] Signed up user with tempNewUsecase")
+			return &gqlmodel.SignupPayload{User: gqlmodel.ToUserFromFlow(flowUser)}, nil
+		}
+	}
+	log.Printf("WARNING:[mutationResolver.Signup] Fallback to traditional usecase")
+
 	au := adapter.GetAuthInfo(ctx)
 	if au == nil {
 		return nil, interfaces.ErrOperationDenied

--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -67,6 +67,12 @@ func tempNewAuthMiddleware(gqlClient *gql.Client) echo.MiddlewareFunc {
 	}
 }
 
+func jwtOnlyMiddlewares() []echo.MiddlewareFunc {
+	return []echo.MiddlewareFunc{
+		jwtContextMiddleware(),
+	}
+}
+
 // TODO: This function is in the process of migrating the task "Replace user management in API with reearth accounts".
 // Once completed, only `tempNewAuthMWs` will be used, making this function unnecessary.
 func conditionalGraphQLAuthMiddleware(
@@ -90,6 +96,8 @@ func conditionalGraphQLAuthMiddleware(
 				switch body.OperationName {
 				case "GetMe":
 					middlewares = tempNewAuthMWs
+				case "Signup":
+					middlewares = append(defaultMWs, jwtOnlyMiddlewares()...)
 				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace", "UpdateMemberOfWorkspace", "RemoveMemberFromWorkspace":
 					middlewares = append(defaultMWs, tempNewAuthMWs...)
 				}

--- a/server/api/internal/infrastructure/gql/user/input.go
+++ b/server/api/internal/infrastructure/gql/user/input.go
@@ -11,3 +11,10 @@ type UpdateMeInput struct {
 	Password             *graphql.String `json:"password,omitempty"`
 	PasswordConfirmation *graphql.String `json:"passwordConfirmation,omitempty"`
 }
+
+type SignupOIDCInput struct {
+	ID          *graphql.ID     `json:"id,omitempty"`
+	Lang        *graphql.String `json:"lang,omitempty"`
+	WorkspaceID *graphql.ID     `json:"workspaceId,omitempty"`
+	Secret      *graphql.String `json:"secret,omitempty"`
+}

--- a/server/api/internal/infrastructure/gql/user/mutation.go
+++ b/server/api/internal/infrastructure/gql/user/mutation.go
@@ -9,3 +9,9 @@ type updateMeMutation struct {
 		Me gqlmodel.Me `graphql:"me"`
 	} `graphql:"updateMe(input: $input)"`
 }
+
+type signupOIDCMutation struct {
+	SignupOIDC struct {
+		User gqlmodel.User `graphql:"user"`
+	} `graphql:"signupOIDC(input: $input)"`
+}

--- a/server/api/internal/infrastructure/gql/user/repo.go
+++ b/server/api/internal/infrastructure/gql/user/repo.go
@@ -94,3 +94,33 @@ func (r *userRepo) UpdateMe(ctx context.Context, a user.UpdateAttrs) (*user.User
 
 	return util.ToMe(m.UpdateMe.Me)
 }
+
+func (r *userRepo) SignupOIDC(ctx context.Context, a user.SignupOIDCAttrs) (*user.User, error) {
+	in := SignupOIDCInput{}
+	if a.UserID != nil {
+		s := graphql.ID(a.UserID.String())
+		in.ID = &s
+	}
+	if a.Lang != nil {
+		langCode := graphql.String(a.Lang.String())
+		in.Lang = &langCode
+	}
+	if a.WorkspaceID != nil {
+		s := graphql.ID(a.WorkspaceID.String())
+		in.WorkspaceID = &s
+	}
+	if a.Secret != nil {
+		s := graphql.String(*a.Secret)
+		in.Secret = &s
+	}
+
+	var m signupOIDCMutation
+	vars := map[string]interface{}{
+		"input": in,
+	}
+	if err := r.client.Mutate(ctx, &m, vars); err != nil {
+		return nil, err
+	}
+
+	return util.ToUser(m.SignupOIDC.User)
+}

--- a/server/api/internal/infrastructure/gql/util/converter_user.go
+++ b/server/api/internal/infrastructure/gql/util/converter_user.go
@@ -35,7 +35,7 @@ func ToMe(m gqlmodel.Me) (*user.User, error) {
 		Build()
 }
 
-func toUser(u gqlmodel.User) (*user.User, error) {
+func ToUser(u gqlmodel.User) (*user.User, error) {
 	uid, err := user.IDFrom(string(u.ID))
 	if err != nil {
 		return nil, err
@@ -74,7 +74,7 @@ func ToUserFromSimple(u gqlmodel.UserSimple) (*user.User, error) {
 func ToUsers(gqlUsers []gqlmodel.User) (user.List, error) {
 	users := make(user.List, 0, len(gqlUsers))
 	for _, gu := range gqlUsers {
-		u, err := toUser(gu)
+		u, err := ToUser(gu)
 		if err != nil {
 			return nil, err
 		}

--- a/server/api/internal/usecase/interactor/user.go
+++ b/server/api/internal/usecase/interactor/user.go
@@ -36,3 +36,13 @@ func (i *User) UpdateMe(ctx context.Context, p interfaces.UpdateMeParam) (*user.
 	}
 	return i.userRepo.UpdateMe(ctx, attrs)
 }
+
+func (i *User) SignupOIDC(ctx context.Context, p interfaces.SignupOIDCParam) (*user.User, error) {
+	attrs := user.SignupOIDCAttrs{
+		UserID:      p.UserID,
+		Lang:        p.Lang,
+		WorkspaceID: p.WorkspaceID,
+		Secret:      p.Secret,
+	}
+	return i.userRepo.SignupOIDC(ctx, attrs)
+}

--- a/server/api/internal/usecase/interfaces/user.go
+++ b/server/api/internal/usecase/interfaces/user.go
@@ -16,8 +16,16 @@ type UpdateMeParam struct {
 	PasswordConfirmation *string
 }
 
+type SignupOIDCParam struct {
+	UserID      *id.UserID
+	Lang        *language.Tag
+	WorkspaceID *id.WorkspaceID
+	Secret      *string
+}
+
 type User interface {
 	FindByIDs(context.Context, id.UserIDList) (user.List, error)
 	UserByNameOrEmail(context.Context, string) (*user.User, error)
 	UpdateMe(context.Context, UpdateMeParam) (*user.User, error)
+	SignupOIDC(context.Context, SignupOIDCParam) (*user.User, error)
 }

--- a/server/api/pkg/user/mockrepo/mockrepo.go
+++ b/server/api/pkg/user/mockrepo/mockrepo.go
@@ -72,6 +72,21 @@ func (mr *MockUserRepoMockRecorder) FindMe(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindMe", reflect.TypeOf((*MockUserRepo)(nil).FindMe), ctx)
 }
 
+// SignupOIDC mocks base method.
+func (m *MockUserRepo) SignupOIDC(ctx context.Context, attrs user.SignupOIDCAttrs) (*user.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SignupOIDC", ctx, attrs)
+	ret0, _ := ret[0].(*user.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SignupOIDC indicates an expected call of SignupOIDC.
+func (mr *MockUserRepoMockRecorder) SignupOIDC(ctx, attrs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SignupOIDC", reflect.TypeOf((*MockUserRepo)(nil).SignupOIDC), ctx, attrs)
+}
+
 // UpdateMe mocks base method.
 func (m *MockUserRepo) UpdateMe(ctx context.Context, attrs user.UpdateAttrs) (*user.User, error) {
 	m.ctrl.T.Helper()

--- a/server/api/pkg/user/repo.go
+++ b/server/api/pkg/user/repo.go
@@ -12,4 +12,5 @@ type Repo interface {
 	FindByIDs(ctx context.Context, ids id.UserIDList) (List, error)
 	UserByNameOrEmail(ctx context.Context, nameOrEmail string) (*User, error)
 	UpdateMe(ctx context.Context, attrs UpdateAttrs) (*User, error)
+	SignupOIDC(ctx context.Context, attrs SignupOIDCAttrs) (*User, error)
 }

--- a/server/api/pkg/user/signup_oidc.go
+++ b/server/api/pkg/user/signup_oidc.go
@@ -1,0 +1,12 @@
+package user
+
+import (
+	"golang.org/x/text/language"
+)
+
+type SignupOIDCAttrs struct {
+	UserID      *ID
+	Lang        *language.Tag
+	WorkspaceID *WorkspaceID
+	Secret      *string
+}


### PR DESCRIPTION
# Overview

**The target branch is feat/replace-user-management-for-removememberofworkspace**

## What I've done

Replaced user management with accounts service for the Signup API

## What I’ve Confirmed Locally

I tested it and confirmed it works locally.

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
