### PR TITLE
fix(ui): Added Multipolygon and Multiline support 

### DIFF
--- a/ui/src/components/visualizations/MapLibre/sources/GeoJson/index.tsx
+++ b/ui/src/components/visualizations/MapLibre/sources/GeoJson/index.tsx
@@ -258,10 +258,6 @@ const GeoJsonDataSource: React.FC<Props> = ({
     [fileContent?.features],
   );
 
-  console.log("hasPointFeatures", hasPointFeatures);
-  console.log("hasLineStringFeatures", hasLineStringFeatures);
-  console.log("hasPolygonFeatures", hasPolygonFeatures);
-
   return (
     <Source
       id={SOURCE_ID}


### PR DESCRIPTION
# Overview
This PR adds support for MultiPolygon and MultiLineString geometry types to a MapLibre GeoJSON data source component. The changes ensure that multi-geometry types are handled consistently alongside their single-geometry counterparts for rendering and feature detection.
## What I've done

- Extended geometry type filters to include MultiLineString and MultiPolygon variants
- Updated feature detection logic to identify both single and multi-geometry types
- Maintained consistent styling and behavior between single and multi-geometry types

## What I haven't done

## How I tested

## Screenshot
<img width="1432" height="635" alt="Screenshot 2025-09-16 at 14 49 59" src="https://github.com/user-attachments/assets/1a615d62-0dfe-4bd3-90f6-4d6a90084537" />

## Which point I want you to review particularly

## Memo
