### PR TITLE
perf(engine): use unbounded channels between DAG nodes

### DIFF
--- a/engine/runtime/runtime/src/executor/execution_dag.rs
+++ b/engine/runtime/runtime/src/executor/execution_dag.rs
@@ -16,7 +16,7 @@ use crate::{
     forwarder::SenderWithPortMapping,
     node::{EdgeId, GraphId, NodeHandle, Port},
 };
-use crossbeam::channel::{bounded, Receiver, Sender};
+use crossbeam::channel::{unbounded, Receiver, Sender};
 use petgraph::graph::NodeIndex;
 use petgraph::{visit::EdgeRef, Direction};
 
@@ -70,7 +70,7 @@ pub struct ExecutionDag {
 impl ExecutionDag {
     pub fn new(
         builder_dag: BuilderDag,
-        channel_buffer_sz: usize,
+        _channel_buffer_sz: usize,
         feature_flush_threshold: usize,
         ingress_state: Arc<State>,
         feature_state: Arc<State>,
@@ -96,7 +96,7 @@ impl ExecutionDag {
             // Create or get channel.
             let (sender, receiver) = match channels.entry((source_node_index, target_node_index)) {
                 Entry::Vacant(entry) => {
-                    let (sender, receiver) = bounded(channel_buffer_sz);
+                    let (sender, receiver) = unbounded();
                     entry.insert((sender.clone(), receiver.clone()));
                     (sender, receiver)
                 }


### PR DESCRIPTION
## Summary
Replace bounded inter-node channels with unbounded channels to eliminate shutdown deadlocks.

## What changed
One file, 3 lines: `bounded(channel_buffer_sz)` → `unbounded()` in `execution_dag.rs`.

## Why
With bounded channels (2048 buffer), accumulating processors that emit many features during `finish()` block on `send()` when the downstream channel is full. The downstream can't drain because it's waiting for Terminate from another branch — classic deadlock. This caused 6-hour batch timeouts on production jobs.

With unbounded channels, `send()` never blocks. Producers emit all features instantly during `finish()`, release internal buffers (reducing memory), and proceed to send Terminate. The pipeline drains naturally.

## Evidence from GCP Batch
- **Okayama fld QC (2.3 GB)**: `FeatureSorter` emitted 285,100 features, `LineOnLineOverlayer` emitted 41,086 features — all `finish()` calls completed without blocking. Zero `wait_until_downstream_empty` timeout events.
- **Okayama tran QC (63 MB)**: Previously hung for 6 hours at the shutdown phase. Now processing normally past the previous hang point with zero deadlocks.

| Job | Before (bounded) | After (unbounded) |
|-----|-----------------|-------------------|
| Okayama fld QC 2.3GB | 6h timeout | Processing normally |
| Okayama tran QC 63MB | 6h timeout | Processing normally |

## Memory impact
Unbounded channels can temporarily hold more features in-flight. In practice:
- Features are small objects (few KB each)
- The real memory consumers are accumulating processor internal buffers, which are freed FASTER with unbounded channels (finish() completes instantly)
- Disk-backed processors already handle large data volumes