### PR TITLE
fix(websocket): improve document transaction handling in copy_document method

### DIFF
--- a/server/websocket/src/application/kv.rs
+++ b/server/websocket/src/application/kv.rs
@@ -45,7 +45,6 @@ use anyhow;
 use async_trait::async_trait;
 use hex;
 use std::convert::TryInto;
-use tracing::info;
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
 use yrs::{Doc, ReadTxn, StateVector, Transact, Transaction, TransactionMut, Update};


### PR DESCRIPTION
…

- Updated the `copy_document` method to ensure proper transaction management by dropping the transaction before flushing the document.
- Enhanced type constraints for the `copy_document` method to include `std::fmt::Display` for better flexibility in key handling.

# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
