### PR TITLE
fix(ui): re-enable handleNodeDragStop for Batch Nodes [FLOW-FE-257]

### DIFF
--- a/ui/src/features/Canvas/index.tsx
+++ b/ui/src/features/Canvas/index.tsx
@@ -78,6 +78,7 @@ const Canvas: React.FC<Props> = ({
   const {
     handleNodesDelete,
     handleNodeDragOver,
+    handleNodeDragStop,
     handleNodeDrop,
     handleNodeSettings,
     handleConnect,
@@ -129,6 +130,7 @@ const Canvas: React.FC<Props> = ({
       onEdgesChange={onEdgesChange}
       onNodeDoubleClick={handleNodeSettings}
       onNodeDragStart={handleCloseContextmenu}
+      onNodeDragStop={handleNodeDragStop}
       onNodesDelete={handleNodesDelete}
       onNodeContextMenu={handleNodeContextMenu}
       onSelectionContextMenu={handleSelectionContextMenu}


### PR DESCRIPTION
# Overview
Batch nodes would only work on resize and not when dragging and dropping a node into it.
## What I've done
Reenabled the `handleNodeDragStop` function which seemed to have been deactivated.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
I have tested and cannot see any adverse effects from said function, so unsure why this was commented out. 