### PR TITLE
feat(server): replace user management to accounts for RemoveMyAuth [FLOW-BE-191]

### DIFF
--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -120,7 +120,7 @@ func conditionalGraphQLAuthMiddleware(
 				switch body.OperationName {
 				case "GetMe":
 					middlewares = tempNewAuthMWs
-				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace", "UpdateMemberOfWorkspace", "RemoveMemberFromWorkspace", "Signup":
+				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace", "UpdateMemberOfWorkspace", "RemoveMemberFromWorkspace", "Signup", "RemoveMyAuth":
 					middlewares = append(defaultMWs, tempNewAuthMWs...)
 				}
 			}

--- a/server/api/internal/infrastructure/gql/user/input.go
+++ b/server/api/internal/infrastructure/gql/user/input.go
@@ -18,3 +18,7 @@ type SignupOIDCInput struct {
 	WorkspaceID *graphql.ID     `json:"workspaceId,omitempty"`
 	Secret      *graphql.String `json:"secret,omitempty"`
 }
+
+type RemoveMyAuthInput struct {
+	Auth graphql.String `json:"auth"`
+}

--- a/server/api/internal/infrastructure/gql/user/mutation.go
+++ b/server/api/internal/infrastructure/gql/user/mutation.go
@@ -15,3 +15,9 @@ type signupOIDCMutation struct {
 		User gqlmodel.User `graphql:"user"`
 	} `graphql:"signupOIDC(input: $input)"`
 }
+
+type removeMyAuthMutation struct {
+	RemoveMyAuth struct {
+		Me gqlmodel.Me `graphql:"me"`
+	} `graphql:"removeMyAuth(input: $input)"`
+}

--- a/server/api/internal/infrastructure/gql/user/repo.go
+++ b/server/api/internal/infrastructure/gql/user/repo.go
@@ -124,3 +124,23 @@ func (r *userRepo) SignupOIDC(ctx context.Context, a user.SignupOIDCAttrs) (*use
 
 	return util.ToUser(m.SignupOIDC.User)
 }
+
+func (r *userRepo) RemoveMyAuth(ctx context.Context, authProvider string) (*user.User, error) {
+	if authProvider == "" {
+		return nil, nil
+	}
+
+	in := RemoveMyAuthInput{
+		Auth: graphql.String(string(authProvider)),
+	}
+
+	var m removeMyAuthMutation
+	vars := map[string]interface{}{
+		"input": in,
+	}
+	if err := r.client.Mutate(ctx, &m, vars); err != nil {
+		return nil, err
+	}
+
+	return util.ToMe(m.RemoveMyAuth.Me)
+}

--- a/server/api/internal/usecase/interactor/user.go
+++ b/server/api/internal/usecase/interactor/user.go
@@ -46,3 +46,7 @@ func (i *User) SignupOIDC(ctx context.Context, p interfaces.SignupOIDCParam) (*u
 	}
 	return i.userRepo.SignupOIDC(ctx, attrs)
 }
+
+func (i *User) RemoveMyAuth(ctx context.Context, authProvider string) (*user.User, error) {
+	return i.userRepo.RemoveMyAuth(ctx, authProvider)
+}

--- a/server/api/internal/usecase/interfaces/user.go
+++ b/server/api/internal/usecase/interfaces/user.go
@@ -28,4 +28,5 @@ type User interface {
 	UserByNameOrEmail(context.Context, string) (*user.User, error)
 	UpdateMe(context.Context, UpdateMeParam) (*user.User, error)
 	SignupOIDC(context.Context, SignupOIDCParam) (*user.User, error)
+	RemoveMyAuth(context.Context, string) (*user.User, error)
 }

--- a/server/api/pkg/user/mockrepo/mockrepo.go
+++ b/server/api/pkg/user/mockrepo/mockrepo.go
@@ -72,6 +72,21 @@ func (mr *MockUserRepoMockRecorder) FindMe(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindMe", reflect.TypeOf((*MockUserRepo)(nil).FindMe), ctx)
 }
 
+// RemoveMyAuth mocks base method.
+func (m *MockUserRepo) RemoveMyAuth(ctx context.Context, authProvider string) (*user.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveMyAuth", ctx, authProvider)
+	ret0, _ := ret[0].(*user.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveMyAuth indicates an expected call of RemoveMyAuth.
+func (mr *MockUserRepoMockRecorder) RemoveMyAuth(ctx, authProvider any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMyAuth", reflect.TypeOf((*MockUserRepo)(nil).RemoveMyAuth), ctx, authProvider)
+}
+
 // SignupOIDC mocks base method.
 func (m *MockUserRepo) SignupOIDC(ctx context.Context, attrs user.SignupOIDCAttrs) (*user.User, error) {
 	m.ctrl.T.Helper()

--- a/server/api/pkg/user/repo.go
+++ b/server/api/pkg/user/repo.go
@@ -13,4 +13,5 @@ type Repo interface {
 	UserByNameOrEmail(ctx context.Context, nameOrEmail string) (*User, error)
 	UpdateMe(ctx context.Context, attrs UpdateAttrs) (*User, error)
 	SignupOIDC(ctx context.Context, attrs SignupOIDCAttrs) (*User, error)
+	RemoveMyAuth(ctx context.Context, authProvider string) (*User, error)
 }


### PR DESCRIPTION
# Overview

## What I've done

Replaced user management with accounts service for the RemoveMyAuth API

## What I’ve Confirmed Locally

I tested it and confirmed it works locally.
https://www.notion.so/eukarya/Epic-Replace-user-management-in-API-with-reearth-accounts-24616e0fb16580aaa44eeb852b769a8a?source=copy_link#26b16e0fb165802ab46bff608180a6be

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
