### PR TITLE
feat(engine): CityGML 3.0 child feature extraction

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6516,7 +6516,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "futures",
  "once_cell",
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "approx",
  "async-trait",
@@ -6582,7 +6582,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "Inflector",
  "approx",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6661,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6729,7 +6729,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6791,7 +6791,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "bytes",
  "clap",
@@ -6829,7 +6829,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6869,7 +6869,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "chrono",
  "futures",
@@ -6883,7 +6883,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6912,7 +6912,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "approx",
  "bvh",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6976,7 +6976,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6985,7 +6985,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7015,7 +7015,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7066,7 +7066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7078,7 +7078,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "bytes",
  "futures",
@@ -7095,7 +7095,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "bytes",
  "futures",
@@ -7114,7 +7114,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7128,7 +7128,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7163,7 +7163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7200,7 +7200,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.361"
+version = "0.0.362"
 dependencies = [
  "async-trait",
  "backon",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.361"
+version = "0.0.362"
 
 [profile.dev]
 opt-level = 0

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -2809,6 +2809,15 @@ Reads CityGML 3.0 files: resolves gml:id references and xlink:href links across 
           "$ref": "#/definitions/Expr"
         }
       ]
+    },
+    "extractedTags": {
+      "title": "Extracted Tags",
+      "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "definitions": {

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -2810,9 +2810,9 @@ Reads CityGML 3.0 files: resolves gml:id references and xlink:href links across 
         }
       ]
     },
-    "extractedTags": {
-      "title": "Extracted Tags",
-      "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+    "flattenFeatureTypes": {
+      "title": "Flatten Feature Types",
+      "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
       "default": [],
       "type": "array",
       "items": {

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -2810,8 +2810,8 @@ Reads CityGML 3.0 files: resolves gml:id references and xlink:href links across 
         }
       ]
     },
-    "flattenFeatureTypes": {
-      "title": "Flatten Feature Types",
+    "extractTags": {
+      "title": "Extract Tags",
       "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
       "default": [],
       "type": "array",

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
@@ -1,0 +1,155 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use super::utils::{local_name, XmlChild, XmlNode};
+
+/// Walks `node`'s subtree bottom-up, lifting out every descendant whose tag is in `included`
+/// (matched by qualified name, local name, or Clark notation `{ns}local`).
+/// Returns the stripped tree and the extracted nodes, deepest-first.
+/// No-op when `included` is empty.
+pub fn extract_by_types(
+    node: &Arc<XmlNode>,
+    included: &HashSet<String>,
+) -> (Arc<XmlNode>, Vec<Arc<XmlNode>>) {
+    if included.is_empty() {
+        return (Arc::clone(node), Vec::new());
+    }
+    let mut extracted: Vec<Arc<XmlNode>> = Vec::new();
+    let stripped = extract_recursive(node, included, &mut extracted);
+    (stripped, extracted)
+}
+
+pub fn tag_matches(node: &XmlNode, included: &HashSet<String>) -> bool {
+    let ln = local_name(&node.name.0);
+    included.contains(node.name.0.as_str())
+        || included.contains(ln)
+        || (!node.name.1.is_empty()
+            && included.contains(&format!("{{{}}}{ln}", node.name.1)))
+}
+
+fn extract_recursive(
+    node: &Arc<XmlNode>,
+    included: &HashSet<String>,
+    out: &mut Vec<Arc<XmlNode>>,
+) -> Arc<XmlNode> {
+    let mut new_children: Option<Vec<XmlChild>> = None;
+
+    for (i, child) in node.children.iter().enumerate() {
+        match child {
+            XmlChild::Element(e) => {
+                if tag_matches(e, included) {
+                    // Process the child's own subtree first (bottom-up), then lift the child out.
+                    let stripped_child = extract_recursive(e, included, out);
+                    out.push(stripped_child);
+
+                    if new_children.is_none() {
+                        new_children = Some(node.children[..i].to_vec());
+                    }
+                    // deliberately not pushed into new_children — it is extracted
+                } else {
+                    let stripped_child = extract_recursive(e, included, out);
+                    match new_children {
+                        None => {
+                            if !Arc::ptr_eq(&stripped_child, e) {
+                                let mut nc = node.children[..i].to_vec();
+                                nc.push(XmlChild::Element(stripped_child));
+                                new_children = Some(nc);
+                            }
+                        }
+                        Some(ref mut nc) => {
+                            nc.push(XmlChild::Element(stripped_child));
+                        }
+                    }
+                }
+            }
+            XmlChild::Text(_) => {
+                if let Some(ref mut nc) = new_children {
+                    nc.push(child.clone());
+                }
+            }
+        }
+    }
+
+    match new_children {
+        None => Arc::clone(node),
+        Some(children) => Arc::new(XmlNode {
+            name: node.name.clone(),
+            attrs: node.attrs.clone(),
+            children,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::feature::reader::citygml3::utils::XmlChild;
+
+    fn node(name: &str, children: Vec<XmlChild>) -> Arc<XmlNode> {
+        Arc::new(XmlNode {
+            name: (name.to_string(), String::new()),
+            attrs: Vec::new(),
+            children,
+        })
+    }
+
+    fn elem(n: Arc<XmlNode>) -> XmlChild {
+        XmlChild::Element(n)
+    }
+
+    fn included(tags: &[&str]) -> HashSet<String> {
+        tags.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn matching_child_extracted_from_parent() {
+        let part = node("bldg:BuildingPart", vec![]);
+        let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
+        let (stripped, extracted) = extract_by_types(&root, &included(&["bldg:BuildingPart"]));
+        assert!(stripped.children.is_empty());
+        assert_eq!(extracted.len(), 1);
+        assert!(Arc::ptr_eq(&extracted[0], &part));
+    }
+
+    #[test]
+    fn deep_match_extracted_before_shallow() {
+        // Building > BuildingPart > Room — inclusion: BuildingPart, Room
+        // Expect: Room first (deepest), BuildingPart second, BuildingPart no longer contains Room
+        let room = node("bldg:Room", vec![]);
+        let part = node("bldg:BuildingPart", vec![elem(Arc::clone(&room))]);
+        let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
+
+        let (stripped, extracted) =
+            extract_by_types(&root, &included(&["bldg:BuildingPart", "bldg:Room"]));
+
+        assert!(stripped.children.is_empty());
+        assert_eq!(extracted.len(), 2);
+        assert_eq!(extracted[0].name.0, "bldg:Room");
+        assert_eq!(extracted[1].name.0, "bldg:BuildingPart");
+        assert!(extracted[1].children.is_empty());
+    }
+
+    #[test]
+    fn local_name_match() {
+        let part = node("bldg:BuildingPart", vec![]);
+        let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
+        let (stripped, extracted) = extract_by_types(&root, &included(&["BuildingPart"]));
+        assert!(stripped.children.is_empty());
+        assert_eq!(extracted.len(), 1);
+    }
+
+    #[test]
+    fn clark_notation_match() {
+        let ns = "http://www.opengis.net/citygml/building/3.0";
+        let part = Arc::new(XmlNode {
+            name: ("bldg:BuildingPart".to_string(), ns.to_string()),
+            attrs: Vec::new(),
+            children: Vec::new(),
+        });
+        let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
+        let clark = format!("{{{ns}}}BuildingPart");
+        let (stripped, extracted) = extract_by_types(&root, &included(&[&clark]));
+        assert!(stripped.children.is_empty());
+        assert_eq!(extracted.len(), 1);
+    }
+}

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
@@ -1,42 +1,82 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use super::utils::{gml_id_attr, local_name, XmlChild, XmlNode};
+use super::utils::{
+    gml_id_attr, local_name, NamespaceRegistry, NsId, XmlChild, XmlNode, EMPTY_NS_ID,
+};
+
+/// Pre-processed form of the `included` tag set that avoids per-node allocation.
+/// Clark-notation entries (`{ns}local`) are resolved to `(NsId, local)` pairs once at the
+/// `extract()` boundary, so matching is a cheap integer + string-ref comparison.
+struct MatchSets {
+    raw: HashSet<String>,
+    clark: HashMap<NsId, HashSet<String>>,
+}
+
+impl MatchSets {
+    fn new(included: &HashSet<String>, ns_reg: &NamespaceRegistry) -> Self {
+        let mut clark: HashMap<NsId, HashSet<String>> = HashMap::new();
+        for s in included {
+            if let Some(rest) = s.strip_prefix('{') {
+                if let Some(end) = rest.find('}') {
+                    let uri = &rest[..end];
+                    let local = rest[end + 1..].to_string();
+                    if let Some(id) = ns_reg.get(uri) {
+                        clark.entry(id).or_default().insert(local);
+                    }
+                }
+            }
+        }
+        Self {
+            raw: included.clone(),
+            clark,
+        }
+    }
+}
+
+fn tag_matches(node: &XmlNode, sets: &MatchSets) -> bool {
+    let ln = local_name(&node.name.0);
+    sets.raw.contains(node.name.0.as_str())
+        || sets.raw.contains(ln)
+        || (node.name.1 != EMPTY_NS_ID
+            && sets
+                .clark
+                .get(&node.name.1)
+                .is_some_and(|locals| locals.contains(ln)))
+}
 
 /// Extracts all nodes whose tag is in `included` from `node`'s subtree (including `node` itself),
 /// deepest-first. Each extracted node has its own matching descendants stripped out.
-pub fn extract(node: &Arc<XmlNode>, included: &HashSet<String>) -> Vec<Arc<XmlNode>> {
+pub(super) fn extract(
+    node: &Arc<XmlNode>,
+    included: &HashSet<String>,
+    ns_registry: &NamespaceRegistry,
+) -> Vec<Arc<XmlNode>> {
     if included.is_empty() {
         return Vec::new();
     }
+    let sets = MatchSets::new(included, ns_registry);
     let mut out = Vec::new();
-    extract_inner(node, included, &mut out);
+    extract_inner(node, &sets, &mut out);
     out
 }
 
-fn extract_inner(node: &Arc<XmlNode>, included: &HashSet<String>, out: &mut Vec<Arc<XmlNode>>) {
-    if tag_matches(node, included) {
-        let stripped = extract_recursive(node, included, out);
+fn extract_inner(node: &Arc<XmlNode>, sets: &MatchSets, out: &mut Vec<Arc<XmlNode>>) {
+    if tag_matches(node, sets) {
+        let stripped = extract_recursive(node, sets, out);
         out.push(stripped);
     } else {
         for child in &node.children {
             if let XmlChild::Element(e) = child {
-                extract_inner(e, included, out);
+                extract_inner(e, sets, out);
             }
         }
     }
 }
 
-pub fn tag_matches(node: &XmlNode, included: &HashSet<String>) -> bool {
-    let ln = local_name(&node.name.0);
-    included.contains(node.name.0.as_str())
-        || included.contains(ln)
-        || (!node.name.1.is_empty() && included.contains(&format!("{{{}}}{ln}", node.name.1)))
-}
-
 /// Tracks the nearest ancestor `gml:id` for every node in a tree.
 /// Build with [`ParentIdTracker::collect`], then query with [`ParentIdTracker::parent_gml_id`].
-pub struct ParentIdTracker {
+pub(super) struct ParentIdTracker {
     /// node gml:id → nearest ancestor gml:id (None when the node is a root)
     map: HashMap<String, Option<String>>,
 }
@@ -76,7 +116,7 @@ impl ParentIdTracker {
 
 fn extract_recursive(
     node: &Arc<XmlNode>,
-    included: &HashSet<String>,
+    sets: &MatchSets,
     out: &mut Vec<Arc<XmlNode>>,
 ) -> Arc<XmlNode> {
     let mut new_children: Option<Vec<XmlChild>> = None;
@@ -84,9 +124,8 @@ fn extract_recursive(
     for (i, child) in node.children.iter().enumerate() {
         match child {
             XmlChild::Element(e) => {
-                if tag_matches(e, included) {
-                    // Process the child's own subtree first (bottom-up), then lift the child out.
-                    let stripped_child = extract_recursive(e, included, out);
+                if tag_matches(e, sets) {
+                    let stripped_child = extract_recursive(e, sets, out);
                     out.push(stripped_child);
 
                     if new_children.is_none() {
@@ -94,7 +133,7 @@ fn extract_recursive(
                     }
                     // deliberately not pushed into new_children — it is extracted
                 } else {
-                    let stripped_child = extract_recursive(e, included, out);
+                    let stripped_child = extract_recursive(e, sets, out);
                     match new_children {
                         None => {
                             if !Arc::ptr_eq(&stripped_child, e) {
@@ -130,11 +169,11 @@ fn extract_recursive(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::feature::reader::citygml3::utils::XmlChild;
+    use crate::feature::reader::citygml3::utils::{NamespaceRegistry, XmlChild, EMPTY_NS_ID};
 
     fn node(name: &str, children: Vec<XmlChild>) -> Arc<XmlNode> {
         Arc::new(XmlNode {
-            name: (name.to_string(), String::new()),
+            name: (name.to_string(), EMPTY_NS_ID),
             attrs: Vec::new(),
             children,
         })
@@ -150,22 +189,26 @@ mod tests {
 
     #[test]
     fn matching_child_extracted_from_parent() {
+        let ns_reg = NamespaceRegistry::new();
         let part = node("bldg:BuildingPart", vec![]);
         let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
-        let extracted = extract(&root, &included(&["bldg:BuildingPart"]));
+        let extracted = extract(&root, &included(&["bldg:BuildingPart"]), &ns_reg);
         assert_eq!(extracted.len(), 1);
         assert!(Arc::ptr_eq(&extracted[0], &part));
     }
 
     #[test]
     fn deep_match_extracted_before_shallow() {
-        // Building > BuildingPart > Room — inclusion: BuildingPart, Room
-        // Expect: Room first (deepest), BuildingPart second, BuildingPart no longer contains Room
+        let ns_reg = NamespaceRegistry::new();
         let room = node("bldg:Room", vec![]);
         let part = node("bldg:BuildingPart", vec![elem(Arc::clone(&room))]);
         let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
 
-        let extracted = extract(&root, &included(&["bldg:BuildingPart", "bldg:Room"]));
+        let extracted = extract(
+            &root,
+            &included(&["bldg:BuildingPart", "bldg:Room"]),
+            &ns_reg,
+        );
 
         assert_eq!(extracted.len(), 2);
         assert_eq!(extracted[0].name.0, "bldg:Room");
@@ -175,23 +218,26 @@ mod tests {
 
     #[test]
     fn local_name_match() {
+        let ns_reg = NamespaceRegistry::new();
         let part = node("bldg:BuildingPart", vec![]);
         let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
-        let extracted = extract(&root, &included(&["BuildingPart"]));
+        let extracted = extract(&root, &included(&["BuildingPart"]), &ns_reg);
         assert_eq!(extracted.len(), 1);
     }
 
     #[test]
     fn clark_notation_match() {
+        let mut ns_reg = NamespaceRegistry::new();
         let ns = "http://www.opengis.net/citygml/building/3.0";
+        let ns_id = ns_reg.intern(ns);
         let part = Arc::new(XmlNode {
-            name: ("bldg:BuildingPart".to_string(), ns.to_string()),
+            name: ("bldg:BuildingPart".to_string(), ns_id),
             attrs: Vec::new(),
             children: Vec::new(),
         });
         let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
         let clark = format!("{{{ns}}}BuildingPart");
-        let extracted = extract(&root, &included(&[&clark]));
+        let extracted = extract(&root, &included(&[&clark]), &ns_reg);
         assert_eq!(extracted.len(), 1);
     }
 }

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
@@ -1,22 +1,30 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use super::utils::{local_name, XmlChild, XmlNode};
+use super::utils::{gml_id_attr, local_name, XmlChild, XmlNode};
 
-/// Walks `node`'s subtree bottom-up, lifting out every descendant whose tag is in `included`
-/// (matched by qualified name, local name, or Clark notation `{ns}local`).
-/// Returns the stripped tree and the extracted nodes, deepest-first.
-/// No-op when `included` is empty.
-pub fn extract_by_types(
-    node: &Arc<XmlNode>,
-    included: &HashSet<String>,
-) -> (Arc<XmlNode>, Vec<Arc<XmlNode>>) {
+/// Extracts all nodes whose tag is in `included` from `node`'s subtree (including `node` itself),
+/// deepest-first. Each extracted node has its own matching descendants stripped out.
+pub fn extract(node: &Arc<XmlNode>, included: &HashSet<String>) -> Vec<Arc<XmlNode>> {
     if included.is_empty() {
-        return (Arc::clone(node), Vec::new());
+        return Vec::new();
     }
-    let mut extracted: Vec<Arc<XmlNode>> = Vec::new();
-    let stripped = extract_recursive(node, included, &mut extracted);
-    (stripped, extracted)
+    let mut out = Vec::new();
+    extract_inner(node, included, &mut out);
+    out
+}
+
+fn extract_inner(node: &Arc<XmlNode>, included: &HashSet<String>, out: &mut Vec<Arc<XmlNode>>) {
+    if tag_matches(node, included) {
+        let stripped = extract_recursive(node, included, out);
+        out.push(stripped);
+    } else {
+        for child in &node.children {
+            if let XmlChild::Element(e) = child {
+                extract_inner(e, included, out);
+            }
+        }
+    }
 }
 
 pub fn tag_matches(node: &XmlNode, included: &HashSet<String>) -> bool {
@@ -24,6 +32,46 @@ pub fn tag_matches(node: &XmlNode, included: &HashSet<String>) -> bool {
     included.contains(node.name.0.as_str())
         || included.contains(ln)
         || (!node.name.1.is_empty() && included.contains(&format!("{{{}}}{ln}", node.name.1)))
+}
+
+/// Tracks the nearest ancestor `gml:id` for every node in a tree.
+/// Build with [`ParentIdTracker::collect`], then query with [`ParentIdTracker::parent_gml_id`].
+pub struct ParentIdTracker {
+    /// node gml:id → nearest ancestor gml:id (None when the node is a root)
+    map: HashMap<String, Option<String>>,
+}
+
+impl ParentIdTracker {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    /// Walk `node` and record every descendant's parent id.
+    pub fn collect(&mut self, node: &XmlNode) {
+        self.walk(node, None);
+    }
+
+    /// Return the nearest ancestor `gml:id` for the given node id, or `None` if it was a root
+    /// or is unknown.
+    pub fn parent_gml_id(&self, gml_id: &str) -> Option<&str> {
+        self.map.get(gml_id)?.as_deref()
+    }
+
+    fn walk(&mut self, node: &XmlNode, parent_gml_id: Option<&str>) {
+        let my_id = gml_id_attr(node);
+        if let Some(id) = &my_id {
+            self.map
+                .insert(id.clone(), parent_gml_id.map(str::to_string));
+        }
+        let child_parent = my_id.as_deref().or(parent_gml_id);
+        for child in &node.children {
+            if let XmlChild::Element(e) = child {
+                self.walk(e, child_parent);
+            }
+        }
+    }
 }
 
 fn extract_recursive(
@@ -104,8 +152,7 @@ mod tests {
     fn matching_child_extracted_from_parent() {
         let part = node("bldg:BuildingPart", vec![]);
         let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
-        let (stripped, extracted) = extract_by_types(&root, &included(&["bldg:BuildingPart"]));
-        assert!(stripped.children.is_empty());
+        let extracted = extract(&root, &included(&["bldg:BuildingPart"]));
         assert_eq!(extracted.len(), 1);
         assert!(Arc::ptr_eq(&extracted[0], &part));
     }
@@ -118,10 +165,8 @@ mod tests {
         let part = node("bldg:BuildingPart", vec![elem(Arc::clone(&room))]);
         let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
 
-        let (stripped, extracted) =
-            extract_by_types(&root, &included(&["bldg:BuildingPart", "bldg:Room"]));
+        let extracted = extract(&root, &included(&["bldg:BuildingPart", "bldg:Room"]));
 
-        assert!(stripped.children.is_empty());
         assert_eq!(extracted.len(), 2);
         assert_eq!(extracted[0].name.0, "bldg:Room");
         assert_eq!(extracted[1].name.0, "bldg:BuildingPart");
@@ -132,8 +177,7 @@ mod tests {
     fn local_name_match() {
         let part = node("bldg:BuildingPart", vec![]);
         let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
-        let (stripped, extracted) = extract_by_types(&root, &included(&["BuildingPart"]));
-        assert!(stripped.children.is_empty());
+        let extracted = extract(&root, &included(&["BuildingPart"]));
         assert_eq!(extracted.len(), 1);
     }
 
@@ -147,8 +191,7 @@ mod tests {
         });
         let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
         let clark = format!("{{{ns}}}BuildingPart");
-        let (stripped, extracted) = extract_by_types(&root, &included(&[&clark]));
-        assert!(stripped.children.is_empty());
+        let extracted = extract(&root, &included(&[&clark]));
         assert_eq!(extracted.len(), 1);
     }
 }

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
@@ -15,6 +15,7 @@ struct MatchSets {
 
 impl MatchSets {
     fn new(included: &HashSet<String>, ns_reg: &NamespaceRegistry) -> Self {
+        let mut raw: HashSet<String> = HashSet::new();
         let mut clark: HashMap<NsId, HashSet<String>> = HashMap::new();
         for s in included {
             if let Some(rest) = s.strip_prefix('{') {
@@ -25,12 +26,11 @@ impl MatchSets {
                         clark.entry(id).or_default().insert(local);
                     }
                 }
+            } else {
+                raw.insert(s.clone());
             }
         }
-        Self {
-            raw: included.clone(),
-            clark,
-        }
+        Self { raw, clark }
     }
 }
 

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
@@ -142,7 +142,9 @@ fn extract_recursive(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::feature::reader::citygml3::utils::{NamespaceRegistry, XmlChild, EMPTY_NS_ID, GML_NS_ID};
+    use crate::feature::reader::citygml3::utils::{
+        NamespaceRegistry, XmlChild, EMPTY_NS_ID, GML_NS_ID,
+    };
 
     fn node(name: &str, children: Vec<XmlChild>) -> Arc<XmlNode> {
         Arc::new(XmlNode {
@@ -236,7 +238,13 @@ mod tests {
 
         assert_eq!(extracted.len(), 2);
         let parents: Vec<_> = extracted.iter().map(|(_, p)| p.as_deref()).collect();
-        assert!(parents.contains(&Some("a")), "first emission should have parent a");
-        assert!(parents.contains(&Some("b")), "second emission should have parent b");
+        assert!(
+            parents.contains(&Some("a")),
+            "first emission should have parent a"
+        );
+        assert!(
+            parents.contains(&Some("b")),
+            "second emission should have parent b"
+        );
     }
 }

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
@@ -47,68 +47,37 @@ fn tag_matches(node: &XmlNode, sets: &MatchSets) -> bool {
 
 /// Extracts all nodes whose tag is in `included` from `node`'s subtree (including `node` itself),
 /// deepest-first. Each extracted node has its own matching descendants stripped out.
+/// Returns `(node, nearest_ancestor_gml_id)` pairs; the parent ID is correct even when the same
+/// node is reached via multiple paths (e.g. shared xlink targets).
 pub(super) fn extract(
     node: &Arc<XmlNode>,
     included: &HashSet<String>,
     ns_registry: &NamespaceRegistry,
-) -> Vec<Arc<XmlNode>> {
+) -> Vec<(Arc<XmlNode>, Option<String>)> {
     if included.is_empty() {
         return Vec::new();
     }
     let sets = MatchSets::new(included, ns_registry);
     let mut out = Vec::new();
-    extract_inner(node, &sets, &mut out);
+    extract_inner(node, &sets, &mut out, None);
     out
 }
 
-fn extract_inner(node: &Arc<XmlNode>, sets: &MatchSets, out: &mut Vec<Arc<XmlNode>>) {
+fn extract_inner(
+    node: &Arc<XmlNode>,
+    sets: &MatchSets,
+    out: &mut Vec<(Arc<XmlNode>, Option<String>)>,
+    parent_gml_id: Option<&str>,
+) {
     if tag_matches(node, sets) {
-        let stripped = extract_recursive(node, sets, out);
-        out.push(stripped);
+        let stripped = extract_recursive(node, sets, out, parent_gml_id);
+        out.push((stripped, parent_gml_id.map(str::to_string)));
     } else {
-        for child in &node.children {
-            if let XmlChild::Element(e) = child {
-                extract_inner(e, sets, out);
-            }
-        }
-    }
-}
-
-/// Tracks the nearest ancestor `gml:id` for every node in a tree.
-/// Build with [`ParentIdTracker::collect`], then query with [`ParentIdTracker::parent_gml_id`].
-pub(super) struct ParentIdTracker {
-    /// node gml:id → nearest ancestor gml:id (None when the node is a root)
-    map: HashMap<String, Option<String>>,
-}
-
-impl ParentIdTracker {
-    pub fn new() -> Self {
-        Self {
-            map: HashMap::new(),
-        }
-    }
-
-    /// Walk `node` and record every descendant's parent id.
-    pub fn collect(&mut self, node: &XmlNode) {
-        self.walk(node, None);
-    }
-
-    /// Return the nearest ancestor `gml:id` for the given node id, or `None` if it was a root
-    /// or is unknown.
-    pub fn parent_gml_id(&self, gml_id: &str) -> Option<&str> {
-        self.map.get(gml_id)?.as_deref()
-    }
-
-    fn walk(&mut self, node: &XmlNode, parent_gml_id: Option<&str>) {
         let my_id = gml_id_attr(node);
-        if let Some(id) = &my_id {
-            self.map
-                .insert(id.clone(), parent_gml_id.map(str::to_string));
-        }
-        let child_parent = my_id.as_deref().or(parent_gml_id);
+        let next_parent = my_id.as_deref().or(parent_gml_id);
         for child in &node.children {
             if let XmlChild::Element(e) = child {
-                self.walk(e, child_parent);
+                extract_inner(e, sets, out, next_parent);
             }
         }
     }
@@ -117,23 +86,27 @@ impl ParentIdTracker {
 fn extract_recursive(
     node: &Arc<XmlNode>,
     sets: &MatchSets,
-    out: &mut Vec<Arc<XmlNode>>,
+    out: &mut Vec<(Arc<XmlNode>, Option<String>)>,
+    parent_gml_id: Option<&str>,
 ) -> Arc<XmlNode> {
+    let my_id = gml_id_attr(node);
+    let child_parent = my_id.as_deref().or(parent_gml_id);
+
     let mut new_children: Option<Vec<XmlChild>> = None;
 
     for (i, child) in node.children.iter().enumerate() {
         match child {
             XmlChild::Element(e) => {
                 if tag_matches(e, sets) {
-                    let stripped_child = extract_recursive(e, sets, out);
-                    out.push(stripped_child);
+                    let stripped_child = extract_recursive(e, sets, out, child_parent);
+                    out.push((stripped_child, child_parent.map(str::to_string)));
 
                     if new_children.is_none() {
                         new_children = Some(node.children[..i].to_vec());
                     }
                     // deliberately not pushed into new_children — it is extracted
                 } else {
-                    let stripped_child = extract_recursive(e, sets, out);
+                    let stripped_child = extract_recursive(e, sets, out, child_parent);
                     match new_children {
                         None => {
                             if !Arc::ptr_eq(&stripped_child, e) {
@@ -169,7 +142,7 @@ fn extract_recursive(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::feature::reader::citygml3::utils::{NamespaceRegistry, XmlChild, EMPTY_NS_ID};
+    use crate::feature::reader::citygml3::utils::{NamespaceRegistry, XmlChild, EMPTY_NS_ID, GML_NS_ID};
 
     fn node(name: &str, children: Vec<XmlChild>) -> Arc<XmlNode> {
         Arc::new(XmlNode {
@@ -187,6 +160,14 @@ mod tests {
         tags.iter().map(|s| s.to_string()).collect()
     }
 
+    fn gml_id(name: &str, id: &str, children: Vec<XmlChild>) -> Arc<XmlNode> {
+        Arc::new(XmlNode {
+            name: (name.to_string(), EMPTY_NS_ID),
+            attrs: vec![(("gml:id".to_string(), GML_NS_ID), id.to_string())],
+            children,
+        })
+    }
+
     #[test]
     fn matching_child_extracted_from_parent() {
         let ns_reg = NamespaceRegistry::new();
@@ -194,7 +175,7 @@ mod tests {
         let root = node("bldg:Building", vec![elem(Arc::clone(&part))]);
         let extracted = extract(&root, &included(&["bldg:BuildingPart"]), &ns_reg);
         assert_eq!(extracted.len(), 1);
-        assert!(Arc::ptr_eq(&extracted[0], &part));
+        assert!(Arc::ptr_eq(&extracted[0].0, &part));
     }
 
     #[test]
@@ -211,9 +192,9 @@ mod tests {
         );
 
         assert_eq!(extracted.len(), 2);
-        assert_eq!(extracted[0].name.0, "bldg:Room");
-        assert_eq!(extracted[1].name.0, "bldg:BuildingPart");
-        assert!(extracted[1].children.is_empty());
+        assert_eq!(extracted[0].0.name.0, "bldg:Room");
+        assert_eq!(extracted[1].0.name.0, "bldg:BuildingPart");
+        assert!(extracted[1].0.children.is_empty());
     }
 
     #[test]
@@ -239,5 +220,23 @@ mod tests {
         let clark = format!("{{{ns}}}BuildingPart");
         let extracted = extract(&root, &included(&[&clark]), &ns_reg);
         assert_eq!(extracted.len(), 1);
+    }
+
+    #[test]
+    fn shared_node_gets_correct_parent_per_occurrence() {
+        // C is referenced under both A and B (same Arc, simulating xlink resolution).
+        // Each emission of C must carry the parent from its own traversal position.
+        let ns_reg = NamespaceRegistry::new();
+        let c = gml_id("bldg:Unit", "c", vec![]);
+        let a = gml_id("bldg:Building", "a", vec![elem(Arc::clone(&c))]);
+        let b = gml_id("bldg:Building", "b", vec![elem(Arc::clone(&c))]);
+        let root = node("root", vec![elem(Arc::clone(&a)), elem(Arc::clone(&b))]);
+
+        let extracted = extract(&root, &included(&["bldg:Unit"]), &ns_reg);
+
+        assert_eq!(extracted.len(), 2);
+        let parents: Vec<_> = extracted.iter().map(|(_, p)| p.as_deref()).collect();
+        assert!(parents.contains(&Some("a")), "first emission should have parent a");
+        assert!(parents.contains(&Some("b")), "second emission should have parent b");
     }
 }

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
@@ -49,6 +49,8 @@ fn tag_matches(node: &XmlNode, sets: &MatchSets) -> bool {
 /// deepest-first. Each extracted node has its own matching descendants stripped out.
 /// Returns `(node, nearest_ancestor_gml_id)` pairs; the parent ID is correct even when the same
 /// node is reached via multiple paths (e.g. shared xlink targets).
+/// Note: if a parent and a descendant tag both appear in `included`, the descendant's geometry
+/// and attributes are stripped from the parent and emitted separately.
 pub(super) fn extract(
     node: &Arc<XmlNode>,
     included: &HashSet<String>,

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/flatten.rs
@@ -23,8 +23,7 @@ pub fn tag_matches(node: &XmlNode, included: &HashSet<String>) -> bool {
     let ln = local_name(&node.name.0);
     included.contains(node.name.0.as_str())
         || included.contains(ln)
-        || (!node.name.1.is_empty()
-            && included.contains(&format!("{{{}}}{ln}", node.name.1)))
+        || (!node.name.1.is_empty() && included.contains(&format!("{{{}}}{ln}", node.name.1)))
 }
 
 fn extract_recursive(

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/geometry.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/geometry.rs
@@ -5,7 +5,7 @@ use reearth_flow_geometry::types::line_string::LineString3D;
 use reearth_flow_geometry::types::polygon::Polygon3D;
 use reearth_flow_types::{GeometryType, GmlGeometry};
 
-use super::utils::{local_name, XmlChild, XmlNode, GML_NS};
+use super::utils::{local_name, XmlChild, XmlNode, GML_NS_ID};
 
 pub fn extract_geometries(node: &Arc<XmlNode>) -> (Arc<XmlNode>, Vec<GmlGeometry>) {
     let mut out: Vec<GmlGeometry> = Vec::new();
@@ -503,7 +503,7 @@ fn gml_element_geometry_type(local: &str) -> Option<GeometryType> {
 fn gml_id(node: &XmlNode) -> Option<String> {
     node.attrs
         .iter()
-        .find(|((q, ns), _)| local_name(q) == "id" && ns == GML_NS)
+        .find(|((q, ns), _)| local_name(q) == "id" && *ns == GML_NS_ID)
         .map(|(_, v)| v.clone())
 }
 
@@ -533,18 +533,28 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::feature::reader::citygml3::utils::XmlChild;
+    use crate::feature::reader::citygml3::utils::{
+        NsId, XmlChild, EMPTY_NS_ID, GML_NS, GML_NS_ID, XLINK_NS, XLINK_NS_ID,
+    };
 
     fn text_node(t: &str) -> XmlChild {
         XmlChild::Text(t.to_string())
     }
 
+    fn ns_id(ns: &str) -> NsId {
+        match ns {
+            GML_NS => GML_NS_ID,
+            XLINK_NS => XLINK_NS_ID,
+            _ => EMPTY_NS_ID,
+        }
+    }
+
     fn elem(name: &str, attrs: Vec<(&str, &str, &str)>, children: Vec<XmlChild>) -> XmlNode {
         XmlNode {
-            name: (name.to_string(), String::new()),
+            name: (name.to_string(), EMPTY_NS_ID),
             attrs: attrs
                 .into_iter()
-                .map(|(q, ns, v)| ((q.to_string(), ns.to_string()), v.to_string()))
+                .map(|(q, ns, v)| ((q.to_string(), ns_id(ns)), v.to_string()))
                 .collect(),
             children,
         }

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/mod.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod flatten;
 pub(crate) mod geometry;
 pub(crate) mod parser;
 pub(crate) mod processor;

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/parser.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/parser.rs
@@ -10,8 +10,8 @@ use reearth_flow_types::{Attribute, AttributeValue, Attributes, CitygmlFeatureEx
 use url::Url;
 
 use super::utils::{
-    gml_id_attr, local_name as utils_local_name, xlink_href_attr, QName, XmlChild, XmlNode, GML_NS,
-    XLINK_NS,
+    gml_id_attr, local_name as utils_local_name, xlink_href_attr, NamespaceRegistry, NsId, QName,
+    XmlChild, XmlNode, EMPTY_NS_ID, GML_NS_ID, XLINK_NS_ID,
 };
 
 pub(super) type RawNodeKey = (String, String); // (file_url, gml_id)
@@ -44,53 +44,96 @@ pub enum ParseError {
     UnexpectedEof,
 }
 
-pub fn parse(
-    source: &[u8],
-    source_url: &Url,
-    registry: &mut RawRegistry,
-) -> Result<Vec<Arc<RawNode>>, ParseError> {
-    let src = std::str::from_utf8(source)
-        .map_err(|e| ParseError::Encoding(format!("Non-UTF-8 content: {e}")))?;
-    let mut reader = NsReader::from_str(src);
-    let mut buf = Vec::new();
+/// First pass parser which builds gml:id and namespace lookups
+/// Call `parse()` once per file, then `finish()` to hand off the raw state for xlink resolution.
+pub(super) struct Parser {
+    raw_registry: RawRegistry,
+    pub(super) ns_registry: NamespaceRegistry,
+    pending: Vec<Arc<RawNode>>,
+}
 
-    loop {
-        match next_event(&mut reader, &mut buf)? {
-            OwnedEvent::Start { name, .. } if local_name(&name.0) == "CityModel" => break,
-            OwnedEvent::Eof => return Err(ParseError::NoCityModel),
-            _ => {}
+impl Default for Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for Parser {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Parser")
+            .field("pending", &self.pending.len())
+            .field("raw_registry", &self.raw_registry.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Parser {
+    pub(super) fn new() -> Self {
+        Self {
+            raw_registry: RawRegistry::new(),
+            ns_registry: NamespaceRegistry::new(),
+            pending: Vec::new(),
         }
     }
 
-    let mut features = Vec::new();
+    pub(super) fn parse(&mut self, source: &[u8], source_url: &Url) -> Result<(), ParseError> {
+        let src = std::str::from_utf8(source)
+            .map_err(|e| ParseError::Encoding(format!("Non-UTF-8 content: {e}")))?;
+        let mut reader = NsReader::from_str(src);
+        let mut buf = Vec::new();
 
-    loop {
-        match next_event(&mut reader, &mut buf)? {
-            OwnedEvent::Start { name, attrs } => {
-                let ln = local_name(&name.0);
-                if ln == "cityObjectMember" || ln == "featureMember" {
-                    let member = parse_element(&mut reader, &mut buf, name, attrs, source_url)?;
-                    if let Some(feature_node) = member.children.iter().find_map(|child| match child
-                    {
-                        RawChild::Element(node) => Some(Arc::clone(node)),
-                        _ => None,
-                    }) {
-                        collect_ids(&feature_node, source_url.as_str(), registry);
-                        features.push(feature_node);
-                    } else {
-                        tracing::warn!("citygml3: empty cityObjectMember/featureMember, skipped");
-                    }
-                } else {
-                    skip_element(&mut reader, &mut buf)?;
-                }
+        loop {
+            match next_event(&mut reader, &mut buf, &mut self.ns_registry)? {
+                OwnedEvent::Start { name, .. } if local_name(&name.0) == "CityModel" => break,
+                OwnedEvent::Eof => return Err(ParseError::NoCityModel),
+                _ => {}
             }
-            OwnedEvent::End => break,
-            OwnedEvent::Eof => return Err(ParseError::UnexpectedEof),
-            _ => {}
         }
+
+        loop {
+            match next_event(&mut reader, &mut buf, &mut self.ns_registry)? {
+                OwnedEvent::Start { name, attrs } => {
+                    let ln = local_name(&name.0);
+                    if ln == "cityObjectMember" || ln == "featureMember" {
+                        let member = parse_element(
+                            &mut reader,
+                            &mut buf,
+                            name,
+                            attrs,
+                            source_url,
+                            &mut self.ns_registry,
+                        )?;
+                        if let Some(feature_node) =
+                            member.children.iter().find_map(|child| match child {
+                                RawChild::Element(node) => Some(Arc::clone(node)),
+                                _ => None,
+                            })
+                        {
+                            collect_ids(&feature_node, source_url.as_str(), &mut self.raw_registry);
+                            self.pending.push(feature_node);
+                        } else {
+                            tracing::warn!(
+                                "citygml3: empty cityObjectMember/featureMember, skipped"
+                            );
+                        }
+                    } else {
+                        skip_element(&mut reader, &mut buf, &mut self.ns_registry)?;
+                    }
+                }
+                OwnedEvent::End => break,
+                OwnedEvent::Eof => return Err(ParseError::UnexpectedEof),
+                _ => {}
+            }
+        }
+
+        Ok(())
     }
 
-    Ok(features)
+    /// Consume the parser and return raw state for xlink resolution and downstream processing.
+    /// Caller is responsible for running `xlink::resolve(pending, &raw_registry)`.
+    pub(super) fn finish(self) -> (Vec<Arc<RawNode>>, RawRegistry, NamespaceRegistry) {
+        (self.pending, self.raw_registry, self.ns_registry)
+    }
 }
 
 pub fn to_feature(node: &XmlNode) -> Feature {
@@ -142,7 +185,7 @@ pub fn node_to_attribute_value(node: &XmlNode) -> AttributeValue {
 pub(super) fn raw_gml_id(node: &RawNode) -> Option<String> {
     node.attrs
         .iter()
-        .find(|((q, ns), _)| local_name(q) == "id" && ns == GML_NS)
+        .find(|((q, ns), _)| local_name(q) == "id" && *ns == GML_NS_ID)
         .map(|(_, v)| v.clone())
 }
 
@@ -197,23 +240,24 @@ enum OwnedEvent {
 fn next_event<R: BufRead>(
     reader: &mut NsReader<R>,
     buf: &mut Vec<u8>,
+    ns_reg: &mut NamespaceRegistry,
 ) -> Result<OwnedEvent, ParseError> {
     let (ns_result, event) = reader
         .read_resolved_event_into(buf)
         .map_err(ParseError::Xml)?;
-    let elem_ns = match ns_result {
-        ResolveResult::Bound(ns) => decode_utf8(ns.into_inner(), "element namespace")?,
-        _ => String::new(),
+    let elem_ns_id = match ns_result {
+        ResolveResult::Bound(ns) => intern_ns(ns.into_inner(), ns_reg)?,
+        _ => EMPTY_NS_ID,
     };
     match event {
         Event::Start(e) => Ok(OwnedEvent::Start {
-            name: (decode_utf8(e.name().as_ref(), "element name")?, elem_ns),
-            attrs: extract_attrs(&e, reader)?,
+            name: (decode_utf8(e.name().as_ref(), "element name")?, elem_ns_id),
+            attrs: extract_attrs(&e, reader, ns_reg)?,
         }),
         Event::End(_) => Ok(OwnedEvent::End),
         Event::Empty(e) => Ok(OwnedEvent::Empty {
-            name: (decode_utf8(e.name().as_ref(), "element name")?, elem_ns),
-            attrs: extract_attrs(&e, reader)?,
+            name: (decode_utf8(e.name().as_ref(), "element name")?, elem_ns_id),
+            attrs: extract_attrs(&e, reader, ns_reg)?,
         }),
         Event::Text(t) => Ok(OwnedEvent::Text(
             t.unescape().map_err(ParseError::Xml)?.to_string(),
@@ -230,13 +274,14 @@ fn parse_element<R: BufRead>(
     name: QName,
     attrs: Vec<(QName, String)>,
     source_url: &Url,
+    ns_reg: &mut NamespaceRegistry,
 ) -> Result<RawNode, ParseError> {
     let href = xlink_href_attr(&attrs)
         .and_then(|href| href_to_key(href, source_url))
         .map(|key| {
             let filtered = attrs
                 .iter()
-                .filter(|((q, ns), _)| !(local_name(q) == "href" && ns == XLINK_NS))
+                .filter(|((q, ns), _)| !(local_name(q) == "href" && *ns == XLINK_NS_ID))
                 .cloned()
                 .collect::<Vec<_>>();
             (key, filtered)
@@ -244,12 +289,12 @@ fn parse_element<R: BufRead>(
     let mut children = Vec::new();
 
     loop {
-        match next_event(reader, buf)? {
+        match next_event(reader, buf, ns_reg)? {
             OwnedEvent::Start {
                 name: cn,
                 attrs: ca,
             } => {
-                let child = parse_element(reader, buf, cn, ca, source_url)?;
+                let child = parse_element(reader, buf, cn, ca, source_url, ns_reg)?;
                 children.push(RawChild::Element(Arc::new(child)));
             }
             OwnedEvent::Empty {
@@ -260,7 +305,7 @@ fn parse_element<R: BufRead>(
                     if let Some(key) = href_to_key(href, source_url) {
                         let filtered: Vec<(QName, String)> = ca
                             .into_iter()
-                            .filter(|((q, ns), _)| !(local_name(q) == "href" && ns == XLINK_NS))
+                            .filter(|((q, ns), _)| !(local_name(q) == "href" && *ns == XLINK_NS_ID))
                             .collect();
                         children.push(RawChild::Element(Arc::new(RawNode {
                             name: cn,
@@ -313,10 +358,14 @@ fn parse_element<R: BufRead>(
     })
 }
 
-fn skip_element<R: BufRead>(reader: &mut NsReader<R>, buf: &mut Vec<u8>) -> Result<(), ParseError> {
+fn skip_element<R: BufRead>(
+    reader: &mut NsReader<R>,
+    buf: &mut Vec<u8>,
+    ns_reg: &mut NamespaceRegistry,
+) -> Result<(), ParseError> {
     let mut depth: usize = 1;
     loop {
-        match next_event(reader, buf)? {
+        match next_event(reader, buf, ns_reg)? {
             OwnedEvent::Start { .. } => depth += 1,
             OwnedEvent::End => {
                 depth -= 1;
@@ -334,22 +383,29 @@ fn skip_element<R: BufRead>(reader: &mut NsReader<R>, buf: &mut Vec<u8>) -> Resu
 fn extract_attrs<R: BufRead>(
     e: &quick_xml::events::BytesStart<'_>,
     reader: &NsReader<R>,
+    ns_reg: &mut NamespaceRegistry,
 ) -> Result<Vec<(QName, String)>, ParseError> {
     e.attributes()
         .map(|a| {
             let a = a.map_err(|err| ParseError::Malformed(format!("invalid attribute: {err}")))?;
             let qname_str = decode_utf8(a.key.as_ref(), "attribute name")?;
-            let ns_uri = match reader.resolve_attribute(a.key).0 {
-                ResolveResult::Bound(ns) => decode_utf8(ns.into_inner(), "attribute namespace")?,
-                _ => String::new(),
+            let ns_id = match reader.resolve_attribute(a.key).0 {
+                ResolveResult::Bound(ns) => intern_ns(ns.into_inner(), ns_reg)?,
+                _ => EMPTY_NS_ID,
             };
             let v = a
                 .unescape_value()
                 .map_err(|err| ParseError::Malformed(format!("invalid attribute value: {err}")))?
                 .to_string();
-            Ok(((qname_str, ns_uri), v))
+            Ok(((qname_str, ns_id), v))
         })
         .collect()
+}
+
+fn intern_ns(bytes: &[u8], ns_reg: &mut NamespaceRegistry) -> Result<NsId, ParseError> {
+    let s = std::str::from_utf8(bytes)
+        .map_err(|e| ParseError::Encoding(format!("invalid UTF-8 in namespace URI: {e}")))?;
+    Ok(ns_reg.intern(s))
 }
 
 fn decode_utf8(bytes: &[u8], context: &str) -> Result<String, ParseError> {
@@ -385,7 +441,7 @@ mod tests {
     use reearth_flow_types::CitygmlFeatureExt;
     use url::Url;
 
-    use crate::feature::reader::citygml3::utils::{XmlChild, XmlNode, GML_NS};
+    use crate::feature::reader::citygml3::utils::{XmlChild, XmlNode, EMPTY_NS_ID, GML_NS_ID};
 
     fn dummy_url() -> Url {
         Url::parse("file:///test.gml").unwrap()
@@ -393,15 +449,15 @@ mod tests {
 
     fn make_node(
         name: &str,
-        ns: &str,
-        attrs: Vec<(&str, &str, &str)>,
+        ns: NsId,
+        attrs: Vec<(&str, NsId, &str)>,
         children: Vec<XmlChild>,
     ) -> XmlNode {
         XmlNode {
-            name: (name.to_string(), ns.to_string()),
+            name: (name.to_string(), ns),
             attrs: attrs
                 .into_iter()
-                .map(|(q, ns, v)| ((q.to_string(), ns.to_string()), v.to_string()))
+                .map(|(q, ns, v)| ((q.to_string(), ns), v.to_string()))
                 .collect(),
             children,
         }
@@ -415,12 +471,15 @@ mod tests {
         XmlChild::Element(Arc::new(node))
     }
 
+    fn parse_test(xml: &[u8]) -> Result<(), ParseError> {
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url())
+    }
+
     #[test]
     fn parse_errors_for_non_citygml() {
-        let xml = b"<Foo/>";
-        let mut reg = RawRegistry::new();
         assert!(matches!(
-            parse(xml, &dummy_url(), &mut reg),
+            parse_test(b"<Foo/>"),
             Err(ParseError::NoCityModel)
         ));
     }
@@ -442,13 +501,14 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"#;
 
-        let mut reg = RawRegistry::new();
-        let raw = parse(xml, &dummy_url(), &mut reg).unwrap();
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (pending, _, _) = parser.finish();
 
-        assert_eq!(raw.len(), 2);
-        assert_eq!(raw_gml_id(&raw[0]), Some("bldg001".to_string()));
-        assert_eq!(raw_gml_id(&raw[1]), Some("bldg002".to_string()));
-        assert_eq!(raw[0].name.0, "bldg:Building");
+        assert_eq!(pending.len(), 2);
+        assert_eq!(raw_gml_id(&pending[0]), Some("bldg001".to_string()));
+        assert_eq!(raw_gml_id(&pending[1]), Some("bldg002".to_string()));
+        assert_eq!(pending[0].name.0, "bldg:Building");
     }
 
     #[test]
@@ -463,10 +523,11 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"#;
 
-        let mut reg = RawRegistry::new();
-        let raw = parse(xml, &dummy_url(), &mut reg).unwrap();
-        assert_eq!(raw_gml_id(&raw[0]), Some("bldg001".to_string()));
-        assert!(reg.contains_key(&(dummy_url().to_string(), "bldg001".to_string())));
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (pending, raw_reg, _) = parser.finish();
+        assert_eq!(raw_gml_id(&pending[0]), Some("bldg001".to_string()));
+        assert!(raw_reg.contains_key(&(dummy_url().to_string(), "bldg001".to_string())));
     }
 
     #[test]
@@ -483,12 +544,13 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"#;
 
-        let mut reg = RawRegistry::new();
-        parse(xml, &dummy_url(), &mut reg).unwrap();
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (_, raw_reg, _) = parser.finish();
 
         let url = dummy_url().to_string();
-        assert!(reg.contains_key(&(url.clone(), "bldg001".to_string())));
-        assert!(reg.contains_key(&(url, "part001".to_string())));
+        assert!(raw_reg.contains_key(&(url.clone(), "bldg001".to_string())));
+        assert!(raw_reg.contains_key(&(url, "part001".to_string())));
     }
 
     #[test]
@@ -506,17 +568,18 @@ mod tests {
         let url_a = Url::parse("file:///a.gml").unwrap();
         let url_b = Url::parse("file:///b.gml").unwrap();
 
-        let mut reg = RawRegistry::new();
-        parse(xml, &url_a, &mut reg).unwrap();
-        parse(xml, &url_b, &mut reg).unwrap();
+        let mut parser = Parser::new();
+        parser.parse(xml, &url_a).unwrap();
+        parser.parse(xml, &url_b).unwrap();
+        let (_, raw_reg, _) = parser.finish();
 
-        assert_eq!(reg.len(), 2);
-        assert!(reg.contains_key(&(url_a.to_string(), "shared001".to_string())));
-        assert!(reg.contains_key(&(url_b.to_string(), "shared001".to_string())));
-        let node_a = reg
+        assert_eq!(raw_reg.len(), 2);
+        assert!(raw_reg.contains_key(&(url_a.to_string(), "shared001".to_string())));
+        assert!(raw_reg.contains_key(&(url_b.to_string(), "shared001".to_string())));
+        let node_a = raw_reg
             .get(&(url_a.to_string(), "shared001".to_string()))
             .unwrap();
-        let node_b = reg
+        let node_b = raw_reg
             .get(&(url_b.to_string(), "shared001".to_string()))
             .unwrap();
         assert!(!Arc::ptr_eq(node_a, node_b));
@@ -535,9 +598,10 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"#;
 
-        let mut reg = RawRegistry::new();
-        let raw = parse(xml, &dummy_url(), &mut reg).unwrap();
-        assert_eq!(raw.len(), 1);
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (pending, _, _) = parser.finish();
+        assert_eq!(pending.len(), 1);
     }
 
     #[test]
@@ -551,11 +615,7 @@ mod tests {
     <bldg:Building gml:id="bldg001"/>
   </core:cityObjectMember>"#;
 
-        let mut reg = RawRegistry::new();
-        assert!(matches!(
-            parse(xml, &dummy_url(), &mut reg),
-            Err(ParseError::UnexpectedEof)
-        ));
+        assert!(matches!(parse_test(xml), Err(ParseError::UnexpectedEof)));
     }
 
     #[test]
@@ -571,14 +631,15 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"#;
 
-        let mut reg = RawRegistry::new();
-        let raw = parse(xml, &dummy_url(), &mut reg).unwrap();
-        assert_eq!(raw.len(), 1);
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (pending, _, _) = parser.finish();
+        assert_eq!(pending.len(), 1);
     }
 
     #[test]
     fn node_to_attribute_value_pure_text() {
-        let node = make_node("gml:name", GML_NS, vec![], vec![text("Building A")]);
+        let node = make_node("gml:name", GML_NS_ID, vec![], vec![text("Building A")]);
         let av = node_to_attribute_value(&node);
         assert_eq!(av, AttributeValue::String("Building A".to_string()));
     }
@@ -587,8 +648,8 @@ mod tests {
     fn node_to_attribute_value_attrs_become_map() {
         let node = make_node(
             "gml:name",
-            GML_NS,
-            vec![("gml:id", GML_NS, "n1")],
+            GML_NS_ID,
+            vec![("gml:id", GML_NS_ID, "n1")],
             vec![text("foo")],
         );
         let av = node_to_attribute_value(&node);
@@ -609,8 +670,8 @@ mod tests {
     fn node_to_attribute_value_non_standard_prefix_preserves_qname() {
         let node = make_node(
             "bldg:Building",
-            "",
-            vec![("g:id", GML_NS, "bldg001")],
+            EMPTY_NS_ID,
+            vec![("g:id", GML_NS_ID, "bldg001")],
             vec![],
         );
         let AttributeValue::Map(map) = node_to_attribute_value(&node) else {
@@ -634,11 +695,12 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"#;
 
-        let mut reg = RawRegistry::new();
-        let raw = parse(xml, &dummy_url(), &mut reg).unwrap();
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (pending, _, _) = parser.finish();
 
         assert_eq!(
-            raw[0]
+            pending[0]
                 .attrs
                 .iter()
                 .find(|((q, _), _)| q == "codeSpace")
@@ -651,11 +713,11 @@ mod tests {
     fn node_to_attribute_value_repeated_children_become_array() {
         let node = make_node(
             "parent",
-            "",
+            EMPTY_NS_ID,
             vec![],
             vec![
-                elem(make_node("item", "", vec![], vec![text("a")])),
-                elem(make_node("item", "", vec![], vec![text("b")])),
+                elem(make_node("item", EMPTY_NS_ID, vec![], vec![text("a")])),
+                elem(make_node("item", EMPTY_NS_ID, vec![], vec![text("b")])),
             ],
         );
         let AttributeValue::Map(map) = node_to_attribute_value(&node) else {
@@ -671,9 +733,14 @@ mod tests {
     fn node_to_attribute_value_single_child_not_wrapped_in_array() {
         let node = make_node(
             "parent",
-            "",
+            EMPTY_NS_ID,
             vec![],
-            vec![elem(make_node("item", "", vec![], vec![text("only")]))],
+            vec![elem(make_node(
+                "item",
+                EMPTY_NS_ID,
+                vec![],
+                vec![text("only")],
+            ))],
         );
         let AttributeValue::Map(map) = node_to_attribute_value(&node) else {
             panic!("expected Map");
@@ -685,12 +752,11 @@ mod tests {
     fn to_feature_sets_feature_type_and_id() {
         let node = make_node(
             "bldg:Building",
-            "",
-            vec![("gml:id", GML_NS, "bldg001")],
+            EMPTY_NS_ID,
+            vec![("gml:id", GML_NS_ID, "bldg001")],
             vec![],
         );
         let feature = to_feature(&node);
-
         assert_eq!(feature.feature_type(), Some("bldg:Building".to_string()));
         assert_eq!(feature.feature_id(), Some("bldg001".to_string()));
     }

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
@@ -29,7 +29,7 @@ use reearth_flow_types::{
 use crate::feature::errors::FeatureProcessorError;
 
 use super::{
-    flatten::{self, ParentIdTracker},
+    flatten,
     geometry,
     parser::{self, Parser},
     utils::{gml_id_attr, XmlNode},
@@ -200,15 +200,13 @@ impl Processor for FeatureCityGml3Reader {
                 ));
             } else {
                 let root_gml_id = gml_id_attr(&feature_root);
-                let mut tracker = ParentIdTracker::new();
-                tracker.collect(&feature_root);
 
-                for node in flatten::extract(&feature_root, &self.extracted_tags, &ns_registry) {
+                for (node, parent_id) in flatten::extract(&feature_root, &self.extracted_tags, &ns_registry) {
                     let mut feature = build_feature(&node);
-                    if let Some(id) = gml_id_attr(&node).and_then(|id| tracker.parent_gml_id(&id)) {
+                    if let Some(id) = parent_id {
                         feature.insert(
                             CITYGML_PARENT_GML_ID_KEY,
-                            AttributeValue::String(id.to_string()),
+                            AttributeValue::String(id),
                         );
                     }
                     if let Some(ref id) = root_gml_id {

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
@@ -92,14 +92,14 @@ impl ProcessorFactory for FeatureCityGml3ReaderFactory {
             .compile(params.dataset.as_ref())
             .map_err(|e| FeatureProcessorError::FileCityGml3ReaderFactory(format!("{e:?}")))?;
 
-        let flatten_feature_types: HashSet<String> =
-            params.flatten_feature_types.into_iter().collect();
+        let extract_tags: HashSet<String> =
+            params.extract_tags.into_iter().collect();
 
         Ok(Box::new(FeatureCityGml3Reader {
             global_params: with,
             dataset_ast,
             original_dataset: params.dataset,
-            flatten_feature_types,
+            extract_tags,
             parser: Parser::new(),
         }))
     }
@@ -112,19 +112,19 @@ pub struct FeatureCityGml3ReaderParam {
     /// # Dataset
     /// Path expression resolving to the CityGML 3.0 file to read.
     dataset: Expr,
-    /// # Flatten Feature Types
+    /// # Extract Tags
     /// Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`),
     /// local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all
     /// top-level city objects unchanged.
     #[serde(default)]
-    flatten_feature_types: Vec<String>,
+    extract_tags: Vec<String>,
 }
 
 pub struct FeatureCityGml3Reader {
     global_params: Option<HashMap<String, serde_json::Value>>,
     dataset_ast: rhai::AST,
     original_dataset: Expr,
-    flatten_feature_types: HashSet<String>,
+    extract_tags: HashSet<String>,
     parser: Parser,
 }
 
@@ -142,7 +142,7 @@ impl Clone for FeatureCityGml3Reader {
             global_params: self.global_params.clone(),
             dataset_ast: self.dataset_ast.clone(),
             original_dataset: self.original_dataset.clone(),
-            flatten_feature_types: self.flatten_feature_types.clone(),
+            extract_tags: self.extract_tags.clone(),
             parser: Parser::new(),
         }
     }
@@ -191,7 +191,7 @@ impl Processor for FeatureCityGml3Reader {
     ) -> Result<(), BoxedError> {
         let (pending, raw_registry, ns_registry) = std::mem::take(&mut self.parser).finish();
         for feature_root in xlink::resolve(pending, &raw_registry) {
-            if self.flatten_feature_types.is_empty() {
+            if self.extract_tags.is_empty() {
                 let feature = build_feature(&feature_root);
                 fw.send(ExecutorContext::new_with_node_context_feature_and_port(
                     &ctx,
@@ -202,7 +202,7 @@ impl Processor for FeatureCityGml3Reader {
                 let root_gml_id = gml_id_attr(&feature_root);
 
                 for (node, parent_id) in
-                    flatten::extract(&feature_root, &self.flatten_feature_types, &ns_registry)
+                    flatten::extract(&feature_root, &self.extract_tags, &ns_registry)
                 {
                     let mut feature = build_feature(&node);
                     if let Some(id) = parent_id {

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{collections::{HashMap, HashSet}, str::FromStr, sync::Arc};
 
 use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::{
@@ -22,8 +22,10 @@ use reearth_flow_types::{CityGmlGeometry, Geometry, GeometryType, GeometryValue,
 use crate::feature::errors::FeatureProcessorError;
 
 use super::{
+    flatten,
     geometry,
     parser::{self, RawNode, RawRegistry},
+    utils::XmlNode,
     xlink,
 };
 
@@ -84,10 +86,13 @@ impl ProcessorFactory for FeatureCityGml3ReaderFactory {
             .compile(params.dataset.as_ref())
             .map_err(|e| FeatureProcessorError::FileCityGml3ReaderFactory(format!("{e:?}")))?;
 
+        let extracted_tags: HashSet<String> = params.extracted_tags.into_iter().collect();
+
         Ok(Box::new(FeatureCityGml3Reader {
             global_params: with,
             dataset_ast,
             original_dataset: params.dataset,
+            extracted_tags,
             raw_registry: RawRegistry::new(),
             pending: Vec::new(),
         }))
@@ -101,12 +106,19 @@ pub struct FeatureCityGml3ReaderParam {
     /// # Dataset
     /// Path expression resolving to the CityGML 3.0 file to read.
     dataset: Expr,
+    /// # Extracted Tags
+    /// Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local
+    /// (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level
+    /// city objects unchanged.
+    #[serde(default)]
+    extracted_tags: Vec<String>,
 }
 
 pub struct FeatureCityGml3Reader {
     global_params: Option<HashMap<String, serde_json::Value>>,
     dataset_ast: rhai::AST,
     original_dataset: Expr,
+    extracted_tags: HashSet<String>,
     raw_registry: RawRegistry,
     pending: Vec<Arc<RawNode>>,
 }
@@ -126,6 +138,7 @@ impl Clone for FeatureCityGml3Reader {
             global_params: self.global_params.clone(),
             dataset_ast: self.dataset_ast.clone(),
             original_dataset: self.original_dataset.clone(),
+            extracted_tags: self.extracted_tags.clone(),
             raw_registry: RawRegistry::new(),
             pending: Vec::new(),
         }
@@ -176,20 +189,20 @@ impl Processor for FeatureCityGml3Reader {
     ) -> Result<(), BoxedError> {
         let registry = std::mem::take(&mut self.raw_registry);
         for feature_root in xlink::resolve(std::mem::take(&mut self.pending), &registry) {
-            let (stripped, raw_geoms) = geometry::extract_geometries(&feature_root);
-            let mut feature = parser::to_feature(&stripped);
+            if self.extracted_tags.is_empty() {
+                emit_node(&feature_root, &ctx, fw);
+            } else {
+                let root_matches = flatten::tag_matches(&feature_root, &self.extracted_tags);
+                let (stripped_root, extracted) =
+                    flatten::extract_by_types(&feature_root, &self.extracted_tags);
 
-            if !raw_geoms.is_empty() {
-                *feature.geometry_mut() = Geometry::with_value(GeometryValue::CityGmlGeometry(
-                    build_citygml_geometry(raw_geoms),
-                ));
+                for node in extracted {
+                    emit_node(&node, &ctx, fw);
+                }
+                if root_matches {
+                    emit_node(&stripped_root, &ctx, fw);
+                }
             }
-
-            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
-                &ctx,
-                feature,
-                DEFAULT_PORT.clone(),
-            ));
         }
         Ok(())
     }
@@ -197,6 +210,21 @@ impl Processor for FeatureCityGml3Reader {
     fn name(&self) -> &str {
         "FeatureCityGml3Reader"
     }
+}
+
+fn emit_node(node: &Arc<XmlNode>, ctx: &NodeContext, fw: &ProcessorChannelForwarder) {
+    let (stripped, raw_geoms) = geometry::extract_geometries(node);
+    let mut feature = parser::to_feature(&stripped);
+    if !raw_geoms.is_empty() {
+        *feature.geometry_mut() = Geometry::with_value(GeometryValue::CityGmlGeometry(
+            build_citygml_geometry(raw_geoms),
+        ));
+    }
+    fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+        ctx,
+        feature,
+        DEFAULT_PORT.clone(),
+    ));
 }
 
 // pos is assigned here; neutral appearance arrays prevent out-of-bounds access in downstream consumers.

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
@@ -29,8 +29,7 @@ use reearth_flow_types::{
 use crate::feature::errors::FeatureProcessorError;
 
 use super::{
-    flatten,
-    geometry,
+    flatten, geometry,
     parser::{self, Parser},
     utils::{gml_id_attr, XmlNode},
     xlink,
@@ -201,13 +200,12 @@ impl Processor for FeatureCityGml3Reader {
             } else {
                 let root_gml_id = gml_id_attr(&feature_root);
 
-                for (node, parent_id) in flatten::extract(&feature_root, &self.extracted_tags, &ns_registry) {
+                for (node, parent_id) in
+                    flatten::extract(&feature_root, &self.extracted_tags, &ns_registry)
+                {
                     let mut feature = build_feature(&node);
                     if let Some(id) = parent_id {
-                        feature.insert(
-                            CITYGML_PARENT_GML_ID_KEY,
-                            AttributeValue::String(id),
-                        );
+                        feature.insert(CITYGML_PARENT_GML_ID_KEY, AttributeValue::String(id));
                     }
                     if let Some(ref id) = root_gml_id {
                         feature.insert(CITYGML_ROOT_GML_ID_KEY, AttributeValue::String(id.clone()));

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
@@ -21,14 +21,18 @@ use url::Url;
 use reearth_flow_geometry::types::line_string::LineString2D;
 use reearth_flow_geometry::types::multi_polygon::MultiPolygon2D;
 use reearth_flow_geometry::types::polygon::{Polygon2D, Polygon3D};
-use reearth_flow_types::{CityGmlGeometry, Geometry, GeometryType, GeometryValue, GmlGeometry};
+use reearth_flow_types::{
+    AttributeValue, CityGmlGeometry, Feature, Geometry, GeometryType, GeometryValue, GmlGeometry,
+    CITYGML_PARENT_GML_ID_KEY, CITYGML_ROOT_GML_ID_KEY,
+};
 
 use crate::feature::errors::FeatureProcessorError;
 
 use super::{
-    flatten, geometry,
+    flatten::{self, ParentIdTracker},
+    geometry,
     parser::{self, RawNode, RawRegistry},
-    utils::XmlNode,
+    utils::{gml_id_attr, XmlNode},
     xlink,
 };
 
@@ -193,17 +197,33 @@ impl Processor for FeatureCityGml3Reader {
         let registry = std::mem::take(&mut self.raw_registry);
         for feature_root in xlink::resolve(std::mem::take(&mut self.pending), &registry) {
             if self.extracted_tags.is_empty() {
-                emit_node(&feature_root, &ctx, fw);
+                let feature = build_feature(&feature_root);
+                fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                    &ctx,
+                    feature,
+                    DEFAULT_PORT.clone(),
+                ));
             } else {
-                let root_matches = flatten::tag_matches(&feature_root, &self.extracted_tags);
-                let (stripped_root, extracted) =
-                    flatten::extract_by_types(&feature_root, &self.extracted_tags);
+                let root_gml_id = gml_id_attr(&feature_root);
+                let mut tracker = ParentIdTracker::new();
+                tracker.collect(&feature_root);
 
-                for node in extracted {
-                    emit_node(&node, &ctx, fw);
-                }
-                if root_matches {
-                    emit_node(&stripped_root, &ctx, fw);
+                for node in flatten::extract(&feature_root, &self.extracted_tags) {
+                    let mut feature = build_feature(&node);
+                    if let Some(id) = gml_id_attr(&node).and_then(|id| tracker.parent_gml_id(&id)) {
+                        feature.insert(
+                            CITYGML_PARENT_GML_ID_KEY,
+                            AttributeValue::String(id.to_string()),
+                        );
+                    }
+                    if let Some(ref id) = root_gml_id {
+                        feature.insert(CITYGML_ROOT_GML_ID_KEY, AttributeValue::String(id.clone()));
+                    }
+                    fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                        &ctx,
+                        feature,
+                        DEFAULT_PORT.clone(),
+                    ));
                 }
             }
         }
@@ -215,7 +235,7 @@ impl Processor for FeatureCityGml3Reader {
     }
 }
 
-fn emit_node(node: &Arc<XmlNode>, ctx: &NodeContext, fw: &ProcessorChannelForwarder) {
+fn build_feature(node: &Arc<XmlNode>) -> Feature {
     let (stripped, raw_geoms) = geometry::extract_geometries(node);
     let mut feature = parser::to_feature(&stripped);
     if !raw_geoms.is_empty() {
@@ -223,11 +243,7 @@ fn emit_node(node: &Arc<XmlNode>, ctx: &NodeContext, fw: &ProcessorChannelForwar
             build_citygml_geometry(raw_geoms),
         ));
     }
-    fw.send(ExecutorContext::new_with_node_context_feature_and_port(
-        ctx,
-        feature,
-        DEFAULT_PORT.clone(),
-    ));
+    feature
 }
 
 // pos is assigned here; neutral appearance arrays prevent out-of-bounds access in downstream consumers.

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
@@ -1,4 +1,8 @@
-use std::{collections::{HashMap, HashSet}, str::FromStr, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+    sync::Arc,
+};
 
 use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::{
@@ -22,8 +26,7 @@ use reearth_flow_types::{CityGmlGeometry, Geometry, GeometryType, GeometryValue,
 use crate::feature::errors::FeatureProcessorError;
 
 use super::{
-    flatten,
-    geometry,
+    flatten, geometry,
     parser::{self, RawNode, RawRegistry},
     utils::XmlNode,
     xlink,

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
@@ -31,7 +31,7 @@ use crate::feature::errors::FeatureProcessorError;
 use super::{
     flatten::{self, ParentIdTracker},
     geometry,
-    parser::{self, RawNode, RawRegistry},
+    parser::{self, Parser},
     utils::{gml_id_attr, XmlNode},
     xlink,
 };
@@ -100,8 +100,7 @@ impl ProcessorFactory for FeatureCityGml3ReaderFactory {
             dataset_ast,
             original_dataset: params.dataset,
             extracted_tags,
-            raw_registry: RawRegistry::new(),
-            pending: Vec::new(),
+            parser: Parser::new(),
         }))
     }
 }
@@ -126,15 +125,13 @@ pub struct FeatureCityGml3Reader {
     dataset_ast: rhai::AST,
     original_dataset: Expr,
     extracted_tags: HashSet<String>,
-    raw_registry: RawRegistry,
-    pending: Vec<Arc<RawNode>>,
+    parser: Parser,
 }
 
 impl std::fmt::Debug for FeatureCityGml3Reader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FeatureCityGml3Reader")
-            .field("pending", &self.pending.len())
-            .field("raw_registry", &self.raw_registry.len())
+            .field("parser", &self.parser)
             .finish_non_exhaustive()
     }
 }
@@ -146,8 +143,7 @@ impl Clone for FeatureCityGml3Reader {
             dataset_ast: self.dataset_ast.clone(),
             original_dataset: self.original_dataset.clone(),
             extracted_tags: self.extracted_tags.clone(),
-            raw_registry: RawRegistry::new(),
-            pending: Vec::new(),
+            parser: Parser::new(),
         }
     }
 }
@@ -182,10 +178,9 @@ impl Processor for FeatureCityGml3Reader {
             FeatureProcessorError::FileCityGml3Reader(format!("File read error: {e}"))
         })?;
 
-        let mut features = parser::parse(&bytes, &source_url, &mut self.raw_registry)
+        self.parser
+            .parse(&bytes, &source_url)
             .map_err(|e| FeatureProcessorError::FileCityGml3Reader(format!("{e}")))?;
-
-        self.pending.append(&mut features);
         Ok(())
     }
 
@@ -194,8 +189,8 @@ impl Processor for FeatureCityGml3Reader {
         ctx: NodeContext,
         fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
-        let registry = std::mem::take(&mut self.raw_registry);
-        for feature_root in xlink::resolve(std::mem::take(&mut self.pending), &registry) {
+        let (pending, raw_registry, ns_registry) = std::mem::take(&mut self.parser).finish();
+        for feature_root in xlink::resolve(pending, &raw_registry) {
             if self.extracted_tags.is_empty() {
                 let feature = build_feature(&feature_root);
                 fw.send(ExecutorContext::new_with_node_context_feature_and_port(
@@ -208,7 +203,7 @@ impl Processor for FeatureCityGml3Reader {
                 let mut tracker = ParentIdTracker::new();
                 tracker.collect(&feature_root);
 
-                for node in flatten::extract(&feature_root, &self.extracted_tags) {
+                for node in flatten::extract(&feature_root, &self.extracted_tags, &ns_registry) {
                     let mut feature = build_feature(&node);
                     if let Some(id) = gml_id_attr(&node).and_then(|id| tracker.parent_gml_id(&id)) {
                         feature.insert(

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
@@ -92,13 +92,14 @@ impl ProcessorFactory for FeatureCityGml3ReaderFactory {
             .compile(params.dataset.as_ref())
             .map_err(|e| FeatureProcessorError::FileCityGml3ReaderFactory(format!("{e:?}")))?;
 
-        let extracted_tags: HashSet<String> = params.extracted_tags.into_iter().collect();
+        let flatten_feature_types: HashSet<String> =
+            params.flatten_feature_types.into_iter().collect();
 
         Ok(Box::new(FeatureCityGml3Reader {
             global_params: with,
             dataset_ast,
             original_dataset: params.dataset,
-            extracted_tags,
+            flatten_feature_types,
             parser: Parser::new(),
         }))
     }
@@ -111,19 +112,19 @@ pub struct FeatureCityGml3ReaderParam {
     /// # Dataset
     /// Path expression resolving to the CityGML 3.0 file to read.
     dataset: Expr,
-    /// # Extracted Tags
-    /// Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local
-    /// (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level
-    /// city objects unchanged.
+    /// # Flatten Feature Types
+    /// Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`),
+    /// local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all
+    /// top-level city objects unchanged.
     #[serde(default)]
-    extracted_tags: Vec<String>,
+    flatten_feature_types: Vec<String>,
 }
 
 pub struct FeatureCityGml3Reader {
     global_params: Option<HashMap<String, serde_json::Value>>,
     dataset_ast: rhai::AST,
     original_dataset: Expr,
-    extracted_tags: HashSet<String>,
+    flatten_feature_types: HashSet<String>,
     parser: Parser,
 }
 
@@ -141,7 +142,7 @@ impl Clone for FeatureCityGml3Reader {
             global_params: self.global_params.clone(),
             dataset_ast: self.dataset_ast.clone(),
             original_dataset: self.original_dataset.clone(),
-            extracted_tags: self.extracted_tags.clone(),
+            flatten_feature_types: self.flatten_feature_types.clone(),
             parser: Parser::new(),
         }
     }
@@ -190,7 +191,7 @@ impl Processor for FeatureCityGml3Reader {
     ) -> Result<(), BoxedError> {
         let (pending, raw_registry, ns_registry) = std::mem::take(&mut self.parser).finish();
         for feature_root in xlink::resolve(pending, &raw_registry) {
-            if self.extracted_tags.is_empty() {
+            if self.flatten_feature_types.is_empty() {
                 let feature = build_feature(&feature_root);
                 fw.send(ExecutorContext::new_with_node_context_feature_and_port(
                     &ctx,
@@ -201,7 +202,7 @@ impl Processor for FeatureCityGml3Reader {
                 let root_gml_id = gml_id_attr(&feature_root);
 
                 for (node, parent_id) in
-                    flatten::extract(&feature_root, &self.extracted_tags, &ns_registry)
+                    flatten::extract(&feature_root, &self.flatten_feature_types, &ns_registry)
                 {
                     let mut feature = build_feature(&node);
                     if let Some(id) = parent_id {

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
@@ -92,8 +92,7 @@ impl ProcessorFactory for FeatureCityGml3ReaderFactory {
             .compile(params.dataset.as_ref())
             .map_err(|e| FeatureProcessorError::FileCityGml3ReaderFactory(format!("{e:?}")))?;
 
-        let extract_tags: HashSet<String> =
-            params.extract_tags.into_iter().collect();
+        let extract_tags: HashSet<String> = params.extract_tags.into_iter().collect();
 
         Ok(Box::new(FeatureCityGml3Reader {
             global_params: with,

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/utils.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/utils.rs
@@ -1,10 +1,16 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub(super) const GML_NS: &str = "http://www.opengis.net/gml/3.2";
 pub(super) const XLINK_NS: &str = "http://www.w3.org/1999/xlink";
 
-/// `(qname, ns-uri)`
-pub type QName = (String, String);
+pub type NsId = u32;
+pub const EMPTY_NS_ID: NsId = 0;
+pub(super) const GML_NS_ID: NsId = 1;
+pub(super) const XLINK_NS_ID: NsId = 2;
+
+/// `(qname, ns-id)`
+pub type QName = (String, NsId);
 
 #[derive(Debug, Clone)]
 pub struct XmlNode {
@@ -19,6 +25,43 @@ pub enum XmlChild {
     Text(String),
 }
 
+/// Interns namespace URIs as u32 IDs, avoiding repeated allocation of long URI strings.
+/// IDs 0–2 are always pre-assigned: 0="" (no namespace), 1=GML_NS, 2=XLINK_NS.
+pub(super) struct NamespaceRegistry {
+    uris: Vec<String>,
+    index: HashMap<String, NsId>,
+}
+
+impl NamespaceRegistry {
+    pub(super) fn new() -> Self {
+        let mut r = Self {
+            uris: Vec::new(),
+            index: HashMap::new(),
+        };
+        for uri in ["", GML_NS, XLINK_NS] {
+            let id = r.uris.len() as NsId;
+            r.uris.push(uri.to_string());
+            r.index.insert(uri.to_string(), id);
+        }
+        r
+    }
+
+    pub(super) fn intern(&mut self, uri: &str) -> NsId {
+        if let Some(&id) = self.index.get(uri) {
+            return id;
+        }
+        let id = self.uris.len() as NsId;
+        self.uris.push(uri.to_string());
+        self.index.insert(uri.to_string(), id);
+        id
+    }
+
+    /// Returns the ID for a URI only if it was already interned during parsing.
+    pub(super) fn get(&self, uri: &str) -> Option<NsId> {
+        self.index.get(uri).copied()
+    }
+}
+
 pub(super) fn local_name(qname: &str) -> &str {
     qname.rfind(':').map(|i| &qname[i + 1..]).unwrap_or(qname)
 }
@@ -26,13 +69,13 @@ pub(super) fn local_name(qname: &str) -> &str {
 pub(super) fn gml_id_attr(node: &XmlNode) -> Option<String> {
     node.attrs
         .iter()
-        .find(|((q, ns), _)| local_name(q) == "id" && ns == GML_NS)
+        .find(|((q, ns), _)| local_name(q) == "id" && *ns == GML_NS_ID)
         .map(|(_, v)| v.clone())
 }
 
 pub(super) fn xlink_href_attr(attrs: &[(QName, String)]) -> Option<&str> {
     attrs
         .iter()
-        .find(|((q, ns), _)| local_name(q) == "href" && ns == XLINK_NS)
+        .find(|((q, ns), _)| local_name(q) == "href" && *ns == XLINK_NS_ID)
         .map(|(_, v)| v.as_str())
 }

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/xlink.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/xlink.rs
@@ -80,11 +80,18 @@ mod tests {
     use url::Url;
 
     use super::*;
-    use crate::feature::reader::citygml3::parser::{parse, RawRegistry};
+    use crate::feature::reader::citygml3::parser::{Parser, RawNode, RawRegistry};
     use crate::feature::reader::citygml3::utils::{local_name, XmlChild};
 
     fn dummy_url() -> Url {
         Url::parse("file:///test.gml").unwrap()
+    }
+
+    fn parse_test(xml: &[u8], url: &Url) -> (Vec<Arc<RawNode>>, RawRegistry) {
+        let mut parser = Parser::new();
+        parser.parse(xml, url).unwrap();
+        let (pending, raw_reg, _) = parser.finish();
+        (pending, raw_reg)
     }
 
     #[test]
@@ -105,8 +112,7 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"##;
 
-        let mut reg = RawRegistry::new();
-        let raw = parse(xml, &dummy_url(), &mut reg).unwrap();
+        let (raw, reg) = parse_test(xml, &dummy_url());
         let resolved = resolve(raw, &reg);
         assert_eq!(resolved.len(), 1);
         let tlf = &resolved[0];
@@ -142,8 +148,7 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"##;
 
-        let mut reg = RawRegistry::new();
-        let raw = parse(xml, &dummy_url(), &mut reg).unwrap();
+        let (raw, reg) = parse_test(xml, &dummy_url());
         let resolved = resolve(raw, &reg);
         assert_eq!(resolved.len(), 1);
         let tlf = &resolved[0];
@@ -177,8 +182,7 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"##;
 
-        let mut reg = RawRegistry::new();
-        let raw = parse(xml, &dummy_url(), &mut reg).unwrap();
+        let (raw, reg) = parse_test(xml, &dummy_url());
         let resolved = resolve(raw, &reg);
         assert_eq!(resolved.len(), 1);
         let tlf = &resolved[0];
@@ -211,8 +215,7 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"##;
 
-        let mut reg = RawRegistry::new();
-        let raw = parse(xml, &dummy_url(), &mut reg).unwrap();
+        let (raw, reg) = parse_test(xml, &dummy_url());
         let resolved = resolve(raw, &reg);
         assert_eq!(resolved.len(), 1);
         let tlf = &resolved[0];
@@ -255,9 +258,9 @@ mod tests {
         let url_a = Url::parse("file:///a.gml").unwrap();
         let url_b = Url::parse("file:///b.gml").unwrap();
 
-        let mut reg = RawRegistry::new();
-        let raw_a = parse(xml_a, &url_a, &mut reg).unwrap();
-        parse(xml_b, &url_b, &mut reg).unwrap();
+        let (raw_a, mut reg) = parse_test(xml_a, &url_a);
+        let (_, reg_b) = parse_test(xml_b, &url_b);
+        reg.extend(reg_b);
 
         let resolved = resolve(raw_a, &reg);
         assert_eq!(resolved.len(), 1);
@@ -292,8 +295,7 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"##;
 
-        let mut reg = RawRegistry::new();
-        let raw = parse(xml, &dummy_url(), &mut reg).unwrap();
+        let (raw, reg) = parse_test(xml, &dummy_url());
         let resolved = resolve(raw, &reg);
         assert_eq!(resolved.len(), 2);
         let _ = resolved;
@@ -322,8 +324,7 @@ mod tests {
   </core:cityObjectMember>
 </core:CityModel>"##;
 
-        let mut reg = RawRegistry::new();
-        let raw = parse(xml, &dummy_url(), &mut reg).unwrap();
+        let (raw, reg) = parse_test(xml, &dummy_url());
         let resolved = resolve(raw, &reg);
 
         let polygon_arc = |feature: &Arc<XmlNode>| match &feature.children[0] {

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
@@ -192,18 +192,16 @@ impl Cesium3DTilesWriter {
     fn process_default(&mut self, ctx: &ExecutorContext) -> crate::errors::Result<()> {
         let geometry = &ctx.feature.geometry;
         if geometry.is_empty() {
-            return Err(SinkError::Cesium3DTilesWriter(
-                "Unsupported input".to_string(),
-            ));
+            tracing::warn!("Cesium3DTilesWriter: skipping feature with no geometry");
+            return Ok(());
         };
         let geometry_value = &geometry.value;
         if !matches!(
             geometry_value,
             geometry_types::GeometryValue::CityGmlGeometry(_)
         ) {
-            return Err(SinkError::Cesium3DTilesWriter(
-                "Unsupported input".to_string(),
-            ));
+            tracing::warn!("Cesium3DTilesWriter: skipping feature with non-CityGML geometry");
+            return Ok(());
         }
 
         let filename = self

--- a/engine/runtime/examples/fixture/workflow/examples/citygml3-reader/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/citygml3-reader/workflow.yml
@@ -48,7 +48,7 @@ graphs:
         with:
           dataset: |
             env.get("__value")["path"]
-          extractedTags:
+          extractTags:
             - bldg:Building
             - con:FloorSurface
             - tran:Road

--- a/engine/runtime/examples/fixture/workflow/examples/citygml3-reader/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/citygml3-reader/workflow.yml
@@ -48,6 +48,12 @@ graphs:
         with:
           dataset: |
             env.get("__value")["path"]
+          extractedTags:
+            - bldg:Building
+            - con:FloorSurface
+            - tran:Road
+            - tran:TrafficArea
+            - frn:CityFurniture
 
       # PLATEAU CityGML 3 coordinates are in JGD2011 geographic (lat/lon/ellipsoidal-height).
       # Shift ellipsoidal height → WGS84 orthometric height before tile output.

--- a/engine/runtime/types/src/feature.rs
+++ b/engine/runtime/types/src/feature.rs
@@ -22,6 +22,8 @@ use crate::{all_attribute_keys, attribute::Attribute, geometry::Geometry, lod::L
 pub(crate) const CITYGML_GML_ID_KEY: &str = "__citygml_gml_id";
 pub(crate) const CITYGML_FEATURE_TYPE_KEY: &str = "__citygml_feature_type";
 pub(crate) const CITYGML_LOD_MASK_KEY: &str = "__citygml_lod_mask";
+pub const CITYGML_PARENT_GML_ID_KEY: &str = "__citygml_parent_gml_id";
+pub const CITYGML_ROOT_GML_ID_KEY: &str = "__citygml_root_gml_id";
 
 #[nutype(
     sanitize(trim),

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -2809,6 +2809,15 @@
                 "$ref": "#/definitions/Expr"
               }
             ]
+          },
+          "extractedTags": {
+            "title": "Extracted Tags",
+            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "definitions": {

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -2810,9 +2810,9 @@
               }
             ]
           },
-          "extractedTags": {
-            "title": "Extracted Tags",
-            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+          "flattenFeatureTypes": {
+            "title": "Flatten Feature Types",
+            "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",
             "items": {

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -2810,8 +2810,8 @@
               }
             ]
           },
-          "flattenFeatureTypes": {
-            "title": "Flatten Feature Types",
+          "extractTags": {
+            "title": "Extract Tags",
             "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -2809,6 +2809,15 @@
                 "$ref": "#/definitions/Expr"
               }
             ]
+          },
+          "extractedTags": {
+            "title": "Extracted Tags",
+            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "definitions": {

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -2810,9 +2810,9 @@
               }
             ]
           },
-          "extractedTags": {
-            "title": "Extracted Tags",
-            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+          "flattenFeatureTypes": {
+            "title": "Flatten Feature Types",
+            "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",
             "items": {

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -2810,8 +2810,8 @@
               }
             ]
           },
-          "flattenFeatureTypes": {
-            "title": "Flatten Feature Types",
+          "extractTags": {
+            "title": "Extract Tags",
             "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -2809,6 +2809,15 @@
                 "$ref": "#/definitions/Expr"
               }
             ]
+          },
+          "extractedTags": {
+            "title": "Extracted Tags",
+            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "definitions": {

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -2810,9 +2810,9 @@
               }
             ]
           },
-          "extractedTags": {
-            "title": "Extracted Tags",
-            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+          "flattenFeatureTypes": {
+            "title": "Flatten Feature Types",
+            "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",
             "items": {

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -2810,8 +2810,8 @@
               }
             ]
           },
-          "flattenFeatureTypes": {
-            "title": "Flatten Feature Types",
+          "extractTags": {
+            "title": "Extract Tags",
             "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -2809,6 +2809,15 @@
                 "$ref": "#/definitions/Expr"
               }
             ]
+          },
+          "extractedTags": {
+            "title": "Extracted Tags",
+            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "definitions": {

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -2810,9 +2810,9 @@
               }
             ]
           },
-          "extractedTags": {
-            "title": "Extracted Tags",
-            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+          "flattenFeatureTypes": {
+            "title": "Flatten Feature Types",
+            "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",
             "items": {

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -2810,8 +2810,8 @@
               }
             ]
           },
-          "flattenFeatureTypes": {
-            "title": "Flatten Feature Types",
+          "extractTags": {
+            "title": "Extract Tags",
             "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -2809,6 +2809,15 @@
                 "$ref": "#/definitions/Expr"
               }
             ]
+          },
+          "extractedTags": {
+            "title": "Extracted Tags",
+            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "definitions": {

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -2810,9 +2810,9 @@
               }
             ]
           },
-          "extractedTags": {
-            "title": "Extracted Tags",
-            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+          "flattenFeatureTypes": {
+            "title": "Flatten Feature Types",
+            "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",
             "items": {

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -2810,8 +2810,8 @@
               }
             ]
           },
-          "flattenFeatureTypes": {
-            "title": "Flatten Feature Types",
+          "extractTags": {
+            "title": "Extract Tags",
             "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -2809,6 +2809,15 @@
                 "$ref": "#/definitions/Expr"
               }
             ]
+          },
+          "extractedTags": {
+            "title": "Extracted Tags",
+            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "definitions": {

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -2810,9 +2810,9 @@
               }
             ]
           },
-          "extractedTags": {
-            "title": "Extracted Tags",
-            "description": "Tag names to extract as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
+          "flattenFeatureTypes": {
+            "title": "Flatten Feature Types",
+            "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",
             "items": {

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -2810,8 +2810,8 @@
               }
             ]
           },
-          "flattenFeatureTypes": {
-            "title": "Flatten Feature Types",
+          "extractTags": {
+            "title": "Extract Tags",
             "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged.",
             "default": [],
             "type": "array",

--- a/engine/testing/data/testcases/examples/citygml3-reader/xlink/citymodel/udx/feature_xlink_referrer.gml
+++ b/engine/testing/data/testcases/examples/citygml3-reader/xlink/citymodel/udx/feature_xlink_referrer.gml
@@ -23,6 +23,20 @@
 
   <core:cityObjectMember>
     <bldg:Building gml:id="building1">
+      <core:lod1MultiSurface>
+        <gml:MultiSurface>
+          <gml:surfaceMember>
+            <gml:Polygon>
+              <gml:exterior>
+                <gml:LinearRing>
+                  <!-- building footprint at ground level -->
+                  <gml:posList>139.7454 35.6586 0.0 139.7455 35.6586 0.0 139.7455 35.6587 0.0 139.7454 35.6587 0.0 139.7454 35.6586 0.0</gml:posList>
+                </gml:LinearRing>
+              </gml:exterior>
+            </gml:Polygon>
+          </gml:surfaceMember>
+        </gml:MultiSurface>
+      </core:lod1MultiSurface>
       <core:boundary>
         <con:FloorSurface gml:id="floorsurface1">
           <core:relatedTo>


### PR DESCRIPTION
## Overview

This PR implements `extractedTags` parameter in CityGML 3.0 reader. This is equivalent to `flatten=true` in `FeatureCitygmlReader`, but users must specify all tags that are considered a "feature", instead of relying on hard-coded PLATEAU-specific tag names. Some other options and problems:

1. parse XSDs of ADE: users still need to provide ADE files, or reader need to fetch HTTP XSD files which is unreliable
2. create another PLATEAU CityGML reader with feature type hard-coded: this leaves CityGML 3.0 reader not supporting ADE, which is probably not wanted.

## Changes

- feature CityGML3 reader: add extractedTags parameter to specify feature tags to be extracted as toplevels.
- create `__citygml_parent_gml_id` and `__citygml_root_gml_id` to preserve topology info.
- a subfeature xlink referred multiple times will be emitted multiple times with referrer's gml:id as parent ID.
- cesium 3D tiles writer: should not simply fail whole processor when geometry is missing or wrong geometry type in a single feature. Now logs a warning and skip.

## Notes

- parent/root ID are orthogonal to extractedTags. They should always point to the direct parent/toplevel feature in the original XML even they are not extracted.
- currently no stack overflow protection for recursive tree traversal, maybe add a depth limitation in the future