### PR TITLE
refactor(websocket): update load_doc_v2 to use transactions and add copy_document functionality

### DIFF
--- a/server/websocket/src/application/kv.rs
+++ b/server/websocket/src/application/kv.rs
@@ -398,28 +398,27 @@ where
         }
     }
 
-    async fn load_doc_v2<K: AsRef<[u8]> + ?Sized + Sync>(&self, name: &K) -> Result<Doc, Error> {
+    async fn load_doc_v2<K: AsRef<[u8]> + ?Sized + Sync>(
+        &self,
+        name: &K,
+        txn: &mut TransactionMut,
+    ) -> Result<(), Error> {
         let doc_key = format!("doc_v2:{}", hex::encode(name.as_ref()));
         let doc_key_bytes = doc_key.as_bytes();
 
-        match self.get(doc_key_bytes).await? {
-            Some(data) => {
-                let doc = Doc::new();
-                let mut txn = doc.transact_mut();
-
-                let decompressed_data = decompress_brotli(data.as_ref())?;
-                if let Ok(update) = Update::decode_v2(&decompressed_data) {
-                    txn.apply_update(update)?;
-                }
-                drop(txn);
-                Ok(doc)
+        if let Some(data) = self.get(doc_key_bytes).await? {
+            if data.as_ref().is_empty() {
+                return Err(anyhow::anyhow!(
+                    "Document data is empty for key: {}",
+                    doc_key
+                ));
             }
-
-            None => Err(anyhow::anyhow!(
-                "Document not found: {}",
-                hex::encode(name.as_ref())
-            )),
+            let decompressed_data = decompress_brotli(data.as_ref())?;
+            if let Ok(update) = Update::decode_v2(&decompressed_data) {
+                txn.apply_update(update)?;
+            }
         }
+        Ok(())
     }
 
     async fn flush_doc_v2<K: AsRef<[u8]> + ?Sized + Sync>(
@@ -435,6 +434,15 @@ where
         let compressed_data = compress_brotli(&state, 4, 22)?;
 
         self.upsert(doc_key_bytes, &compressed_data).await?;
+        Ok(())
+    }
+
+    async fn copy_document<K: AsRef<[u8]> + ?Sized + Sync>(&self, name: &K) -> Result<(), Error> {
+        let doc = Doc::new();
+        let mut txn = doc.transact_mut();
+
+        self.load_doc_v2(name, &mut txn).await?;
+        self.flush_doc_v2(name, &doc.transact()).await?;
         Ok(())
     }
 }

--- a/server/websocket/tests/ydoc.rs
+++ b/server/websocket/tests/ydoc.rs
@@ -316,7 +316,9 @@ mod tests {
         let txn = doc.transact();
         store.flush_doc_v2(doc_name, &txn).await.unwrap();
 
-        let loaded_doc = store.load_doc_v2(doc_name).await.unwrap();
+        let loaded_doc = Doc::new();
+        let mut txn = loaded_doc.transact_mut();
+        store.load_doc_v2(doc_name, &mut txn).await.unwrap();
 
         let loaded_text = loaded_doc.get_or_insert_text("test");
         let txn = loaded_doc.transact();


### PR DESCRIPTION
…opy_document functionality

- Modified the `load_doc_v2` function to accept a mutable transaction reference and return a result indicating success or failure.
- Enhanced error handling for empty document data.
- Introduced a new `copy_document` function to facilitate document copying using the updated transaction mechanism.
- Updated related calls in the `BroadcastGroupManager`, `BroadcastPool`, and `DocumentHandler` to align with the new `load_doc_v2` signature.

# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
