### PR TITLE
fix(ui): add anyOf for Expr definitions check for RJSF fields [FLOW-DEV-70]

### DIFF
--- a/ui/src/components/SchemaForm/Templates/BaseInputTemplate.tsx
+++ b/ui/src/components/SchemaForm/Templates/BaseInputTemplate.tsx
@@ -64,6 +64,9 @@ const BaseInputTemplate = <
           def?.properties?.[name]?.$ref === "#/definitions/Expr" ||
           def?.properties?.[name]?.allOf?.some(
             (item: any) => item.$ref === "#/definitions/Expr",
+          ) ||
+          def?.properties?.[name]?.anyOf?.some(
+            (item: any) => item.$ref === "#/definitions/Expr",
           ),
       );
     }

--- a/ui/src/components/SchemaForm/index.tsx
+++ b/ui/src/components/SchemaForm/index.tsx
@@ -43,7 +43,8 @@ const buildExprUiSchema = (
 
   const isExprType =
     schemaObj.$ref === "#/definitions/Expr" ||
-    schemaObj.allOf?.some((item: any) => item.$ref === "#/definitions/Expr");
+    schemaObj.allOf?.some((item: any) => item.$ref === "#/definitions/Expr") ||
+    schemaObj.anyOf?.some((item: any) => item.$ref === "#/definitions/Expr");
 
   // Check if this schema references any definition that contains expressions
   let referencesExprDefinition = false;
@@ -71,6 +72,9 @@ const buildExprUiSchema = (
               const propHasExpr =
                 prop?.$ref === "#/definitions/Expr" ||
                 prop?.allOf?.some(
+                  (item: any) => item.$ref === "#/definitions/Expr",
+                ) ||
+                prop?.anyOf?.some(
                   (item: any) => item.$ref === "#/definitions/Expr",
                 );
 

--- a/ui/src/components/SchemaForm/index.tsx
+++ b/ui/src/components/SchemaForm/index.tsx
@@ -55,7 +55,10 @@ const buildExprUiSchema = (
       referencesExprDefinition = Object.values(referencedDef.properties).some(
         (prop: any) =>
           prop?.$ref === "#/definitions/Expr" ||
-          prop?.allOf?.some((item: any) => item.$ref === "#/definitions/Expr"),
+          prop?.allOf?.some(
+            (item: any) => item.$ref === "#/definitions/Expr",
+          ) ||
+          prop?.anyOf?.some((item: any) => item.$ref === "#/definitions/Expr"),
       );
     }
   }


### PR DESCRIPTION
# Overview
Updates SchemaForm expression-field detection so fields referencing `#/definitions/Expr` via `anyOf` are recognized (in addition to existing `$ref` and `allOf` checks), improving RJSF UI behavior for nullable/union expression fields.

## What I've done
- Extend `Expr` detection in `BaseInputTemplate` to consider `anyOf` entries referencing `#/definitions/Expr`.
- Extend `buildExprUiSchema`’s expression detection to consider `anyOf` references (both at the schema level and within definition property scanning).
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
