### PR TITLE
feat(engine): add zstd compression to jsonl intermediate data

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5173,7 +5173,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.118"
+version = "0.0.119"
 dependencies = [
  "directories",
  "log",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "futures",
  "once_cell",
@@ -5916,7 +5916,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "approx",
  "async-trait",
@@ -5959,7 +5959,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "Inflector",
  "approx",
@@ -6005,7 +6005,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "indexmap 2.11.1",
  "once_cell",
@@ -6025,7 +6025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6088,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "bytes",
  "clap",
@@ -6172,7 +6172,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6207,7 +6207,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "chrono",
  "futures",
@@ -6221,7 +6221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6250,7 +6250,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "approx",
  "bytes",
@@ -6275,7 +6275,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "ahash 0.8.12",
  "byteorder",
@@ -6304,7 +6304,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6313,7 +6313,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6343,7 +6343,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6376,7 +6376,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -6393,7 +6393,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -6405,7 +6405,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "bytes",
  "reearth-flow-common",
@@ -6420,7 +6420,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "bytes",
  "futures",
@@ -6438,7 +6438,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -6452,7 +6452,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "bytes",
  "directories",
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -6517,7 +6517,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "async-trait",
  "backon",
@@ -10087,7 +10087,7 @@ checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6415,6 +6415,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -10414,18 +10415,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.88" # Remember to update clippy.toml as well
-version = "0.0.121"
+version = "0.0.122"
 
 [profile.dev]
 opt-level = 0

--- a/engine/README.md
+++ b/engine/README.md
@@ -208,7 +208,7 @@ $ cargo run --package reearth-flow-cli -- run --workflow ${workflow_path}
 #### Enable zstd compression for State I/O
 
 ```console
-$ export FLOW_RUNTIME_ENABLE_ZSTD=true
+$ export FLOW_RUNTIME_ZSTD_ENABLE=true
 $ cargo run --package reearth-flow-cli -- run --workflow ${workflow_path}
 ```
 

--- a/engine/README.md
+++ b/engine/README.md
@@ -150,6 +150,7 @@ export FLOW_VAR_targetPackages='["bldg", "fld"]'
 | FLOW_RUNTIME_SLOW_ACTION_THRESHOLD            | Threshold for writing slow action logs(ms)                         | 300     |
 | FLOW_RUNTIME_WORKING_DIRECTORY                | working directory                                                  | macOS: `$HOME/Library/Caches/<project_path>`, Linux: `$HOME/.cache/<project_path>`, Windows: `%LOCALAPPDATA%\<project_path>` |
 | FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS | Delay (ms) to ensure node status events propagate                  | 500     |
+| FLOW_RUNTIME_ZSTD_ENABLE                      | Enable zstd compression for State I/O (.json[.zst], .jsonl[.zst])  | false   |
 
 ## Intermediate Data & Cache
 
@@ -201,6 +202,13 @@ ls <cache_directory>/projects/<project>/jobs/<job_id>/
 ### Run workflow
 
 ```console
+$ cargo run --package reearth-flow-cli -- run --workflow ${workflow_path}
+```
+
+#### Enable zstd compression for State I/O
+
+```console
+$ export FLOW_RUNTIME_ENABLE_ZSTD=true
 $ cargo run --package reearth-flow-cli -- run --workflow ${workflow_path}
 ```
 

--- a/engine/cli/src/run.rs
+++ b/engine/cli/src/run.rs
@@ -142,8 +142,7 @@ impl RunCliCommand {
         let state_uri = setup_job_directory("engine", "feature-store", job_id)
             .map_err(crate::errors::Error::init)?;
         let state = Arc::new(
-            State::new_with_compression(&state_uri, &storage_resolver)
-                .map_err(crate::errors::Error::init)?,
+            State::new(&state_uri, &storage_resolver).map_err(crate::errors::Error::init)?,
         );
 
         let logger_factory = Arc::new(LoggerFactory::new(

--- a/engine/cli/src/run.rs
+++ b/engine/cli/src/run.rs
@@ -142,7 +142,8 @@ impl RunCliCommand {
         let state_uri = setup_job_directory("engine", "feature-store", job_id)
             .map_err(crate::errors::Error::init)?;
         let state = Arc::new(
-            State::new(&state_uri, &storage_resolver).map_err(crate::errors::Error::init)?,
+            State::new_with_compression(&state_uri, &storage_resolver)
+                .map_err(crate::errors::Error::init)?,
         );
 
         let logger_factory = Arc::new(LoggerFactory::new(

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.118"
+version = "0.0.119"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/runtime/examples/fixture/tests/Cargo.toml
+++ b/engine/runtime/examples/fixture/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.21"
+version = "0.1.22"
 edition = "2021"
 
 [dependencies]

--- a/engine/runtime/state/Cargo.toml
+++ b/engine/runtime/state/Cargo.toml
@@ -20,3 +20,4 @@ serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 uuid.workspace = true
+zstd.workspace = true

--- a/engine/runtime/state/src/lib.rs
+++ b/engine/runtime/state/src/lib.rs
@@ -12,7 +12,7 @@ use reearth_flow_storage::storage::Storage;
 
 const CHUNK_SIZE: usize = 1000;
 
-const ZSTD_LEVEL: i32 = 3;
+const ZSTD_LEVEL: i32 = 1;
 
 #[derive(Debug, Clone)]
 pub struct State {

--- a/engine/runtime/state/src/lib.rs
+++ b/engine/runtime/state/src/lib.rs
@@ -12,14 +12,29 @@ use reearth_flow_storage::storage::Storage;
 
 const CHUNK_SIZE: usize = 1000;
 
+const ZSTD_LEVEL: i32 = 3;
+
 #[derive(Debug, Clone)]
 pub struct State {
     storage: Arc<Storage>,
     root: PathBuf,
+    use_compression: bool,
 }
 
 impl State {
     pub fn new(root: &Uri, storage_resolver: &StorageResolver) -> Result<Self> {
+        Self::new_internal(root, storage_resolver, false)
+    }
+
+    pub fn new_with_compression(root: &Uri, storage_resolver: &StorageResolver) -> Result<Self> {
+        Self::new_internal(root, storage_resolver, true)
+    }
+
+    fn new_internal(
+        root: &Uri,
+        storage_resolver: &StorageResolver,
+        use_compression: bool,
+    ) -> Result<Self> {
         let storage = storage_resolver
             .resolve(root)
             .map_err(std::io::Error::other)?;
@@ -29,6 +44,7 @@ impl State {
                 remove_trailing_slash(root.path().to_str().unwrap_or_default()).as_str(),
             )
             .to_path_buf(),
+            use_compression,
         })
     }
 
@@ -37,8 +53,8 @@ impl State {
         for<'de> T: Serialize + Deserialize<'de>,
     {
         let s = self.object_to_string(obj)?;
-        let content = bytes::Bytes::from(s);
-        let p = self.id_to_location(id, "json");
+        let content = self.encode(s.as_bytes())?;
+        let p = self.id_to_location(id, self.json_ext());
         self.storage
             .put(p.as_path(), content)
             .await
@@ -50,8 +66,8 @@ impl State {
         for<'de> T: Serialize + Deserialize<'de>,
     {
         let s = self.object_to_string(obj)?;
-        let content = bytes::Bytes::from(s);
-        let p = self.id_to_location(id, "json");
+        let content = self.encode(s.as_bytes())?;
+        let p = self.id_to_location(id, self.json_ext());
         self.storage
             .put_sync(p.as_path(), content)
             .map_err(Error::other)
@@ -61,9 +77,9 @@ impl State {
     where
         for<'de> T: Serialize + Deserialize<'de>,
     {
-        let s = self.object_to_string(obj)?;
-        let content = bytes::Bytes::from(s + "\n");
-        let p = self.id_to_location(id, "jsonl");
+        let s = self.object_to_string(obj)? + "\n";
+        let content = self.encode(s.as_bytes())?;
+        let p = self.id_to_location(id, self.jsonl_ext());
         self.storage
             .append(p.as_path(), content)
             .await
@@ -74,9 +90,10 @@ impl State {
         if all.is_empty() {
             return Ok(());
         }
-        let p = self.id_to_location(id, "jsonl");
+        let p = self.id_to_location(id, self.jsonl_ext());
         for chunk in all.chunks(CHUNK_SIZE) {
-            let content = bytes::Bytes::from(chunk.join("\n") + "\n");
+            let s = chunk.join("\n") + "\n";
+            let content = self.encode(s.as_bytes())?;
             self.storage
                 .append(p.as_path(), content)
                 .await
@@ -89,9 +106,9 @@ impl State {
     where
         for<'de> T: Serialize + Deserialize<'de>,
     {
-        let s = self.object_to_string(obj)?;
-        let content = bytes::Bytes::from(s + "\n");
-        let p = self.id_to_location(id, "jsonl");
+        let s = self.object_to_string(obj)? + "\n";
+        let content = self.encode(s.as_bytes())?;
+        let p = self.id_to_location(id, self.jsonl_ext());
         self.storage
             .append_sync(p.as_path(), content)
             .map_err(Error::other)
@@ -103,16 +120,17 @@ impl State {
     {
         let result = self
             .storage
-            .get(self.id_to_location(id, "json").as_path())
+            .get(self.id_to_location(id, self.json_ext()).as_path())
             .await?;
         let byte = result.bytes().await?;
-        let content = String::from_utf8(byte.to_vec()).map_err(Error::other)?;
+        let data = self.decode(byte.as_ref())?;
+        let content = String::from_utf8(data).map_err(Error::other)?;
         self.string_to_object(content.as_str())
     }
 
     pub async fn delete(&self, id: &str) -> Result<()> {
         self.storage
-            .delete(self.id_to_location(id, "json").as_path())
+            .delete(self.id_to_location(id, self.json_ext()).as_path())
             .await
             .map_err(Error::other)
     }
@@ -133,6 +151,40 @@ impl State {
     pub fn object_to_string<T: Serialize>(&self, obj: &T) -> Result<String> {
         serde_json::to_string(obj).map_err(Error::other)
     }
+
+    fn json_ext(&self) -> &'static str {
+        if self.use_compression {
+            "json.zst"
+        } else {
+            "json"
+        }
+    }
+
+    fn jsonl_ext(&self) -> &'static str {
+        if self.use_compression {
+            "jsonl.zst"
+        } else {
+            "jsonl"
+        }
+    }
+
+    fn encode(&self, bytes: &[u8]) -> Result<bytes::Bytes> {
+        if self.use_compression {
+            let compressed = zstd::stream::encode_all(bytes, ZSTD_LEVEL).map_err(Error::other)?;
+            Ok(bytes::Bytes::from(compressed))
+        } else {
+            Ok(bytes::Bytes::from(bytes.to_vec()))
+        }
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Result<Vec<u8>> {
+        if self.use_compression {
+            let v = zstd::stream::decode_all(bytes).map_err(Error::other)?;
+            Ok(v)
+        } else {
+            Ok(bytes.to_vec())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -140,24 +192,32 @@ mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, Debug, PartialEq)]
     struct Data {
         x: i32,
     }
 
     #[tokio::test]
     async fn test_write_and_read() {
-        #[derive(Serialize, Deserialize)]
-        struct Data {
-            x: i32,
-        }
-
         let storage_resolver = Arc::new(StorageResolver::new());
 
         let state = State::new(&Uri::for_test("ram:///workflows"), &storage_resolver).unwrap();
         let data = Data { x: 42 };
         state.save(&data, "test").await.unwrap();
         let result: Data = state.get("test").await.unwrap();
-        assert_eq!(result.x, 42);
+        assert_eq!(result, data);
+    }
+
+    #[tokio::test]
+    async fn test_write_and_read_zstd() {
+        let storage_resolver = Arc::new(StorageResolver::new());
+
+        let state =
+            State::new_with_compression(&Uri::for_test("ram:///workflows"), &storage_resolver)
+                .unwrap();
+        let data = Data { x: 42 };
+        state.save(&data, "test").await.unwrap();
+        let result: Data = state.get("test").await.unwrap();
+        assert_eq!(result, data);
     }
 }


### PR DESCRIPTION
# Overview

Notion task: https://www.notion.so/eukarya/Investigation-Large-intermediate-data-takes-long-time-longer-than-output-data-22216e0fb16580f9a1ede3013fe8c26d?v=22216e0fb16580aa8bdc000c8fdf9a18

I actually benchmarked several options including Parquet.
The details are below.
[https://www.notion.so/eukarya/Investigation-Large-intermediate-data-takes-long-time[…]013fe8c26d?v=22216e0fb16580aa8bdc000c8fdf9a18&source=copy_link](https://www.notion.so/eukarya/Investigation-Large-intermediate-data-takes-long-time-longer-than-output-data-22216e0fb16580f9a1ede3013fe8c26d?v=22216e0fb16580aa8bdc000c8fdf9a18&source=copy_link#27f16e0fb1658083b540e901bc4d1cc8)
The main bottleneck we were facing was the time it took to generate and process intermediate data. After benchmarking different approaches, we found that JSONL + Zstd offered the best balance for our use case.

After discussing with Piyush-san, we decided to implement the 'JSONL + Zstd' approach.

## Summary

- Added optional Zstd compression for intermediate JSON/JSONL.
- Local runs: runtime ≈ the same (± a few %).
- File size: massively smaller (GB → MB).

## Why it still helps

- In real envs (GCS/S3), the bottleneck is I/O + network.
- Fewer bytes → faster uploads/downloads and lower cost.
- Expect end-to-end speedups even if local CPU time is flat.

## What I've done

## What I haven't done

## How I tested

https://www.notion.so/eukarya/Investigation-Large-intermediate-data-takes-long-time-longer-than-output-data-22216e0fb16580f9a1ede3013fe8c26d?v=22216e0fb16580aa8bdc000c8fdf9a18&source=copy_link#28516e0fb16580d88e74c07b955ac298

## Screenshot

## Which point I want you to review particularly

## Memo
