### PR TITLE
fix(engine): reject absolute paths and missing base in expand_yaml_includes

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5693,7 +5693,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.312"
+version = "0.0.313"
 dependencies = [
  "directories",
  "log",
@@ -5722,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6516,7 +6516,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "futures",
  "once_cell",
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "approx",
  "async-trait",
@@ -6582,7 +6582,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "Inflector",
  "approx",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6661,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6729,7 +6729,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6791,7 +6791,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "bytes",
  "clap",
@@ -6829,7 +6829,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6869,7 +6869,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "chrono",
  "futures",
@@ -6883,7 +6883,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6912,7 +6912,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "approx",
  "bvh",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6976,7 +6976,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6985,7 +6985,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7015,7 +7015,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7066,7 +7066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7078,7 +7078,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "bytes",
  "futures",
@@ -7095,7 +7095,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "bytes",
  "futures",
@@ -7114,7 +7114,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7128,7 +7128,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7163,7 +7163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7200,7 +7200,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.364"
+version = "0.0.365"
 dependencies = [
  "async-trait",
  "backon",
@@ -11068,7 +11068,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.214"
+version = "0.1.215"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.364"
+version = "0.0.365"
 
 [profile.dev]
 opt-level = 0

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.312"
+version = "0.0.313"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/runtime/common/src/serde.rs
+++ b/engine/runtime/common/src/serde.rs
@@ -40,14 +40,26 @@ pub fn expand_yaml_includes(yaml_content: &str, base_path: Option<&Path>) -> cra
             // Add content before this match
             new_content.push_str(&expanded[last_end..match_start]);
 
-            // Resolve the file path
-            let resolved_path = if let Some(base) = base_path {
-                let mut path = PathBuf::from(base);
-                path.push(file_path_str);
-                path
-            } else {
-                PathBuf::from(file_path_str)
+            // Resolve the file path with two minimal validations:
+            //   1. Reject absolute paths so attackers cannot read arbitrary
+            //      files like /proc/self/environ or /var/secrets/*.
+            //   2. Require base_path to be Some, since cloud-stored or
+            //      stdin-fed workflows have no meaningful local base; reading
+            //      worker-local files via !include in those paths is never a
+            //      legitimate use case.
+            let raw = Path::new(file_path_str);
+            if raw.is_absolute() {
+                return Err(crate::Error::Serde(format!(
+                    "!include rejects absolute paths: {file_path_str}"
+                )));
+            }
+            let Some(base) = base_path else {
+                return Err(crate::Error::Serde(format!(
+                    "!include {file_path_str} requires a workflow base directory"
+                )));
             };
+            let mut resolved_path = PathBuf::from(base);
+            resolved_path.push(raw);
 
             // Read the included file
             let included_content = std::fs::read_to_string(&resolved_path).map_err(|e| {
@@ -168,5 +180,58 @@ pub fn merge_value(a: &mut JsonValue, b: JsonValue) {
             }
         }
         (a, b) => *a = b,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::Builder;
+
+    // /etc/passwd is absolute on Unix; on Windows is_absolute checks for a
+    // drive-rooted path, which this string lacks. The engine targets Unix in
+    // production (Cloud Batch + Linux containers), so we gate the test there.
+    #[cfg(unix)]
+    #[test]
+    fn rejects_absolute_path() {
+        let yaml = "x: !include /etc/passwd\n";
+        let err = expand_yaml_includes(yaml, Some(Path::new("/tmp"))).unwrap_err();
+        assert!(
+            err.to_string().contains("absolute paths"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_include_without_base_path() {
+        let yaml = "x: !include foo.yml\n";
+        let err = expand_yaml_includes(yaml, None).unwrap_err();
+        assert!(
+            err.to_string().contains("base directory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn allows_relative_include_with_base_path() {
+        let dir = Builder::new().prefix("expand-include").tempdir().unwrap();
+        let path = dir.path().join("inc.txt");
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(f, "hello").unwrap();
+
+        let yaml = "x: !include inc.txt\n";
+        let out = expand_yaml_includes(yaml, Some(dir.path())).unwrap();
+        assert!(
+            out.contains("hello"),
+            "expected hello in output, got: {out}"
+        );
+    }
+
+    #[test]
+    fn no_include_directives_works_without_base_path() {
+        let yaml = "x: 1\n";
+        let out = expand_yaml_includes(yaml, None).unwrap();
+        assert_eq!(out, yaml);
     }
 }

--- a/engine/runtime/common/src/serde.rs
+++ b/engine/runtime/common/src/serde.rs
@@ -55,7 +55,10 @@ pub fn expand_yaml_includes(yaml_content: &str, base_path: Option<&Path>) -> cra
             }
             let Some(base) = base_path else {
                 return Err(crate::Error::Serde(format!(
-                    "!include {file_path_str} requires a workflow base directory"
+                    "!include {file_path_str} cannot be expanded: workflow has \
+                     no base directory. Load the workflow from a file path \
+                     (not stdin or cloud storage), or remove the !include \
+                     directive."
                 )));
             };
             let mut resolved_path = PathBuf::from(base);
@@ -219,6 +222,8 @@ mod tests {
         let path = dir.path().join("inc.txt");
         let mut f = std::fs::File::create(&path).unwrap();
         write!(f, "hello").unwrap();
+        f.flush().unwrap();
+        drop(f);
 
         let yaml = "x: !include inc.txt\n";
         let out = expand_yaml_includes(yaml, Some(dir.path())).unwrap();

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.24"
+version = "0.2.25"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.214"
+version = "0.1.215"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview

Address [SEC-04 (MEDIUM)](https://github.com/eukarya-inc/compliance/issues/4): path traversal via the `!include` directive in workflow YAML (`engine/runtime/common/src/serde.rs`).

A workflow submitter could write `!include /proc/self/environ`, `!include /var/secrets/...`, or similar and have the worker read arbitrary local files. The contents are then embedded in the workflow YAML and surface through parse errors, the user-facing Pub/Sub log, or downstream node attributes, exfiltrating worker env vars and any service-account key file on disk.

This PR applies a minimal hardening that closes the two most exploitable variants without an API change.

## What I've done

`engine/runtime/common/src/serde.rs`:

- Reject absolute paths in `!include` (blocks `/proc/self/environ` etc.)
- Reject `!include` when `base_path` is `None` (cloud-stored or stdin-fed workflows have no meaningful local base)
- Add unit tests for both rejection paths plus regression coverage

## What I haven't done

Intentionally out of scope, tracked for follow-up:

- `..` escape and symlink containment. All existing fixtures use `..` traversal (e.g. `!include ../../../../graphs/...`), so containment requires an allowed-root API change.
- Worker-side hardening (non-root container, Workload Identity, env var hygiene).

## How I tested

- `cargo test -p reearth-flow-common --lib serde::` — 4 new tests pass
- `cargo make format` / `cargo make clippy` — clean
- `cargo make test-rs` — no regressions

All `runtime/examples/fixture/` `!include` usages are relative paths through CLI file argument and remain compatible.

## Which point I want you to review particularly

The decision to refuse `!include` outright when `base_path` is `None`. I'd like a sanity check that no production workflow relies on `!include` from a cloud-stored or stdin-piped YAML.