### PR TITLE
fix(ui): Node Picker Hot Keys Added [FLOW-FE-266]

### DIFF
--- a/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/NodePickerDialog/index.tsx
@@ -34,7 +34,7 @@ const NodePickerDialog: React.FC<Props> = ({
     containerRef,
     itemRefs,
     selected,
-    setSearchTerm,
+    handleSearchTerm,
     handleSingleClick,
     handleDoubleClick,
   } = useHooks({ openedActionType, isMainWorkflow, onNodesAdd, onClose });
@@ -47,7 +47,7 @@ const NodePickerDialog: React.FC<Props> = ({
           className="mx-auto w-full rounded-none border-x-0 border-t-0 border-zinc-700 bg-secondary focus-visible:ring-0"
           placeholder={t("Search")}
           autoFocus
-          onChange={(e) => setSearchTerm(e.target.value)}
+          onChange={(e) => handleSearchTerm(e.target.value)}
         />
         <div ref={containerRef} className="max-h-[50vh] overflow-scroll">
           {actionsList.map((action, idx) => (


### PR DESCRIPTION
# Overview
This PR adds keyboard navigation functionality to the node picker dialog, allowing users to navigate through options using arrow keys and select with Enter key.

## What I've done
- Added keyboard hotkey constants for node dialog navigation (Enter, ArrowUp, ArrowDown).
- Implemented keyboard navigation logic using react-hotkeys-hook with arrow key navigation and Enter key selection.
- Refactored selection state management to properly handle keyboard navigation and search filtering.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
