### PR TITLE
fix(ui): preserve title for patched anyOf items for UI

### DIFF
--- a/ui/src/components/SchemaForm/patchSchemaTypes.ts
+++ b/ui/src/components/SchemaForm/patchSchemaTypes.ts
@@ -26,10 +26,10 @@ const simplifyAnyOf = (
     // If only one type remains, replace `anyOf` with that schema
     if (filteredSchemas.length === 1) {
       if (isJSONSchema(filteredSchemas[0])) {
-        const title = filteredSchemas[0].title || newSchema.title;
+        const originalTitle = newSchema.title;
         newSchema = { ...filteredSchemas[0] };
-        // Preserve the title
-        if (title) newSchema.title = title;
+        // Preserve the title if missing from the new schema
+        if (!newSchema.title && originalTitle) newSchema.title = originalTitle;
       }
     } else {
       newSchema.anyOf = filteredSchemas;


### PR DESCRIPTION
# Overview

This PR fixes a bug where title information was being lost when simplifying anyOf schema structures in the UI component. The fix preserves the title property from either the filtered schema item or the original schema when reducing an anyOf with a single remaining schema.

## What I've done

- Preserve title property when simplifying anyOf schemas with single items
- Add fallback logic to use original schema title if filtered schema lacks one

## What I haven't done

## How I tested

## Screenshot
<img width="894" height="551" alt="Screenshot 2025-10-07 at 9 11 21" src="https://github.com/user-attachments/assets/74070ecd-9f4b-41ef-a613-c1b2930b64ab" />

## Which point I want you to review particularly

## Memo
