### PR TITLE
fix(websocket): adjust configuration for authentication feature

### DIFF
--- a/server/websocket/src/conf.rs
+++ b/server/websocket/src/conf.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "auth")]
+use crate::domain::value_objects::conf::DEFAULT_AUTH_URL;
 use crate::domain::value_objects::conf::{
-    DEFAULT_APP_ENV, DEFAULT_AUTH_URL, DEFAULT_GCS_BUCKET, DEFAULT_ORIGINS, DEFAULT_REDIS_TTL,
-    DEFAULT_REDIS_URL, DEFAULT_WS_PORT,
+    DEFAULT_APP_ENV, DEFAULT_GCS_BUCKET, DEFAULT_ORIGINS, DEFAULT_REDIS_TTL, DEFAULT_REDIS_URL,
+    DEFAULT_WS_PORT,
 };
 use dotenv;
 use serde::Deserialize;
@@ -63,12 +65,9 @@ impl Config {
         if let Ok(endpoint) = env::var("REEARTH_FLOW_GCS_ENDPOINT") {
             builder = builder.gcs_endpoint(Some(endpoint));
         }
-
         #[cfg(feature = "auth")]
-        {
-            if let Ok(url) = env::var("REEARTH_FLOW_THRIFT_AUTH_URL") {
-                builder = builder.auth_url(url);
-            }
+        if let Ok(url) = env::var("REEARTH_FLOW_THRIFT_AUTH_URL") {
+            builder = builder.auth_url(url);
         }
 
         if let Ok(env_val) = env::var("REEARTH_FLOW_APP_ENV") {

--- a/server/websocket/src/lib.rs
+++ b/server/websocket/src/lib.rs
@@ -55,10 +55,13 @@ pub use auth::AuthService;
 pub use broadcast::sub::Subscription;
 pub use conf::Config;
 pub use domain::value_objects::conf::{
-    DEFAULT_APP_ENV, DEFAULT_AUTH_URL, DEFAULT_GCS_BUCKET, DEFAULT_ORIGINS, DEFAULT_REDIS_TTL,
-    DEFAULT_REDIS_URL, DEFAULT_WS_PORT,
+    DEFAULT_APP_ENV, DEFAULT_GCS_BUCKET, DEFAULT_ORIGINS, DEFAULT_REDIS_TTL, DEFAULT_REDIS_URL,
+    DEFAULT_WS_PORT,
 };
 pub use domain::value_objects::http::*;
+
+#[cfg(feature = "auth")]
+pub use domain::value_objects::conf::DEFAULT_AUTH_URL;
 pub use domain::value_objects::redis::{
     RedisConfig, RedisField, RedisFields, RedisPool, RedisStreamMessage, RedisStreamResult,
     RedisStreamResults, StreamMessages, MESSAGE_TYPE_AWARENESS, MESSAGE_TYPE_SYNC, OID_LOCK_KEY,


### PR DESCRIPTION
- Moved the `DEFAULT_AUTH_URL` import to be conditional based on the `auth` feature flag.
- Simplified the logic for setting the authentication URL in the configuration builder by removing unnecessary block structure.
- Ensured that the configuration remains clean and maintainable while supporting the authentication feature.

# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
