### PR TITLE
fix(websocket): remove unused variable in BroadcastGroup sync logic

### DIFF
--- a/server/websocket/src/broadcast/group.rs
+++ b/server/websocket/src/broadcast/group.rs
@@ -278,7 +278,6 @@ impl BroadcastGroup {
                         let awareness = awareness_clone.read().await;
                         let txn = awareness.doc().transact();
                         let state_vector = txn.state_vector();
-                        let doc_name = awareness_clone.read().await.client_id();
 
                         let sync_msg = Message::Sync(SyncMessage::SyncStep1(state_vector));
                         let encoded_msg = sync_msg.encode_v1();


### PR DESCRIPTION
- Eliminated the unused `doc_name` variable from the sync message handling in the BroadcastGroup, streamlining the code for better readability and performance.

# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
