### PR TITLE
fix(websocket): fixed issue where WebSocket resources were not cleaned up correctly

### DIFF
--- a/server/websocket/src/bin/websocket.rs
+++ b/server/websocket/src/bin/websocket.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use tracing::error;
 use uuid::Uuid;
 use websocket::{
-    conf::Config, infrastructure::gcs::GcsStore,
-    infrastructure::redis::trimmer::spawn_stream_trimmer, infrastructure::redis::RedisStore,
+    conf::Config, infrastructure::gcs::GcsStore, infrastructure::redis::RedisStore,
     pool::BroadcastPool, server::start_server, AppState,
 };
 
@@ -62,26 +61,6 @@ async fn main() {
         }
     });
 
-    let trimmer_shutdown = if let Some(ref rs) = redis_store {
-        let trimmer_shutdown = spawn_stream_trimmer(
-            Arc::clone(&pool),
-            Arc::clone(rs),
-            Arc::clone(&store),
-            config.redis.stream_trim_interval,
-            config.redis.stream_max_message_age,
-            config.redis.stream_max_length,
-        );
-        tracing::info!(
-            "Stream trimmer started with awareness integration: interval: {}s, max age: {}ms, max length: {}",
-            config.redis.stream_trim_interval,
-            config.redis.stream_max_message_age,
-            config.redis.stream_max_length
-        );
-        Some(trimmer_shutdown)
-    } else {
-        None
-    };
-
     let instance_id = Uuid::new_v4().to_string();
     tracing::info!("Generated instance ID: {}", instance_id);
 
@@ -109,14 +88,6 @@ async fn main() {
     });
 
     let server_result = start_server(state, &config.ws_port, &config).await;
-
-    if let Some(shutdown_sender) = trimmer_shutdown {
-        if shutdown_sender.send(()).is_err() {
-            tracing::warn!("Stream trimmer already stopped");
-        } else {
-            tracing::info!("Sent shutdown signal to stream trimmer");
-        }
-    }
 
     if let Err(e) = server_result {
         error!("Server error: {}", e);

--- a/server/websocket/src/broadcast/pool.rs
+++ b/server/websocket/src/broadcast/pool.rs
@@ -133,9 +133,14 @@ impl BroadcastPool {
         Ok(group)
     }
 
+    pub fn get_existing_group(&self, doc_id: &str) -> Option<Arc<BroadcastGroup>> {
+        self.groups.get(doc_id).map(|group| group.clone())
+    }
+
     pub async fn cleanup_group(&self, doc_id: &str) {
-        if let Some((_, _group)) = self.groups.remove(doc_id) {
-            info!("Cleaned up BroadcastGroup for doc_id: {}", doc_id);
+        if let Some((_, group)) = self.groups.remove(doc_id) {
+            let _ = group.shutdown().await;
+            info!("Shutdown BroadcastGroup for doc_id: {}", doc_id);
         }
     }
 

--- a/server/websocket/src/domain/value_objects/conf.rs
+++ b/server/websocket/src/domain/value_objects/conf.rs
@@ -1,6 +1,6 @@
 pub const DEFAULT_REDIS_URL: &str = "redis://127.0.0.1:6379";
 pub const DEFAULT_REDIS_TTL: u64 = 43200;
-pub const DEFAULT_REDIS_STREAM_TRIM_INTERVAL: u64 = 60; // 10 minutes
+pub const DEFAULT_REDIS_STREAM_TRIM_INTERVAL: u64 = 60;
 pub const DEFAULT_REDIS_STREAM_MAX_MESSAGE_AGE: u64 = 3600000; // 1 hour in milliseconds
 pub const DEFAULT_REDIS_STREAM_MAX_LENGTH: u64 = 100;
 pub const DEFAULT_GCS_BUCKET: &str = "yrs-dev";

--- a/server/websocket/src/domain/value_objects/sub.rs
+++ b/server/websocket/src/domain/value_objects/sub.rs
@@ -16,3 +16,28 @@ impl Subscription {
         res.map_err(|e| Error::Other(e.into()))?
     }
 }
+
+pub struct ShutdownHandle {
+    pub awareness_updater: JoinHandle<()>,
+    pub awareness_shutdown_tx: tokio::sync::oneshot::Sender<()>,
+    pub redis_subscriber_task: JoinHandle<()>,
+    pub redis_subscriber_shutdown_tx: tokio::sync::oneshot::Sender<()>,
+    pub heartbeat_task: JoinHandle<()>,
+    pub heartbeat_shutdown_tx: tokio::sync::oneshot::Sender<()>,
+    pub sync_task: JoinHandle<()>,
+    pub sync_shutdown_tx: tokio::sync::oneshot::Sender<()>,
+}
+
+impl ShutdownHandle {
+    pub fn shutdown_sync(self) {
+        let _ = self.awareness_shutdown_tx.send(());
+        let _ = self.heartbeat_shutdown_tx.send(());
+        let _ = self.redis_subscriber_shutdown_tx.send(());
+        let _ = self.sync_shutdown_tx.send(());
+
+        self.awareness_updater.abort();
+        self.redis_subscriber_task.abort();
+        self.heartbeat_task.abort();
+        self.sync_task.abort();
+    }
+}

--- a/server/websocket/src/interface/websocket/conn.rs
+++ b/server/websocket/src/interface/websocket/conn.rs
@@ -90,11 +90,6 @@ impl<Sink, Stream> Drop for Connection<Sink, Stream> {
                     error!("Failed to cleanup awareness: {}", e);
                 }
             });
-            tokio::spawn(async move {
-                if let Err(e) = group.shutdown().await {
-                    error!("Failed to shutdown group: {}", e);
-                }
-            });
         }
     }
 }


### PR DESCRIPTION
- Removed the stream trimmer logic from the main function, simplifying the startup process.
- Introduced a new `ShutdownHandle` struct to manage shutdown tasks for various components in `BroadcastGroup`.
- Updated the `shutdown` method to utilize the new `ShutdownHandle` for cleaner resource management.
- Enhanced the cleanup process in `BroadcastPool` to ensure proper shutdown of broadcast groups.

# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
