### PR TITLE
fix(engine): fix cross-device file moving

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.400"
+version = "0.0.401"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.400"
+version = "0.0.401"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/common/src/dir.rs
+++ b/engine/runtime/common/src/dir.rs
@@ -1,5 +1,5 @@
 use std::{
-    env, io, fs,
+    env, fs, io,
     path::{Path, PathBuf},
     str::FromStr,
 };

--- a/engine/runtime/common/src/dir.rs
+++ b/engine/runtime/common/src/dir.rs
@@ -78,7 +78,7 @@ pub fn copy_files(dest: &Path, files: &[Uri]) -> crate::Result<()> {
 
 /// Moves a file like Unix `mv`: rename if possible, else copy + delete.
 /// Always use this function instead of fs::rename to move files to another directory.
-pub fn move_file<P: AsRef<Path>>(src: P, dst: P) -> io::Result<()> {
+pub fn move_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
     match fs::rename(&src, &dst) {
         Ok(_) => Ok(()),
         Err(err) if err.kind() == io::ErrorKind::CrossesDevices => {

--- a/engine/runtime/common/src/dir.rs
+++ b/engine/runtime/common/src/dir.rs
@@ -1,5 +1,5 @@
 use std::{
-    env, fs,
+    env, io, fs,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -76,10 +76,24 @@ pub fn copy_files(dest: &Path, files: &[Uri]) -> crate::Result<()> {
     Ok(())
 }
 
+/// Moves a file like Unix `mv`: rename if possible, else copy + delete.
+pub fn move_file<P: AsRef<Path>>(src: P, dst: P) -> io::Result<()> {
+    match fs::rename(&src, &dst) {
+        Ok(_) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::CrossesDevices => {
+            // Cross-device move: copy, then delete source
+            fs::copy(&src, &dst)?;
+            fs::remove_file(&src)?;
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
 pub fn move_files(dest: &Path, files: &[Uri]) -> crate::Result<()> {
     for file in files {
         let file_path = dest.join(file.file_name().ok_or(Error::dir("Invalid file path"))?);
-        fs::rename(file.path(), file_path.clone()).map_err(Error::dir)?;
+        move_file(file.path(), file_path).map_err(Error::dir)?;
     }
     Ok(())
 }

--- a/engine/runtime/common/src/dir.rs
+++ b/engine/runtime/common/src/dir.rs
@@ -77,6 +77,9 @@ pub fn copy_files(dest: &Path, files: &[Uri]) -> crate::Result<()> {
 }
 
 /// Moves a file like Unix `mv`: rename if possible, else copy + delete.
+/// Always use this function instead of fs::rename to move files.
+/// Example: tempfile::tempdir() creates a temporary directory in /tmp (tmpfs on Linux),
+/// which will cause fs::rename to fail with CrossesDevices error when moving files to hard disk.
 pub fn move_file<P: AsRef<Path>>(src: P, dst: P) -> io::Result<()> {
     match fs::rename(&src, &dst) {
         Ok(_) => Ok(()),
@@ -93,9 +96,7 @@ pub fn move_file<P: AsRef<Path>>(src: P, dst: P) -> io::Result<()> {
 pub fn move_files(dest: &Path, files: &[Uri]) -> crate::Result<()> {
     for file in files {
         let file_path = dest.join(file.file_name().ok_or(Error::dir("Invalid file path"))?);
-        // Changed from fs::rename to move_file because tempfile::tempdir() creates directories
-        // in /tmp (tmpfs on Linux), causing fs::rename to fail with CrossesDevices error when
-        // moving to a different filesystem. move_file handles this by falling back to copy+delete.
+        // changed from fs::rename to fix CrossesDevices error
         move_file(file.path(), file_path).map_err(Error::dir)?;
     }
     Ok(())

--- a/engine/runtime/common/src/dir.rs
+++ b/engine/runtime/common/src/dir.rs
@@ -77,7 +77,7 @@ pub fn copy_files(dest: &Path, files: &[Uri]) -> crate::Result<()> {
 }
 
 /// Moves a file like Unix `mv`: rename if possible, else copy + delete.
-/// Always use this function instead of fs::rename to move files to another directory.
+/// Use this function instead of fs::rename when destination cannot be proved to be the same filesystem
 pub fn move_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
     match fs::rename(&src, &dst) {
         Ok(_) => Ok(()),

--- a/engine/runtime/common/src/dir.rs
+++ b/engine/runtime/common/src/dir.rs
@@ -77,9 +77,7 @@ pub fn copy_files(dest: &Path, files: &[Uri]) -> crate::Result<()> {
 }
 
 /// Moves a file like Unix `mv`: rename if possible, else copy + delete.
-/// Always use this function instead of fs::rename to move files.
-/// Example: tempfile::tempdir() creates a temporary directory in /tmp (tmpfs on Linux),
-/// which will cause fs::rename to fail with CrossesDevices error when moving files to hard disk.
+/// Always use this function instead of fs::rename to move files to another directory.
 pub fn move_file<P: AsRef<Path>>(src: P, dst: P) -> io::Result<()> {
     match fs::rename(&src, &dst) {
         Ok(_) => Ok(()),
@@ -143,7 +141,7 @@ pub fn move_files_with_structure(dest: &Path, files: &[Uri]) -> crate::Result<()
             }
         }
 
-        fs::rename(file_path, &dest_path).map_err(Error::dir)?;
+        move_file(file_path, &dest_path).map_err(Error::dir)?;
     }
 
     // Clean up empty source directories (from deepest to shallowest)

--- a/engine/runtime/common/src/dir.rs
+++ b/engine/runtime/common/src/dir.rs
@@ -81,7 +81,7 @@ pub fn move_file<P: AsRef<Path>>(src: P, dst: P) -> io::Result<()> {
     match fs::rename(&src, &dst) {
         Ok(_) => Ok(()),
         Err(err) if err.kind() == io::ErrorKind::CrossesDevices => {
-            // Cross-device move: copy, then delete source
+            // Cross-device move: copy source to destination, then delete source
             fs::copy(&src, &dst)?;
             fs::remove_file(&src)?;
             Ok(())
@@ -93,6 +93,9 @@ pub fn move_file<P: AsRef<Path>>(src: P, dst: P) -> io::Result<()> {
 pub fn move_files(dest: &Path, files: &[Uri]) -> crate::Result<()> {
     for file in files {
         let file_path = dest.join(file.file_name().ok_or(Error::dir("Invalid file path"))?);
+        // Changed from fs::rename to move_file because tempfile::tempdir() creates directories
+        // in /tmp (tmpfs on Linux), causing fs::rename to fail with CrossesDevices error when
+        // moving to a different filesystem. move_file handles this by falling back to copy+delete.
         move_file(file.path(), file_path).map_err(Error::dir)?;
     }
     Ok(())


### PR DESCRIPTION
# Overview

This PR generalize rename to copy files when they are on different devices. This fixes workflow-tests failing on Linux which uses tmpfs as the default cache dir and fail with the `rename`.

Semantically, unlike `rename`, it is the standard to use copy fallback for `move_file` implementation in high-level filesystem libraries such as `fs_extra`'s `move_file`.

## Note

- The reason that CI passed without error is because CI uses Ubuntu 22.04 which disables systemd's `tmp.mount` so tmp is using root filesystem, not tmpfs. This will trigger error since Ubuntu 24.10. See https://documentation.ubuntu.com/release-notes/26.04/summary-for-lts-users/.
- Checked all other `fs::rename` call sites in reearth-flow and they are guaranteed to be same-device moving, not need to switch to `move_file`.