### PR TITLE
fix(engine): correct `_lod` attribute using both feature and branch info

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6543,7 +6543,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "futures",
  "once_cell",
@@ -6563,7 +6563,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "approx",
  "async-trait",
@@ -6609,7 +6609,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "Inflector",
  "approx",
@@ -6667,7 +6667,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6688,7 +6688,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6756,7 +6756,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6807,7 +6807,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "bytes",
  "clap",
@@ -6845,7 +6845,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6885,7 +6885,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "chrono",
  "futures",
@@ -6899,7 +6899,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6928,7 +6928,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "approx",
  "bvh",
@@ -6958,7 +6958,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6992,7 +6992,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7001,7 +7001,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7031,7 +7031,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7065,7 +7065,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7082,7 +7082,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7094,7 +7094,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "bytes",
  "futures",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "bytes",
  "futures",
@@ -7130,7 +7130,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7144,7 +7144,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7179,7 +7179,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7216,7 +7216,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.358"
+version = "0.0.359"
 dependencies = [
  "async-trait",
  "backon",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.358"
+version = "0.0.359"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
@@ -487,7 +487,7 @@ graphs:
           let mask = env.get("__value")["__citygml_lod_mask"];
           let lod = 0;
           let i = 0;
-          while i < 8 {
+          while i <= 4 {
             if (mask & (1 << i)) != 0 { lod = i; }
             i += 1;
           }

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
@@ -481,17 +481,6 @@ graphs:
         method: remove
       - attribute: dirRoot
         method: remove
-      - attribute: _lod
-        method: create
-        value: |
-          let mask = env.get("__value")["__citygml_lod_mask"];
-          let lod = 0;
-          let i = 0;
-          while i <= 4 {
-            if (mask & (1 << i)) != 0 { lod = i; }
-            i += 1;
-          }
-          lod
   - id: c32a279d-97be-4584-b282-4d65627b1132
     name: FeatureLodFilter
     type: action
@@ -523,6 +512,17 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+      - attribute: _lod
+        method: create
+        value: |
+          let mask = env.get("__value")["__citygml_lod_mask"];
+          let lod = 0;
+          let i = 0;
+          while i <= 4 {
+            if (mask & (1 << i)) != 0 { lod = i; }
+            i += 1;
+          }
+          lod
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0ec
     name: VerticalReprojectorByLod1
     type: action
@@ -554,6 +554,17 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+      - attribute: _lod
+        method: create
+        value: |
+          let mask = env.get("__value")["__citygml_lod_mask"];
+          let lod = 0;
+          let i = 0;
+          while i <= 4 {
+            if (mask & (1 << i)) != 0 { lod = i; }
+            i += 1;
+          }
+          lod
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d2
     name: VerticalReprojectorByLod2
     type: action
@@ -585,6 +596,17 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+      - attribute: _lod
+        method: create
+        value: |
+          let mask = env.get("__value")["__citygml_lod_mask"];
+          let lod = 0;
+          let i = 0;
+          while i <= 4 {
+            if (mask & (1 << i)) != 0 { lod = i; }
+            i += 1;
+          }
+          lod
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d3
     name: VerticalReprojectorByLod2NoTexture
     type: action
@@ -616,6 +638,17 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+      - attribute: _lod
+        method: create
+        value: |
+          let mask = env.get("__value")["__citygml_lod_mask"];
+          let lod = 0;
+          let i = 0;
+          while i <= 4 {
+            if (mask & (1 << i)) != 0 { lod = i; }
+            i += 1;
+          }
+          lod
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d4
     name: VerticalReprojectorByLod3
     type: action
@@ -647,6 +680,17 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+      - attribute: _lod
+        method: create
+        value: |
+          let mask = env.get("__value")["__citygml_lod_mask"];
+          let lod = 0;
+          let i = 0;
+          while i <= 4 {
+            if (mask & (1 << i)) != 0 { lod = i; }
+            i += 1;
+          }
+          lod
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d5
     name: VerticalReprojectorByLod3NoTexture
     type: action
@@ -678,6 +722,17 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+      - attribute: _lod
+        method: create
+        value: |
+          let mask = env.get("__value")["__citygml_lod_mask"];
+          let lod = 0;
+          let i = 0;
+          while i <= 4 {
+            if (mask & (1 << i)) != 0 { lod = i; }
+            i += 1;
+          }
+          lod
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d6
     name: VerticalReprojectorByLod4
     type: action
@@ -709,6 +764,17 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+      - attribute: _lod
+        method: create
+        value: |
+          let mask = env.get("__value")["__citygml_lod_mask"];
+          let lod = 0;
+          let i = 0;
+          while i <= 4 {
+            if (mask & (1 << i)) != 0 { lod = i; }
+            i += 1;
+          }
+          lod
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d7
     name: VerticalReprojectorByLod4NoTexture
     type: action

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
@@ -481,6 +481,17 @@ graphs:
         method: remove
       - attribute: dirRoot
         method: remove
+      - attribute: _lod
+        method: create
+        value: |
+          let mask = env.get("__value")["__citygml_lod_mask"];
+          let lod = 0;
+          let i = 0;
+          while i < 8 {
+            if (mask & (1 << i)) != 0 { lod = i; }
+            i += 1;
+          }
+          lod
   - id: c32a279d-97be-4584-b282-4d65627b1132
     name: FeatureLodFilter
     type: action
@@ -512,9 +523,6 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-      - attribute: _lod
-        method: create
-        value: '1'
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0ec
     name: VerticalReprojectorByLod1
     type: action
@@ -546,9 +554,6 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-      - attribute: _lod
-        method: create
-        value: '2'
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d2
     name: VerticalReprojectorByLod2
     type: action
@@ -580,9 +585,6 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-      - attribute: _lod
-        method: create
-        value: '2'
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d3
     name: VerticalReprojectorByLod2NoTexture
     type: action
@@ -614,9 +616,6 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-      - attribute: _lod
-        method: create
-        value: '3'
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d4
     name: VerticalReprojectorByLod3
     type: action
@@ -648,9 +647,6 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-      - attribute: _lod
-        method: create
-        value: '3'
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d5
     name: VerticalReprojectorByLod3NoTexture
     type: action
@@ -682,9 +678,6 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-      - attribute: _lod
-        method: create
-        value: '4'
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d6
     name: VerticalReprojectorByLod4
     type: action
@@ -716,9 +709,6 @@ graphs:
         method: create
         value: |
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-      - attribute: _lod
-        method: create
-        value: '4'
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d7
     name: VerticalReprojectorByLod4NoTexture
     type: action

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
@@ -223,7 +223,7 @@ graphs:
             # Derive _lod by recovering highest LOD from bitmask (same for all LODs). Notes:
             # 1. FeatureLodFilter filters __citygml_lod_mask to a single-bit mask representing the LOD
             # 2. Setting _lod before FeatureLodFilter would incorrectly capture the original highest LOD
-            # 3. FeatureLodFilter routes best fallback, so LOD0~2 features also exist in lod4 branch with _lod=2
+            # 3. FeatureLodFilter routes best fallback. LOD0~2 features should also exist in lod4 branch with _lod=2
             - attribute: _lod
               method: create
               value: |

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
@@ -220,6 +220,10 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+            # Derive _lod by recovering highest LOD from bitmask (same for all LODs). Notes:
+            # 1. FeatureLodFilter filters __citygml_lod_mask to a single-bit mask representing the LOD
+            # 2. Setting _lod before FeatureLodFilter would incorrectly capture the original highest LOD
+            # 3. FeatureLodFilter routes best fallback, so LOD0~2 features also exist in lod4 branch with _lod=2
             - attribute: _lod
               method: create
               value: |

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
@@ -186,6 +186,17 @@ graphs:
               method: remove
             - attribute: dirRoot
               method: remove
+            - attribute: _lod
+              method: create
+              value: |
+                let mask = env.get("__value")["__citygml_lod_mask"];
+                let lod = 0;
+                let i = 0;
+                while i < 8 {
+                  if (mask & (1 << i)) != 0 { lod = i; }
+                  i += 1;
+                }
+                lod
 
       - id: c32a279d-97be-4584-b282-4d65627b1132
         name: FeatureLodFilter
@@ -220,9 +231,6 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-            - attribute: _lod
-              method: create
-              value: '1'
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0ec
         name: VerticalReprojectorByLod1
@@ -257,9 +265,6 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-            - attribute: _lod
-              method: create
-              value: '2'
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d2
         name: VerticalReprojectorByLod2
@@ -294,9 +299,6 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-            - attribute: _lod
-              method: create
-              value: '2'
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d3
         name: VerticalReprojectorByLod2NoTexture
@@ -331,9 +333,6 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-            - attribute: _lod
-              method: create
-              value: '3'
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d4
         name: VerticalReprojectorByLod3
@@ -368,9 +367,6 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-            - attribute: _lod
-              method: create
-              value: '3'
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d5
         name: VerticalReprojectorByLod3NoTexture
@@ -405,9 +401,6 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-            - attribute: _lod
-              method: create
-              value: '4'
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d6
         name: VerticalReprojectorByLod4
@@ -442,9 +435,6 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-            - attribute: _lod
-              method: create
-              value: '4'
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d7
         name: VerticalReprojectorByLod4NoTexture

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
@@ -186,17 +186,6 @@ graphs:
               method: remove
             - attribute: dirRoot
               method: remove
-            - attribute: _lod
-              method: create
-              value: |
-                let mask = env.get("__value")["__citygml_lod_mask"];
-                let lod = 0;
-                let i = 0;
-                while i <= 4 {
-                  if (mask & (1 << i)) != 0 { lod = i; }
-                  i += 1;
-                }
-                lod
 
       - id: c32a279d-97be-4584-b282-4d65627b1132
         name: FeatureLodFilter
@@ -231,6 +220,17 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+            - attribute: _lod
+              method: create
+              value: |
+                let mask = env.get("__value")["__citygml_lod_mask"];
+                let lod = 0;
+                let i = 0;
+                while i <= 4 {
+                  if (mask & (1 << i)) != 0 { lod = i; }
+                  i += 1;
+                }
+                lod
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0ec
         name: VerticalReprojectorByLod1
@@ -265,6 +265,17 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+            - attribute: _lod
+              method: create
+              value: |
+                let mask = env.get("__value")["__citygml_lod_mask"];
+                let lod = 0;
+                let i = 0;
+                while i <= 4 {
+                  if (mask & (1 << i)) != 0 { lod = i; }
+                  i += 1;
+                }
+                lod
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d2
         name: VerticalReprojectorByLod2
@@ -299,6 +310,17 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+            - attribute: _lod
+              method: create
+              value: |
+                let mask = env.get("__value")["__citygml_lod_mask"];
+                let lod = 0;
+                let i = 0;
+                while i <= 4 {
+                  if (mask & (1 << i)) != 0 { lod = i; }
+                  i += 1;
+                }
+                lod
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d3
         name: VerticalReprojectorByLod2NoTexture
@@ -333,6 +355,17 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+            - attribute: _lod
+              method: create
+              value: |
+                let mask = env.get("__value")["__citygml_lod_mask"];
+                let lod = 0;
+                let i = 0;
+                while i <= 4 {
+                  if (mask & (1 << i)) != 0 { lod = i; }
+                  i += 1;
+                }
+                lod
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d4
         name: VerticalReprojectorByLod3
@@ -367,6 +400,17 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+            - attribute: _lod
+              method: create
+              value: |
+                let mask = env.get("__value")["__citygml_lod_mask"];
+                let lod = 0;
+                let i = 0;
+                while i <= 4 {
+                  if (mask & (1 << i)) != 0 { lod = i; }
+                  i += 1;
+                }
+                lod
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d5
         name: VerticalReprojectorByLod3NoTexture
@@ -401,6 +445,17 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+            - attribute: _lod
+              method: create
+              value: |
+                let mask = env.get("__value")["__citygml_lod_mask"];
+                let lod = 0;
+                let i = 0;
+                while i <= 4 {
+                  if (mask & (1 << i)) != 0 { lod = i; }
+                  i += 1;
+                }
+                lod
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d6
         name: VerticalReprojectorByLod4
@@ -435,6 +490,17 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+            - attribute: _lod
+              method: create
+              value: |
+                let mask = env.get("__value")["__citygml_lod_mask"];
+                let lod = 0;
+                let i = 0;
+                while i <= 4 {
+                  if (mask & (1 << i)) != 0 { lod = i; }
+                  i += 1;
+                }
+                lod
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d7
         name: VerticalReprojectorByLod4NoTexture

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
@@ -192,7 +192,7 @@ graphs:
                 let mask = env.get("__value")["__citygml_lod_mask"];
                 let lod = 0;
                 let i = 0;
-                while i < 8 {
+                while i <= 4 {
                   if (mask & (1 << i)) != 0 { lod = i; }
                   i += 1;
                 }


### PR DESCRIPTION
## Overview

PR #1953 fixed lod value to match tileset branch but introduced another issue.

Previously `__lod` was injected as highest lod, not the value of `__lod` metadata which is a bitmask. However, lod now becomes a general `__citygml_lod_mask` attribute so such a specialized injection is unwanted.

Note that `_lod` must be set after `FeatureLodFilter` which also filters the correct bitmask for the corresponding branch. See comments in the workflow:

https://github.com/reearth/reearth-flow/blob/6373582104a9e1ffc040889ea9487169677966c1/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml#L223-L237

## Table of behavior

`_lod` value | up to lod2 feature sent to lod4 branch | up to lod4 feature sent to lod2 branch
--- | --- | ---
before #1953 | 2 | 4
after #1953 | 4 | 2
this PR | 2 | 2

## Notes

The fix applies a bit extraction for each branch which is a bit verbose. A better solution is to drop current bitmask design but simply attach a lod to GeometryTrait so highest lod can be naturally obtained without bit-level calculation.