### PR TITLE
fix(ui): update edge styling for queued job status in DefaultEdge component [FLOW-DEV-22]

### DIFF
--- a/ui/src/lib/reactFlow/edgeTypes/DefaultEdge/index.tsx
+++ b/ui/src/lib/reactFlow/edgeTypes/DefaultEdge/index.tsx
@@ -61,14 +61,9 @@ const DefaultEdge: React.FC<CustomEdgeProps> = ({
         ))}
       {jobStatus === "queued" &&
         (selected ? (
-          <path d={edgePath} stroke="#27272A" fill="none" className="pulse" />
+          <path d={edgePath} stroke="#555" fill="none" />
         ) : (
-          <path
-            d={edgePath}
-            stroke="#27272A"
-            fill="none"
-            className="stroke-dashed"
-          />
+          <path d={edgePath} stroke="#27272A" fill="none" className="pulse" />
         ))}
       {jobStatus === "running" && (
         <>
@@ -107,7 +102,7 @@ const DefaultEdge: React.FC<CustomEdgeProps> = ({
           </g>
         </>
       )}
-      {/* {sourceNodeStatus === "failed" && (
+      {/* {jobStatus === "failed" && (
         <path d={edgePath} stroke="#fc4444" strokeWidth="1" fill="none" />
       )} */}
     </>

--- a/ui/src/lib/reactFlow/edgeTypes/DefaultEdge/index.tsx
+++ b/ui/src/lib/reactFlow/edgeTypes/DefaultEdge/index.tsx
@@ -102,9 +102,12 @@ const DefaultEdge: React.FC<CustomEdgeProps> = ({
           </g>
         </>
       )}
-      {/* {jobStatus === "failed" && (
+      {jobStatus === "cancelled" && (
+        <path d={edgePath} stroke="#ee9733" strokeWidth="1" fill="none" />
+      )}
+      {jobStatus === "failed" && (
         <path d={edgePath} stroke="#fc4444" strokeWidth="1" fill="none" />
-      )} */}
+      )}
     </>
   );
 };


### PR DESCRIPTION
# Overview
- Updated queued-edge styling to render a static stroke when selected and a pulsing stroke when not selected.
- Added failure edge `if JobStatus === failure`
- Added cancelled  edge` if jobStatus === cancelled`
## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
