### PR TITLE
feat(api): update copyProject mutation to include source parameter

### DIFF
--- a/server/api/gql/document.graphql
+++ b/server/api/gql/document.graphql
@@ -34,7 +34,7 @@ extend type Mutation {
   saveSnapshot(projectId: ID!): Boolean!
   previewSnapshot(projectId: ID!, version: Int!, name: String): PreviewSnapshot
   rollbackProject(projectId: ID!, version: Int!): ProjectDocument
-  copyProject(projectId: ID!): Boolean!
+  copyProject(projectId: ID!, source: ID!): Boolean!
   importProject(projectId: ID!, data: Bytes!): Boolean!
 }
 

--- a/server/api/internal/adapter/gql/generated.go
+++ b/server/api/internal/adapter/gql/generated.go
@@ -271,7 +271,7 @@ type ComplexityRoot struct {
 	Mutation struct {
 		AddMemberToWorkspace      func(childComplexity int, input gqlmodel.AddMemberToWorkspaceInput) int
 		CancelJob                 func(childComplexity int, input gqlmodel.CancelJobInput) int
-		CopyProject               func(childComplexity int, projectID gqlmodel.ID) int
+		CopyProject               func(childComplexity int, projectID gqlmodel.ID, source gqlmodel.ID) int
 		CreateAsset               func(childComplexity int, input gqlmodel.CreateAssetInput) int
 		CreateDeployment          func(childComplexity int, input gqlmodel.CreateDeploymentInput) int
 		CreateProject             func(childComplexity int, input gqlmodel.CreateProjectInput) int
@@ -568,7 +568,7 @@ type MutationResolver interface {
 	SaveSnapshot(ctx context.Context, projectID gqlmodel.ID) (bool, error)
 	PreviewSnapshot(ctx context.Context, projectID gqlmodel.ID, version int, name *string) (*gqlmodel.PreviewSnapshot, error)
 	RollbackProject(ctx context.Context, projectID gqlmodel.ID, version int) (*gqlmodel.ProjectDocument, error)
-	CopyProject(ctx context.Context, projectID gqlmodel.ID) (bool, error)
+	CopyProject(ctx context.Context, projectID gqlmodel.ID, source gqlmodel.ID) (bool, error)
 	ImportProject(ctx context.Context, projectID gqlmodel.ID, data gqlmodel.Bytes) (bool, error)
 	CancelJob(ctx context.Context, input gqlmodel.CancelJobInput) (*gqlmodel.CancelJobPayload, error)
 	DeclareParameter(ctx context.Context, projectID gqlmodel.ID, input gqlmodel.DeclareParameterInput) (*gqlmodel.Parameter, error)
@@ -1575,7 +1575,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.CopyProject(childComplexity, args["projectId"].(gqlmodel.ID)), true
+		return e.complexity.Mutation.CopyProject(childComplexity, args["projectId"].(gqlmodel.ID), args["source"].(gqlmodel.ID)), true
 
 	case "Mutation.createAsset":
 		if e.complexity.Mutation.CreateAsset == nil {
@@ -3714,7 +3714,7 @@ extend type Mutation {
   saveSnapshot(projectId: ID!): Boolean!
   previewSnapshot(projectId: ID!, version: Int!, name: String): PreviewSnapshot
   rollbackProject(projectId: ID!, version: Int!): ProjectDocument
-  copyProject(projectId: ID!): Boolean!
+  copyProject(projectId: ID!, source: ID!): Boolean!
   importProject(projectId: ID!, data: Bytes!): Boolean!
 }
 
@@ -4444,6 +4444,11 @@ func (ec *executionContext) field_Mutation_copyProject_args(ctx context.Context,
 		return nil, err
 	}
 	args["projectId"] = arg0
+	arg1, err := ec.field_Mutation_copyProject_argsSource(ctx, rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	args["source"] = arg1
 	return args, nil
 }
 func (ec *executionContext) field_Mutation_copyProject_argsProjectID(
@@ -4457,6 +4462,24 @@ func (ec *executionContext) field_Mutation_copyProject_argsProjectID(
 
 	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("projectId"))
 	if tmp, ok := rawArgs["projectId"]; ok {
+		return ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, tmp)
+	}
+
+	var zeroVal gqlmodel.ID
+	return zeroVal, nil
+}
+
+func (ec *executionContext) field_Mutation_copyProject_argsSource(
+	ctx context.Context,
+	rawArgs map[string]any,
+) (gqlmodel.ID, error) {
+	if _, ok := rawArgs["source"]; !ok {
+		var zeroVal gqlmodel.ID
+		return zeroVal, nil
+	}
+
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("source"))
+	if tmp, ok := rawArgs["source"]; ok {
 		return ec.unmarshalNID2githubᚗcomᚋreearthᚋreearthᚑflowᚋapiᚋinternalᚋadapterᚋgqlᚋgqlmodelᚐID(ctx, tmp)
 	}
 
@@ -13733,7 +13756,7 @@ func (ec *executionContext) _Mutation_copyProject(ctx context.Context, field gra
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().CopyProject(rctx, fc.Args["projectId"].(gqlmodel.ID))
+		return ec.resolvers.Mutation().CopyProject(rctx, fc.Args["projectId"].(gqlmodel.ID), fc.Args["source"].(gqlmodel.ID))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/server/api/internal/adapter/gql/resolver_document.go
+++ b/server/api/internal/adapter/gql/resolver_document.go
@@ -92,8 +92,8 @@ func (r *mutationResolver) PreviewSnapshot(ctx context.Context, projectID gqlmod
 	}, nil
 }
 
-func (r *mutationResolver) CopyProject(ctx context.Context, projectId gqlmodel.ID) (bool, error) {
-	err := usecases(ctx).Websocket.CopyDocument(ctx, string(projectId))
+func (r *mutationResolver) CopyProject(ctx context.Context, projectId gqlmodel.ID, source gqlmodel.ID) (bool, error) {
+	err := usecases(ctx).Websocket.CopyDocument(ctx, string(projectId), string(source))
 	if err != nil {
 		return false, err
 	}

--- a/server/api/internal/infrastructure/websocket/client.go
+++ b/server/api/internal/infrastructure/websocket/client.go
@@ -385,8 +385,8 @@ func (c *Client) CreateSnapshot(ctx context.Context, docID string, version int, 
 	}, nil
 }
 
-func (c *Client) CopyDocument(ctx context.Context, docID string) error {
-	url := fmt.Sprintf("%s/api/document/%s/copy", c.config.ServerURL, docID)
+func (c *Client) CopyDocument(ctx context.Context, docID string, source string) error {
+	url := fmt.Sprintf("%s/api/document/%s/%s/copy", c.config.ServerURL, docID, source)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, nil)
 	if err != nil {

--- a/server/api/internal/usecase/interactor/websocket.go
+++ b/server/api/internal/usecase/interactor/websocket.go
@@ -43,8 +43,8 @@ func (i *Websocket) CreateSnapshot(ctx context.Context, docID string, version in
 	return i.client.CreateSnapshot(ctx, docID, version, name)
 }
 
-func (i *Websocket) CopyProject(ctx context.Context, id string) error {
-	return i.client.CopyDocument(ctx, id)
+func (i *Websocket) CopyProject(ctx context.Context, id string, source string) error {
+	return i.client.CopyDocument(ctx, id, source)
 }
 
 func (i *Websocket) ImportProject(ctx context.Context, id string, data []byte) error {

--- a/server/api/internal/usecase/interfaces/websocket.go
+++ b/server/api/internal/usecase/interfaces/websocket.go
@@ -14,7 +14,7 @@ type WebsocketClient interface {
 	Rollback(ctx context.Context, id string, version int) (*websocket.Document, error)
 	FlushToGCS(ctx context.Context, id string) error
 	CreateSnapshot(ctx context.Context, docID string, version int, name string) (*websocket.Document, error)
-	CopyDocument(ctx context.Context, docID string) error
+	CopyDocument(ctx context.Context, docID string, source string) error
 	ImportDocument(ctx context.Context, docID string, data []byte) error
 
 	Close() error


### PR DESCRIPTION
- Modified the GraphQL schema to accept a source ID for the copyProject mutation.
- Updated the resolver and related functions to handle the new source parameter.
- Adjusted the websocket client and usecase to support copying documents from a specified source.

# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
