### PR TITLE
fix(ui): prevent default for reader, transformers and writer dialog

### DIFF
--- a/ui/src/features/Canvas/hooks.ts
+++ b/ui/src/features/Canvas/hooks.ts
@@ -160,12 +160,15 @@ export default ({
     const hasModifier = event.metaKey || event.ctrlKey;
     switch (handler.keys?.join("")) {
       case "r":
+        event.preventDefault();
         onNodePickerOpen?.({ x: 0, y: 0 }, "reader", true);
         break;
       case "t":
+        event.preventDefault();
         onNodePickerOpen?.({ x: 0, y: 0 }, "transformer");
         break;
       case "w":
+        event.preventDefault();
         onNodePickerOpen?.({ x: 0, y: 0 }, "writer", true);
         break;
       case "c":


### PR DESCRIPTION
# Overview
PR fixes an issue for when the user would hit the shortcut key for either reader, transformers or writer it would write that letter in the dialog input.
## What I've done
Added an `event.preventDefault();` to each of these cases in the switch case
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
