### PR TITLE
fix(websocket): implement locking mechanism for BroadcastGroup

### DIFF
--- a/server/websocket/src/broadcast/pool.rs
+++ b/server/websocket/src/broadcast/pool.rs
@@ -162,8 +162,7 @@ impl BroadcastPool {
             } else {
                 info!(
                     "Skipping cleanup for doc_id: {} ({} active connections)",
-                    doc_id,
-                    active_connections
+                    doc_id, active_connections
                 );
             }
         } else {


### PR DESCRIPTION
# Overview
- Added a locking mechanism using `tokio::sync::Mutex` to ensure safe concurrent access to `BroadcastGroup` instances.
- Introduced a `locks` field in `BroadcastPool` to manage locks for each document ID.
- Updated `get_group` and `cleanup_group` methods to utilize the locking mechanism, preventing race conditions during group retrieval and cleanup.
## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
