### PR TITLE
fix(engine): line on line overlayer performance improvements

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5693,7 +5693,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.311"
+version = "0.0.312"
 dependencies = [
  "directories",
  "log",
@@ -5722,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6516,7 +6516,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "futures",
  "once_cell",
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "approx",
  "async-trait",
@@ -6582,7 +6582,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "Inflector",
  "approx",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6661,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6729,7 +6729,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6791,7 +6791,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "bytes",
  "clap",
@@ -6829,7 +6829,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6869,7 +6869,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "chrono",
  "futures",
@@ -6883,7 +6883,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6912,7 +6912,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "approx",
  "bvh",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6976,7 +6976,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6985,7 +6985,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7015,7 +7015,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7066,7 +7066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7078,7 +7078,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "bytes",
  "futures",
@@ -7095,7 +7095,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "bytes",
  "futures",
@@ -7114,7 +7114,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7128,7 +7128,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7163,7 +7163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7200,7 +7200,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.360"
+version = "0.0.361"
 dependencies = [
  "async-trait",
  "backon",
@@ -11068,7 +11068,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.213"
+version = "0.1.214"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.360"
+version = "0.0.361"
 
 [profile.dev]
 opt-level = 0

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.311"
+version = "0.0.312"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -427,11 +427,6 @@ impl DiskBackedFeatures {
         Ok(serde_json::from_slice(&buf)?)
     }
 
-    fn read_geometry(&self, i: usize) -> Result<Arc<Geometry>, BoxedError> {
-        let feature = self.read_feature(i)?;
-        Ok(feature.geometry)
-    }
-
     fn len(&self) -> usize {
         self.offsets.len()
     }
@@ -502,32 +497,19 @@ fn process_group<W: Write>(
     }
 
     let disk_feats = DiskBackedFeatures::scan(&features_path)?;
-    let geometries: Vec<Arc<Geometry>> = (0..disk_feats.len())
-        .map(|i| disk_feats.read_geometry(i))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    let lss_per_feature: Vec<Vec<LineString2D<f64>>> = geometries
-        .iter()
-        .map(|g| match &g.value {
+    let mut attributes_by_feature: Vec<Arc<Attributes>> = Vec::with_capacity(disk_feats.len());
+    let mut lss_per_feature: Vec<Vec<LineString2D<f64>>> = Vec::with_capacity(disk_feats.len());
+    for i in 0..disk_feats.len() {
+        let feat = disk_feats.read_feature(i)?;
+        let lss = match &feat.geometry.value {
             GeometryValue::FlowGeometry2D(g2) => extract_line_strings(g2),
             _ => Vec::new(),
-        })
-        .collect();
+        };
+        attributes_by_feature.push(feat.attributes);
+        lss_per_feature.push(lss);
+    }
 
     let overlay = overlay_entries(&entries, &lss_per_feature, tolerance);
-
-    let mut attributes_cache: HashMap<usize, Arc<Attributes>> = HashMap::new();
-    let load_attrs = |i: usize,
-                      cache: &mut HashMap<usize, Arc<Attributes>>|
-     -> Result<Arc<Attributes>, BoxedError> {
-        if let Some(a) = cache.get(&i) {
-            return Ok(a.clone());
-        }
-        let feat = disk_feats.read_feature(i)?;
-        let a = feat.attributes.clone();
-        cache.insert(i, a.clone());
-        Ok(a)
-    };
 
     let mut line_count: usize = 0;
     for meta in &overlay.line_strings_with_metadata {
@@ -545,7 +527,7 @@ fn process_group<W: Write>(
 
         let mut overlaid_list: Vec<AttributeValue> = Vec::with_capacity(source_feature_idxs.len());
         for &fi in &source_feature_idxs {
-            let attrs = load_attrs(fi, &mut attributes_cache)?;
+            let attrs = &attributes_by_feature[fi];
             let attrs_map: HashMap<String, AttributeValue> = attrs
                 .as_ref()
                 .iter()
@@ -560,7 +542,7 @@ fn process_group<W: Write>(
 
         if let Some(group_by) = group_by {
             let first_fi = source_feature_idxs[0];
-            let first_attrs = load_attrs(first_fi, &mut attributes_cache)?;
+            let first_attrs = &attributes_by_feature[first_fi];
             for gb in group_by {
                 if let Some(value) = first_attrs.get(gb) {
                     attributes.insert(gb.clone(), value.clone());
@@ -596,7 +578,7 @@ fn process_group<W: Write>(
     for coord in &overlay.split_coords {
         let attributes: IndexMap<Attribute, AttributeValue> =
             if let (Some(group_by), Some(lfi)) = (group_by, last_feature_idx) {
-                let attrs = load_attrs(lfi, &mut attributes_cache)?;
+                let attrs = &attributes_by_feature[lfi];
                 group_by
                     .iter()
                     .filter_map(|gb| attrs.get(gb).cloned().map(|v| (gb.clone(), v)))

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -498,14 +498,14 @@ fn process_group<W: Write>(
 
     let disk_feats = DiskBackedFeatures::scan(&features_path)?;
     if disk_feats.len() != aabbs_per_feature.len() {
-        return Err(Box::new(GeometryProcessorError::LineOnLineOverlayerFactory(
-            format!(
+        return Err(Box::new(
+            GeometryProcessorError::LineOnLineOverlayerFactory(format!(
                 "aabbs/features row count mismatch in {}: aabbs={}, features={}",
                 group_dir.display(),
                 aabbs_per_feature.len(),
                 disk_feats.len(),
-            ),
-        )));
+            )),
+        ));
     }
     let mut attributes_by_feature: Vec<Arc<Attributes>> = Vec::with_capacity(disk_feats.len());
     let mut lss_per_feature: Vec<Vec<LineString2D<f64>>> = Vec::with_capacity(disk_feats.len());

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -123,7 +123,7 @@ pub struct LineOnLineOverlayer {
     group_by: Option<Vec<Attribute>>,
     tolerance: f64,
     overlaid_lists_attr_name: String,
-    // Disk-backed state (mirrors AreaOnAreaOverlayer).
+    // Disk-backed state
     group_map: HashMap<AttributeValue, usize>,
     group_count: usize,
     temp_dir: Option<PathBuf>,
@@ -738,8 +738,7 @@ fn overlay_entries(
     }
 
     // Each physical intersection is discovered by both sides of the crossing plus extras
-    // from 3+-way near-coincidences, so dedup by tolerance-expanded envelope. Sources are
-    // discarded by design, matching pre-rewrite behavior.
+    // from 3+-way near-coincidences, so dedup by tolerance-expanded envelope.
     #[derive(Clone, Copy)]
     struct PointEntry {
         idx: usize,

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -1,6 +1,14 @@
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufRead, BufReader, BufWriter, Read as _, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use reearth_flow_geometry::algorithm::line_intersection::LineIntersection;
 use reearth_flow_geometry::algorithm::line_string_ops::{
     LineStringOps, LineStringSplitResult, LineStringWithTree2D,
@@ -10,22 +18,23 @@ use reearth_flow_geometry::types::coordinate::Coordinate2D;
 use reearth_flow_geometry::types::geometry::Geometry2D;
 use reearth_flow_geometry::types::line_string::LineString2D;
 use reearth_flow_geometry::types::no_value::NoValue;
-use reearth_flow_geometry::types::point::Point;
-use reearth_flow_runtime::node::REJECTED_PORT;
+use reearth_flow_geometry::types::point::{Point, Point2D};
 use reearth_flow_runtime::{
+    cache::executor_cache_subdir,
     errors::BoxedError,
     event::EventHub,
     executor_operation::{ExecutorContext, NodeContext},
     forwarder::ProcessorChannelForwarder,
-    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT, REJECTED_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue, Attributes, Feature, GeometryValue};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes, Feature, Geometry, GeometryValue};
+use rstar::{RTree, RTreeObject, AABB};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
-use std::collections::HashMap;
 
 use super::errors::GeometryProcessorError;
+use crate::ACCUMULATOR_BUFFER_BYTE_THRESHOLD;
 
 pub static POINT_PORT: Lazy<Port> = Lazy::new(|| Port::new("point"));
 pub static LINE_PORT: Lazy<Port> = Lazy::new(|| Port::new("line"));
@@ -88,7 +97,12 @@ impl ProcessorFactory for LineOnLineOverlayerFactory {
             overlaid_lists_attr_name: params
                 .overlaid_lists_attr_name
                 .unwrap_or_else(|| "overlaidLists".to_string()),
+            group_map: HashMap::new(),
+            group_count: 0,
+            temp_dir: None,
             buffer: HashMap::new(),
+            buffer_bytes: 0,
+            executor_id: None,
         }))
     }
 }
@@ -105,21 +119,143 @@ pub struct LineOnLineOverlayerParam {
     overlaid_lists_attr_name: Option<String>,
 }
 
-#[allow(clippy::type_complexity)]
-#[derive(Debug, Clone)]
 pub struct LineOnLineOverlayer {
     group_by: Option<Vec<Attribute>>,
     tolerance: f64,
     overlaid_lists_attr_name: String,
-    buffer: HashMap<AttributeValue, Vec<Feature>>,
+    // Disk-backed state (mirrors AreaOnAreaOverlayer).
+    group_map: HashMap<AttributeValue, usize>,
+    group_count: usize,
+    temp_dir: Option<PathBuf>,
+    /// group_idx -> Vec<(aabbs_json_for_feature, feature_json)>.
+    /// `aabbs_json_for_feature` is a JSON array `[[minx, miny, maxx, maxy], ...]` with one
+    /// entry per sub-line-string of the feature. Row i of `aabbs.jsonl` matches row i of
+    /// `features.jsonl`.
+    buffer: HashMap<usize, Vec<(String, String)>>,
+    buffer_bytes: usize,
+    executor_id: Option<uuid::Uuid>,
+}
+
+impl std::fmt::Debug for LineOnLineOverlayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LineOnLineOverlayer")
+            .field("group_count", &self.group_count)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Clone for LineOnLineOverlayer {
+    fn clone(&self) -> Self {
+        Self {
+            group_by: self.group_by.clone(),
+            tolerance: self.tolerance,
+            overlaid_lists_attr_name: self.overlaid_lists_attr_name.clone(),
+            group_map: HashMap::new(),
+            group_count: 0,
+            temp_dir: None,
+            buffer: HashMap::new(),
+            buffer_bytes: 0,
+            executor_id: self.executor_id,
+        }
+    }
+}
+
+fn engine_cache_dir(executor_id: uuid::Uuid) -> PathBuf {
+    executor_cache_subdir(executor_id, "processors")
+}
+
+impl LineOnLineOverlayer {
+    fn ensure_temp_dir(&mut self) -> Result<&PathBuf, BoxedError> {
+        if self.temp_dir.is_none() {
+            let executor_id = self.executor_id.unwrap_or_else(uuid::Uuid::nil);
+            let dir = engine_cache_dir(executor_id).join(format!("lol-{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&dir)?;
+            self.temp_dir = Some(dir);
+        }
+        Ok(self.temp_dir.as_ref().unwrap())
+    }
+
+    fn ensure_group_dir(&mut self, group_idx: usize) -> Result<PathBuf, BoxedError> {
+        let dir = self.ensure_temp_dir()?.clone();
+        let group_dir = dir.join(format!("group_{group_idx:06}"));
+        std::fs::create_dir_all(&group_dir)?;
+        Ok(group_dir)
+    }
+
+    fn append_to_group(
+        &mut self,
+        group_idx: usize,
+        aabbs_json: &str,
+        feature_json: &str,
+    ) -> Result<(), BoxedError> {
+        self.buffer_bytes += aabbs_json.len() + feature_json.len();
+        self.buffer
+            .entry(group_idx)
+            .or_default()
+            .push((aabbs_json.to_string(), feature_json.to_string()));
+
+        if self.buffer_bytes >= ACCUMULATOR_BUFFER_BYTE_THRESHOLD {
+            self.flush_buffer()?;
+        }
+        Ok(())
+    }
+
+    fn flush_buffer(&mut self) -> Result<(), BoxedError> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+
+        for (group_idx, entries) in std::mem::take(&mut self.buffer) {
+            let group_dir = self.ensure_group_dir(group_idx)?;
+
+            let aabbs_file = File::options()
+                .create(true)
+                .append(true)
+                .open(group_dir.join("aabbs.jsonl"))?;
+            let mut aabb_w = BufWriter::new(aabbs_file);
+            let feats_file = File::options()
+                .create(true)
+                .append(true)
+                .open(group_dir.join("features.jsonl"))?;
+            let mut feat_w = BufWriter::new(feats_file);
+
+            for (aabbs_json, feature_json) in &entries {
+                aabb_w.write_all(aabbs_json.as_bytes())?;
+                aabb_w.write_all(b"\n")?;
+                feat_w.write_all(feature_json.as_bytes())?;
+                feat_w.write_all(b"\n")?;
+            }
+            aabb_w.flush()?;
+            feat_w.flush()?;
+        }
+
+        self.buffer_bytes = 0;
+        Ok(())
+    }
+}
+
+impl Drop for LineOnLineOverlayer {
+    fn drop(&mut self) {
+        if let Some(ref dir) = self.temp_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
 }
 
 impl Processor for LineOnLineOverlayer {
+    fn is_accumulating(&self) -> bool {
+        true
+    }
+
     fn process(
         &mut self,
         ctx: ExecutorContext,
         fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
+        if self.executor_id.is_none() {
+            self.executor_id = Some(fw.executor_id());
+        }
+
         let feature = &ctx.feature;
         let geometry = &feature.geometry;
         if geometry.is_empty() {
@@ -127,10 +263,13 @@ impl Processor for LineOnLineOverlayer {
             return Ok(());
         }
         match &geometry.value {
-            GeometryValue::None => {
-                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
-            }
-            GeometryValue::FlowGeometry2D(_) => {
+            GeometryValue::FlowGeometry2D(geom_2d) => {
+                let line_strings = extract_line_strings(geom_2d);
+                if line_strings.is_empty() {
+                    fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+                    return Ok(());
+                }
+
                 let key = if let Some(group_by) = &self.group_by {
                     AttributeValue::Array(
                         group_by
@@ -141,21 +280,19 @@ impl Processor for LineOnLineOverlayer {
                 } else {
                     AttributeValue::Null
                 };
+                let group_idx = if let Some(&idx) = self.group_map.get(&key) {
+                    idx
+                } else {
+                    let idx = self.group_count;
+                    self.group_map.insert(key, idx);
+                    self.group_count += 1;
+                    idx
+                };
 
-                if !self.buffer.contains_key(&key) {
-                    let overlaid = self.overlay()?;
-                    for feature in &overlaid.line {
-                        fw.send(ctx.new_with_feature_and_port(feature.clone(), LINE_PORT.clone()));
-                    }
-                    for feature in &overlaid.point {
-                        fw.send(ctx.new_with_feature_and_port(feature.clone(), POINT_PORT.clone()));
-                    }
-                    self.buffer.clear();
-                }
-                self.buffer
-                    .entry(key.clone())
-                    .or_default()
-                    .push(feature.clone());
+                let aabbs: Vec<[f64; 4]> = line_strings.iter().map(aabb_of_line_string).collect();
+                let aabbs_json = serde_json::to_string(&aabbs)?;
+                let feature_json = serde_json::to_string(&ctx.feature)?;
+                self.append_to_group(group_idx, &aabbs_json, &feature_json)?;
             }
             _ => {
                 fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
@@ -169,20 +306,51 @@ impl Processor for LineOnLineOverlayer {
         ctx: NodeContext,
         fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
-        let overlaid = self.overlay()?;
-        for feature in &overlaid.line {
-            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
-                &ctx,
-                feature.clone(),
-                LINE_PORT.clone(),
-            ));
+        self.flush_buffer()?;
+
+        let temp_dir = match &self.temp_dir {
+            Some(d) => d.clone(),
+            None => return Ok(()),
+        };
+
+        let output_id = uuid::Uuid::new_v4();
+        let line_path = temp_dir.join(format!("lol-line-{output_id}.jsonl.zst"));
+        let point_path = temp_dir.join(format!("lol-point-{output_id}.jsonl.zst"));
+        let mut line_writer = BufWriter::new(zstd::Encoder::new(File::create(&line_path)?, 1)?);
+        let mut point_writer = BufWriter::new(zstd::Encoder::new(File::create(&point_path)?, 1)?);
+        let mut line_count: usize = 0;
+        let mut point_count: usize = 0;
+
+        for group_idx in 0..self.group_count {
+            let group_dir = temp_dir.join(format!("group_{group_idx:06}"));
+            let (lc, pc) = process_group(
+                &group_dir,
+                self.tolerance,
+                self.group_by.as_deref(),
+                &self.overlaid_lists_attr_name,
+                &mut line_writer,
+                &mut point_writer,
+            )?;
+            line_count += lc;
+            point_count += pc;
         }
-        for feature in &overlaid.point {
-            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
-                &ctx,
-                feature.clone(),
-                POINT_PORT.clone(),
-            ));
+
+        line_writer
+            .into_inner()
+            .map_err(|e| e.into_error())?
+            .finish()?;
+        point_writer
+            .into_inner()
+            .map_err(|e| e.into_error())?
+            .finish()?;
+
+        let context = ctx.as_context();
+
+        if line_count > 0 {
+            fw.send_file(line_path, LINE_PORT.clone(), context.clone());
+        }
+        if point_count > 0 {
+            fw.send_file(point_path, POINT_PORT.clone(), context);
         }
 
         Ok(())
@@ -193,354 +361,536 @@ impl Processor for LineOnLineOverlayer {
     }
 }
 
-struct OverlayedFeatures {
-    point: Vec<Feature>,
-    line: Vec<Feature>,
-}
-
-impl OverlayedFeatures {
-    fn new() -> Self {
-        Self {
-            point: Vec::new(),
-            line: Vec::new(),
-        }
-    }
-
-    fn extend(&mut self, other: Self) {
-        self.point.extend(other.point);
-        self.line.extend(other.line);
+/// Extract all sub-line-strings from a 2D geometry. Returns empty for unsupported types.
+fn extract_line_strings(geom: &Geometry2D<f64>) -> Vec<LineString2D<f64>> {
+    match geom {
+        Geometry2D::LineString(line) => vec![line.clone()],
+        Geometry2D::MultiLineString(multi) => multi.0.clone(),
+        Geometry2D::Polygon(polygon) => vec![polygon.exterior().clone()],
+        Geometry2D::MultiPolygon(multi) => multi.0.iter().map(|p| p.exterior().clone()).collect(),
+        _ => Vec::new(),
     }
 }
 
-impl LineOnLineOverlayer {
-    fn overlay(&self) -> Result<OverlayedFeatures, BoxedError> {
-        let mut overlaid = OverlayedFeatures::new();
-        for buffer in self.buffer.values() {
-            let buffered_features_2d = buffer
-                .iter()
-                .filter(|f| matches!(&f.geometry.value, GeometryValue::FlowGeometry2D(_)))
-                .collect::<Vec<_>>();
-            overlaid.extend(self.overlay_2d(buffered_features_2d)?);
-        }
+fn aabb_of_line_string(ls: &LineString2D<f64>) -> [f64; 4] {
+    let env = ls.envelope();
+    let lo = env.lower();
+    let hi = env.upper();
+    [lo.x(), lo.y(), hi.x(), hi.y()]
+}
 
-        Ok(overlaid)
+fn aabb_to_rstar(aabb: [f64; 4]) -> AABB<Point2D<f64>> {
+    AABB::from_corners(
+        Point2D::new_(aabb[0], aabb[1], NoValue),
+        Point2D::new_(aabb[2], aabb[3], NoValue),
+    )
+}
+
+// --- Disk-backed helpers (mirrors AreaOnAreaOverlayer) ---
+
+/// Provides random access to features stored on disk in a JSONL file.
+struct DiskBackedFeatures {
+    path: PathBuf,
+    offsets: Vec<u64>,
+    lengths: Vec<usize>,
+}
+
+impl DiskBackedFeatures {
+    fn scan(path: &Path) -> Result<Self, BoxedError> {
+        let file = File::open(path)?;
+        let mut reader = BufReader::new(file);
+        let mut offsets = Vec::new();
+        let mut lengths = Vec::new();
+        let mut offset: u64 = 0;
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let bytes_read = reader.read_line(&mut line)?;
+            if bytes_read == 0 {
+                break;
+            }
+            let trimmed_len = line.trim_end_matches('\n').len();
+            if trimmed_len > 0 {
+                offsets.push(offset);
+                lengths.push(trimmed_len);
+            }
+            offset += bytes_read as u64;
+        }
+        Ok(Self {
+            path: path.to_path_buf(),
+            offsets,
+            lengths,
+        })
     }
 
-    fn overlay_2d(&self, features_2d: Vec<&Feature>) -> Result<OverlayedFeatures, BoxedError> {
-        // mapping from line string index to feature index
-        let mut map_ls_to_features = Vec::new();
-        let line_strings = features_2d
+    fn read_feature(&self, i: usize) -> Result<Feature, BoxedError> {
+        let mut file = File::open(&self.path)?;
+        file.seek(SeekFrom::Start(self.offsets[i]))?;
+        let mut buf = vec![0u8; self.lengths[i]];
+        file.read_exact(&mut buf)?;
+        Ok(serde_json::from_slice(&buf)?)
+    }
+
+    fn read_geometry(&self, i: usize) -> Result<Arc<Geometry>, BoxedError> {
+        let feature = self.read_feature(i)?;
+        Ok(feature.geometry)
+    }
+
+    fn len(&self) -> usize {
+        self.offsets.len()
+    }
+}
+
+// --- Phase A / Phase B core types ---
+
+#[derive(Clone, Copy)]
+struct AabbEntry {
+    entry_idx: usize,
+    feature_idx: usize,
+    ls_local_idx: usize,
+    aabb: AABB<Point2D<f64>>,
+}
+
+impl RTreeObject for AabbEntry {
+    type Envelope = AABB<Point2D<f64>>;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.aabb
+    }
+}
+
+/// Per-group handler — runs Phase A (pair enumeration) and Phase B (dedup) on one group's
+/// disk-backed inputs, streaming outputs to the writers.
+fn process_group<W: Write>(
+    group_dir: &Path,
+    tolerance: f64,
+    group_by: Option<&[Attribute]>,
+    overlaid_lists_attr_name: &str,
+    line_writer: &mut W,
+    point_writer: &mut W,
+) -> Result<(usize, usize), BoxedError> {
+    let aabbs_path = group_dir.join("aabbs.jsonl");
+    let features_path = group_dir.join("features.jsonl");
+    if !aabbs_path.exists() || !features_path.exists() {
+        return Ok((0, 0));
+    }
+
+    // Load per-feature AABB arrays from disk, flatten into entry list.
+    let aabbs_per_feature: Vec<Vec<[f64; 4]>> = {
+        let file = File::open(&aabbs_path)?;
+        let reader = BufReader::new(file);
+        let mut out = Vec::new();
+        for line in reader.lines() {
+            let line = line?;
+            if line.is_empty() {
+                continue;
+            }
+            let v: Vec<[f64; 4]> = serde_json::from_str(&line)?;
+            out.push(v);
+        }
+        out
+    };
+
+    let mut entries: Vec<AabbEntry> = Vec::new();
+    for (feature_idx, lss) in aabbs_per_feature.iter().enumerate() {
+        for (ls_local_idx, aabb) in lss.iter().enumerate() {
+            entries.push(AabbEntry {
+                entry_idx: entries.len(),
+                feature_idx,
+                ls_local_idx,
+                aabb: aabb_to_rstar(*aabb),
+            });
+        }
+    }
+    if entries.is_empty() {
+        return Ok((0, 0));
+    }
+
+    // Random-access index over features + cached per-feature geometry vector.
+    let disk_feats = DiskBackedFeatures::scan(&features_path)?;
+    let geometries: Vec<Arc<Geometry>> = (0..disk_feats.len())
+        .map(|i| disk_feats.read_geometry(i))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Extract sub-line-string vectors once — index by feature_idx then ls_local_idx.
+    let lss_per_feature: Vec<Vec<LineString2D<f64>>> = geometries
+        .iter()
+        .map(|g| match &g.value {
+            GeometryValue::FlowGeometry2D(g2) => extract_line_strings(g2),
+            _ => Vec::new(),
+        })
+        .collect();
+
+    // Run the R-tree-backed overlay across all sub-line-strings in the group.
+    let overlay = overlay_entries(&entries, &lss_per_feature, tolerance);
+
+    // --- Emit line-port features ---
+    // Attribute cache keyed by feature_idx for on-demand attribute loads.
+    let mut attributes_cache: HashMap<usize, Arc<Attributes>> = HashMap::new();
+    let load_attrs = |i: usize,
+                      cache: &mut HashMap<usize, Arc<Attributes>>|
+     -> Result<Arc<Attributes>, BoxedError> {
+        if let Some(a) = cache.get(&i) {
+            return Ok(a.clone());
+        }
+        let feat = disk_feats.read_feature(i)?;
+        let a = feat.attributes.clone();
+        cache.insert(i, a.clone());
+        Ok(a)
+    };
+
+    let mut line_count: usize = 0;
+    for meta in &overlay.line_strings_with_metadata {
+        // overlay_ids indexes into `entries` (entry_idx); map each to its source feature_idx.
+        let source_feature_idxs: Vec<usize> = meta
+            .overlay_ids
             .iter()
-            .enumerate()
-            .filter_map(|(i, f)| f.geometry.value.as_flow_geometry_2d().map(|f| (i, f)))
-            .filter_map(|(i, g)| {
-                if let Geometry2D::LineString(line) = g {
-                    map_ls_to_features.push(i);
-                    Some(vec![line.clone()])
-                } else if let Geometry2D::MultiLineString(multi_line) = g {
-                    // Add one entry for each line in the multi-line
-                    for _ in 0..multi_line.0.len() {
-                        map_ls_to_features.push(i);
-                    }
-                    Some(multi_line.0.clone())
-                } else if let Geometry2D::Polygon(polygon) = g {
-                    // Extract exterior ring as LineString
-                    map_ls_to_features.push(i);
-                    Some(vec![polygon.exterior().clone()])
-                } else if let Geometry2D::MultiPolygon(multi_polygon) = g {
-                    // Extract all exterior rings as LineStrings
-                    // Add one entry for each polygon in the multi-polygon
-                    for _ in 0..multi_polygon.0.len() {
-                        map_ls_to_features.push(i);
-                    }
-                    Some(
-                        multi_polygon
-                            .0
-                            .iter()
-                            .map(|p| p.exterior().clone())
-                            .collect(),
-                    )
+            .map(|&entry_idx| entries[entry_idx].feature_idx)
+            .collect();
+
+        let mut attributes = Attributes::new();
+        attributes.insert(
+            Attribute::new("overlayCount"),
+            AttributeValue::Number(Number::from(meta.overlay_count)),
+        );
+
+        let mut overlaid_list: Vec<AttributeValue> = Vec::with_capacity(source_feature_idxs.len());
+        for &fi in &source_feature_idxs {
+            let attrs = load_attrs(fi, &mut attributes_cache)?;
+            let attrs_map: HashMap<String, AttributeValue> = attrs
+                .as_ref()
+                .iter()
+                .map(|(k, v)| (k.clone().inner(), v.clone()))
+                .collect();
+            overlaid_list.push(AttributeValue::Map(attrs_map));
+        }
+        attributes.insert(
+            Attribute::new(overlaid_lists_attr_name),
+            AttributeValue::Array(overlaid_list),
+        );
+
+        if let Some(group_by) = group_by {
+            let first_fi = source_feature_idxs[0];
+            let first_attrs = load_attrs(first_fi, &mut attributes_cache)?;
+            for gb in group_by {
+                if let Some(value) = first_attrs.get(gb) {
+                    attributes.insert(gb.clone(), value.clone());
                 } else {
-                    None
+                    return Err(Box::new(
+                        GeometryProcessorError::LineOnLineOverlayerFactory(
+                            "Group by attribute not found in feature".to_string(),
+                        ),
+                    ));
                 }
-            })
-            .flatten()
-            .collect::<Vec<_>>();
-
-        let line_string_intersection_result =
-            line_string_intersection_2d(&line_strings, self.tolerance);
-
-        let mut overlaid = OverlayedFeatures::new();
-
-        for ls in &line_string_intersection_result.line_strings_with_metadata {
-            let LineString2DWithMetadata {
-                line_string: result_ls,
-                overlay_count,
-                overlay_ids,
-            } = ls;
-            let mut attributes = Attributes::new();
-            attributes.insert(
-                Attribute::new("overlayCount"),
-                AttributeValue::Number(Number::from(*overlay_count)),
-            );
-            attributes.insert(
-                Attribute::new(&self.overlaid_lists_attr_name),
-                AttributeValue::Array(
-                    overlay_ids
-                        .iter()
-                        .map(|&id| {
-                            AttributeValue::Map(
-                                features_2d[map_ls_to_features[id]]
-                                    .attributes
-                                    .as_ref()
-                                    .clone()
-                                    .into_iter()
-                                    .map(|(k, v)| (k.inner(), v))
-                                    .collect::<HashMap<_, _>>(),
-                            )
-                        })
-                        .collect::<Vec<_>>(),
-                ),
-            );
-
-            // Add common attributes. These are attributes that are listed in `group_by` and exist in all overlaid features.
-            if let Some(group_by) = &self.group_by {
-                let attr = &features_2d[map_ls_to_features[overlay_ids[0]]].attributes;
-                for group_by in group_by {
-                    if let Some(value) = attr.get(group_by) {
-                        attributes.insert(group_by.clone(), value.clone());
-                    } else {
-                        return Err(Box::new(
-                            GeometryProcessorError::LineOnLineOverlayerFactory(
-                                "Group by attribute not found in feature".to_string(),
-                            ),
-                        ));
-                    }
-                }
-            };
-            let geometry = reearth_flow_types::Geometry {
-                value: GeometryValue::FlowGeometry2D(Geometry2D::LineString(result_ls.clone())),
-                ..Default::default()
-            };
-            let feature = Feature::new_with_attributes_and_geometry(attributes, geometry);
-            overlaid.line.push(feature);
+            }
         }
 
-        let last_feature = features_2d.last().unwrap();
+        let geometry = Geometry {
+            value: GeometryValue::FlowGeometry2D(Geometry2D::LineString(meta.line_string.clone())),
+            ..Default::default()
+        };
+        let out = Feature::new_with_attributes_and_geometry(attributes, geometry);
+        serde_json::to_writer(&mut *line_writer, &out)?;
+        line_writer.write_all(b"\n")?;
+        line_count += 1;
+    }
 
-        for result_coords in line_string_intersection_result.split_coords {
-            let attributes = if let Some(group_by) = &self.group_by {
+    // --- Emit point-port features ---
+    // Preserve the existing convention: point attributes come from the last feature in the
+    // group (by insertion order), filtered by group_by if set.
+    let last_feature_idx = if disk_feats.len() == 0 {
+        None
+    } else {
+        Some(disk_feats.len() - 1)
+    };
+
+    let mut point_count: usize = 0;
+    for coord in &overlay.split_coords {
+        let attributes: IndexMap<Attribute, AttributeValue> =
+            if let (Some(group_by), Some(lfi)) = (group_by, last_feature_idx) {
+                let attrs = load_attrs(lfi, &mut attributes_cache)?;
                 group_by
                     .iter()
-                    .filter_map(|attr| {
-                        let value = last_feature.get(attr).cloned()?;
-                        Some((attr.clone(), value))
-                    })
-                    .collect::<IndexMap<_, _>>()
+                    .filter_map(|gb| attrs.get(gb).cloned().map(|v| (gb.clone(), v)))
+                    .collect()
             } else {
                 IndexMap::new()
             };
-
-            let geometry = reearth_flow_types::Geometry {
-                value: GeometryValue::FlowGeometry2D(Geometry2D::Point(Point(result_coords))),
-                ..Default::default()
-            };
-            let feature = Feature::new_with_attributes_and_geometry(attributes, geometry);
-            overlaid.point.push(feature);
-        }
-
-        Ok(overlaid)
+        let geometry = Geometry {
+            value: GeometryValue::FlowGeometry2D(Geometry2D::Point(Point(*coord))),
+            ..Default::default()
+        };
+        let out = Feature::new_with_attributes_and_geometry(attributes, geometry);
+        serde_json::to_writer(&mut *point_writer, &out)?;
+        point_writer.write_all(b"\n")?;
+        point_count += 1;
     }
+
+    Ok((line_count, point_count))
 }
 
-/// Coordinates of the intersection point to output
-#[derive(Debug, Clone)]
-struct OverlayResultCoordinates {
-    i_by: usize,
-    i_other: usize,
-    coordinates: Coordinate2D<f64>,
-}
+// --- Overlay core ---
 
 #[derive(Debug, Clone)]
 struct LineString2DWithMetadata<T: GeoFloat> {
     line_string: LineString2D<T>,
-    /// Number of original line strings that contributed to this line string
+    /// Number of original entries that contributed to this line string.
     overlay_count: usize,
-    /// Indices of original line strings that contributed to this line string
-    /// It must be of size `overlay_count`
+    /// Indices into the `entries` slice passed to `overlay_entries`.
     overlay_ids: Vec<usize>,
 }
 
-/// Result of overlaying line strings
 #[derive(Debug, Clone)]
 struct OverlayResult {
     line_strings_with_metadata: Vec<LineString2DWithMetadata<f64>>,
     split_coords: Vec<Coordinate2D<f64>>,
 }
 
-/// Calculate the intersection between line strings
-fn line_string_intersection_2d(
-    line_strings: &[LineString2D<f64>],
+/// Core overlay: for each entry (one sub-line-string), use the R-tree to find candidate
+/// neighbours by AABB, compute pairwise intersections via `LineStringWithTree2D`, then split
+/// each entry's line string at the intersection points. Deduplicate segments / split points
+/// via R-trees.
+fn overlay_entries(
+    entries: &[AabbEntry],
+    lss_per_feature: &[Vec<LineString2D<f64>>],
     tolerance: f64,
 ) -> OverlayResult {
-    // Pre-compute bounding boxes so the inner loop can skip pairs whose
-    // envelopes don't overlap (cheap AABB test vs expensive intersection).
-    use rstar::{Envelope, RTreeObject};
-    let envelopes: Vec<_> = line_strings.iter().map(|ls| ls.envelope()).collect();
+    // Bulk-load the R-tree over sub-line-string AABBs.
+    let rtree: RTree<AabbEntry> = RTree::bulk_load(entries.to_vec());
 
-    let results = line_strings.par_iter().enumerate().map(|(i, line_string)| {
-        let packed_line_string = LineStringWithTree2D::new(line_string.clone());
+    // Phase A: per-entry parallel work.
+    //   - Query the R-tree lazily for candidates whose AABB overlaps self.
+    //   - Skip candidates from the same feature (feature-level self-skip, matches the old
+    //     `j != i` when indices were feature-level).
+    //   - Emit this entry's split segments (tagged with entry_idx) and split coords.
+    type PhaseAEntryResult = (Vec<(usize, LineString2D<f64>)>, Vec<Coordinate2D<f64>>);
+    let per_entry_results: Vec<PhaseAEntryResult> = entries
+        .par_iter()
+        .map(|entry_i| {
+            let self_ls = &lss_per_feature[entry_i.feature_idx][entry_i.ls_local_idx];
+            let packed = LineStringWithTree2D::new(self_ls.clone());
 
-        struct IntersectionWithIndex {
-            i_by: usize,
-            i_other: usize,
-            intersection: LineIntersection<f64, NoValue>,
-        }
-
-        let env_i = &envelopes[i];
-        let inters_with_index = (0..line_strings.len())
-            .filter(|&j| j != i && env_i.intersects(&envelopes[j]))
-            .map(|j| (j, &line_strings[j]))
-            .filter_map(|(j, other_line_string)| {
-                let intersections = packed_line_string.intersection(other_line_string);
-                if intersections.is_empty() {
-                    return None;
+            // Lazy iteration over R-tree candidates; never materialises the pair list.
+            let mut intersection_coords: Vec<Coordinate2D<f64>> = Vec::new();
+            for entry_j in rtree.locate_in_envelope_intersecting(&entry_i.aabb) {
+                if entry_j.entry_idx == entry_i.entry_idx {
+                    continue;
                 }
-
-                let inters = intersections
-                    .into_iter()
-                    .map(|intersection| IntersectionWithIndex {
-                        i_by: i,
-                        i_other: j,
-                        intersection,
-                    })
-                    .collect::<Vec<_>>();
-
-                Some(inters)
-            })
-            .collect::<Vec<_>>();
-
-        let split_coords_with_index = inters_with_index
-            .iter()
-            .flatten()
-            .flat_map(|inter| {
-                let coords = match inter.intersection {
-                    LineIntersection::SinglePoint { intersection, .. } => vec![intersection],
-                    LineIntersection::Collinear { intersection } => {
-                        // treat collinear as points
-                        vec![intersection.start, intersection.end]
+                if entry_j.feature_idx == entry_i.feature_idx {
+                    continue;
+                }
+                let other_ls = &lss_per_feature[entry_j.feature_idx][entry_j.ls_local_idx];
+                for intersection in packed.intersection(other_ls) {
+                    match intersection {
+                        LineIntersection::SinglePoint { intersection, .. } => {
+                            intersection_coords.push(intersection);
+                        }
+                        LineIntersection::Collinear { intersection } => {
+                            intersection_coords.push(intersection.start);
+                            intersection_coords.push(intersection.end);
+                        }
                     }
-                };
+                }
+            }
 
-                coords
-                    .into_iter()
-                    .map(|coordinates| OverlayResultCoordinates {
-                        coordinates,
-                        i_by: inter.i_by,
-                        i_other: inter.i_other,
-                    })
-            })
-            .collect::<Vec<_>>();
+            let LineStringSplitResult {
+                split_line_strings,
+                split_coords,
+            } = packed.split(&intersection_coords, tolerance);
 
-        let split_coords = split_coords_with_index
+            let segs: Vec<(usize, LineString2D<f64>)> = split_line_strings
+                .into_iter()
+                .map(|l| (entry_i.entry_idx, l))
+                .collect();
+
+            (segs, split_coords)
+        })
+        .collect();
+
+    // Flatten Phase A's output. Each segment is tagged with its source entry_idx.
+    let mut segments: Vec<(usize, LineString2D<f64>)> = Vec::new();
+    let mut split_coords_flat: Vec<Coordinate2D<f64>> = Vec::new();
+    for (segs, coords) in per_entry_results {
+        segments.extend(segs);
+        split_coords_flat.extend(coords);
+    }
+
+    // Drop sub-tolerance segments — zero-length stubs and near-coincident endpoint slivers
+    // aren't meaningful overlays and previously dominated the line-port output.
+    segments.retain(|(_, ls)| line_string_length_2d(ls) >= tolerance);
+
+    // Phase B, Block 1 — segment dedup via R-tree.
+    //
+    // Two source entries that overlapped geometrically produce identical split segments from
+    // different Phase A tasks. We cluster them here: R-tree over segment AABBs, single-pass
+    // sweep with a `processed` mask. For each unprocessed segment i, query the R-tree and
+    // compare candidates by coord-by-coord tolerance (forward + reversed). Candidates that
+    // match are merged into i's `overlay_ids` list.
+    let seg_aabbs: Vec<AABB<Point2D<f64>>> = segments.iter().map(|(_, ls)| ls.envelope()).collect();
+
+    #[derive(Clone, Copy)]
+    struct SegEntry {
+        idx: usize,
+        aabb: AABB<Point2D<f64>>,
+    }
+    impl RTreeObject for SegEntry {
+        type Envelope = AABB<Point2D<f64>>;
+        fn envelope(&self) -> Self::Envelope {
+            self.aabb
+        }
+    }
+    let seg_rtree: RTree<SegEntry> = RTree::bulk_load(
+        seg_aabbs
             .iter()
-            .map(|split| split.coordinates)
-            .collect::<Vec<_>>();
+            .enumerate()
+            .map(|(idx, aabb)| SegEntry { idx, aabb: *aabb })
+            .collect(),
+    );
 
-        let LineStringSplitResult {
-            split_line_strings,
-            split_coords,
-        } = packed_line_string.split(&split_coords, tolerance);
-
-        let split_line_strings_with_indices = split_line_strings
-            .into_iter()
-            .map(|l| (i, l))
-            .collect::<Vec<_>>();
-
-        let split_coords_with_indices = split_coords
-            .iter()
-            .map(|&v| {
-                let indices = split_coords_with_index
-                    .iter()
-                    .filter(|&o| (v - o.coordinates).norm() < tolerance)
-                    .flat_map(|o| [o.i_by, o.i_other])
-                    .collect::<Vec<_>>();
-                (v, indices)
-            })
-            .collect::<Vec<_>>();
-
-        (split_line_strings_with_indices, split_coords_with_indices)
-    });
-
-    let (result_line_strings, split_coords_with_indices): (Vec<_>, Vec<_>) = results.unzip();
-    let line_strings_with_indices = result_line_strings
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
-    let split_coords_with_indices = split_coords_with_indices
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
-
-    // We have all the intersection points and line strings now.
-    // What remains is to compute duplicates and overlay counts.
-    let mut line_strings_with_metadata = Vec::new();
-    let mut processed = vec![false; line_strings_with_indices.len()];
-    for (i, (idx1, ls1)) in line_strings_with_indices.iter().enumerate() {
+    let mut processed = vec![false; segments.len()];
+    let mut line_strings_with_metadata: Vec<LineString2DWithMetadata<f64>> = Vec::new();
+    for i in 0..segments.len() {
         if processed[i] {
             continue;
         }
-        let mut overlay_count = 1; // itself
-        let mut overlay_ids = vec![*idx1];
-        for j in i + 1..line_strings_with_indices.len() {
-            let ls2 = &line_strings_with_indices[j].1;
-            let idx2 = &line_strings_with_indices[j].0;
-            if ls1
-                .0
-                .iter()
-                .zip(ls2.0.iter())
-                .all(|(&c1, &c2)| (c1 - c2).norm() < tolerance)
-                || ls1
-                    .0
-                    .iter()
-                    .rev()
-                    .zip(ls2.0.iter())
-                    .all(|(&c1, &c2)| (c1 - c2).norm() < tolerance)
-            {
+        let (idx1, ls1) = segments[i].clone();
+        let feat_i = entries[idx1].feature_idx;
+        let mut overlay_count = 1;
+        let mut overlay_ids = vec![idx1];
+        // A single feature may contribute multiple matching segments (e.g. a closed ring
+        // whose split produces several arcs that all coincide with the rep segment). Count
+        // each feature at most once; extra matching segments dedupe silently.
+        let mut included_feats: std::collections::HashSet<usize> =
+            std::collections::HashSet::from([feat_i]);
+
+        for cand in seg_rtree.locate_in_envelope_intersecting(&seg_aabbs[i]) {
+            let j = cand.idx;
+            if j <= i || processed[j] {
+                continue;
+            }
+            let (idx2, ls2) = (segments[j].0, &segments[j].1);
+            if segments_match(&ls1, ls2, tolerance) {
+                let cand_feat = entries[idx2].feature_idx;
+                if !included_feats.insert(cand_feat) {
+                    processed[j] = true;
+                    continue;
+                }
                 overlay_count += 1;
-                overlay_ids.push(*idx2);
+                overlay_ids.push(idx2);
                 processed[j] = true;
             }
         }
-        let ls_with_metadata = LineString2DWithMetadata {
-            line_string: ls1.clone(),
+
+        line_strings_with_metadata.push(LineString2DWithMetadata {
+            line_string: ls1,
             overlay_count,
             overlay_ids,
-        };
-        line_strings_with_metadata.push(ls_with_metadata);
+        });
     }
 
-    // Split coordinate duplicates
-    let mut unique_split_coords = Vec::new();
-    let mut processed_coords = vec![false; split_coords_with_indices.len()];
-    for (i, coord1) in split_coords_with_indices.iter().enumerate() {
-        if processed_coords[i] {
+    // Phase B, Block 2 — split-coord dedup via R-tree.
+    //
+    // Each physical intersection is discovered by both sides of the crossing (task i and
+    // task j), plus multiple times for 3+-way near-coincidences. Build an R-tree over point
+    // AABBs and sweep with a mask; use a tolerance-expanded envelope for the query so near
+    // matches get pulled in. Sources are discarded by design (matches the existing behavior
+    // at the current `line_on_line_overlayer.rs` L542).
+    #[derive(Clone, Copy)]
+    struct PointEntry {
+        idx: usize,
+        point: Point2D<f64>,
+    }
+    impl RTreeObject for PointEntry {
+        type Envelope = AABB<Point2D<f64>>;
+        fn envelope(&self) -> Self::Envelope {
+            AABB::from_point(self.point)
+        }
+    }
+
+    let point_rtree: RTree<PointEntry> = RTree::bulk_load(
+        split_coords_flat
+            .iter()
+            .enumerate()
+            .map(|(idx, c)| PointEntry {
+                idx,
+                point: Point2D::new_(c.x, c.y, NoValue),
+            })
+            .collect(),
+    );
+
+    let mut processed_pts = vec![false; split_coords_flat.len()];
+    let mut unique_coords: Vec<Coordinate2D<f64>> = Vec::new();
+    for i in 0..split_coords_flat.len() {
+        if processed_pts[i] {
             continue;
         }
-        unique_split_coords.push(coord1.clone());
-        for (j, coord2) in split_coords_with_indices.iter().enumerate().skip(i + 1) {
-            if (coord1.0 - coord2.0).norm() < tolerance {
-                processed_coords[j] = true;
-                // Merge the line string indices
-                unique_split_coords.last_mut().unwrap().1.extend(&coord2.1);
+        processed_pts[i] = true;
+        let c_i = split_coords_flat[i];
+        unique_coords.push(c_i);
+
+        let search_env = AABB::from_corners(
+            Point2D::new_(c_i.x - tolerance, c_i.y - tolerance, NoValue),
+            Point2D::new_(c_i.x + tolerance, c_i.y + tolerance, NoValue),
+        );
+        for cand in point_rtree.locate_in_envelope_intersecting(&search_env) {
+            let j = cand.idx;
+            if j <= i || processed_pts[j] {
+                continue;
+            }
+            let c_j = split_coords_flat[j];
+            if (c_i - c_j).norm() < tolerance {
+                processed_pts[j] = true;
             }
         }
     }
 
     OverlayResult {
         line_strings_with_metadata,
-        split_coords: unique_split_coords.into_iter().map(|(c, _)| c).collect(),
+        split_coords: unique_coords,
     }
+}
+
+fn line_string_length_2d(ls: &LineString2D<f64>) -> f64 {
+    ls.0.windows(2).map(|w| (w[1] - w[0]).norm()).sum()
+}
+
+fn segments_match(a: &LineString2D<f64>, b: &LineString2D<f64>, tolerance: f64) -> bool {
+    if a.0.len() != b.0.len() {
+        return false;
+    }
+    let forward =
+        a.0.iter()
+            .zip(b.0.iter())
+            .all(|(&c1, &c2)| (c1 - c2).norm() < tolerance);
+    if forward {
+        return true;
+    }
+    a.0.iter()
+        .rev()
+        .zip(b.0.iter())
+        .all(|(&c1, &c2)| (c1 - c2).norm() < tolerance)
+}
+
+/// In-memory entry point kept for unit tests. Wraps `overlay_entries` with one entry per
+/// line string (each line treated as its own feature).
+#[cfg(test)]
+fn line_string_intersection_2d(
+    line_strings: &[LineString2D<f64>],
+    tolerance: f64,
+) -> OverlayResult {
+    let lss_per_feature: Vec<Vec<LineString2D<f64>>> =
+        line_strings.iter().map(|ls| vec![ls.clone()]).collect();
+    let entries: Vec<AabbEntry> = line_strings
+        .iter()
+        .enumerate()
+        .map(|(i, ls)| AabbEntry {
+            entry_idx: i,
+            feature_idx: i,
+            ls_local_idx: 0,
+            aabb: ls.envelope(),
+        })
+        .collect();
+    overlay_entries(&entries, &lss_per_feature, tolerance)
 }
 
 #[cfg(test)]
@@ -549,7 +899,6 @@ mod tests {
 
     #[test]
     fn test_overlay() {
-        // Test the overlay functionality
         let line_string1 = LineString2D::new(vec![
             Coordinate2D::new_(0.0, 0.0),
             Coordinate2D::new_(5.0, 5.0),
@@ -561,7 +910,6 @@ mod tests {
 
         let overlay_result = line_string_intersection_2d(&[line_string1, line_string2], 0.1);
 
-        // Assert the overlay result
         let OverlayResult {
             line_strings_with_metadata,
             split_coords,
@@ -645,7 +993,6 @@ mod tests {
 
         let overlay_result = line_string_intersection_2d(&[line_string1, line_string2], 0.1);
 
-        // Assert the overlay result
         let OverlayResult {
             line_strings_with_metadata,
             split_coords,
@@ -681,7 +1028,6 @@ mod tests {
         let overlay_result =
             line_string_intersection_2d(&[line_string1, line_string2, line_string3], 0.1);
 
-        // Assert the overlay result
         let OverlayResult {
             line_strings_with_metadata,
             split_coords,
@@ -694,5 +1040,223 @@ mod tests {
         overlap_counts.sort();
         assert_eq!(overlap_counts, vec![1, 1, 1, 2, 2]);
         assert_eq!(split_coords.len(), 2);
+    }
+
+    #[test]
+    fn test_overlay_sub_tolerance_segments_dropped() {
+        // Two collinear lines with a 0.005-long overlap, well below tolerance=0.1.
+        // The overlap would have emitted a matched short-segment pair previously.
+        let line_string1 = LineString2D::new(vec![
+            Coordinate2D::new_(0.0, 0.0),
+            Coordinate2D::new_(1.005, 0.0),
+        ]);
+        let line_string2 = LineString2D::new(vec![
+            Coordinate2D::new_(1.0, 0.0),
+            Coordinate2D::new_(2.0, 0.0),
+        ]);
+
+        let tolerance = 0.1;
+        let result = line_string_intersection_2d(&[line_string1, line_string2], tolerance);
+
+        for meta in &result.line_strings_with_metadata {
+            let len = line_string_length_2d(&meta.line_string);
+            assert!(len >= tolerance, "sub-tolerance segment emitted: len={len}");
+        }
+        assert!(result
+            .line_strings_with_metadata
+            .iter()
+            .all(|m| m.overlay_count == 1));
+    }
+
+    #[test]
+    fn test_overlay_same_feature_duplicate_rings_not_double_counted() {
+        // Feature 0 has two identical sub-line-strings (like a degenerate MultiPolygon);
+        // Feature 1 is a separate collinear line overlapping part of them.
+        // Expect: overlap segment has overlay_count=2 (feat 0 + feat 1), not 3.
+        let f0_a = LineString2D::new(vec![
+            Coordinate2D::new_(0.0, 0.0),
+            Coordinate2D::new_(4.0, 0.0),
+        ]);
+        let f0_b = f0_a.clone();
+        let f1 = LineString2D::new(vec![
+            Coordinate2D::new_(1.0, 0.0),
+            Coordinate2D::new_(3.0, 0.0),
+        ]);
+
+        let lss_per_feature = vec![vec![f0_a.clone(), f0_b.clone()], vec![f1.clone()]];
+        let entries = vec![
+            AabbEntry {
+                entry_idx: 0,
+                feature_idx: 0,
+                ls_local_idx: 0,
+                aabb: f0_a.envelope(),
+            },
+            AabbEntry {
+                entry_idx: 1,
+                feature_idx: 0,
+                ls_local_idx: 1,
+                aabb: f0_b.envelope(),
+            },
+            AabbEntry {
+                entry_idx: 2,
+                feature_idx: 1,
+                ls_local_idx: 0,
+                aabb: f1.envelope(),
+            },
+        ];
+
+        let result = overlay_entries(&entries, &lss_per_feature, 0.01);
+
+        for meta in &result.line_strings_with_metadata {
+            let feats: Vec<usize> = meta
+                .overlay_ids
+                .iter()
+                .map(|&e| entries[e].feature_idx)
+                .collect();
+            let unique: std::collections::HashSet<_> = feats.iter().copied().collect();
+            assert_eq!(
+                feats.len(),
+                unique.len(),
+                "overlay_ids contains duplicate feature_idx: {feats:?}"
+            );
+            assert_eq!(meta.overlay_count, meta.overlay_ids.len());
+        }
+
+        let overlapping: Vec<_> = result
+            .line_strings_with_metadata
+            .iter()
+            .filter(|m| m.overlay_count >= 2)
+            .collect();
+        assert!(!overlapping.is_empty(), "expected an overlap segment");
+        for m in &overlapping {
+            assert_eq!(m.overlay_count, 2);
+        }
+    }
+
+    #[test]
+    fn test_overlay_multiple_same_feature_candidates_dedupe() {
+        // Feature 1 contributes two identical sub-line-strings that both match the rep segment
+        // from feature 0 — neither is the rep, but both are the same feature. The old
+        // "candidate-same-as-rep" check wouldn't catch this; the feature-set dedup must.
+        let f0 = LineString2D::new(vec![
+            Coordinate2D::new_(0.0, 0.0),
+            Coordinate2D::new_(4.0, 0.0),
+        ]);
+        let f1_a = LineString2D::new(vec![
+            Coordinate2D::new_(1.0, 0.0),
+            Coordinate2D::new_(3.0, 0.0),
+        ]);
+        let f1_b = f1_a.clone();
+
+        let lss_per_feature = vec![vec![f0.clone()], vec![f1_a.clone(), f1_b.clone()]];
+        let entries = vec![
+            AabbEntry {
+                entry_idx: 0,
+                feature_idx: 0,
+                ls_local_idx: 0,
+                aabb: f0.envelope(),
+            },
+            AabbEntry {
+                entry_idx: 1,
+                feature_idx: 1,
+                ls_local_idx: 0,
+                aabb: f1_a.envelope(),
+            },
+            AabbEntry {
+                entry_idx: 2,
+                feature_idx: 1,
+                ls_local_idx: 1,
+                aabb: f1_b.envelope(),
+            },
+        ];
+
+        let result = overlay_entries(&entries, &lss_per_feature, 0.01);
+
+        let overlap: Vec<_> = result
+            .line_strings_with_metadata
+            .iter()
+            .filter(|m| m.overlay_count >= 2)
+            .collect();
+        assert!(!overlap.is_empty(), "expected an overlap segment");
+        for m in &overlap {
+            let feats: std::collections::HashSet<usize> = m
+                .overlay_ids
+                .iter()
+                .map(|&e| entries[e].feature_idx)
+                .collect();
+            assert_eq!(
+                feats.len(),
+                m.overlay_ids.len(),
+                "duplicate feature_idx in overlay_ids: {:?}",
+                m.overlay_ids
+                    .iter()
+                    .map(|&e| entries[e].feature_idx)
+                    .collect::<Vec<_>>()
+            );
+            assert_eq!(m.overlay_count, 2);
+        }
+    }
+
+    #[test]
+    fn test_process_group_two_crossing_lines() {
+        use reearth_flow_types::Geometry;
+
+        let dir =
+            engine_cache_dir(uuid::Uuid::nil()).join(format!("test-lol-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let group_dir = dir.join("group_000000");
+        std::fs::create_dir_all(&group_dir).unwrap();
+
+        let f1 = {
+            let ls = LineString2D::new(vec![
+                Coordinate2D::new_(0.0, 0.0),
+                Coordinate2D::new_(5.0, 5.0),
+            ]);
+            let geom =
+                Geometry::with_value(GeometryValue::FlowGeometry2D(Geometry2D::LineString(ls)));
+            Feature::new_with_attributes_and_geometry(Attributes::new(), geom)
+        };
+        let f2 = {
+            let ls = LineString2D::new(vec![
+                Coordinate2D::new_(0.0, 5.0),
+                Coordinate2D::new_(5.0, 0.0),
+            ]);
+            let geom =
+                Geometry::with_value(GeometryValue::FlowGeometry2D(Geometry2D::LineString(ls)));
+            Feature::new_with_attributes_and_geometry(Attributes::new(), geom)
+        };
+
+        // aabbs.jsonl — one JSON array per feature.
+        {
+            let mut w = BufWriter::new(File::create(group_dir.join("aabbs.jsonl")).unwrap());
+            let a1: Vec<[f64; 4]> = vec![[0.0, 0.0, 5.0, 5.0]];
+            let a2: Vec<[f64; 4]> = vec![[0.0, 0.0, 5.0, 5.0]];
+            writeln!(w, "{}", serde_json::to_string(&a1).unwrap()).unwrap();
+            writeln!(w, "{}", serde_json::to_string(&a2).unwrap()).unwrap();
+            w.flush().unwrap();
+        }
+        // features.jsonl
+        {
+            let mut w = BufWriter::new(File::create(group_dir.join("features.jsonl")).unwrap());
+            writeln!(w, "{}", serde_json::to_string(&f1).unwrap()).unwrap();
+            writeln!(w, "{}", serde_json::to_string(&f2).unwrap()).unwrap();
+            w.flush().unwrap();
+        }
+
+        let mut line_buf: Vec<u8> = Vec::new();
+        let mut point_buf: Vec<u8> = Vec::new();
+        let (lc, pc) = process_group(
+            &group_dir,
+            0.01,
+            None,
+            "overlaidLists",
+            &mut line_buf,
+            &mut point_buf,
+        )
+        .unwrap();
+        assert_eq!(lc, 4);
+        assert_eq!(pc, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -185,14 +185,14 @@ impl LineOnLineOverlayer {
     fn append_to_group(
         &mut self,
         group_idx: usize,
-        aabbs_json: &str,
-        feature_json: &str,
+        aabbs_json: String,
+        feature_json: String,
     ) -> Result<(), BoxedError> {
         self.buffer_bytes += aabbs_json.len() + feature_json.len();
         self.buffer
             .entry(group_idx)
             .or_default()
-            .push((aabbs_json.to_string(), feature_json.to_string()));
+            .push((aabbs_json, feature_json));
 
         if self.buffer_bytes >= ACCUMULATOR_BUFFER_BYTE_THRESHOLD {
             self.flush_buffer()?;
@@ -292,7 +292,7 @@ impl Processor for LineOnLineOverlayer {
                 let aabbs: Vec<[f64; 4]> = line_strings.iter().map(aabb_of_line_string).collect();
                 let aabbs_json = serde_json::to_string(&aabbs)?;
                 let feature_json = serde_json::to_string(&ctx.feature)?;
-                self.append_to_group(group_idx, &aabbs_json, &feature_json)?;
+                self.append_to_group(group_idx, aabbs_json, feature_json)?;
             }
             _ => {
                 fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
@@ -361,7 +361,6 @@ impl Processor for LineOnLineOverlayer {
     }
 }
 
-/// Extract all sub-line-strings from a 2D geometry. Returns empty for unsupported types.
 fn extract_line_strings(geom: &Geometry2D<f64>) -> Vec<LineString2D<f64>> {
     match geom {
         Geometry2D::LineString(line) => vec![line.clone()],
@@ -386,9 +385,6 @@ fn aabb_to_rstar(aabb: [f64; 4]) -> AABB<Point2D<f64>> {
     )
 }
 
-// --- Disk-backed helpers (mirrors AreaOnAreaOverlayer) ---
-
-/// Provides random access to features stored on disk in a JSONL file.
 struct DiskBackedFeatures {
     path: PathBuf,
     offsets: Vec<u64>,
@@ -439,9 +435,11 @@ impl DiskBackedFeatures {
     fn len(&self) -> usize {
         self.offsets.len()
     }
-}
 
-// --- Phase A / Phase B core types ---
+    fn is_empty(&self) -> bool {
+        self.offsets.is_empty()
+    }
+}
 
 #[derive(Clone, Copy)]
 struct AabbEntry {
@@ -459,8 +457,6 @@ impl RTreeObject for AabbEntry {
     }
 }
 
-/// Per-group handler — runs Phase A (pair enumeration) and Phase B (dedup) on one group's
-/// disk-backed inputs, streaming outputs to the writers.
 fn process_group<W: Write>(
     group_dir: &Path,
     tolerance: f64,
@@ -475,7 +471,6 @@ fn process_group<W: Write>(
         return Ok((0, 0));
     }
 
-    // Load per-feature AABB arrays from disk, flatten into entry list.
     let aabbs_per_feature: Vec<Vec<[f64; 4]>> = {
         let file = File::open(&aabbs_path)?;
         let reader = BufReader::new(file);
@@ -506,13 +501,11 @@ fn process_group<W: Write>(
         return Ok((0, 0));
     }
 
-    // Random-access index over features + cached per-feature geometry vector.
     let disk_feats = DiskBackedFeatures::scan(&features_path)?;
     let geometries: Vec<Arc<Geometry>> = (0..disk_feats.len())
         .map(|i| disk_feats.read_geometry(i))
         .collect::<Result<Vec<_>, _>>()?;
 
-    // Extract sub-line-string vectors once — index by feature_idx then ls_local_idx.
     let lss_per_feature: Vec<Vec<LineString2D<f64>>> = geometries
         .iter()
         .map(|g| match &g.value {
@@ -521,11 +514,8 @@ fn process_group<W: Write>(
         })
         .collect();
 
-    // Run the R-tree-backed overlay across all sub-line-strings in the group.
     let overlay = overlay_entries(&entries, &lss_per_feature, tolerance);
 
-    // --- Emit line-port features ---
-    // Attribute cache keyed by feature_idx for on-demand attribute loads.
     let mut attributes_cache: HashMap<usize, Arc<Attributes>> = HashMap::new();
     let load_attrs = |i: usize,
                       cache: &mut HashMap<usize, Arc<Attributes>>|
@@ -541,7 +531,6 @@ fn process_group<W: Write>(
 
     let mut line_count: usize = 0;
     for meta in &overlay.line_strings_with_metadata {
-        // overlay_ids indexes into `entries` (entry_idx); map each to its source feature_idx.
         let source_feature_idxs: Vec<usize> = meta
             .overlay_ids
             .iter()
@@ -595,10 +584,9 @@ fn process_group<W: Write>(
         line_count += 1;
     }
 
-    // --- Emit point-port features ---
-    // Preserve the existing convention: point attributes come from the last feature in the
-    // group (by insertion order), filtered by group_by if set.
-    let last_feature_idx = if disk_feats.len() == 0 {
+    // Point attributes come from the last feature in the group (by insertion order),
+    // filtered by group_by if set — preserves pre-rewrite convention.
+    let last_feature_idx = if disk_feats.is_empty() {
         None
     } else {
         Some(disk_feats.len() - 1)
@@ -629,8 +617,6 @@ fn process_group<W: Write>(
     Ok((line_count, point_count))
 }
 
-// --- Overlay core ---
-
 #[derive(Debug, Clone)]
 struct LineString2DWithMetadata<T: GeoFloat> {
     line_string: LineString2D<T>,
@@ -646,25 +632,15 @@ struct OverlayResult {
     split_coords: Vec<Coordinate2D<f64>>,
 }
 
-/// Core overlay: for each entry (one sub-line-string), use the R-tree to find candidate
-/// neighbours by AABB, compute pairwise intersections via `LineStringWithTree2D`, then split
-/// each entry's line string at the intersection points. Deduplicate segments / split points
-/// via R-trees.
 fn overlay_entries(
     entries: &[AabbEntry],
     lss_per_feature: &[Vec<LineString2D<f64>>],
     tolerance: f64,
 ) -> OverlayResult {
-    // Bulk-load the R-tree over sub-line-string AABBs.
     let rtree: RTree<AabbEntry> = RTree::bulk_load(entries.to_vec());
 
-    // Phase A: per-entry parallel work.
-    //   - Query the R-tree lazily for candidates whose AABB overlaps self.
-    //   - Skip candidates from the same feature (feature-level self-skip, matches the old
-    //     `j != i` when indices were feature-level).
-    //   - Emit this entry's split segments (tagged with entry_idx) and split coords.
-    type PhaseAEntryResult = (Vec<(usize, LineString2D<f64>)>, Vec<Coordinate2D<f64>>);
-    let per_entry_results: Vec<PhaseAEntryResult> = entries
+    type PerEntryResult = (Vec<(usize, LineString2D<f64>)>, Vec<Coordinate2D<f64>>);
+    let per_entry_results: Vec<PerEntryResult> = entries
         .par_iter()
         .map(|entry_i| {
             let self_ls = &lss_per_feature[entry_i.feature_idx][entry_i.ls_local_idx];
@@ -673,9 +649,6 @@ fn overlay_entries(
             // Lazy iteration over R-tree candidates; never materialises the pair list.
             let mut intersection_coords: Vec<Coordinate2D<f64>> = Vec::new();
             for entry_j in rtree.locate_in_envelope_intersecting(&entry_i.aabb) {
-                if entry_j.entry_idx == entry_i.entry_idx {
-                    continue;
-                }
                 if entry_j.feature_idx == entry_i.feature_idx {
                     continue;
                 }
@@ -707,7 +680,6 @@ fn overlay_entries(
         })
         .collect();
 
-    // Flatten Phase A's output. Each segment is tagged with its source entry_idx.
     let mut segments: Vec<(usize, LineString2D<f64>)> = Vec::new();
     let mut split_coords_flat: Vec<Coordinate2D<f64>> = Vec::new();
     for (segs, coords) in per_entry_results {
@@ -719,13 +691,8 @@ fn overlay_entries(
     // aren't meaningful overlays and previously dominated the line-port output.
     segments.retain(|(_, ls)| line_string_length_2d(ls) >= tolerance);
 
-    // Phase B, Block 1 — segment dedup via R-tree.
-    //
     // Two source entries that overlapped geometrically produce identical split segments from
-    // different Phase A tasks. We cluster them here: R-tree over segment AABBs, single-pass
-    // sweep with a `processed` mask. For each unprocessed segment i, query the R-tree and
-    // compare candidates by coord-by-coord tolerance (forward + reversed). Candidates that
-    // match are merged into i's `overlay_ids` list.
+    // different per-entry tasks; we cluster them here.
     let seg_aabbs: Vec<AABB<Point2D<f64>>> = segments.iter().map(|(_, ls)| ls.envelope()).collect();
 
     #[derive(Clone, Copy)]
@@ -788,13 +755,9 @@ fn overlay_entries(
         });
     }
 
-    // Phase B, Block 2 — split-coord dedup via R-tree.
-    //
-    // Each physical intersection is discovered by both sides of the crossing (task i and
-    // task j), plus multiple times for 3+-way near-coincidences. Build an R-tree over point
-    // AABBs and sweep with a mask; use a tolerance-expanded envelope for the query so near
-    // matches get pulled in. Sources are discarded by design (matches the existing behavior
-    // at the current `line_on_line_overlayer.rs` L542).
+    // Each physical intersection is discovered by both sides of the crossing plus extras
+    // from 3+-way near-coincidences, so dedup by tolerance-expanded envelope. Sources are
+    // discarded by design, matching pre-rewrite behavior.
     #[derive(Clone, Copy)]
     struct PointEntry {
         idx: usize,
@@ -871,8 +834,6 @@ fn segments_match(a: &LineString2D<f64>, b: &LineString2D<f64>, tolerance: f64) 
         .all(|(&c1, &c2)| (c1 - c2).norm() < tolerance)
 }
 
-/// In-memory entry point kept for unit tests. Wraps `overlay_entries` with one entry per
-/// line string (each line treated as its own feature).
 #[cfg(test)]
 fn line_string_intersection_2d(
     line_strings: &[LineString2D<f64>],
@@ -1199,8 +1160,6 @@ mod tests {
 
     #[test]
     fn test_process_group_two_crossing_lines() {
-        use reearth_flow_types::Geometry;
-
         let dir =
             engine_cache_dir(uuid::Uuid::nil()).join(format!("test-lol-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&dir).unwrap();
@@ -1226,7 +1185,6 @@ mod tests {
             Feature::new_with_attributes_and_geometry(Attributes::new(), geom)
         };
 
-        // aabbs.jsonl — one JSON array per feature.
         {
             let mut w = BufWriter::new(File::create(group_dir.join("aabbs.jsonl")).unwrap());
             let a1: Vec<[f64; 4]> = vec![[0.0, 0.0, 5.0, 5.0]];
@@ -1235,7 +1193,6 @@ mod tests {
             writeln!(w, "{}", serde_json::to_string(&a2).unwrap()).unwrap();
             w.flush().unwrap();
         }
-        // features.jsonl
         {
             let mut w = BufWriter::new(File::create(group_dir.join("features.jsonl")).unwrap());
             writeln!(w, "{}", serde_json::to_string(&f1).unwrap()).unwrap();

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -419,6 +419,10 @@ impl DiskBackedFeatures {
         })
     }
 
+    // Opens a fresh fd per call so `&self` callers can be parallelised in the future.
+    // The current sole caller is sequential, so the N file opens are wasted — but
+    // they scale linearly and the target is a local filesystem, so the overhead
+    // is bounded.
     fn read_feature(&self, i: usize) -> Result<Feature, BoxedError> {
         let mut file = File::open(&self.path)?;
         file.seek(SeekFrom::Start(self.offsets[i]))?;

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -497,6 +497,16 @@ fn process_group<W: Write>(
     }
 
     let disk_feats = DiskBackedFeatures::scan(&features_path)?;
+    if disk_feats.len() != aabbs_per_feature.len() {
+        return Err(Box::new(GeometryProcessorError::LineOnLineOverlayerFactory(
+            format!(
+                "aabbs/features row count mismatch in {}: aabbs={}, features={}",
+                group_dir.display(),
+                aabbs_per_feature.len(),
+                disk_feats.len(),
+            ),
+        )));
+    }
     let mut attributes_by_feature: Vec<Arc<Attributes>> = Vec::with_capacity(disk_feats.len());
     let mut lss_per_feature: Vec<Vec<LineString2D<f64>>> = Vec::with_capacity(disk_feats.len());
     for i in 0..disk_feats.len() {

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -438,7 +438,6 @@ impl DiskBackedFeatures {
 
 #[derive(Clone, Copy)]
 struct AabbEntry {
-    entry_idx: usize,
     feature_idx: usize,
     ls_local_idx: usize,
     aabb: AABB<Point2D<f64>>,
@@ -481,11 +480,11 @@ fn process_group<W: Write>(
         out
     };
 
-    let mut entries: Vec<AabbEntry> = Vec::new();
+    let total_entries: usize = aabbs_per_feature.iter().map(|v| v.len()).sum();
+    let mut entries: Vec<AabbEntry> = Vec::with_capacity(total_entries);
     for (feature_idx, lss) in aabbs_per_feature.iter().enumerate() {
         for (ls_local_idx, aabb) in lss.iter().enumerate() {
             entries.push(AabbEntry {
-                entry_idx: entries.len(),
                 feature_idx,
                 ls_local_idx,
                 aabb: aabb_to_rstar(*aabb),
@@ -519,24 +518,20 @@ fn process_group<W: Write>(
         lss_per_feature.push(lss);
     }
 
-    let overlay = overlay_entries(&entries, &lss_per_feature, tolerance);
+    let overlay = overlay_entries(entries, &lss_per_feature, tolerance);
 
     let mut line_count: usize = 0;
     for meta in &overlay.line_strings_with_metadata {
-        let source_feature_idxs: Vec<usize> = meta
-            .overlay_ids
-            .iter()
-            .map(|&entry_idx| entries[entry_idx].feature_idx)
-            .collect();
+        let source_feature_idxs = &meta.source_feature_idxs;
 
         let mut attributes = Attributes::new();
         attributes.insert(
             Attribute::new("overlayCount"),
-            AttributeValue::Number(Number::from(meta.overlay_count)),
+            AttributeValue::Number(Number::from(source_feature_idxs.len())),
         );
 
         let mut overlaid_list: Vec<AttributeValue> = Vec::with_capacity(source_feature_idxs.len());
-        for &fi in &source_feature_idxs {
+        for &fi in source_feature_idxs {
             let attrs = &attributes_by_feature[fi];
             let attrs_map: HashMap<String, AttributeValue> = attrs
                 .as_ref()
@@ -612,10 +607,9 @@ fn process_group<W: Write>(
 #[derive(Debug, Clone)]
 struct LineString2DWithMetadata<T: GeoFloat> {
     line_string: LineString2D<T>,
-    /// Number of original entries that contributed to this line string.
-    overlay_count: usize,
-    /// Indices into the `entries` slice passed to `overlay_entries`.
-    overlay_ids: Vec<usize>,
+    /// feature_idx of each source feature that contributed to this segment.
+    /// Deduplicated — each feature appears at most once.
+    source_feature_idxs: Vec<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -625,16 +619,17 @@ struct OverlayResult {
 }
 
 fn overlay_entries(
-    entries: &[AabbEntry],
+    entries: Vec<AabbEntry>,
     lss_per_feature: &[Vec<LineString2D<f64>>],
     tolerance: f64,
 ) -> OverlayResult {
-    let rtree: RTree<AabbEntry> = RTree::bulk_load(entries.to_vec());
+    let rtree: RTree<AabbEntry> = RTree::bulk_load(entries);
+    let rtree_items: Vec<&AabbEntry> = rtree.iter().collect();
 
     type PerEntryResult = (Vec<(usize, LineString2D<f64>)>, Vec<Coordinate2D<f64>>);
-    let per_entry_results: Vec<PerEntryResult> = entries
+    let per_entry_results: Vec<PerEntryResult> = rtree_items
         .par_iter()
-        .map(|entry_i| {
+        .map(|&entry_i| {
             let self_ls = &lss_per_feature[entry_i.feature_idx][entry_i.ls_local_idx];
             let packed = LineStringWithTree2D::new(self_ls.clone());
 
@@ -665,7 +660,7 @@ fn overlay_entries(
 
             let segs: Vec<(usize, LineString2D<f64>)> = split_line_strings
                 .into_iter()
-                .map(|l| (entry_i.entry_idx, l))
+                .map(|l| (entry_i.feature_idx, l))
                 .collect();
 
             (segs, split_coords)
@@ -712,13 +707,11 @@ fn overlay_entries(
         if processed[i] {
             continue;
         }
-        let (idx1, ls1) = segments[i].clone();
-        let feat_i = entries[idx1].feature_idx;
-        let mut overlay_count = 1;
-        let mut overlay_ids = vec![idx1];
+        let (feat_i, ls1) = segments[i].clone();
         // A single feature may contribute multiple matching segments (e.g. a closed ring
         // whose split produces several arcs that all coincide with the rep segment). Count
         // each feature at most once; extra matching segments dedupe silently.
+        let mut source_feature_idxs = vec![feat_i];
         let mut included_feats: std::collections::HashSet<usize> =
             std::collections::HashSet::from([feat_i]);
 
@@ -727,23 +720,20 @@ fn overlay_entries(
             if j <= i || processed[j] {
                 continue;
             }
-            let (idx2, ls2) = (segments[j].0, &segments[j].1);
+            let (feat_j, ls2) = (segments[j].0, &segments[j].1);
             if segments_match(&ls1, ls2, tolerance) {
-                let cand_feat = entries[idx2].feature_idx;
-                if !included_feats.insert(cand_feat) {
+                if !included_feats.insert(feat_j) {
                     processed[j] = true;
                     continue;
                 }
-                overlay_count += 1;
-                overlay_ids.push(idx2);
+                source_feature_idxs.push(feat_j);
                 processed[j] = true;
             }
         }
 
         line_strings_with_metadata.push(LineString2DWithMetadata {
             line_string: ls1,
-            overlay_count,
-            overlay_ids,
+            source_feature_idxs,
         });
     }
 
@@ -837,13 +827,12 @@ fn line_string_intersection_2d(
         .iter()
         .enumerate()
         .map(|(i, ls)| AabbEntry {
-            entry_idx: i,
             feature_idx: i,
             ls_local_idx: 0,
             aabb: ls.envelope(),
         })
         .collect();
-    overlay_entries(&entries, &lss_per_feature, tolerance)
+    overlay_entries(entries, &lss_per_feature, tolerance)
 }
 
 #[cfg(test)]
@@ -900,7 +889,7 @@ mod tests {
         assert_eq!(line_strings_with_metadata.len(), 4);
         let mut overlay_counts = line_strings_with_metadata
             .iter()
-            .map(|ls| ls.overlay_count)
+            .map(|ls| ls.source_feature_idxs.len())
             .collect::<Vec<_>>();
         overlay_counts.sort();
         assert_eq!(overlay_counts, vec![1, 2, 2, 3]);
@@ -953,7 +942,7 @@ mod tests {
         assert_eq!(line_strings_with_metadata.len(), 4);
         assert!(line_strings_with_metadata
             .iter()
-            .all(|ls| ls.overlay_count == 1));
+            .all(|ls| ls.source_feature_idxs.len() == 1));
         assert_eq!(split_coords.len(), 1);
     }
 
@@ -988,7 +977,7 @@ mod tests {
         assert_eq!(line_strings_with_metadata.len(), 5);
         let mut overlap_counts = line_strings_with_metadata
             .iter()
-            .map(|ls| ls.overlay_count)
+            .map(|ls| ls.source_feature_idxs.len())
             .collect::<Vec<_>>();
         overlap_counts.sort();
         assert_eq!(overlap_counts, vec![1, 1, 1, 2, 2]);
@@ -1018,7 +1007,7 @@ mod tests {
         assert!(result
             .line_strings_with_metadata
             .iter()
-            .all(|m| m.overlay_count == 1));
+            .all(|m| m.source_feature_idxs.len() == 1));
     }
 
     #[test]
@@ -1039,50 +1028,42 @@ mod tests {
         let lss_per_feature = vec![vec![f0_a.clone(), f0_b.clone()], vec![f1.clone()]];
         let entries = vec![
             AabbEntry {
-                entry_idx: 0,
                 feature_idx: 0,
                 ls_local_idx: 0,
                 aabb: f0_a.envelope(),
             },
             AabbEntry {
-                entry_idx: 1,
                 feature_idx: 0,
                 ls_local_idx: 1,
                 aabb: f0_b.envelope(),
             },
             AabbEntry {
-                entry_idx: 2,
                 feature_idx: 1,
                 ls_local_idx: 0,
                 aabb: f1.envelope(),
             },
         ];
 
-        let result = overlay_entries(&entries, &lss_per_feature, 0.01);
+        let result = overlay_entries(entries, &lss_per_feature, 0.01);
 
         for meta in &result.line_strings_with_metadata {
-            let feats: Vec<usize> = meta
-                .overlay_ids
-                .iter()
-                .map(|&e| entries[e].feature_idx)
-                .collect();
+            let feats = &meta.source_feature_idxs;
             let unique: std::collections::HashSet<_> = feats.iter().copied().collect();
             assert_eq!(
                 feats.len(),
                 unique.len(),
-                "overlay_ids contains duplicate feature_idx: {feats:?}"
+                "source_feature_idxs contains duplicates: {feats:?}"
             );
-            assert_eq!(meta.overlay_count, meta.overlay_ids.len());
         }
 
         let overlapping: Vec<_> = result
             .line_strings_with_metadata
             .iter()
-            .filter(|m| m.overlay_count >= 2)
+            .filter(|m| m.source_feature_idxs.len() >= 2)
             .collect();
         assert!(!overlapping.is_empty(), "expected an overlap segment");
         for m in &overlapping {
-            assert_eq!(m.overlay_count, 2);
+            assert_eq!(m.source_feature_idxs.len(), 2);
         }
     }
 
@@ -1104,49 +1085,40 @@ mod tests {
         let lss_per_feature = vec![vec![f0.clone()], vec![f1_a.clone(), f1_b.clone()]];
         let entries = vec![
             AabbEntry {
-                entry_idx: 0,
                 feature_idx: 0,
                 ls_local_idx: 0,
                 aabb: f0.envelope(),
             },
             AabbEntry {
-                entry_idx: 1,
                 feature_idx: 1,
                 ls_local_idx: 0,
                 aabb: f1_a.envelope(),
             },
             AabbEntry {
-                entry_idx: 2,
                 feature_idx: 1,
                 ls_local_idx: 1,
                 aabb: f1_b.envelope(),
             },
         ];
 
-        let result = overlay_entries(&entries, &lss_per_feature, 0.01);
+        let result = overlay_entries(entries, &lss_per_feature, 0.01);
 
         let overlap: Vec<_> = result
             .line_strings_with_metadata
             .iter()
-            .filter(|m| m.overlay_count >= 2)
+            .filter(|m| m.source_feature_idxs.len() >= 2)
             .collect();
         assert!(!overlap.is_empty(), "expected an overlap segment");
         for m in &overlap {
-            let feats: std::collections::HashSet<usize> = m
-                .overlay_ids
-                .iter()
-                .map(|&e| entries[e].feature_idx)
-                .collect();
+            let feats: std::collections::HashSet<usize> =
+                m.source_feature_idxs.iter().copied().collect();
             assert_eq!(
                 feats.len(),
-                m.overlay_ids.len(),
-                "duplicate feature_idx in overlay_ids: {:?}",
-                m.overlay_ids
-                    .iter()
-                    .map(|&e| entries[e].feature_idx)
-                    .collect::<Vec<_>>()
+                m.source_feature_idxs.len(),
+                "duplicate feature_idx in source_feature_idxs: {:?}",
+                m.source_feature_idxs
             );
-            assert_eq!(m.overlay_count, 2);
+            assert_eq!(m.source_feature_idxs.len(), 2);
         }
     }
 

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -2509,9 +2509,9 @@ graphs:
       groupBy:
       - lod
       - fileIndex
-      - gmlId
+      - gmlRootId
       - package
-      tolerance: 1e-9
+      tolerance: 0.01
   - id: 0c979585-82b2-41aa-909c-00d9b8d017d0
     name: FeatureSorter
     type: action
@@ -2607,7 +2607,7 @@ graphs:
       - lod
       - package
       generateList: areaOverlapList
-      tolerance: 1e-9
+      tolerance: 0.01
   - id: b0568e70-1c73-4ee0-8bae-8db3687e3d7d
     name: FilterAreaOverlaps
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -2590,7 +2590,7 @@ graphs:
     action: AttributeDuplicateFilter
     with:
       filterBy:
-      - gmlId
+      - gmlRootId
   - id: 2261a5c9-46a4-45ce-a292-d277a3dc0ebc
     name: GeometryReplacer
     type: action
@@ -2630,16 +2630,16 @@ graphs:
     action: ListConcatenator
     with:
       list: areaOverlapList
-      attribute: gmlId
+      attribute: gmlRootId
       separateCharacter: ','
-      outputAttributeName: concatenatedGmlIds
+      outputAttributeName: concatenatedGmlRootIds
   - id: 518572d2-8561-4b60-ab28-fcd66d90afa2
     name: DuplicateFilter
     type: action
     action: AttributeDuplicateFilter
     with:
       filterBy:
-      - concatenatedGmlIds
+      - concatenatedGmlRootIds
   - id: 2ccf00f0-202b-4bf5-b2a1-0c27a0e82a37
     name: ListExploderForAreaOverlaps
     type: action
@@ -2669,7 +2669,7 @@ graphs:
           env.get("__value")["lod"] ?? ""
       - attribute: gml:id
         expr: |
-          env.get("__value")["gmlId"] ?? ""
+          env.get("__value")["gmlRootId"] ?? ""
       - attribute: 隣接ID
         expr: |
           env.get("__value")["areaOverlapIndex"] ?? ""

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -2552,7 +2552,7 @@ graphs:
       groupBy:
       - lod
       - package
-      tolerance: 1e-9
+      tolerance: 0.01
   - id: 5dab814a-c4c6-47e0-8688-1c5667c775fb
     name: LineOnLineOverlayerLOD23
     type: action
@@ -2561,7 +2561,7 @@ graphs:
       groupBy:
       - lod
       - package
-      tolerance: 1e-9
+      tolerance: 0.01
   - id: b03dfe7a-a32a-4334-90a1-23c7486576dc
     name: FilterOverlaps
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -2509,7 +2509,7 @@ graphs:
       groupBy:
       - lod
       - fileIndex
-      - gmlRootId
+      - gmlId
       - package
       tolerance: 0.01
   - id: 0c979585-82b2-41aa-909c-00d9b8d017d0
@@ -2590,7 +2590,7 @@ graphs:
     action: AttributeDuplicateFilter
     with:
       filterBy:
-      - gmlRootId
+      - gmlId
   - id: 2261a5c9-46a4-45ce-a292-d277a3dc0ebc
     name: GeometryReplacer
     type: action
@@ -2630,16 +2630,16 @@ graphs:
     action: ListConcatenator
     with:
       list: areaOverlapList
-      attribute: gmlRootId
+      attribute: gmlId
       separateCharacter: ','
-      outputAttributeName: concatenatedGmlRootIds
+      outputAttributeName: concatenatedGmlIds
   - id: 518572d2-8561-4b60-ab28-fcd66d90afa2
     name: DuplicateFilter
     type: action
     action: AttributeDuplicateFilter
     with:
       filterBy:
-      - concatenatedGmlRootIds
+      - concatenatedGmlIds
   - id: 2ccf00f0-202b-4bf5-b2a1-0c27a0e82a37
     name: ListExploderForAreaOverlaps
     type: action
@@ -2669,7 +2669,7 @@ graphs:
           env.get("__value")["lod"] ?? ""
       - attribute: gml:id
         expr: |
-          env.get("__value")["gmlRootId"] ?? ""
+          env.get("__value")["gmlId"] ?? ""
       - attribute: 隣接ID
         expr: |
           env.get("__value")["areaOverlapIndex"] ?? ""

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -327,9 +327,9 @@ graphs:
           groupBy:
             - lod
             - fileIndex
-            - gmlId
+            - gmlRootId
             - package
-          tolerance: 0.000000001
+          tolerance: 0.01
 
       # FeatureSorter
       - id: 0c979585-82b2-41aa-909c-00d9b8d017d0
@@ -447,7 +447,7 @@ graphs:
             - lod
             - package
           generateList: areaOverlapList
-          tolerance: 0.000000001
+          tolerance: 0.01
 
       # Filter for overlapping areas
       - id: b0568e70-1c73-4ee0-8bae-8db3687e3d7d

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -420,13 +420,14 @@ graphs:
         with:
           sourceAttribute: overlaidLists
 
-      # DuplicateFilter to remove duplicates based on gmlId
+      # DuplicateFilter to remove duplicates based on gmlRootId
       - id: f94ccdb2-2133-4b0d-886d-9c933c0d645f
         name: DuplicateFilterLineOverlaps
         type: action
         action: AttributeDuplicateFilter
         with:
-          filterBy: ["gmlId"]
+          filterBy:
+            - gmlRootId
 
       # Replace geometry from attribute
       - id: 2261a5c9-46a4-45ce-a292-d277a3dc0ebc
@@ -469,24 +470,25 @@ graphs:
           countStart: 0
           outputAttribute: areaOverlapIndex
 
-      # Concatenate gmlId from each element in areaOverlapList
+      # Concatenate gmlRootId from each element in areaOverlapList
       - id: 8d7f5e2a-1b3c-4f9e-a7d8-3e9b6c4a2f1d
         name: ListConcatenator
         type: action
         action: ListConcatenator
         with:
           list: areaOverlapList
-          attribute: gmlId
+          attribute: gmlRootId
           separateCharacter: ","
-          outputAttributeName: concatenatedGmlIds
+          outputAttributeName: concatenatedGmlRootIds
 
-      # DuplicateFilter to remove duplicates based on gmlId
+      # DuplicateFilter to remove duplicates based on gmlRootId
       - id: 518572d2-8561-4b60-ab28-fcd66d90afa2
         name: DuplicateFilter
         type: action
         action: AttributeDuplicateFilter
         with:
-          filterBy: ["concatenatedGmlIds"]
+          filterBy:
+            - concatenatedGmlRootIds
 
       # List exploder for area overlaps
       - id: 2ccf00f0-202b-4bf5-b2a1-0c27a0e82a37
@@ -520,7 +522,7 @@ graphs:
                 env.get("__value")["lod"] ?? ""
             - attribute: "gml:id"
               expr: |
-                env.get("__value")["gmlId"] ?? ""
+                env.get("__value")["gmlRootId"] ?? ""
             - attribute: 隣接ID
               expr: |
                 env.get("__value")["areaOverlapIndex"] ?? ""

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -379,7 +379,7 @@ graphs:
           groupBy:
             - lod
             - package
-          tolerance: 0.000000001
+          tolerance: 0.01
 
       # Detect overlaps between different Road instances for LOD2 and LOD3
       - id: 5dab814a-c4c6-47e0-8688-1c5667c775fb
@@ -390,7 +390,7 @@ graphs:
           groupBy:
             - lod
             - package
-          tolerance: 0.000000001
+          tolerance: 0.01
 
       # Filter features with overlaps (lines that have overlap attribute > 1)
       - id: b03dfe7a-a32a-4334-90a1-23c7486576dc

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -327,7 +327,7 @@ graphs:
           groupBy:
             - lod
             - fileIndex
-            - gmlRootId
+            - gmlId
             - package
           tolerance: 0.01
 
@@ -420,14 +420,13 @@ graphs:
         with:
           sourceAttribute: overlaidLists
 
-      # DuplicateFilter to remove duplicates based on gmlRootId
+      # DuplicateFilter to remove duplicates based on gmlId
       - id: f94ccdb2-2133-4b0d-886d-9c933c0d645f
         name: DuplicateFilterLineOverlaps
         type: action
         action: AttributeDuplicateFilter
         with:
-          filterBy:
-            - gmlRootId
+          filterBy: ["gmlId"]
 
       # Replace geometry from attribute
       - id: 2261a5c9-46a4-45ce-a292-d277a3dc0ebc
@@ -470,25 +469,24 @@ graphs:
           countStart: 0
           outputAttribute: areaOverlapIndex
 
-      # Concatenate gmlRootId from each element in areaOverlapList
+      # Concatenate gmlId from each element in areaOverlapList
       - id: 8d7f5e2a-1b3c-4f9e-a7d8-3e9b6c4a2f1d
         name: ListConcatenator
         type: action
         action: ListConcatenator
         with:
           list: areaOverlapList
-          attribute: gmlRootId
+          attribute: gmlId
           separateCharacter: ","
-          outputAttributeName: concatenatedGmlRootIds
+          outputAttributeName: concatenatedGmlIds
 
-      # DuplicateFilter to remove duplicates based on gmlRootId
+      # DuplicateFilter to remove duplicates based on gmlId
       - id: 518572d2-8561-4b60-ab28-fcd66d90afa2
         name: DuplicateFilter
         type: action
         action: AttributeDuplicateFilter
         with:
-          filterBy:
-            - concatenatedGmlRootIds
+          filterBy: ["concatenatedGmlIds"]
 
       # List exploder for area overlaps
       - id: 2ccf00f0-202b-4bf5-b2a1-0c27a0e82a37
@@ -522,7 +520,7 @@ graphs:
                 env.get("__value")["lod"] ?? ""
             - attribute: "gml:id"
               expr: |
-                env.get("__value")["gmlRootId"] ?? ""
+                env.get("__value")["gmlId"] ?? ""
             - attribute: 隣接ID
               expr: |
                 env.get("__value")["areaOverlapIndex"] ?? ""

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.23"
+version = "0.2.24"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.213"
+version = "0.1.214"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR rewrites `LineOnLineOverlayer` with the R-tree candidate pair lookup and a careful disk-backing to avoid quadratic memory usage. It also contains some bug fixes for the QC tran workflow.

## What I've done
- `LineOnLineOverlayer` was using O(n^2) intersection checks for AABBs, which were making the action take more than 6h for the QC Okayama tran workflow. After the following major rewrite, now it completes in under 10 mins:
  - It now uses an R-tree for intersecting AABB pair lookup. Furthermore, since we iterate over the candidate pair instead of computing all AABB pairs upfront, O(n^2)-many pair candidates will not be loaded onto memory at once.
  - Disk-backing is introduced to prevent geometry data piles up in memory before `finish()`. (See the memo below for a trade-off made for this) 
- There is one behavioral change; `LineOnLineOverlayer` do not output lines with length less than tolerance (i.e. degenerate line strings). 
- This PR contains bug fixes for QC tran workflow (though they do not affect the inspection results, as all of them are related to an "OK error" 隣接面重複): 
  - It was using stale tolerance values based of the geographic coordinates from early days, though now it uses Cartesian local coordinates. These tolerance values are fixed.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
- `LineOnLineOverlayer` still loads all geometries onto memory at `finish()`. We could further modify it so that the each geometry will be loaded to memory only when it's one from a candidate AABB pair, but this PR does not implement it. This is a trade-off with memory and speed; we chose speed, and this is likely fine as the memory usage is still linear.