### PR TITLE
fix(ui): update CSS class for empty paragraph styling in NoteNode component

### DIFF
--- a/ui/src/lib/reactFlow/nodeTypes/NoteNode/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/NoteNode/index.tsx
@@ -106,7 +106,7 @@ const NoteNode: React.FC<NoteNodeProps> = ({
         </div>
         <div>
           <div
-            className="nowheel nodrag size-full resize-none bg-transparent text-xs focus-visible:outline-hidden [&_a]:text-blue-400 [&_a]:underline [&_b]:font-bold [&_i]:italic [&_li]:ml-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-1 [&_pre]:font-mono [&_s]:line-through [&_u]:underline [&_ul]:list-disc [&_ul]:pl-4"
+            className="nowheel nodrag size-full resize-none bg-transparent text-xs focus-visible:outline-hidden [&_a]:text-blue-400 [&_a]:underline [&_b]:font-bold [&_i]:italic [&_li]:ml-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_p:empty]:pt-1 [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-1 [&_pre]:font-mono [&_s]:line-through [&_u]:underline [&_ul]:list-disc [&_ul]:pl-4"
             dangerouslySetInnerHTML={{
               __html: DOMPurify.sanitize(data.customizations?.content ?? "", {
                 ALLOWED_TAGS: [


### PR DESCRIPTION
# Overview
Updates NoteNode’s Tailwind selector intended to adjust spacing/styling for “empty” paragraphs in the note content rendered via dangerouslySetInnerHTML.
## What I've done
- Adjusts the NoteNode content container’s Tailwind arbitrary selector to add padding on empty `<p>` elements (`[&_p:empty]:pt-1`).
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
