### PR TITLE
feat(server): replace user management to accounts for DeleteMe [FLOW-BE-191]

### DIFF
--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -120,7 +120,7 @@ func conditionalGraphQLAuthMiddleware(
 				switch body.OperationName {
 				case "GetMe":
 					middlewares = tempNewAuthMWs
-				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace", "UpdateMemberOfWorkspace", "RemoveMemberFromWorkspace", "Signup", "RemoveMyAuth":
+				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace", "UpdateMemberOfWorkspace", "RemoveMemberFromWorkspace", "Signup", "RemoveMyAuth", "DeleteMe":
 					middlewares = append(defaultMWs, tempNewAuthMWs...)
 				}
 			}

--- a/server/api/internal/infrastructure/gql/user/input.go
+++ b/server/api/internal/infrastructure/gql/user/input.go
@@ -22,3 +22,7 @@ type SignupOIDCInput struct {
 type RemoveMyAuthInput struct {
 	Auth graphql.String `json:"auth"`
 }
+
+type DeleteMeInput struct {
+	ID graphql.ID `json:"userId"`
+}

--- a/server/api/internal/infrastructure/gql/user/mutation.go
+++ b/server/api/internal/infrastructure/gql/user/mutation.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"github.com/hasura/go-graphql-client"
 	"github.com/reearth/reearth-flow/api/internal/infrastructure/gql/gqlmodel"
 )
 
@@ -20,4 +21,10 @@ type removeMyAuthMutation struct {
 	RemoveMyAuth struct {
 		Me gqlmodel.Me `graphql:"me"`
 	} `graphql:"removeMyAuth(input: $input)"`
+}
+
+type deleteMeMutation struct {
+	DeleteMe struct {
+		ID graphql.ID `graphql:"userId"`
+	} `graphql:"deleteMe(input: $input)"`
 }

--- a/server/api/internal/infrastructure/gql/user/repo.go
+++ b/server/api/internal/infrastructure/gql/user/repo.go
@@ -144,3 +144,19 @@ func (r *userRepo) RemoveMyAuth(ctx context.Context, authProvider string) (*user
 
 	return util.ToMe(m.RemoveMyAuth.Me)
 }
+
+func (r *userRepo) DeleteMe(ctx context.Context, uid id.UserID) error {
+	in := DeleteMeInput{
+		ID: graphql.ID(uid.String()),
+	}
+
+	var m deleteMeMutation
+	vars := map[string]interface{}{
+		"input": in,
+	}
+	if err := r.client.Mutate(ctx, &m, vars); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/server/api/internal/usecase/interactor/user.go
+++ b/server/api/internal/usecase/interactor/user.go
@@ -50,3 +50,7 @@ func (i *User) SignupOIDC(ctx context.Context, p interfaces.SignupOIDCParam) (*u
 func (i *User) RemoveMyAuth(ctx context.Context, authProvider string) (*user.User, error) {
 	return i.userRepo.RemoveMyAuth(ctx, authProvider)
 }
+
+func (i *User) DeleteMe(ctx context.Context, uid id.UserID) error {
+	return i.userRepo.DeleteMe(ctx, uid)
+}

--- a/server/api/internal/usecase/interfaces/user.go
+++ b/server/api/internal/usecase/interfaces/user.go
@@ -29,4 +29,5 @@ type User interface {
 	UpdateMe(context.Context, UpdateMeParam) (*user.User, error)
 	SignupOIDC(context.Context, SignupOIDCParam) (*user.User, error)
 	RemoveMyAuth(context.Context, string) (*user.User, error)
+	DeleteMe(context.Context, id.UserID) error
 }

--- a/server/api/pkg/user/mockrepo/mockrepo.go
+++ b/server/api/pkg/user/mockrepo/mockrepo.go
@@ -42,6 +42,20 @@ func (m *MockUserRepo) EXPECT() *MockUserRepoMockRecorder {
 	return m.recorder
 }
 
+// DeleteMe mocks base method.
+func (m *MockUserRepo) DeleteMe(ctx context.Context, uid id.UserID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteMe", ctx, uid)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteMe indicates an expected call of DeleteMe.
+func (mr *MockUserRepoMockRecorder) DeleteMe(ctx, uid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMe", reflect.TypeOf((*MockUserRepo)(nil).DeleteMe), ctx, uid)
+}
+
 // FindByIDs mocks base method.
 func (m *MockUserRepo) FindByIDs(ctx context.Context, ids id.UserIDList) (user.List, error) {
 	m.ctrl.T.Helper()

--- a/server/api/pkg/user/repo.go
+++ b/server/api/pkg/user/repo.go
@@ -14,4 +14,5 @@ type Repo interface {
 	UpdateMe(ctx context.Context, attrs UpdateAttrs) (*User, error)
 	SignupOIDC(ctx context.Context, attrs SignupOIDCAttrs) (*User, error)
 	RemoveMyAuth(ctx context.Context, authProvider string) (*User, error)
+	DeleteMe(ctx context.Context, uid id.UserID) error
 }


### PR DESCRIPTION
# Overview

## What I've done

Replaced user management with accounts service for the DeleteMe API

## What I’ve Confirmed Locally

I tested it and confirmed it works locally.
https://www.notion.so/eukarya/Epic-Replace-user-management-in-API-with-reearth-accounts-24616e0fb16580aaa44eeb852b769a8a?source=copy_link#27016e0fb165808cb505c64bb14fce9b

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
