### PR TITLE
fix(websocket): fix versioning, race condition, and position drift after rollback

### DIFF
--- a/server/websocket/src/infrastructure/gcs/mod.rs
+++ b/server/websocket/src/infrastructure/gcs/mod.rs
@@ -22,7 +22,7 @@ use google_cloud_storage::{
 use hex;
 use serde::Deserialize;
 use time::OffsetDateTime;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 use yrs::{
     updates::decoder::Decode, updates::encoder::Encode, Doc, ReadTxn, StateVector, Transact, Update,
 };
@@ -333,6 +333,87 @@ impl GcsStore {
 
         drop(txn);
         Ok(doc)
+    }
+
+    /// Delete all GCS update objects with clock > target_clock.
+    /// Used after rollback to remove stale "future" versions so that
+    /// `get_updates()` / `get_history()` only return valid versions.
+    pub async fn delete_updates_after(&self, doc_id: &str, target_clock: u32) -> Result<usize> {
+        let oid = match get_oid(self, doc_id.as_bytes()).await? {
+            Some(oid) => oid,
+            None => return Ok(0),
+        };
+
+        let prefix_bytes = [V1, KEYSPACE_DOC]
+            .iter()
+            .chain(&oid.to_be_bytes())
+            .chain(&[SUB_UPDATE])
+            .copied()
+            .collect::<Vec<_>>();
+        let prefix_str = hex::encode(&prefix_bytes);
+
+        let mut all_objects = Vec::new();
+        let mut page_token = None;
+
+        loop {
+            let request = ListObjectsRequest {
+                bucket: self.bucket.clone(),
+                prefix: Some(prefix_str.clone()),
+                page_token: page_token.clone(),
+                ..Default::default()
+            };
+
+            let response = self.client.list_objects(&request).await?;
+            let items = response.items.unwrap_or_default();
+            all_objects.extend(items);
+
+            if let Some(token) = response.next_page_token {
+                page_token = Some(token);
+            } else {
+                break;
+            }
+        }
+
+        let mut to_delete = Vec::new();
+        for obj in &all_objects {
+            if let Ok(key_bytes) = hex::decode(&obj.name) {
+                if key_bytes.len() >= 12 {
+                    if let Ok(clock_bytes) = key_bytes[7..11].try_into() {
+                        let clock = u32::from_be_bytes(clock_bytes);
+                        if clock > target_clock {
+                            to_delete.push(obj.name.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        let count = to_delete.len();
+        for chunk in to_delete.chunks(BATCH_SIZE) {
+            let delete_futures = chunk.iter().map(|obj_name| {
+                let bucket = self.bucket.clone();
+                let object = obj_name.clone();
+                async move {
+                    self.client
+                        .delete_object(&DeleteObjectRequest {
+                            bucket,
+                            object,
+                            ..Default::default()
+                        })
+                        .await
+                }
+            });
+            let _ = join_all(delete_futures).await;
+        }
+
+        if count > 0 {
+            info!(
+                "Deleted {} update objects after clock {} for doc '{}'",
+                count, target_clock, doc_id
+            );
+        }
+
+        Ok(count)
     }
 
     pub async fn get_updates(&self, doc_id: &str) -> Result<Vec<UpdateInfo>> {

--- a/server/websocket/src/infrastructure/gcs/mod.rs
+++ b/server/websocket/src/infrastructure/gcs/mod.rs
@@ -22,7 +22,7 @@ use google_cloud_storage::{
 use hex;
 use serde::Deserialize;
 use time::OffsetDateTime;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 use yrs::{
     updates::decoder::Decode, updates::encoder::Encode, Doc, ReadTxn, StateVector, Transact, Update,
 };
@@ -376,15 +376,36 @@ impl GcsStore {
 
         let mut to_delete = Vec::new();
         for obj in &all_objects {
-            if let Ok(key_bytes) = hex::decode(&obj.name) {
-                if key_bytes.len() >= 12 {
-                    if let Ok(clock_bytes) = key_bytes[7..11].try_into() {
-                        let clock = u32::from_be_bytes(clock_bytes);
-                        if clock > target_clock {
-                            to_delete.push(obj.name.clone());
-                        }
-                    }
+            let key_bytes = match hex::decode(&obj.name) {
+                Ok(b) => b,
+                Err(e) => {
+                    warn!(
+                        "Skipping update object with non-hex name '{}' for doc '{}': {}",
+                        obj.name, doc_id, e
+                    );
+                    continue;
                 }
+            };
+            if key_bytes.len() < 12 {
+                warn!(
+                    "Skipping update object with unexpected key length '{}' for doc '{}': got {} bytes",
+                    obj.name, doc_id, key_bytes.len()
+                );
+                continue;
+            }
+            let clock_bytes: [u8; 4] = match key_bytes[7..11].try_into() {
+                Ok(b) => b,
+                Err(_) => {
+                    warn!(
+                        "Skipping update object with unreadable clock bytes '{}' for doc '{}'",
+                        obj.name, doc_id
+                    );
+                    continue;
+                }
+            };
+            let clock = u32::from_be_bytes(clock_bytes);
+            if clock > target_clock {
+                to_delete.push(obj.name.clone());
             }
         }
 
@@ -403,7 +424,10 @@ impl GcsStore {
                         .await
                 }
             });
-            let _ = join_all(delete_futures).await;
+            let delete_results = join_all(delete_futures).await;
+            for result in delete_results {
+                result?;
+            }
         }
 
         if count > 0 {

--- a/server/websocket/src/infrastructure/repository/document.rs
+++ b/server/websocket/src/infrastructure/repository/document.rs
@@ -175,6 +175,10 @@ impl DocumentRepository for DocumentRepositoryImpl {
             store.flush_doc_v2(doc_id, &txn).await?;
         }
 
+        // Delete stale update objects beyond the target version so that
+        // get_history() only returns valid versions.
+        store.delete_updates_after(doc_id, version as u32).await?;
+
         let document = Self::to_document(doc_id, doc, version, Utc::now());
         Ok(document)
     }

--- a/server/websocket/src/infrastructure/websocket/broadcast_group.rs
+++ b/server/websocket/src/infrastructure/websocket/broadcast_group.rs
@@ -257,7 +257,11 @@ impl BroadcastGroup {
                         break;
                     },
                     _ = interval.tick() => {
-                        let awareness = awareness_clone.read().await;
+                        // Acquire write lock to serialize after redis_subscriber_task
+                        // (which also takes write lock to apply updates). This ensures
+                        // the state vector includes all Redis updates applied so far,
+                        // preventing stale SyncStep1 messages that cause position drift.
+                        let awareness = awareness_clone.write().await;
                         let txn = awareness.doc().transact();
                         let state_vector = txn.state_vector();
 

--- a/server/websocket/src/infrastructure/websocket/pool.rs
+++ b/server/websocket/src/infrastructure/websocket/pool.rs
@@ -223,9 +223,9 @@ impl BroadcastPool {
 
     /// Force-evict a BroadcastGroup regardless of active connections.
     /// Used after rollback: the rolled-back state has already been persisted
-    /// to GCS, so we skip the normal shutdown flush. Dropping the group
-    /// closes the broadcast sender, which terminates all client sink tasks
-    /// and closes WebSocket connections.
+    /// to GCS, so we skip the normal shutdown flush. Cancels all per-connection
+    /// tasks via CancellationToken, then deletes the Redis stream under the
+    /// lock to prevent evicted tasks from recreating it.
     pub async fn force_evict_group(&self, doc_id: &str) {
         let lock = self.get_or_create_lock(doc_id);
         let guard = lock.lock_owned().await;
@@ -237,6 +237,16 @@ impl BroadcastPool {
                     doc_id, e
                 );
             }
+
+            // Delete Redis stream after cancellation, under the lock, so that
+            // no evicted task can recreate the stream between deletion and eviction.
+            if let Err(e) = self.storage.redis_store().delete_stream(doc_id).await {
+                warn!(
+                    "Failed to delete Redis stream during force-evict for '{}': {}",
+                    doc_id, e
+                );
+            }
+
             info!("Force-evicted BroadcastGroup for doc_id: {}", doc_id);
         }
 

--- a/server/websocket/src/infrastructure/websocket/pool.rs
+++ b/server/websocket/src/infrastructure/websocket/pool.rs
@@ -237,17 +237,16 @@ impl BroadcastPool {
                     doc_id, e
                 );
             }
-
-            // Delete Redis stream after cancellation, under the lock, so that
-            // no evicted task can recreate the stream between deletion and eviction.
-            if let Err(e) = self.storage.redis_store().delete_stream(doc_id).await {
-                warn!(
-                    "Failed to delete Redis stream during force-evict for '{}': {}",
-                    doc_id, e
-                );
-            }
-
             info!("Force-evicted BroadcastGroup for doc_id: {}", doc_id);
+        }
+
+        // Delete Redis stream under the lock even when no in-memory group exists,
+        // so stale updates cannot survive a rollback/force-eviction path.
+        if let Err(e) = self.storage.redis_store().delete_stream(doc_id).await {
+            warn!(
+                "Failed to delete Redis stream during force-evict for '{}': {}",
+                doc_id, e
+            );
         }
 
         drop(guard);

--- a/server/websocket/src/presentation/http/handlers/document_handler.rs
+++ b/server/websocket/src/presentation/http/handlers/document_handler.rs
@@ -105,13 +105,9 @@ impl DocumentHandler {
             group.signal_rollback().await;
         }
 
-        if let Err(e) = state.pool.get_redis_store().delete_stream(&doc_id).await {
-            warn!(
-                "Failed to delete Redis stream during rollback for '{}': {}",
-                doc_id, e
-            );
-        }
-
+        // 3. Force-evict the group: cancels all connection tasks, then deletes
+        //    the Redis stream atomically under the lock (prevents evicted tasks
+        //    from recreating the stream).
         state.pool.force_evict_group(&doc_id).await;
 
         Json(DocumentResponse {


### PR DESCRIPTION
## Summary

Follow-up fixes for issues observed after merging #2045 (rollback data corruption fix).

### 1. Versioning broken after rollback
`flush_doc_v2` persisted the rolled-back snapshot but left stale GCS update objects (versions beyond the rollback target) in place. `get_history()` listed all of them, showing invalid "future" versions.

**Fix:** Add `delete_updates_after(doc_id, target_clock)` to GCS store. Called during rollback to prune update objects with `clock > target_clock`. History now only shows valid versions.

### 2. Race condition between delete_stream and force_evict
`delete_stream` ran before `force_evict_group` in the rollback handler. During that gap, evicted tasks could still write to Redis, recreating the stream. Reconnecting clients then loaded stale data.

**Fix:** Move `delete_stream` inside `force_evict_group`, executed under the lock after `CancellationToken` cancels all connection tasks. No task can recreate the stream between deletion and eviction.

### 3. Position drift (200px drag → ~180px land)
The periodic `sync_task` (every 30s) read the doc state vector with a **read lock**, racing with `redis_subscriber_task` which applies updates with a **write lock**. If sync_task read before Redis updates were applied, the stale `SyncStep1` caused clients to miss the last few pixels of a position change. Worse with cross-region latency (test env: Cloud Run in us-central1, Redis in asia-northeast1).

**Fix:** `sync_task` now acquires **write lock** to serialize after `redis_subscriber_task`, ensuring the state vector always includes all applied Redis updates before broadcasting `SyncStep1`.

## Test plan

- [x] `cargo test --all-features` in `server/websocket/`
- [x] `cargo clippy --all-features -- -D warnings` passes
- [x] `go build ./...` in `server/api/`
- [ ] Manual: Rollback a project → version history shows only versions up to rollback target
- [ ] Manual: Two users editing → position changes reflect accurately after drop
- [ ] Manual: Rollback with concurrent editor → no NaN corruption, no stale state on reconnect