### PR TITLE
feat(server): remove reearthx.usecase of user and workspace from gql.adapter [FLOW-BE-191]

### DIFF
--- a/server/api/e2e/gql_asset_test.go
+++ b/server/api/e2e/gql_asset_test.go
@@ -19,7 +19,7 @@ func TestQueryAssets(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Query assets for the workspace
 	query := fmt.Sprintf(`query { assets(workspaceId: "%s", pagination: {page: 1, pageSize: 10}) { nodes { id fileName size contentType } totalCount } }`, wId1)
@@ -45,7 +45,7 @@ func TestCreateAsset(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create multipart form with file upload
 	body := &bytes.Buffer{}
@@ -97,7 +97,7 @@ func TestDeleteAsset(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create an asset first
 	body := &bytes.Buffer{}
@@ -173,7 +173,7 @@ func TestAssetSorting(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create multiple assets
 	fileNames := []string{"b.png", "a.png", "c.png"}
@@ -235,7 +235,7 @@ func TestAssetKeywordSearch(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create assets with different names
 	fileNames := []string{"document.pdf", "image.png", "data.csv"}
@@ -295,7 +295,7 @@ func TestWorkspaceAssetsQuery(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Query workspace with assets field - should return empty
 	query := fmt.Sprintf(`query { node(id: "%s", type: WORKSPACE) { ... on Workspace { id assets(pagination: {page: 1, pageSize: 10}) { nodes { id } totalCount } } } }`, wId1)

--- a/server/api/e2e/gql_deployment_pagination_test.go
+++ b/server/api/e2e/gql_deployment_pagination_test.go
@@ -20,7 +20,7 @@ func TestDeploymentsPagination(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Log workspace and user info
 	t.Log("Workspace ID:", wId1.String())

--- a/server/api/e2e/gql_pagination_test.go
+++ b/server/api/e2e/gql_pagination_test.go
@@ -19,7 +19,7 @@ func TestProjectsPagination(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create multiple projects for testing
 	projectIDs := make([]string, 5)
@@ -262,7 +262,7 @@ func TestJobsPagination(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	deploymentQuery := `mutation($input: CreateDeploymentInput!) {
 		createDeployment(input: $input) {
@@ -663,7 +663,7 @@ func TestTriggersPagination(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create a test deployment first
 	deploymentId := createTestDeployment(t, e)

--- a/server/api/e2e/gql_param_test.go
+++ b/server/api/e2e/gql_param_test.go
@@ -74,7 +74,7 @@ func TestDeclareParameter(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create a test project first
 	projectID := createTestProject(t, e)
@@ -221,7 +221,7 @@ func TestUpdateParameter(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create a test project first
 	projectID := createTestProject(t, e)
@@ -323,7 +323,7 @@ func TestUpdateParameterOrder(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create a test project first
 	projectID := createTestProject(t, e)
@@ -424,7 +424,7 @@ func TestRemoveParameter(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create a test project first
 	projectID := createTestProject(t, e)
@@ -506,7 +506,7 @@ func TestParametersQuery(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create a test project first
 	projectID := createTestProject(t, e)

--- a/server/api/e2e/gql_projectAccess_test.go
+++ b/server/api/e2e/gql_projectAccess_test.go
@@ -101,7 +101,7 @@ func TestProjectShareFlow(t *testing.T) {
 		},
 		Host:       "https://example.com",
 		SharedPath: "shared",
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// create a project
 	pId := testCreateProject(t, e)

--- a/server/api/e2e/gql_project_test.go
+++ b/server/api/e2e/gql_project_test.go
@@ -18,7 +18,7 @@ func TestProjectWorkflows(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	projectId := testCreateProject(t, e)
 
@@ -229,7 +229,7 @@ func TestListProjects(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	// Create test projects
 	projectIDs := make([]string, 3)

--- a/server/api/e2e/gql_trigger_test.go
+++ b/server/api/e2e/gql_trigger_test.go
@@ -18,7 +18,7 @@ func TestCreateTimeDrivenTrigger(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	deploymentId := createTestDeployment(t, e)
 	assert.NotEmpty(t, deploymentId)
@@ -194,7 +194,7 @@ func TestUpdateTrigger(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	deploymentId := createTestDeployment(t, e)
 	query := `mutation($input: CreateTriggerInput!) {
@@ -304,7 +304,7 @@ func TestCreateAPIDrivenTrigger(t *testing.T) {
 		AuthSrv: config.AuthSrvConfig{
 			Disabled: true,
 		},
-	}, true, baseSeederUser, true)
+	}, true, baseSeederUser, true, nil)
 
 	deploymentId := createTestDeployment(t, e)
 	assert.NotEmpty(t, deploymentId)

--- a/server/api/internal/adapter/context.go
+++ b/server/api/internal/adapter/context.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/reearth/reearth-flow/api/internal/usecase"
 	"github.com/reearth/reearth-flow/api/internal/usecase/interfaces"
-	pkguser "github.com/reearth/reearth-flow/api/pkg/user"
-	"github.com/reearth/reearthx/account/accountdomain/user"
+	"github.com/reearth/reearth-flow/api/pkg/user"
+	reearthxuser "github.com/reearth/reearthx/account/accountdomain/user"
 	"github.com/reearth/reearthx/appx"
 	"golang.org/x/text/language"
 )
 
-type flowUserKey struct{}
+type userKey struct{}
 type jwtTokenKey struct{}
 type gqlOperationNameKey struct{}
 
@@ -35,14 +35,13 @@ type AuthInfo struct {
 	EmailVerified *bool
 }
 
-func AttachUser(ctx context.Context, u *user.User) context.Context {
+// TODO: After migration, remove this function
+func AttachReearthxUser(ctx context.Context, u *reearthxuser.User) context.Context {
 	return context.WithValue(ctx, contextUser, u)
 }
 
-// TODO: Keep using AttachUser during the migration period.
-// After migration, unify it so that AttachUser returns a FlowUser (from flow/pkg).
-func AttachFlowUser(ctx context.Context, u *pkguser.User) context.Context {
-	return context.WithValue(ctx, flowUserKey{}, u)
+func AttachUser(ctx context.Context, u *user.User) context.Context {
+	return context.WithValue(ctx, userKey{}, u)
 }
 
 func AttachOperator(ctx context.Context, o *usecase.Operator) context.Context {
@@ -66,19 +65,18 @@ func AttachGQLOperationName(ctx context.Context, op string) context.Context {
 	return context.WithValue(ctx, gqlOperationNameKey{}, op)
 }
 
-func User(ctx context.Context) *user.User {
+// TODO: After migration, remove this function
+func ReearthxUser(ctx context.Context) *reearthxuser.User {
 	if v := ctx.Value(contextUser); v != nil {
-		if u, ok := v.(*user.User); ok {
+		if u, ok := v.(*reearthxuser.User); ok {
 			return u
 		}
 	}
 	return nil
 }
 
-// TODO: Keep using User during the migration period.
-// After migration, unify it so that User returns a FlowUser (from flow/pkg).
-func FlowUser(ctx context.Context) *pkguser.User {
-	u, _ := ctx.Value(flowUserKey{}).(*pkguser.User)
+func User(ctx context.Context) *user.User {
+	u, _ := ctx.Value(userKey{}).(*user.User)
 	return u
 }
 
@@ -87,7 +85,7 @@ func Lang(ctx context.Context, lang *language.Tag) string {
 		return lang.String()
 	}
 
-	u := User(ctx)
+	u := ReearthxUser(ctx)
 	if u == nil {
 		return defaultLang.String()
 	}

--- a/server/api/internal/adapter/gql/context.go
+++ b/server/api/internal/adapter/gql/context.go
@@ -4,11 +4,8 @@ import (
 	"context"
 
 	"github.com/reearth/reearth-flow/api/internal/adapter"
-	"github.com/reearth/reearth-flow/api/internal/usecase"
 	"github.com/reearth/reearth-flow/api/internal/usecase/interfaces"
-	pkguser "github.com/reearth/reearth-flow/api/pkg/user"
-	"github.com/reearth/reearthx/account/accountdomain/user"
-	"github.com/reearth/reearthx/account/accountusecase"
+	"github.com/reearth/reearth-flow/api/pkg/user"
 )
 
 type ContextKey string
@@ -31,23 +28,6 @@ func AttachUsecases(ctx context.Context, u *interfaces.Container, enableDataLoad
 
 func getUser(ctx context.Context) *user.User {
 	return adapter.User(ctx)
-}
-
-// TODO: Keep using getUser during the migration period.
-// After migration, unify it so that getUser returns a FlowUser (from flow/pkg).
-func getFlowUser(ctx context.Context) *pkguser.User {
-	return adapter.FlowUser(ctx)
-}
-
-func getOperator(ctx context.Context) *usecase.Operator {
-	return adapter.Operator(ctx)
-}
-
-func getAcOperator(ctx context.Context) *accountusecase.Operator {
-	if op := getOperator(ctx); op != nil {
-		return op.AcOperator
-	}
-	return nil
 }
 
 func usecases(ctx context.Context) *interfaces.Container {

--- a/server/api/internal/adapter/gql/gqlmodel/convert_user.go
+++ b/server/api/internal/adapter/gql/gqlmodel/convert_user.go
@@ -8,22 +8,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-func ToUser(u *user.User) *User {
-	if u == nil {
-		return nil
-	}
-
-	return &User{
-		ID:       IDFrom(u.ID()),
-		Name:     u.Name(),
-		Email:    u.Email(),
-		Host:     lo.EmptyableToPtr(u.Host()),
-		Metadata: ToUserMetadataFromAccount(u.Metadata()),
-	}
-}
-
-// TODO: After migration, delete ToUser and rename ToUserFromFlow to ToUser.
-func ToUserFromFlow(u *pkguser.User) *User {
+func ToUser(u *pkguser.User) *User {
 	if u == nil {
 		return nil
 	}
@@ -56,31 +41,7 @@ func ToUserFromSimple(u *user.Simple) *User {
 	}
 }
 
-func ToMe(u *user.User) *Me {
-	if u == nil {
-		return nil
-	}
-
-	lang := language.English // Default language
-	if u.Metadata() != nil {
-		lang = u.Metadata().Lang()
-	}
-
-	return &Me{
-		ID:            IDFrom(u.ID()),
-		Name:          u.Name(),
-		Email:         u.Email(),
-		Lang:          lang,
-		MyWorkspaceID: IDFrom(u.Workspace()),
-		Auths: util.Map(u.Auths(), func(a user.Auth) string {
-			return a.Provider
-		}),
-	}
-}
-
-// TODO: Keep using ToMe during the migration period.
-// After migration, ToMe will be updated to handle FlowUser (from flow/pkg) and ToMeFromFlow will be removed.
-func ToMeFromFlow(u *pkguser.User) *Me {
+func ToMe(u *pkguser.User) *Me {
 	if u == nil {
 		return nil
 	}

--- a/server/api/internal/adapter/gql/gqlmodel/convert_workspace.go
+++ b/server/api/internal/adapter/gql/gqlmodel/convert_workspace.go
@@ -5,30 +5,7 @@ import (
 	"github.com/reearth/reearthx/account/accountdomain/workspace"
 )
 
-func ToWorkspace(t *workspace.Workspace) *Workspace {
-	if t == nil {
-		return nil
-	}
-
-	memberMap := t.Members().Users()
-	members := make([]*WorkspaceMember, 0, len(memberMap))
-	for u, r := range memberMap {
-		members = append(members, &WorkspaceMember{
-			UserID: IDFrom(u),
-			Role:   ToRole(r.Role),
-		})
-	}
-
-	return &Workspace{
-		ID:       IDFrom(t.ID()),
-		Name:     t.Name(),
-		Personal: t.IsPersonal(),
-		Members:  members,
-	}
-}
-
-// TODO: After migration, delete ToWorkspace and rename ToWorkspaceFromFlow to ToWorkspace.
-func ToWorkspaceFromFlow(t *pkgworkspace.Workspace) *Workspace {
+func ToWorkspace(t *pkgworkspace.Workspace) *Workspace {
 	if t == nil {
 		return nil
 	}
@@ -79,22 +56,7 @@ func ToRole(r workspace.Role) Role {
 	return Role("")
 }
 
-func FromRole(r Role) workspace.Role {
-	switch r {
-	case RoleReader:
-		return workspace.RoleReader
-	case RoleWriter:
-		return workspace.RoleWriter
-	case RoleMaintainer:
-		return workspace.RoleMaintainer
-	case RoleOwner:
-		return workspace.RoleOwner
-	}
-	return workspace.Role("")
-}
-
-// TODO: After migration, delete FromRole and rename FromRoleToFlow to FromRole.
-func FromRoleToFlow(r Role) pkgworkspace.Role {
+func FromRole(r Role) pkgworkspace.Role {
 	switch r {
 	case RoleReader:
 		return pkgworkspace.RoleReader

--- a/server/api/internal/adapter/gql/gqlmodel/convert_workspace.go
+++ b/server/api/internal/adapter/gql/gqlmodel/convert_workspace.go
@@ -1,11 +1,11 @@
 package gqlmodel
 
 import (
-	pkgworkspace "github.com/reearth/reearth-flow/api/pkg/workspace"
-	"github.com/reearth/reearthx/account/accountdomain/workspace"
+	"github.com/reearth/reearth-flow/api/pkg/workspace"
+	reearthxworkspace "github.com/reearth/reearthx/account/accountdomain/workspace"
 )
 
-func ToWorkspace(t *pkgworkspace.Workspace) *Workspace {
+func ToWorkspace(t *workspace.Workspace) *Workspace {
 	if t == nil {
 		return nil
 	}
@@ -14,7 +14,7 @@ func ToWorkspace(t *pkgworkspace.Workspace) *Workspace {
 
 	for _, member := range t.Members() {
 		switch m := member.(type) {
-		case pkgworkspace.UserMember:
+		case workspace.UserMember:
 			workspaceMember := &WorkspaceMember{
 				UserID: IDFrom(m.UserID),
 				Role:   Role(m.Role),
@@ -28,7 +28,7 @@ func ToWorkspace(t *pkgworkspace.Workspace) *Workspace {
 				}
 			}
 			members = append(members, workspaceMember)
-		case pkgworkspace.IntegrationMember:
+		case workspace.IntegrationMember:
 			// For IntegrationMember, the current WorkspaceMember structure does not support it.
 			continue
 		}
@@ -42,30 +42,46 @@ func ToWorkspace(t *pkgworkspace.Workspace) *Workspace {
 	}
 }
 
-func ToRole(r workspace.Role) Role {
+// TODO: After migration, rename this function to ToRole
+func ToRoleFromReearthx(r reearthxworkspace.Role) Role {
 	switch r {
-	case workspace.RoleReader:
+	case reearthxworkspace.RoleReader:
 		return RoleReader
-	case workspace.RoleWriter:
+	case reearthxworkspace.RoleWriter:
 		return RoleWriter
-	case workspace.RoleMaintainer:
+	case reearthxworkspace.RoleMaintainer:
 		return RoleMaintainer
-	case workspace.RoleOwner:
+	case reearthxworkspace.RoleOwner:
 		return RoleOwner
 	}
 	return Role("")
 }
 
-func FromRole(r Role) pkgworkspace.Role {
+// TODO: After migration, remove this function
+func FromRoleToReearthx(r Role) reearthxworkspace.Role {
 	switch r {
 	case RoleReader:
-		return pkgworkspace.RoleReader
+		return reearthxworkspace.RoleReader
 	case RoleWriter:
-		return pkgworkspace.RoleWriter
+		return reearthxworkspace.RoleWriter
 	case RoleMaintainer:
-		return pkgworkspace.RoleMaintainer
+		return reearthxworkspace.RoleMaintainer
 	case RoleOwner:
-		return pkgworkspace.RoleOwner
+		return reearthxworkspace.RoleOwner
 	}
-	return pkgworkspace.Role("")
+	return reearthxworkspace.Role("")
+}
+
+func FromRole(r Role) workspace.Role {
+	switch r {
+	case RoleReader:
+		return workspace.RoleReader
+	case RoleWriter:
+		return workspace.RoleWriter
+	case RoleMaintainer:
+		return workspace.RoleMaintainer
+	case RoleOwner:
+		return workspace.RoleOwner
+	}
+	return workspace.Role("")
 }

--- a/server/api/internal/adapter/gql/gqlmodel/convert_workspace_test.go
+++ b/server/api/internal/adapter/gql/gqlmodel/convert_workspace_test.go
@@ -8,17 +8,17 @@ import (
 )
 
 func TestToRole(t *testing.T) {
-	assert.Equal(t, Role(RoleOwner), ToRole(workspace.RoleOwner))
-	assert.Equal(t, Role(RoleMaintainer), ToRole(workspace.RoleMaintainer))
-	assert.Equal(t, Role(RoleWriter), ToRole(workspace.RoleWriter))
-	assert.Equal(t, Role(RoleReader), ToRole(workspace.RoleReader))
-	assert.Equal(t, Role(""), ToRole(workspace.Role("unknown")))
+	assert.Equal(t, Role(RoleOwner), ToRoleFromReearthx(workspace.RoleOwner))
+	assert.Equal(t, Role(RoleMaintainer), ToRoleFromReearthx(workspace.RoleMaintainer))
+	assert.Equal(t, Role(RoleWriter), ToRoleFromReearthx(workspace.RoleWriter))
+	assert.Equal(t, Role(RoleReader), ToRoleFromReearthx(workspace.RoleReader))
+	assert.Equal(t, Role(""), ToRoleFromReearthx(workspace.Role("unknown")))
 }
 
 func TestFromRole(t *testing.T) {
-	assert.Equal(t, workspace.RoleOwner, FromRole(RoleOwner))
-	assert.Equal(t, workspace.RoleMaintainer, FromRole(RoleMaintainer))
-	assert.Equal(t, workspace.RoleWriter, FromRole(RoleWriter))
-	assert.Equal(t, workspace.RoleReader, FromRole(RoleReader))
-	assert.Equal(t, workspace.Role(""), FromRole("unknown"))
+	assert.Equal(t, workspace.RoleOwner, FromRoleToReearthx(RoleOwner))
+	assert.Equal(t, workspace.RoleMaintainer, FromRoleToReearthx(RoleMaintainer))
+	assert.Equal(t, workspace.RoleWriter, FromRoleToReearthx(RoleWriter))
+	assert.Equal(t, workspace.RoleReader, FromRoleToReearthx(RoleReader))
+	assert.Equal(t, workspace.Role(""), FromRoleToReearthx("unknown"))
 }

--- a/server/api/internal/adapter/gql/loader.go
+++ b/server/api/internal/adapter/gql/loader.go
@@ -51,8 +51,8 @@ func NewLoaders(usecases *interfaces.Container) *Loaders {
 		Parameter:  NewParameterLoader(usecases.Parameter),
 		Project:    NewProjectLoader(usecases.Project),
 		Trigger:    NewTriggerLoader(usecases.Trigger),
-		User:       NewUserLoader(usecases.User, usecases.TempNewUser),                // TODO: After migration, remove accountinterfaces.User and rename tempNewUsecase to usecase.
-		Workspace:  NewWorkspaceLoader(usecases.Workspace, usecases.TempNewWorkspace), // TODO: After migration, remove accountinterfaces.Workspace and rename tempNewUsecase to usecase.
+		User:       NewUserLoader(usecases.User),
+		Workspace:  NewWorkspaceLoader(usecases.Workspace),
 	}
 }
 

--- a/server/api/internal/adapter/gql/loader_user.go
+++ b/server/api/internal/adapter/gql/loader_user.go
@@ -2,76 +2,31 @@ package gql
 
 import (
 	"context"
-	"log"
 
 	"github.com/reearth/reearth-flow/api/internal/adapter/gql/gqldataloader"
 	"github.com/reearth/reearth-flow/api/internal/adapter/gql/gqlmodel"
 	"github.com/reearth/reearth-flow/api/internal/usecase/interfaces"
 	"github.com/reearth/reearth-flow/api/pkg/id"
-	"github.com/reearth/reearthx/account/accountdomain"
-	"github.com/reearth/reearthx/account/accountusecase/accountinterfaces"
 	"github.com/reearth/reearthx/util"
 )
 
-// TODO: After migration, remove accountinterfaces.User and rename tempNewUsecase to usecase.
 type UserLoader struct {
-	usecase        accountinterfaces.User
-	tempNewUsecase interfaces.User
+	usecase interfaces.User
 }
 
-func NewUserLoader(usecase accountinterfaces.User, tempNewUsecase interfaces.User) *UserLoader {
+func NewUserLoader(usecase interfaces.User) *UserLoader {
 	return &UserLoader{
-		usecase:        usecase,
-		tempNewUsecase: tempNewUsecase,
+		usecase: usecase,
 	}
 }
 
-// TODO: After migration, remove this logic and use the new usecase directly.
 func (c *UserLoader) Fetch(ctx context.Context, ids []gqlmodel.ID) ([]*gqlmodel.User, []error) {
-	if c.tempNewUsecase != nil {
-		users := c.fetchWithTempNewUsecase(ctx, ids)
-		if len(users) > 0 {
-			log.Printf("DEBUG:[UserLoader.Fetch] Fetched %d users with tempNewUsecase", len(users))
-			return users, nil
-		}
-	}
-	log.Printf("WARNING:[UserLoader.Fetch] Fallback to traditional usecase for %d IDs", len(ids))
-	return c.fetchWithTraditionalUsecase(ctx, ids)
-}
-
-func (c *UserLoader) fetchWithTempNewUsecase(ctx context.Context, ids []gqlmodel.ID) []*gqlmodel.User {
 	uids, err := util.TryMap(ids, gqlmodel.ToID[id.User])
-	if err != nil {
-		log.Printf("WARNING:[UserLoader.fetchWithTempNewUsecase] Failed to convert IDs: %v", err)
-		return nil
-	}
-
-	res, err := c.tempNewUsecase.FindByIDs(ctx, uids)
-	if err != nil {
-		log.Printf("WARNING:[UserLoader.fetchWithTempNewUsecase] Failed to find users: %v", err)
-		return nil
-	}
-
-	if len(res) == 0 {
-		log.Printf("DEBUG:[UserLoader.fetchWithTempNewUsecase] No users found for IDs: %v", ids)
-		return nil
-	}
-
-	users := make([]*gqlmodel.User, 0, len(res))
-	for _, u := range res {
-		users = append(users, gqlmodel.ToUserFromFlow(u))
-	}
-
-	return users
-}
-
-func (c *UserLoader) fetchWithTraditionalUsecase(ctx context.Context, ids []gqlmodel.ID) ([]*gqlmodel.User, []error) {
-	uids, err := util.TryMap(ids, gqlmodel.ToID[accountdomain.User])
 	if err != nil {
 		return nil, []error{err}
 	}
 
-	res, err := c.usecase.FetchByID(ctx, uids)
+	res, err := c.usecase.FindByIDs(ctx, uids)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -84,41 +39,13 @@ func (c *UserLoader) fetchWithTraditionalUsecase(ctx context.Context, ids []gqlm
 	return users, nil
 }
 
-// TODO: After migration, remove this logic and use the new usecase directly.
 func (c *UserLoader) SearchUser(ctx context.Context, nameOrEmail string) (*gqlmodel.User, error) {
-	if c.tempNewUsecase != nil {
-		u := c.searchUserWithTempNewUsecase(ctx, nameOrEmail)
-		if u != nil {
-			log.Printf("DEBUG:[UserLoader.SearchUser] Fetched user with tempNewUsecase id: %s", u.ID)
-			return u, nil
-		}
-	}
-	log.Printf("WARNING:[UserLoader.SearchUser] Fallback to traditional usecase for search")
-
-	res, err := c.usecase.SearchUser(ctx, nameOrEmail)
+	res, err := c.usecase.UserByNameOrEmail(ctx, nameOrEmail)
 	if err != nil {
 		return nil, err
 	}
 
-	users := gqlmodel.ToUsersFromSimple(res)
-	if len(users) == 0 {
-		return nil, nil
-	}
-	return users[0], nil
-}
-
-func (c *UserLoader) searchUserWithTempNewUsecase(ctx context.Context, nameOrEmail string) *gqlmodel.User {
-	res, err := c.tempNewUsecase.UserByNameOrEmail(ctx, nameOrEmail)
-	if err != nil {
-		log.Printf("WARNING:[UserLoader.SearchUser] Failed to search users: %v", err)
-		return nil
-	}
-	if res == nil {
-		log.Printf("DEBUG:[UserLoader.SearchUser] No user found for nameOrEmail: %s", nameOrEmail)
-		return nil
-	}
-
-	return gqlmodel.ToUserFromFlow(res)
+	return gqlmodel.ToUser(res), nil
 }
 
 // data loader

--- a/server/api/internal/adapter/gql/loader_workspace.go
+++ b/server/api/internal/adapter/gql/loader_workspace.go
@@ -2,75 +2,31 @@ package gql
 
 import (
 	"context"
-	"log"
 
 	"github.com/reearth/reearth-flow/api/internal/adapter/gql/gqldataloader"
 	"github.com/reearth/reearth-flow/api/internal/adapter/gql/gqlmodel"
 	"github.com/reearth/reearth-flow/api/internal/usecase/interfaces"
 	"github.com/reearth/reearth-flow/api/pkg/id"
-	"github.com/reearth/reearthx/account/accountdomain"
-	"github.com/reearth/reearthx/account/accountusecase/accountinterfaces"
 	"github.com/reearth/reearthx/util"
 )
 
-// TODO: After migration, remove accountinterfaces.Workspace and rename tempNewUsecase to usecase.
 type WorkspaceLoader struct {
-	usecase        accountinterfaces.Workspace
-	tempNewUsecase interfaces.Workspace
+	usecase interfaces.Workspace
 }
 
-func NewWorkspaceLoader(usecase accountinterfaces.Workspace, tempNewUsecase interfaces.Workspace) *WorkspaceLoader {
+func NewWorkspaceLoader(usecase interfaces.Workspace) *WorkspaceLoader {
 	return &WorkspaceLoader{
-		usecase:        usecase,
-		tempNewUsecase: tempNewUsecase,
+		usecase: usecase,
 	}
 }
 
-// TODO: After migration, remove this logic and use the new usecase directly.
 func (c *WorkspaceLoader) Fetch(ctx context.Context, ids []gqlmodel.ID) ([]*gqlmodel.Workspace, []error) {
-	if c.tempNewUsecase != nil {
-		workspaces := c.fetchWithTempNewUsecase(ctx, ids)
-		if len(workspaces) > 0 {
-			log.Printf("DEBUG:[WorkspaceLoader.Fetch] Fetched %d workspaces with tempNewUsecase", len(workspaces))
-			return workspaces, nil
-		}
-	}
-	log.Printf("WARNING:[WorkspaceLoader.Fetch] Fallback to traditional usecase for %d IDs", len(ids))
-	return c.fetchWithTraditionalUsecase(ctx, ids)
-}
-
-func (c *WorkspaceLoader) fetchWithTempNewUsecase(ctx context.Context, ids []gqlmodel.ID) []*gqlmodel.Workspace {
 	wids, err := util.TryMap(ids, gqlmodel.ToID[id.Workspace])
-	if err != nil {
-		log.Printf("WARNING:[WorkspaceLoader.fetchWithTempNewUsecase] Failed to convert IDs: %v", err)
-		return nil
-	}
-
-	res, err := c.tempNewUsecase.FindByIDs(ctx, wids)
-	if err != nil {
-		log.Printf("WARNING:[WorkspaceLoader.fetchWithTempNewUsecase] Failed to find workspaces: %v", err)
-		return nil
-	}
-
-	if len(res) == 0 {
-		log.Printf("DEBUG:[WorkspaceLoader.fetchWithTempNewUsecase] No workspaces found for IDs: %v", ids)
-		return nil
-	}
-
-	workspaces := make([]*gqlmodel.Workspace, 0, len(res))
-	for _, t := range res {
-		workspaces = append(workspaces, gqlmodel.ToWorkspaceFromFlow(t))
-	}
-	return workspaces
-}
-
-func (c *WorkspaceLoader) fetchWithTraditionalUsecase(ctx context.Context, ids []gqlmodel.ID) ([]*gqlmodel.Workspace, []error) {
-	uids, err := util.TryMap(ids, gqlmodel.ToID[accountdomain.Workspace])
 	if err != nil {
 		return nil, []error{err}
 	}
 
-	res, err := c.usecase.Fetch(ctx, uids, getAcOperator(ctx))
+	res, err := c.usecase.FindByIDs(ctx, wids)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -82,51 +38,13 @@ func (c *WorkspaceLoader) fetchWithTraditionalUsecase(ctx context.Context, ids [
 	return workspaces, nil
 }
 
-// TODO: After migration, remove this logic and use the new usecase directly.
 func (c *WorkspaceLoader) FindByUser(ctx context.Context, uid gqlmodel.ID) ([]*gqlmodel.Workspace, error) {
-	if c.tempNewUsecase != nil {
-		workspaces := c.findByUserWithTempNewUsecase(ctx, uid)
-		if len(workspaces) > 0 {
-			log.Printf("DEBUG:[WorkspaceLoader.FindByUser] Fetched %d workspaces with tempNewUsecase", len(workspaces))
-			return workspaces, nil
-		}
-	}
-	log.Printf("WARNING:[WorkspaceLoader.FindByUser] Fallback to traditional usecase for %s", uid)
-	return c.findByUserWithTraditionalUsecase(ctx, uid)
-}
-
-func (c *WorkspaceLoader) findByUserWithTempNewUsecase(ctx context.Context, uid gqlmodel.ID) []*gqlmodel.Workspace {
-	tid, err := gqlmodel.ToID[id.User](uid)
-	if err != nil {
-		log.Printf("WARNING:[WorkspaceLoader.findByUserWithTempNewUsecase] Failed to convert ID: %v", err)
-		return nil
-	}
-
-	res, err := c.tempNewUsecase.FindByUser(ctx, tid)
-	if err != nil {
-		log.Printf("WARNING:[WorkspaceLoader.findByUserWithTempNewUsecase] Failed to find workspaces: %v", err)
-		return nil
-	}
-
-	if len(res) == 0 {
-		log.Printf("DEBUG:[WorkspaceLoader.findByUserWithTempNewUsecase] No workspaces found for ID: %s", tid)
-		return nil
-	}
-
-	workspaces := make([]*gqlmodel.Workspace, 0, len(res))
-	for _, t := range res {
-		workspaces = append(workspaces, gqlmodel.ToWorkspaceFromFlow(t))
-	}
-	return workspaces
-}
-
-func (c *WorkspaceLoader) findByUserWithTraditionalUsecase(ctx context.Context, uid gqlmodel.ID) ([]*gqlmodel.Workspace, error) {
-	userid, err := gqlmodel.ToID[accountdomain.User](uid)
+	userid, err := gqlmodel.ToID[id.User](uid)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := c.usecase.FindByUser(ctx, userid, getAcOperator(ctx))
+	res, err := c.usecase.FindByUser(ctx, userid)
 	if err != nil {
 		return nil, err
 	}

--- a/server/api/internal/adapter/gql/resolver_mutation_user.go
+++ b/server/api/internal/adapter/gql/resolver_mutation_user.go
@@ -2,51 +2,18 @@ package gql
 
 import (
 	"context"
-	"log"
 
-	"github.com/reearth/reearth-flow/api/internal/adapter"
 	"github.com/reearth/reearth-flow/api/internal/adapter/gql/gqlmodel"
 	"github.com/reearth/reearth-flow/api/internal/usecase/interfaces"
 	"github.com/reearth/reearth-flow/api/pkg/id"
-	"github.com/reearth/reearthx/account/accountdomain"
-	"github.com/reearth/reearthx/account/accountusecase/accountinterfaces"
 )
 
 func (r *mutationResolver) Signup(ctx context.Context, input gqlmodel.SignupInput) (*gqlmodel.SignupPayload, error) {
-	// TODO: After migration, remove this logic and use the new usecase directly.
-	if usecases(ctx).TempNewUser != nil {
-		flowUser, err := usecases(ctx).TempNewUser.SignupOIDC(ctx, interfaces.SignupOIDCParam{
-			UserID:      gqlmodel.ToIDRef[id.User](input.UserID),
-			Lang:        input.Lang,
-			WorkspaceID: gqlmodel.ToIDRef[id.Workspace](input.WorkspaceID),
-			Secret:      input.Secret,
-		})
-		if err != nil {
-			log.Printf("WARNING:[mutationResolver.signupWithTempNewUsecase] Failed to sign up user: %v", err)
-		} else {
-			log.Printf("DEBUG:[mutationResolver.signupWithTempNewUsecase] Signed up user with tempNewUsecase")
-			return &gqlmodel.SignupPayload{User: gqlmodel.ToUserFromFlow(flowUser)}, nil
-		}
-	}
-	log.Printf("WARNING:[mutationResolver.Signup] Fallback to traditional usecase")
-
-	au := adapter.GetAuthInfo(ctx)
-	if au == nil {
-		return nil, interfaces.ErrOperationDenied
-	}
-
-	u, err := usecases(ctx).User.SignupOIDC(ctx, accountinterfaces.SignupOIDCParam{
-		Sub:         au.Sub,
-		AccessToken: au.Token,
-		Issuer:      au.Iss,
-		Email:       au.Email,
-		Name:        au.Name,
+	u, err := usecases(ctx).User.SignupOIDC(ctx, interfaces.SignupOIDCParam{
+		UserID:      gqlmodel.ToIDRef[id.User](input.UserID),
+		Lang:        input.Lang,
+		WorkspaceID: gqlmodel.ToIDRef[id.Workspace](input.WorkspaceID),
 		Secret:      input.Secret,
-		User: accountinterfaces.SignupUserParam{
-			Lang:        input.Lang,
-			UserID:      gqlmodel.ToIDRef[accountdomain.User](input.UserID),
-			WorkspaceID: gqlmodel.ToIDRef[accountdomain.Workspace](input.WorkspaceID),
-		},
 	})
 	if err != nil {
 		return nil, err
@@ -55,32 +22,14 @@ func (r *mutationResolver) Signup(ctx context.Context, input gqlmodel.SignupInpu
 	return &gqlmodel.SignupPayload{User: gqlmodel.ToUser(u)}, nil
 }
 
-// TODO: After migration, remove this logic and use the new usecase directly.
 func (r *mutationResolver) UpdateMe(ctx context.Context, input gqlmodel.UpdateMeInput) (*gqlmodel.UpdateMePayload, error) {
-	if usecases(ctx).TempNewUser != nil {
-		tempRes, err := usecases(ctx).TempNewUser.UpdateMe(ctx, interfaces.UpdateMeParam{
-			Name:                 input.Name,
-			Email:                input.Email,
-			Lang:                 input.Lang,
-			Password:             input.Password,
-			PasswordConfirmation: input.PasswordConfirmation,
-		})
-		if err != nil {
-			log.Printf("WARNING:[mutationResolver.updateMeWithTempNewUsecase] Failed to update user: %v", err)
-		} else {
-			log.Printf("DEBUG:[mutationResolver.updateMeWithTempNewUsecase] Updated user with tempNewUsecase")
-			return &gqlmodel.UpdateMePayload{Me: gqlmodel.ToMeFromFlow(tempRes)}, nil
-		}
-	}
-	log.Printf("WARNING:[mutationResolver.UpdateMe] Fallback to traditional usecase")
-
-	res, err := usecases(ctx).User.UpdateMe(ctx, accountinterfaces.UpdateMeParam{
+	res, err := usecases(ctx).User.UpdateMe(ctx, interfaces.UpdateMeParam{
 		Name:                 input.Name,
 		Email:                input.Email,
 		Lang:                 input.Lang,
 		Password:             input.Password,
 		PasswordConfirmation: input.PasswordConfirmation,
-	}, getAcOperator(ctx))
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -89,19 +38,7 @@ func (r *mutationResolver) UpdateMe(ctx context.Context, input gqlmodel.UpdateMe
 }
 
 func (r *mutationResolver) RemoveMyAuth(ctx context.Context, input gqlmodel.RemoveMyAuthInput) (*gqlmodel.UpdateMePayload, error) {
-	// TODO: After migration, remove this logic and use the new usecase directly.
-	if usecases(ctx).TempNewUser != nil {
-		tempRes, err := usecases(ctx).TempNewUser.RemoveMyAuth(ctx, input.Auth)
-		if err != nil {
-			log.Printf("WARNING:[mutationResolver.RemoveMyAuth] Failed to remove auth: %v", err)
-		} else {
-			log.Printf("DEBUG:[mutationResolver.RemoveMyAuth] Removed auth with tempNewUsecase")
-			return &gqlmodel.UpdateMePayload{Me: gqlmodel.ToMeFromFlow(tempRes)}, nil
-		}
-	}
-	log.Printf("WARNING:[mutationResolver.RemoveMyAuth] Fallback to traditional usecase")
-
-	res, err := usecases(ctx).User.RemoveMyAuth(ctx, input.Auth, getAcOperator(ctx))
+	res, err := usecases(ctx).User.RemoveMyAuth(ctx, input.Auth)
 	if err != nil {
 		return nil, err
 	}
@@ -110,39 +47,14 @@ func (r *mutationResolver) RemoveMyAuth(ctx context.Context, input gqlmodel.Remo
 }
 
 func (r *mutationResolver) DeleteMe(ctx context.Context, input gqlmodel.DeleteMeInput) (*gqlmodel.DeleteMePayload, error) {
-	// TODO: After migration, remove this logic and use the new usecase directly.
-	if usecases(ctx).TempNewUser != nil {
-		res := r.deleteMeWithTempNewUsecase(ctx, input)
-		if res != nil {
-			log.Printf("DEBUG:[mutationResolver.deleteMeWithTempNewUsecase] Deleted me with tempNewUsecase")
-			return res, nil
-		}
-	}
-	log.Printf("WARNING:[mutationResolver.DeleteMe] Fallback to traditional usecase")
-
-	uid, err := gqlmodel.ToID[accountdomain.User](input.UserID)
+	uid, err := gqlmodel.ToID[id.User](input.UserID)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := usecases(ctx).User.DeleteMe(ctx, uid, getAcOperator(ctx)); err != nil {
+	if err := usecases(ctx).User.DeleteMe(ctx, uid); err != nil {
 		return nil, err
 	}
 
 	return &gqlmodel.DeleteMePayload{UserID: input.UserID}, nil
-}
-
-func (r *mutationResolver) deleteMeWithTempNewUsecase(ctx context.Context, input gqlmodel.DeleteMeInput) *gqlmodel.DeleteMePayload {
-	uid, err := gqlmodel.ToID[id.User](input.UserID)
-	if err != nil {
-		log.Printf("WARNING:[mutationResolver.deleteMeWithTempNewUsecase] Failed to convert ID: %v", err)
-		return nil
-	}
-
-	if err := usecases(ctx).TempNewUser.DeleteMe(ctx, uid); err != nil {
-		log.Printf("WARNING:[mutationResolver.deleteMeWithTempNewUsecase] Failed to delete me: %v", err)
-		return nil
-	}
-
-	return &gqlmodel.DeleteMePayload{UserID: input.UserID}
 }

--- a/server/api/internal/adapter/gql/resolver_mutation_workspace.go
+++ b/server/api/internal/adapter/gql/resolver_mutation_workspace.go
@@ -2,31 +2,14 @@ package gql
 
 import (
 	"context"
-	"log"
 
 	"github.com/reearth/reearth-flow/api/internal/adapter/gql/gqlmodel"
 	"github.com/reearth/reearth-flow/api/pkg/id"
 	pkgworkspace "github.com/reearth/reearth-flow/api/pkg/workspace"
-	"github.com/reearth/reearthx/account/accountdomain"
-	"github.com/reearth/reearthx/account/accountdomain/workspace"
 )
 
-// TODO: After migration, remove this logic and use the new usecase directly.
 func (r *mutationResolver) CreateWorkspace(ctx context.Context, input gqlmodel.CreateWorkspaceInput) (*gqlmodel.CreateWorkspacePayload, error) {
-	if usecases(ctx).TempNewWorkspace != nil {
-		tempRes, err := usecases(ctx).TempNewWorkspace.Create(ctx, input.Name)
-		if err != nil {
-			log.Printf("WARNING:[mutationResolver.CreateWorkspaceWithTempNewUsecase] Failed to create workspace: %v", err)
-		} else if tempRes == nil {
-			log.Printf("DWARNINGEBUG:[mutationResolver.CreateWorkspaceWithTempNewUsecase] Created workspace is nil")
-		} else {
-			log.Printf("DEBUG:[mutationResolver.CreateWorkspaceWithTempNewUsecase] Created workspace with tempNewUsecase")
-			return &gqlmodel.CreateWorkspacePayload{Workspace: gqlmodel.ToWorkspaceFromFlow(tempRes)}, nil
-		}
-	}
-	log.Printf("WARNING:[mutationResolver.CreateWorkspace] Fallback to traditional usecase")
-
-	res, err := usecases(ctx).Workspace.Create(ctx, input.Name, getUser(ctx).ID(), getAcOperator(ctx))
+	res, err := usecases(ctx).Workspace.Create(ctx, input.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -35,58 +18,25 @@ func (r *mutationResolver) CreateWorkspace(ctx context.Context, input gqlmodel.C
 }
 
 func (r *mutationResolver) DeleteWorkspace(ctx context.Context, input gqlmodel.DeleteWorkspaceInput) (*gqlmodel.DeleteWorkspacePayload, error) {
-	if usecases(ctx).TempNewWorkspace != nil {
-		res := r.deleteWorkspaceWithTempNewUsecase(ctx, input)
-		if res != nil {
-			log.Printf("DEBUG:[mutationResolver.deleteWorkspaceWithTempNewUsecase] Deleted workspace with tempNewUsecase")
-			return res, nil
-		}
-	}
-	log.Printf("WARNING:[mutationResolver.deleteWorkspace] Fallback to traditional usecase")
-
-	tid, err := gqlmodel.ToID[accountdomain.Workspace](input.WorkspaceID)
+	tid, err := gqlmodel.ToID[id.Workspace](input.WorkspaceID)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := usecases(ctx).Workspace.Remove(ctx, tid, getAcOperator(ctx)); err != nil {
+	if err := usecases(ctx).Workspace.Delete(ctx, tid); err != nil {
 		return nil, err
 	}
 
 	return &gqlmodel.DeleteWorkspacePayload{WorkspaceID: input.WorkspaceID}, nil
 }
 
-func (r *mutationResolver) deleteWorkspaceWithTempNewUsecase(ctx context.Context, input gqlmodel.DeleteWorkspaceInput) *gqlmodel.DeleteWorkspacePayload {
-	tid, err := gqlmodel.ToID[id.Workspace](input.WorkspaceID)
-	if err != nil {
-		log.Printf("WARNING:[mutationResolver.deleteWorkspaceWithTempNewUsecase] Failed to convert ID: %v", err)
-		return nil
-	}
-
-	if err := usecases(ctx).TempNewWorkspace.Delete(ctx, tid); err != nil {
-		log.Printf("WARNING:[mutationResolver.deleteWorkspaceWithTempNewUsecase] Failed to delete workspace: %v", err)
-		return nil
-	}
-
-	return &gqlmodel.DeleteWorkspacePayload{WorkspaceID: input.WorkspaceID}
-}
-
 func (r *mutationResolver) UpdateWorkspace(ctx context.Context, input gqlmodel.UpdateWorkspaceInput) (*gqlmodel.UpdateWorkspacePayload, error) {
-	if usecases(ctx).TempNewWorkspace != nil {
-		tempNewWorkspace := r.updateWorkspaceWithTempNewUsecase(ctx, input)
-		if tempNewWorkspace != nil {
-			log.Printf("DEBUG:[mutationResolver.updateWorkspaceWithTempNewUsecase] Updated workspace with tempNewUsecase")
-			return tempNewWorkspace, nil
-		}
-	}
-	log.Printf("WARNING:[mutationResolver.UpdateWorkspace] Fallback to traditional usecase")
-
-	tid, err := gqlmodel.ToID[accountdomain.Workspace](input.WorkspaceID)
+	tid, err := gqlmodel.ToID[id.Workspace](input.WorkspaceID)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := usecases(ctx).Workspace.Update(ctx, tid, input.Name, getAcOperator(ctx))
+	res, err := usecases(ctx).Workspace.Update(ctx, tid, input.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -94,38 +44,13 @@ func (r *mutationResolver) UpdateWorkspace(ctx context.Context, input gqlmodel.U
 	return &gqlmodel.UpdateWorkspacePayload{Workspace: gqlmodel.ToWorkspace(res)}, nil
 }
 
-func (r *mutationResolver) updateWorkspaceWithTempNewUsecase(ctx context.Context, input gqlmodel.UpdateWorkspaceInput) *gqlmodel.UpdateWorkspacePayload {
-	tid, err := gqlmodel.ToID[id.Workspace](input.WorkspaceID)
-	if err != nil {
-		log.Printf("WARNING:[mutationResolver.updateWorkspaceWithTempNewUsecase] Failed to convert ID: %v", err)
-		return nil
-	}
-
-	res, err := usecases(ctx).TempNewWorkspace.Update(ctx, tid, input.Name)
-	if err != nil {
-		log.Printf("WARNING:[mutationResolver.updateWorkspaceWithTempNewUsecase] Failed to update workspace: %v", err)
-		return nil
-	}
-
-	return &gqlmodel.UpdateWorkspacePayload{Workspace: gqlmodel.ToWorkspaceFromFlow(res)}
-}
-
 func (r *mutationResolver) AddMemberToWorkspace(ctx context.Context, input gqlmodel.AddMemberToWorkspaceInput) (*gqlmodel.AddMemberToWorkspacePayload, error) {
-	if usecases(ctx).TempNewWorkspace != nil {
-		tempNewWorkspace := r.addMemberToWorkspaceWithTempNewUsecase(ctx, input)
-		if tempNewWorkspace != nil {
-			log.Printf("DEBUG:[mutationResolver.addMemberToWorkspaceWithTempNewUsecase] Added member to workspace with tempNewUsecase")
-			return tempNewWorkspace, nil
-		}
-	}
-	log.Printf("WARNING:[mutationResolver.AddMemberToWorkspace] Fallback to traditional usecase")
-
-	tid, uid, err := gqlmodel.ToID2[accountdomain.Workspace, accountdomain.User](input.WorkspaceID, input.UserID)
+	tid, uid, err := gqlmodel.ToID2[id.Workspace, id.User](input.WorkspaceID, input.UserID)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := usecases(ctx).Workspace.AddUserMember(ctx, tid, map[accountdomain.UserID]workspace.Role{uid: gqlmodel.FromRole(input.Role)}, getAcOperator(ctx))
+	res, err := usecases(ctx).Workspace.AddUserMember(ctx, tid, map[id.UserID]pkgworkspace.Role{uid: gqlmodel.FromRole(input.Role)})
 	if err != nil {
 		return nil, err
 	}
@@ -133,38 +58,13 @@ func (r *mutationResolver) AddMemberToWorkspace(ctx context.Context, input gqlmo
 	return &gqlmodel.AddMemberToWorkspacePayload{Workspace: gqlmodel.ToWorkspace(res)}, nil
 }
 
-func (r *mutationResolver) addMemberToWorkspaceWithTempNewUsecase(ctx context.Context, input gqlmodel.AddMemberToWorkspaceInput) *gqlmodel.AddMemberToWorkspacePayload {
-	tid, uid, err := gqlmodel.ToID2[id.Workspace, id.User](input.WorkspaceID, input.UserID)
-	if err != nil {
-		log.Printf("WARNING:[mutationResolver.addMemberToWorkspaceWithTempNewUsecase] Failed to convert IDs: %v", err)
-		return nil
-	}
-
-	res, err := usecases(ctx).TempNewWorkspace.AddUserMember(ctx, tid, map[id.UserID]pkgworkspace.Role{uid: gqlmodel.FromRoleToFlow(input.Role)})
-	if err != nil {
-		log.Printf("WARNING:[mutationResolver.addMemberToWorkspaceWithTempNewUsecase] Failed to add member to workspace: %v", err)
-		return nil
-	}
-
-	return &gqlmodel.AddMemberToWorkspacePayload{Workspace: gqlmodel.ToWorkspaceFromFlow(res)}
-}
-
 func (r *mutationResolver) RemoveMemberFromWorkspace(ctx context.Context, input gqlmodel.RemoveMemberFromWorkspaceInput) (*gqlmodel.RemoveMemberFromWorkspacePayload, error) {
-	if usecases(ctx).TempNewWorkspace != nil {
-		tempNewWorkspace := r.removeMemberFromWorkspaceWithTempNewUsecase(ctx, input)
-		if tempNewWorkspace != nil {
-			log.Printf("DEBUG:[mutationResolver.removeMemberFromWorkspaceWithTempNewUsecase] Removed member from workspace with tempNewUsecase")
-			return tempNewWorkspace, nil
-		}
-	}
-	log.Printf("WARNING:[mutationResolver.RemoveMemberFromWorkspace] Fallback to traditional usecase")
-
-	tid, uid, err := gqlmodel.ToID2[accountdomain.Workspace, accountdomain.User](input.WorkspaceID, input.UserID)
+	tid, uid, err := gqlmodel.ToID2[id.Workspace, id.User](input.WorkspaceID, input.UserID)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := usecases(ctx).Workspace.RemoveUserMember(ctx, tid, uid, getAcOperator(ctx))
+	res, err := usecases(ctx).Workspace.RemoveUserMember(ctx, tid, uid)
 	if err != nil {
 		return nil, err
 	}
@@ -172,57 +72,16 @@ func (r *mutationResolver) RemoveMemberFromWorkspace(ctx context.Context, input 
 	return &gqlmodel.RemoveMemberFromWorkspacePayload{Workspace: gqlmodel.ToWorkspace(res)}, nil
 }
 
-func (r *mutationResolver) removeMemberFromWorkspaceWithTempNewUsecase(ctx context.Context, input gqlmodel.RemoveMemberFromWorkspaceInput) *gqlmodel.RemoveMemberFromWorkspacePayload {
-	tid, uid, err := gqlmodel.ToID2[id.Workspace, id.User](input.WorkspaceID, input.UserID)
-	if err != nil {
-		log.Printf("WARNING:[mutationResolver.removeMemberFromWorkspaceWithTempNewUsecase] Failed to convert IDs: %v", err)
-		return nil
-	}
-
-	res, err := usecases(ctx).TempNewWorkspace.RemoveUserMember(ctx, tid, uid)
-	if err != nil {
-		log.Printf("WARNING:[mutationResolver.removeMemberFromWorkspaceWithTempNewUsecase] Failed to add member to workspace: %v", err)
-		return nil
-	}
-
-	return &gqlmodel.RemoveMemberFromWorkspacePayload{Workspace: gqlmodel.ToWorkspaceFromFlow(res)}
-}
-
 func (r *mutationResolver) UpdateMemberOfWorkspace(ctx context.Context, input gqlmodel.UpdateMemberOfWorkspaceInput) (*gqlmodel.UpdateMemberOfWorkspacePayload, error) {
-	if usecases(ctx).TempNewWorkspace != nil {
-		tempNewWorkspace := r.updateMemberOfWorkspaceWithTempNewUsecase(ctx, input)
-		if tempNewWorkspace != nil {
-			log.Printf("DEBUG:[mutationResolver.updateMemberOfWorkspaceWithTempNewUsecase] Updated member of workspace with tempNewUsecase")
-			return tempNewWorkspace, nil
-		}
-	}
-	log.Printf("WARNING:[mutationResolver.updateMemberOfWorkspace] Fallback to traditional usecase")
-
-	tid, uid, err := gqlmodel.ToID2[accountdomain.Workspace, accountdomain.User](input.WorkspaceID, input.UserID)
+	tid, uid, err := gqlmodel.ToID2[id.Workspace, id.User](input.WorkspaceID, input.UserID)
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := usecases(ctx).Workspace.UpdateUserMember(ctx, tid, uid, gqlmodel.FromRole(input.Role), getAcOperator(ctx))
+	res, err := usecases(ctx).Workspace.UpdateUserMember(ctx, tid, uid, gqlmodel.FromRole(input.Role))
 	if err != nil {
 		return nil, err
 	}
 
 	return &gqlmodel.UpdateMemberOfWorkspacePayload{Workspace: gqlmodel.ToWorkspace(res)}, nil
-}
-
-func (r *mutationResolver) updateMemberOfWorkspaceWithTempNewUsecase(ctx context.Context, input gqlmodel.UpdateMemberOfWorkspaceInput) *gqlmodel.UpdateMemberOfWorkspacePayload {
-	tid, uid, err := gqlmodel.ToID2[id.Workspace, id.User](input.WorkspaceID, input.UserID)
-	if err != nil {
-		log.Printf("WARNING:[mutationResolver.updateMemberOfWorkspaceWithTempNewUsecase] Failed to convert IDs: %v", err)
-		return nil
-	}
-
-	res, err := usecases(ctx).TempNewWorkspace.UpdateUserMember(ctx, tid, uid, gqlmodel.FromRoleToFlow(input.Role))
-	if err != nil {
-		log.Printf("WARNING:[mutationResolver.updateMemberOfWorkspaceWithTempNewUsecase] Failed to add member to workspace: %v", err)
-		return nil
-	}
-
-	return &gqlmodel.UpdateMemberOfWorkspacePayload{Workspace: gqlmodel.ToWorkspaceFromFlow(res)}
 }

--- a/server/api/internal/adapter/gql/resolver_query.go
+++ b/server/api/internal/adapter/gql/resolver_query.go
@@ -2,7 +2,6 @@ package gql
 
 import (
 	"context"
-	"log"
 
 	"github.com/reearth/reearth-flow/api/internal/adapter/gql/gqlmodel"
 )
@@ -14,20 +13,11 @@ func (r *queryResolver) Assets(ctx context.Context, workspaceID gqlmodel.ID, key
 }
 
 func (r *queryResolver) Me(ctx context.Context) (*gqlmodel.Me, error) {
-	// TODO: During migration, fallback to legacy getUser if FlowUser is unavailable.
-	// Eventually, getUser will be unified to return FlowUser from flow package.
-	u := getFlowUser(ctx)
-	if u != nil {
-		log.Printf("DEBUG:[queryResolver.Me] Uses FlowUser %s", u.ID())
-		return gqlmodel.ToMeFromFlow(u), nil
-	}
-	log.Printf("WARNING:[queryResolver.Me] Fallback to legacy getUser")
-
-	u2 := getUser(ctx)
-	if u2 == nil {
+	u := getUser(ctx)
+	if u == nil {
 		return nil, nil
 	}
-	return gqlmodel.ToMe(u2), nil
+	return gqlmodel.ToMe(u), nil
 }
 
 func (r *queryResolver) Deployments(ctx context.Context, workspaceID gqlmodel.ID, pagination gqlmodel.PageBasedPagination) (*gqlmodel.DeploymentConnection, error) {

--- a/server/api/internal/app/auth_client.go
+++ b/server/api/internal/app/auth_client.go
@@ -78,7 +78,7 @@ func getUser(ctx context.Context, c echo.Context, multiUser accountinterfaces.Us
 }
 
 func attachUserToContext(ctx context.Context, u *user.User, _ *ServerConfig) context.Context {
-	ctx = adapter.AttachUser(ctx, u)
+	ctx = adapter.AttachReearthxUser(ctx, u)
 	log.Debugfc(ctx, "auth: user: id=%s name=%s email=%s", u.ID(), u.Name(), u.Email())
 	return ctx
 }

--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -90,7 +90,7 @@ func tempNewAuthMiddleware(gqlClient *gql.Client, skipOps map[string]struct{}) e
 				return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized: user not found")
 			}
 
-			ctx = adapter.AttachFlowUser(ctx, u)
+			ctx = adapter.AttachUser(ctx, u)
 			c.SetRequest(c.Request().WithContext(ctx))
 			return next(c)
 		}

--- a/server/api/internal/app/auth_middleware.go
+++ b/server/api/internal/app/auth_middleware.go
@@ -118,10 +118,8 @@ func conditionalGraphQLAuthMiddleware(
 				}
 
 				switch body.OperationName {
-				case "GetMe":
+				case "GetMe", "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace", "UpdateMemberOfWorkspace", "RemoveMemberFromWorkspace", "Signup", "RemoveMyAuth", "DeleteMe":
 					middlewares = tempNewAuthMWs
-				case "GetWorkspaceById", "GetWorkspaces", "SearchUser", "UpdateMe", "CreateWorkspace", "UpdateWorkspace", "DeleteWorkspace", "AddMemberToWorkspace", "UpdateMemberOfWorkspace", "RemoveMemberFromWorkspace", "Signup", "RemoveMyAuth", "DeleteMe":
-					middlewares = append(defaultMWs, tempNewAuthMWs...)
 				}
 			}
 

--- a/server/api/internal/app/public.go
+++ b/server/api/internal/app/public.go
@@ -23,7 +23,7 @@ func Signup() echo.HandlerFunc {
 		}
 
 		uc := adapter.Usecases(c.Request().Context())
-		controller := http1.NewUserController(uc.User)
+		controller := http1.NewUserController(uc.ReearthxUser)
 
 		output, err := controller.Signup(c.Request().Context(), inp)
 		if err != nil {
@@ -42,7 +42,7 @@ func PasswordReset() echo.HandlerFunc {
 		}
 
 		uc := adapter.Usecases(c.Request().Context())
-		controller := http1.NewUserController(uc.User)
+		controller := http1.NewUserController(uc.ReearthxUser)
 
 		isStartingNewRequest := len(inp.Email) > 0 && len(inp.Token) == 0 && len(inp.Password) == 0
 		isSettingNewPassword := len(inp.Email) > 0 && len(inp.Token) > 0 && len(inp.Password) > 0
@@ -74,7 +74,7 @@ func StartSignupVerify() echo.HandlerFunc {
 		}
 
 		uc := adapter.Usecases(c.Request().Context())
-		controller := http1.NewUserController(uc.User)
+		controller := http1.NewUserController(uc.ReearthxUser)
 
 		if err := controller.CreateVerification(c.Request().Context(), inp); err != nil {
 			return err
@@ -92,7 +92,7 @@ func SignupVerify() echo.HandlerFunc {
 		}
 
 		uc := adapter.Usecases(c.Request().Context())
-		controller := http1.NewUserController(uc.User)
+		controller := http1.NewUserController(uc.ReearthxUser)
 
 		output, err := controller.VerifyUser(c.Request().Context(), code)
 		if err != nil {

--- a/server/api/internal/usecase/interactor/asset.go
+++ b/server/api/internal/usecase/interactor/asset.go
@@ -80,7 +80,7 @@ func (i *Asset) Create(ctx context.Context, inp interfaces.CreateAssetParam) (re
 	}
 
 	// Get user ID from context
-	user := adapter.User(ctx)
+	user := adapter.ReearthxUser(ctx)
 	if user == nil {
 		return nil, interfaces.ErrOperationDenied
 	}

--- a/server/api/internal/usecase/interactor/asset_test.go
+++ b/server/api/internal/usecase/interactor/asset_test.go
@@ -29,7 +29,7 @@ func TestAsset_Create(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	// aid := asset.NewID() - removed as the ID is generated in the interactor
 

--- a/server/api/internal/usecase/interactor/common.go
+++ b/server/api/internal/usecase/interactor/common.go
@@ -37,33 +37,32 @@ func NewContainer(r *repo.Container, g *gateway.Container,
 ) interfaces.Container {
 	setSkipPermissionCheck(config.SkipPermissionCheck)
 
-	var tempNewUser interfaces.User
+	var user interfaces.User
 	if GQLClient != nil && GQLClient.UserRepo != nil {
-		tempNewUser = NewUser(GQLClient.UserRepo)
+		user = NewUser(GQLClient.UserRepo)
 	}
 
-	var tempNewWorkspace interfaces.Workspace
+	var workspace interfaces.Workspace
 	if GQLClient != nil && GQLClient.WorkspaceRepo != nil {
-		tempNewWorkspace = NewWorkspace(GQLClient.WorkspaceRepo)
+		workspace = NewWorkspace(GQLClient.WorkspaceRepo)
 	}
 
 	return interfaces.Container{
-		Asset:            NewAsset(r, g, permissionChecker),
-		CMS:              NewCMS(r, g, permissionChecker),
-		Job:              job,
-		Deployment:       NewDeployment(r, g, job, permissionChecker),
-		EdgeExecution:    NewEdgeExecution(r, g, permissionChecker),
-		Log:              NewLogInteractor(g.Redis, r.Job, permissionChecker),
-		NodeExecution:    NewNodeExecution(r.NodeExecution, g.Redis, permissionChecker),
-		Parameter:        NewParameter(r, permissionChecker),
-		Project:          NewProject(r, g, job, permissionChecker),
-		ProjectAccess:    NewProjectAccess(r, g, config, permissionChecker),
-		Workspace:        accountinteractor.NewWorkspace(ar, workspaceMemberCountEnforcer(r)),
-		TempNewWorkspace: tempNewWorkspace, // TODO: After migration, remove Workspace and rename TempNewWorkspace to Workspace.
-		Trigger:          NewTrigger(r, g, job, permissionChecker),
-		User:             accountinteractor.NewMultiUser(ar, ag, config.SignupSecret, config.AuthSrvUIDomain, ar.Users),
-		UserFacingLog:    NewUserFacingLogInteractor(g.Redis, r.Job, permissionChecker),
-		TempNewUser:      tempNewUser, // TODO: After migration, remove User and rename tempNewUser to User.
+		Asset:         NewAsset(r, g, permissionChecker),
+		CMS:           NewCMS(r, g, permissionChecker),
+		Job:           job,
+		Deployment:    NewDeployment(r, g, job, permissionChecker),
+		EdgeExecution: NewEdgeExecution(r, g, permissionChecker),
+		Log:           NewLogInteractor(g.Redis, r.Job, permissionChecker),
+		NodeExecution: NewNodeExecution(r.NodeExecution, g.Redis, permissionChecker),
+		Parameter:     NewParameter(r, permissionChecker),
+		Project:       NewProject(r, g, job, permissionChecker),
+		ProjectAccess: NewProjectAccess(r, g, config, permissionChecker),
+		Workspace:     workspace,
+		Trigger:       NewTrigger(r, g, job, permissionChecker),
+		User:          user,
+		ReearthxUser:  accountinteractor.NewMultiUser(ar, ag, config.SignupSecret, config.AuthSrvUIDomain, ar.Users), // TODO: After migration, remove this
+		UserFacingLog: NewUserFacingLogInteractor(g.Redis, r.Job, permissionChecker),
 	}
 }
 
@@ -107,7 +106,7 @@ func checkPermission(ctx context.Context, permissionChecker gateway.PermissionCh
 		return nil
 	}
 
-	user := adapter.User(ctx)
+	user := adapter.ReearthxUser(ctx)
 	if user == nil {
 		log.Printf("WARNING: User not found for resource=%s action=%s", resource, action)
 		return nil

--- a/server/api/internal/usecase/interactor/log_test.go
+++ b/server/api/internal/usecase/interactor/log_test.go
@@ -92,7 +92,7 @@ func TestLogInteractor_GetLogs(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	nodeID := log.NodeID(id.NewNodeID())
 	jobID := id.NewJobID()
@@ -156,7 +156,7 @@ func TestLogInteractor_SubscribeInitialLogs(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	ch, err := li.Subscribe(ctx, jobID)
 	assert.NoError(t, err)
@@ -191,7 +191,7 @@ func TestLogInteractor_Unsubscribe(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	ch, err := liInterface.Subscribe(ctx, jobID)
 	if err != nil {
@@ -247,7 +247,7 @@ func TestLogInteractor_StopsMonitoringWhenJobCompleted(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	t.Run("monitoring stops when job is completed", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, 2*time.Second)

--- a/server/api/internal/usecase/interactor/parameter_test.go
+++ b/server/api/internal/usecase/interactor/parameter_test.go
@@ -29,7 +29,7 @@ func setupParameterInteractor() (interfaces.Parameter, context.Context, *repo.Co
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	paramRepo := memory.NewParameter()
 	projectRepo := memory.NewProject()

--- a/server/api/internal/usecase/interactor/projectAccess_test.go
+++ b/server/api/internal/usecase/interactor/projectAccess_test.go
@@ -25,7 +25,7 @@ func TestProjectAccess_Fetch(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	mem := memory.New()
 	mockPermissionCheckerTrue := NewMockPermissionChecker(func(ctx context.Context, authInfo *appx.AuthInfo, userId, resource, action string) (bool, error) {
@@ -111,7 +111,7 @@ func TestProjectAccess_Share(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	mem := memory.New()
 	config := ContainerConfig{
@@ -189,7 +189,7 @@ func TestProjectAccess_Unshare(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	mem := memory.New()
 	config := ContainerConfig{

--- a/server/api/internal/usecase/interactor/project_test.go
+++ b/server/api/internal/usecase/interactor/project_test.go
@@ -37,7 +37,7 @@ func TestProject_Create(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	mockPermissionCheckerTrue := NewMockPermissionChecker(func(ctx context.Context, authInfo *appx.AuthInfo, userId, resource, action string) (bool, error) {
 		return true, nil

--- a/server/api/internal/usecase/interactor/trigger_test.go
+++ b/server/api/internal/usecase/interactor/trigger_test.go
@@ -29,7 +29,7 @@ func TestTrigger_Create(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	c := mongotest.Connect(t)(t)
 
@@ -101,7 +101,7 @@ func TestTrigger_Update(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	c := mongotest.Connect(t)(t)
 
@@ -200,7 +200,7 @@ func TestTrigger_Fetch(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	c := mongotest.Connect(t)(t)
 
@@ -257,7 +257,7 @@ func TestTrigger_Delete(t *testing.T) {
 
 	ctx := context.Background()
 	ctx = adapter.AttachAuthInfo(ctx, mockAuthInfo)
-	ctx = adapter.AttachUser(ctx, mockUser)
+	ctx = adapter.AttachReearthxUser(ctx, mockUser)
 
 	c := mongotest.Connect(t)(t)
 

--- a/server/api/internal/usecase/interactor/userfacinglog_test.go
+++ b/server/api/internal/usecase/interactor/userfacinglog_test.go
@@ -58,7 +58,7 @@ func TestUserFacingLogInteractor_GetUserFacingLogs(t *testing.T) {
 
 	// Setup auth info
 	u := user.New().NewID().Email("test@example.com").Name("test").MustBuild()
-	ctx = adapter.AttachUser(ctx, u)
+	ctx = adapter.AttachReearthxUser(ctx, u)
 	ctx = adapter.AttachAuthInfo(ctx, &appx.AuthInfo{})
 
 	metadata := json.RawMessage(`{"key": "value"}`)
@@ -120,7 +120,7 @@ func TestUserFacingLogInteractor_Subscribe(t *testing.T) {
 
 	// Setup auth info
 	u := user.New().NewID().Email("test@example.com").Name("test").MustBuild()
-	ctx = adapter.AttachUser(ctx, u)
+	ctx = adapter.AttachReearthxUser(ctx, u)
 	ctx = adapter.AttachAuthInfo(ctx, &appx.AuthInfo{})
 
 	t.Run("subscribe successfully", func(t *testing.T) {
@@ -163,7 +163,7 @@ func TestUserFacingLogInteractor_Unsubscribe(t *testing.T) {
 
 	// Setup auth info
 	u := user.New().NewID().Email("test@example.com").Name("test").MustBuild()
-	ctx = adapter.AttachUser(ctx, u)
+	ctx = adapter.AttachReearthxUser(ctx, u)
 	ctx = adapter.AttachAuthInfo(ctx, &appx.AuthInfo{})
 
 	redisMock := &mockUserFacingLogGateway{

--- a/server/api/internal/usecase/interfaces/common.go
+++ b/server/api/internal/usecase/interfaces/common.go
@@ -22,20 +22,19 @@ var (
 )
 
 type Container struct {
-	Asset            Asset
-	CMS              CMS
-	Deployment       Deployment
-	EdgeExecution    EdgeExecution
-	Job              Job
-	Log              Log
-	NodeExecution    NodeExecution
-	Parameter        Parameter
-	Project          Project
-	ProjectAccess    ProjectAccess
-	Trigger          Trigger
-	User             accountinterfaces.User
-	UserFacingLog    UserFacingLog
-	TempNewUser      User // TODO: After migration, remove User and rename TempNewUser to User.
-	Workspace        accountinterfaces.Workspace
-	TempNewWorkspace Workspace // TODO: After migration, remove Workspace and rename TempNewWorkspace to Workspace.
+	Asset         Asset
+	CMS           CMS
+	Deployment    Deployment
+	EdgeExecution EdgeExecution
+	Job           Job
+	Log           Log
+	NodeExecution NodeExecution
+	Parameter     Parameter
+	Project       Project
+	ProjectAccess ProjectAccess
+	Trigger       Trigger
+	UserFacingLog UserFacingLog
+	User          User
+	ReearthxUser  accountinterfaces.User // TODO: After migration, remove this
+	Workspace     Workspace
 }

--- a/server/api/internal/usecase/repo/container.go
+++ b/server/api/internal/usecase/repo/container.go
@@ -3,7 +3,6 @@ package repo
 import (
 	"errors"
 
-	"github.com/reearth/reearth-flow/api/pkg/workspace"
 	"github.com/reearth/reearthx/account/accountdomain"
 	"github.com/reearth/reearthx/account/accountusecase/accountrepo"
 	"github.com/reearth/reearthx/authserver"
@@ -13,25 +12,24 @@ import (
 var ErrOperationDenied = errors.New("operation denied")
 
 type Container struct {
-	Asset            Asset
-	AuthRequest      authserver.RequestRepo
-	Config           Config
-	Deployment       Deployment
-	EdgeExecution    EdgeExecution
-	Job              Job
-	Lock             Lock
-	NodeExecution    NodeExecution
-	Parameter        Parameter
-	Permittable      accountrepo.Permittable // TODO: Delete this once the permission check migration is complete.
-	Project          Project
-	ProjectAccess    ProjectAccess
-	Role             accountrepo.Role // TODO: Delete this once the permission check migration is complete.
-	Transaction      usecasex.Transaction
-	Trigger          Trigger
-	User             accountrepo.User
-	Workflow         Workflow
-	Workspace        accountrepo.Workspace
-	TempNewWorkspace workspace.Repo // TODO: After migration, delete Workspace and rename TempNewWorkspace to Workspace.
+	Asset         Asset
+	AuthRequest   authserver.RequestRepo
+	Config        Config
+	Deployment    Deployment
+	EdgeExecution EdgeExecution
+	Job           Job
+	Lock          Lock
+	NodeExecution NodeExecution
+	Parameter     Parameter
+	Permittable   accountrepo.Permittable // TODO: Delete this once the permission check migration is complete.
+	Project       Project
+	ProjectAccess ProjectAccess
+	Role          accountrepo.Role // TODO: Delete this once the permission check migration is complete.
+	Transaction   usecasex.Transaction
+	Trigger       Trigger
+	User          accountrepo.User
+	Workflow      Workflow
+	Workspace     accountrepo.Workspace
 }
 
 func (c *Container) AccountRepos() *accountrepo.Container {


### PR DESCRIPTION
# Overview


## What I've done

remove reearthx.usecase of user and workspace from gql.adapter
fix e2e of user and workspace to user accounts server

## What I’ve Confirmed Locally

I tested it and confirmed it works locally.
https://www.notion.so/eukarya/Epic-Replace-user-management-in-API-with-reearth-accounts-24616e0fb16580aaa44eeb852b769a8a?source=copy_link#27116e0fb16580d1a3b7e437fddaea5b

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
