### PR TITLE
fix(websocket): prevent data corruption on rollback with concurrent editors

### DIFF
--- a/server/websocket/src/infrastructure/repository/document.rs
+++ b/server/websocket/src/infrastructure/repository/document.rs
@@ -159,6 +159,12 @@ impl DocumentRepository for DocumentRepositoryImpl {
     }
 
     async fn rollback(&self, doc_id: &str, version: u64) -> Result<Document> {
+        anyhow::ensure!(
+            version <= u32::MAX as u64,
+            "version {} exceeds maximum supported value ({})",
+            version,
+            u32::MAX
+        );
         let store = self.store();
         let doc = store.rollback_to(doc_id, version as u32).await?;
 

--- a/server/websocket/src/infrastructure/repository/document.rs
+++ b/server/websocket/src/infrastructure/repository/document.rs
@@ -161,6 +161,14 @@ impl DocumentRepository for DocumentRepositoryImpl {
     async fn rollback(&self, doc_id: &str, version: u64) -> Result<Document> {
         let store = self.store();
         let doc = store.rollback_to(doc_id, version as u32).await?;
+
+        // Persist the rolled-back state to GCS so that new BroadcastGroups
+        // (created on client reconnect) load the correct state.
+        {
+            let txn = doc.transact();
+            store.flush_doc_v2(doc_id, &txn).await?;
+        }
+
         let document = Self::to_document(doc_id, doc, version, Utc::now());
         Ok(document)
     }

--- a/server/websocket/src/infrastructure/websocket/broadcast_group.rs
+++ b/server/websocket/src/infrastructure/websocket/broadcast_group.rs
@@ -26,6 +26,7 @@ use yrs::{Doc, Map, ReadTxn, Transact, Update};
 
 use super::redis_channels::RedisChannels;
 use crate::domain::value_objects::broadcast::BroadcastConfig;
+use tokio_util::sync::CancellationToken;
 
 pub struct BroadcastGroup {
     pub(crate) awareness_ref: AwarenessRef,
@@ -39,6 +40,9 @@ pub struct BroadcastGroup {
     shutdown_handle: Arc<Mutex<Option<ShutdownHandle>>>,
     pub(crate) connections_count: ConnectionCounter,
     redis_channels: RedisChannels,
+    /// Cancellation token used to signal all per-connection tasks (sink_task,
+    /// stream_task) to stop. Cancelled during force-evict on rollback.
+    cancel_token: CancellationToken,
 }
 
 impl std::fmt::Debug for BroadcastGroup {
@@ -278,6 +282,7 @@ impl BroadcastGroup {
             redis_store,
             doc_name,
             last_read_id,
+            cancel_token: CancellationToken::new(),
             shutdown_handle: Arc::new(Mutex::new(Some(ShutdownHandle {
                 awareness_updater,
                 awareness_shutdown_tx,
@@ -301,9 +306,12 @@ impl BroadcastGroup {
         &self.redis_store
     }
 
-    /// Write `rollbackInProgress = true` to the Y-doc metadata map.
-    /// The `doc_sub` observer broadcasts this to all connected clients
-    /// via the existing Yjs sync protocol.
+    /// Write `rollbackInProgress = true` to the live in-memory Y-doc metadata map.
+    /// The `doc_sub` observer broadcasts this to all currently connected clients
+    /// via the existing Yjs sync protocol. This flag is intentionally NOT persisted
+    /// to GCS — it only serves as a transient signal to connected clients before
+    /// the group is evicted. Reconnecting clients load the rolled-back state from
+    /// GCS, which does not contain this flag.
     pub async fn signal_rollback(&self) {
         let awareness = self.awareness_ref.write().await;
         let doc = awareness.doc();
@@ -314,10 +322,13 @@ impl BroadcastGroup {
         // which encodes and broadcasts the update to all clients.
     }
 
-    /// Shut down background tasks and clean up heartbeat without flushing
-    /// the in-memory doc state to GCS. Used after rollback, where the
-    /// rolled-back state has already been persisted separately.
+    /// Shut down background tasks, cancel all per-connection tasks, and clean
+    /// up heartbeat without flushing the in-memory doc state to GCS. Used after
+    /// rollback, where the rolled-back state has already been persisted separately.
+    /// Cancelling the token causes all sink_task loops to exit, which closes
+    /// the WebSocket connections even though Arc<BroadcastGroup> refs still exist.
     pub async fn shutdown_without_flush(&self) -> Result<()> {
+        self.cancel_token.cancel();
         if let Ok(mut guard) = self.shutdown_handle.try_lock() {
             if let Some(handle) = guard.take() {
                 handle.shutdown_sync();
@@ -357,22 +368,31 @@ impl BroadcastGroup {
         let sink_task = {
             let sender = self.sender.clone();
             let sink = sink.clone();
+            let cancel = self.cancel_token.clone();
             tokio::spawn(async move {
                 let mut rx = sender.subscribe();
                 loop {
-                    match rx.recv().await {
-                        Ok(msg) => {
-                            let mut sink = sink.lock().await;
-                            if sink.send(msg).await.is_err() {
-                                return Ok(());
-                            }
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            warn!("Client lagged by {} messages, recovering", n);
-                            continue;
-                        }
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    select! {
+                        _ = cancel.cancelled() => {
+                            info!("Connection cancelled (rollback or force-evict)");
                             return Ok(());
+                        }
+                        result = rx.recv() => {
+                            match result {
+                                Ok(msg) => {
+                                    let mut sink = sink.lock().await;
+                                    if sink.send(msg).await.is_err() {
+                                        return Ok(());
+                                    }
+                                }
+                                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                                    warn!("Client lagged by {} messages, recovering", n);
+                                    continue;
+                                }
+                                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                                    return Ok(());
+                                }
+                            }
                         }
                     }
                 }

--- a/server/websocket/src/infrastructure/websocket/broadcast_group.rs
+++ b/server/websocket/src/infrastructure/websocket/broadcast_group.rs
@@ -22,7 +22,7 @@ use yrs::sync::protocol::{MSG_SYNC, MSG_SYNC_UPDATE};
 use yrs::sync::{Error, Message, Protocol, SyncMessage};
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1};
-use yrs::{Doc, ReadTxn, Transact, Update};
+use yrs::{Doc, Map, ReadTxn, Transact, Update};
 
 use super::redis_channels::RedisChannels;
 use crate::domain::value_objects::broadcast::BroadcastConfig;
@@ -299,6 +299,38 @@ impl BroadcastGroup {
 
     pub fn get_redis_store(&self) -> &Arc<RedisStore> {
         &self.redis_store
+    }
+
+    /// Write `rollbackInProgress = true` to the Y-doc metadata map.
+    /// The `doc_sub` observer broadcasts this to all connected clients
+    /// via the existing Yjs sync protocol.
+    pub async fn signal_rollback(&self) {
+        let awareness = self.awareness_ref.write().await;
+        let doc = awareness.doc();
+        let metadata = doc.get_or_insert_map("metadata");
+        let mut txn = doc.transact_mut();
+        metadata.insert(&mut txn, "rollbackInProgress", true);
+        // Dropping txn triggers the observe_update_v1 callback,
+        // which encodes and broadcasts the update to all clients.
+    }
+
+    /// Shut down background tasks and clean up heartbeat without flushing
+    /// the in-memory doc state to GCS. Used after rollback, where the
+    /// rolled-back state has already been persisted separately.
+    pub async fn shutdown_without_flush(&self) -> Result<()> {
+        if let Ok(mut guard) = self.shutdown_handle.try_lock() {
+            if let Some(handle) = guard.take() {
+                handle.shutdown_sync();
+            }
+        }
+        let client_id = {
+            let awareness_read = self.awareness_ref.read().await;
+            awareness_read.client_id()
+        };
+        self.redis_store
+            .remove_instance_heartbeat(&self.doc_name, &client_id)
+            .await?;
+        Ok(())
     }
 
     pub fn get_last_read_id(&self) -> &Arc<Mutex<String>> {

--- a/server/websocket/src/infrastructure/websocket/pool.rs
+++ b/server/websocket/src/infrastructure/websocket/pool.rs
@@ -216,6 +216,29 @@ impl BroadcastPool {
         self.perform_cleanup(doc_id).await;
     }
 
+    /// Force-evict a BroadcastGroup regardless of active connections.
+    /// Used after rollback: the rolled-back state has already been persisted
+    /// to GCS, so we skip the normal shutdown flush. Dropping the group
+    /// closes the broadcast sender, which terminates all client sink tasks
+    /// and closes WebSocket connections.
+    pub async fn force_evict_group(&self, doc_id: &str) {
+        let lock = self.get_or_create_lock(doc_id);
+        let guard = lock.lock_owned().await;
+
+        if let Some((_, group)) = self.groups.remove(doc_id) {
+            if let Err(e) = group.shutdown_without_flush().await {
+                warn!(
+                    "Error during force-evict shutdown for doc '{}': {}",
+                    doc_id, e
+                );
+            }
+            info!("Force-evicted BroadcastGroup for doc_id: {}", doc_id);
+        }
+
+        drop(guard);
+        self.locks.remove(doc_id);
+    }
+
     pub fn get_cached_groups_count(&self) -> usize {
         self.groups.len()
     }

--- a/server/websocket/src/infrastructure/websocket/pool.rs
+++ b/server/websocket/src/infrastructure/websocket/pool.rs
@@ -212,6 +212,11 @@ impl BroadcastPool {
         self.ensure_group(doc_id).await
     }
 
+    /// Return the cached BroadcastGroup if one exists, without creating a new one.
+    pub fn try_get_group(&self, doc_id: &str) -> Option<Arc<BroadcastGroup>> {
+        self.groups.get(doc_id).map(|entry| entry.clone())
+    }
+
     pub async fn cleanup_group(&self, doc_id: &str) {
         self.perform_cleanup(doc_id).await;
     }

--- a/server/websocket/src/presentation/http/handlers/document_handler.rs
+++ b/server/websocket/src/presentation/http/handlers/document_handler.rs
@@ -98,10 +98,10 @@ impl DocumentHandler {
             Err(err) => return handle_service_error(&format!("rollback [{}]", doc_id), err),
         };
 
-        // 2. Signal rollback to all connected clients via Yjs metadata,
-        //    then wipe stale Redis data and force-evict the BroadcastGroup.
-        //    Clients will auto-reconnect and load the fresh rolled-back state.
-        if let Ok(group) = state.pool.get_group(&doc_id).await {
+        // 2. Signal rollback to connected clients via Yjs metadata (if any
+        //    active group exists). Use try_get_group to avoid creating a new
+        //    group just to signal — only signal when clients are connected.
+        if let Some(group) = state.pool.try_get_group(&doc_id) {
             group.signal_rollback().await;
         }
 

--- a/server/websocket/src/presentation/http/handlers/document_handler.rs
+++ b/server/websocket/src/presentation/http/handlers/document_handler.rs
@@ -88,20 +88,39 @@ impl DocumentHandler {
         State(state): State<Arc<AppState>>,
         Json(request): Json<RollbackRequest>,
     ) -> Response {
-        match state
+        // 1. Rollback and persist the rolled-back state to GCS
+        let document = match state
             .document_usecase
             .rollback(&doc_id, request.version)
             .await
         {
-            Ok(document) => Json(DocumentResponse {
-                id: document.id.value().to_string(),
-                updates: document.updates,
-                version: document.version.value(),
-                timestamp: document.timestamp.to_rfc3339(),
-            })
-            .into_response(),
-            Err(err) => handle_service_error(&format!("rollback [{}]", doc_id), err),
+            Ok(doc) => doc,
+            Err(err) => return handle_service_error(&format!("rollback [{}]", doc_id), err),
+        };
+
+        // 2. Signal rollback to all connected clients via Yjs metadata,
+        //    then wipe stale Redis data and force-evict the BroadcastGroup.
+        //    Clients will auto-reconnect and load the fresh rolled-back state.
+        if let Ok(group) = state.pool.get_group(&doc_id).await {
+            group.signal_rollback().await;
         }
+
+        if let Err(e) = state.pool.get_redis_store().delete_stream(&doc_id).await {
+            warn!(
+                "Failed to delete Redis stream during rollback for '{}': {}",
+                doc_id, e
+            );
+        }
+
+        state.pool.force_evict_group(&doc_id).await;
+
+        Json(DocumentResponse {
+            id: document.id.value().to_string(),
+            updates: document.updates,
+            version: document.version.value(),
+            timestamp: document.timestamp.to_rfc3339(),
+        })
+        .into_response()
     }
 
     pub async fn get_history_metadata(


### PR DESCRIPTION
## Summary

Fixes a critical data corruption bug where restoring a previous version while another user is actively editing causes NaN values in node positions, making the project unusable.

**Root cause:** The rollback endpoint was effectively read-only — it reconstructed a historical doc from GCS but never persisted it, never invalidated the live in-memory BroadcastGroup, and never notified connected WebSocket clients. Concurrent edits applied against the stale state caused Yjs CRDT state vector mismatches that corrupted numeric values.

**Fix:**
- **Persist** rolled-back state to GCS (`flush_doc_v2`) so reconnecting clients load the correct state
- **Signal** all connected clients via Yjs metadata map (`rollbackInProgress = true`), enabling future FE loading animation
- **Wipe** stale Redis stream updates from the pre-rollback state
- **Force-evict** the BroadcastGroup regardless of active connections, closing all WebSocket connections (y-websocket auto-reconnects and loads fresh state)

### Sequence

```
User A (rollback)          Server                    User B (editing)
     |-- POST /rollback ----->|                           |
     |                        |-- rollback_to() + flush ->| (GCS persist)
     |                        |-- signal_rollback() ----->| metadata update
     |                        |-- delete_stream() ------->| (Redis wipe)
     |                        |-- force_evict_group() --->| WS closes
     |<-- 200 OK ------------|                           |-- auto-reconnect
     |                        |-- create new group ------>| loads rolled-back state
```

## Test plan

- [x] `cd server/websocket && cargo test --all-features` — 94 tests pass
- [x] `cd server/api && go build ./...` — compiles
- [x] `cargo clippy --all-features` — no warnings
- [ ] Manual: User A + User B open same project. User A rollbacks. User B auto-reconnects with rolled-back state. No NaN values.