### PR TITLE
fix(engine): order contract on input features are removed for some accumulating processors with group-by

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5693,7 +5693,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.314"
+version = "0.0.315"
 dependencies = [
  "directories",
  "log",
@@ -5722,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6516,7 +6516,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "futures",
  "once_cell",
@@ -6536,7 +6536,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "approx",
  "async-trait",
@@ -6582,7 +6582,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "Inflector",
  "approx",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6661,7 +6661,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6729,7 +6729,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6780,7 +6780,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6791,7 +6791,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "bytes",
  "clap",
@@ -6829,7 +6829,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6869,7 +6869,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "chrono",
  "futures",
@@ -6883,7 +6883,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6912,7 +6912,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "approx",
  "bvh",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6976,7 +6976,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6985,7 +6985,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7015,7 +7015,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7049,7 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7066,7 +7066,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7078,7 +7078,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "bytes",
  "futures",
@@ -7095,7 +7095,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "bytes",
  "futures",
@@ -7114,7 +7114,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7128,7 +7128,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7163,7 +7163,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7200,7 +7200,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.366"
+version = "0.0.367"
 dependencies = [
  "async-trait",
  "backon",
@@ -11068,7 +11068,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.216"
+version = "0.1.217"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.366"
+version = "0.0.367"
 
 [profile.dev]
 opt-level = 0

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.314"
+version = "0.0.315"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/runtime/action-processor/src/attribute/aggregator.rs
+++ b/engine/runtime/action-processor/src/attribute/aggregator.rs
@@ -178,7 +178,7 @@ enum Method {
 
 impl Processor for AttributeAggregator {
     fn is_accumulating(&self) -> bool {
-        false
+        true
     }
 
     fn num_threads(&self) -> usize {
@@ -188,7 +188,7 @@ impl Processor for AttributeAggregator {
     fn process(
         &mut self,
         ctx: ExecutorContext,
-        fw: &ProcessorChannelForwarder,
+        _fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         let feature = &ctx.feature;
         let expr_engine = Arc::clone(&ctx.expr_engine);
@@ -224,10 +224,6 @@ impl Processor for AttributeAggregator {
             );
         };
         let key = AttributeValue::Array(aggregates);
-        if !self.buffer.contains_key(&key) {
-            self.flush_buffer(ctx.as_context(), fw);
-            self.buffer.clear();
-        }
         match &self.method {
             Method::Max => {
                 let value = self.buffer.entry(key).or_insert(0);
@@ -251,6 +247,7 @@ impl Processor for AttributeAggregator {
         fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         self.flush_buffer(ctx.as_context(), fw);
+        self.buffer.clear();
         Ok(())
     }
 
@@ -282,5 +279,112 @@ impl AttributeAggregator {
                 DEFAULT_PORT.clone(),
             ));
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use indexmap::IndexMap;
+    use reearth_flow_eval_expr::engine::Engine;
+    use reearth_flow_runtime::{
+        event::EventHub, forwarder::NoopChannelForwarder, kvs, node::DEFAULT_PORT,
+    };
+    use reearth_flow_storage::resolve::StorageResolver;
+    use reearth_flow_types::Feature;
+
+    use super::*;
+    use crate::tests::utils::create_default_execute_context;
+
+    fn make_processor() -> AttributeAggregator {
+        AttributeAggregator {
+            global_params: None,
+            aggregate_attributes: vec![CompliledAggregateAttribute {
+                new_attribute: Attribute::new("file"),
+                attribute: Some(Attribute::new("file")),
+                attribute_value: None,
+            }],
+            calculation: None,
+            calculation_value: Some(1),
+            calculation_attribute: Attribute::new("count"),
+            method: Method::Count,
+            buffer: HashMap::new(),
+        }
+    }
+
+    fn make_feature(file: &str) -> Feature {
+        let mut attrs: IndexMap<Attribute, AttributeValue> = IndexMap::new();
+        attrs.insert(
+            Attribute::new("file"),
+            AttributeValue::String(file.to_string()),
+        );
+        Feature::from(attrs)
+    }
+
+    fn collect_counts(noop: &NoopChannelForwarder) -> Vec<(String, i64)> {
+        let features = noop.send_features.lock().unwrap();
+        let ports = noop.send_ports.lock().unwrap();
+        assert!(
+            ports.iter().all(|p| *p == *DEFAULT_PORT),
+            "all emissions should go to DEFAULT port"
+        );
+        features
+            .iter()
+            .map(|f| {
+                let file = match f.attributes.get(&Attribute::new("file")) {
+                    Some(AttributeValue::String(s)) => s.clone(),
+                    other => panic!("missing/invalid 'file' attr: {other:?}"),
+                };
+                let count = match f.attributes.get(&Attribute::new("count")) {
+                    Some(AttributeValue::Number(n)) => n.as_i64().unwrap(),
+                    other => panic!("missing/invalid 'count' attr: {other:?}"),
+                };
+                (file, count)
+            })
+            .collect()
+    }
+
+    fn make_node_context() -> NodeContext {
+        NodeContext::new(
+            Arc::new(Engine::new()),
+            Arc::new(StorageResolver::new()),
+            Arc::new(kvs::create_kv_store()),
+            EventHub::new(30),
+        )
+    }
+
+    /// Regression test for the flush-on-new-key bug.
+    ///
+    /// Before the fix, `process()` flushed-and-cleared the buffer whenever a new
+    /// key arrived, splitting each key's count across multiple partial emissions.
+    /// Downstream consumers (e.g. `FeatureMerger`) would then see only the LAST
+    /// partial value per key (= 1 in this case), not the true total.
+    ///
+    /// With the fix, all keys accumulate until `finish()`, which emits one
+    /// feature per key with the correct total.
+    #[test]
+    fn count_aggregates_correctly_with_interleaved_keys() {
+        let fw = ProcessorChannelForwarder::Noop(NoopChannelForwarder::default());
+        let mut processor = make_processor();
+
+        // A, B, A, B — each key 2x, fully interleaved.
+        for file in ["A", "B", "A", "B"] {
+            let feature = make_feature(file);
+            let ctx = create_default_execute_context(&feature);
+            processor.process(ctx, &fw).unwrap();
+        }
+        processor.finish(make_node_context(), &fw).unwrap();
+
+        let ProcessorChannelForwarder::Noop(noop) = fw else {
+            unreachable!()
+        };
+        let mut counts = collect_counts(&noop);
+        counts.sort();
+        assert_eq!(
+            counts,
+            vec![("A".to_string(), 2), ("B".to_string(), 2)],
+            "expected one totalled feature per key; before the fix this emitted multiple partial features (e.g. A=1, B=1, A=1, B=1)"
+        );
     }
 }

--- a/engine/runtime/action-processor/src/attribute/aggregator.rs
+++ b/engine/runtime/action-processor/src/attribute/aggregator.rs
@@ -350,15 +350,6 @@ mod tests {
         )
     }
 
-    /// Regression test for the flush-on-new-key bug.
-    ///
-    /// Before the fix, `process()` flushed-and-cleared the buffer whenever a new
-    /// key arrived, splitting each key's count across multiple partial emissions.
-    /// Downstream consumers (e.g. `FeatureMerger`) would then see only the LAST
-    /// partial value per key (= 1 in this case), not the true total.
-    ///
-    /// With the fix, all keys accumulate until `finish()`, which emits one
-    /// feature per key with the correct total.
     #[test]
     fn count_aggregates_correctly_with_interleaved_keys() {
         let fw = ProcessorChannelForwarder::Noop(NoopChannelForwarder::default());

--- a/engine/runtime/action-processor/src/attribute/aggregator.rs
+++ b/engine/runtime/action-processor/src/attribute/aggregator.rs
@@ -284,13 +284,9 @@ impl AttributeAggregator {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use indexmap::IndexMap;
     use reearth_flow_eval_expr::engine::Engine;
-    use reearth_flow_runtime::{
-        event::EventHub, forwarder::NoopChannelForwarder, kvs, node::DEFAULT_PORT,
-    };
+    use reearth_flow_runtime::{forwarder::NoopChannelForwarder, kvs};
     use reearth_flow_storage::resolve::StorageResolver;
     use reearth_flow_types::Feature;
 

--- a/engine/runtime/action-processor/src/geometry/convex_hull_accumulator.rs
+++ b/engine/runtime/action-processor/src/geometry/convex_hull_accumulator.rs
@@ -142,25 +142,18 @@ impl Processor for ConvexHullAccumulator {
                     AttributeValue::Null
                 };
 
-                if !self.buffer.contains_key(&key) {
-                    for hull in self.create_hull() {
-                        fw.send(ctx.new_with_feature_and_port(hull, DEFAULT_PORT.clone()));
-                    }
-                    self.buffer.clear();
-
-                    let common_attr = if let Some(group_by) = &self.group_by {
+                let common_attr: IndexMap<Attribute, AttributeValue> =
+                    if let Some(group_by) = &self.group_by {
                         let vals = key.as_vec().unwrap();
                         group_by.iter().cloned().zip(vals).collect()
                     } else {
                         IndexMap::new()
                     };
-                    self.buffer
-                        .insert(key.clone(), GroupBuffer::new(common_attr));
-                }
-
                 self.buffer
                     .entry(key)
-                    .and_modify(|b| b.geometries.push(ctx.feature.geometry));
+                    .or_insert_with(|| GroupBuffer::new(common_attr))
+                    .geometries
+                    .push(ctx.feature.geometry);
             }
             _ => {
                 fw.send(ctx.new_with_feature_and_port(ctx.feature.clone(), REJECTED_PORT.clone()));

--- a/engine/runtime/action-processor/src/geometry/convex_hull_accumulator.rs
+++ b/engine/runtime/action-processor/src/geometry/convex_hull_accumulator.rs
@@ -142,16 +142,28 @@ impl Processor for ConvexHullAccumulator {
                     AttributeValue::Null
                 };
 
-                let common_attr: IndexMap<Attribute, AttributeValue> =
-                    if let Some(group_by) = &self.group_by {
-                        let vals = key.as_vec().unwrap();
-                        group_by.iter().cloned().zip(vals).collect()
-                    } else {
-                        IndexMap::new()
-                    };
+                let group_by = &self.group_by;
+                let feature_attrs = &ctx.feature.attributes;
                 self.buffer
                     .entry(key)
-                    .or_insert_with(|| GroupBuffer::new(common_attr))
+                    .or_insert_with(|| {
+                        let common_attr: IndexMap<Attribute, AttributeValue> = match group_by {
+                            Some(group_by) => group_by
+                                .iter()
+                                .map(|attr| {
+                                    (
+                                        attr.clone(),
+                                        feature_attrs
+                                            .get(attr)
+                                            .cloned()
+                                            .unwrap_or(AttributeValue::Null),
+                                    )
+                                })
+                                .collect(),
+                            None => IndexMap::new(),
+                        };
+                        GroupBuffer::new(common_attr)
+                    })
                     .geometries
                     .push(ctx.feature.geometry);
             }

--- a/engine/runtime/action-processor/src/geometry/dissolver.rs
+++ b/engine/runtime/action-processor/src/geometry/dissolver.rs
@@ -322,13 +322,6 @@ impl Processor for Dissolver {
                     AttributeValue::Null
                 };
 
-                // If the key is new, dissolve all current groups first
-                if !self.group_map.contains_key(&key) {
-                    for dissolved in self.dissolve_all_groups()? {
-                        fw.send(ctx.new_with_feature_and_port(dissolved, AREA_PORT.clone()));
-                    }
-                }
-
                 // Get or create group index for this key
                 let group_idx = if let Some(&idx) = self.group_map.get(&key) {
                     idx

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.26"
+version = "0.2.27"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.216"
+version = "0.1.217"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
There are three processors with the `group-by` parameter that assume that each group arrives in a single chunk. This assumption is problematic even if the input features actually arrive in chunk; a write lock in the processor core reorders the input features in `num_threads() > 1` case. As a consequence, `test_quality_check_plateau4_06_fld_z_fld_05_unshared_edge_01` has been randomly failing in CI with:
```
  File error summary mismatch for row ["test_unshared_edge01_fld_6697_l1_op.gml"],
  column '共有先のない辺': expected '2', got '1'
```
This PR fix the issue by removing the order contract on the input features.

## Root Cause of the Non-Deterministic Bug
- The `Aggregator`'s `process()` was flushing the buffer as soon as the new key was received. Even though the upstream action preserves the order, multiple rayon threads (`Aggregator` has `num_treads() = 2`), together with `parking_lot::RwLock`'s non-FIFO write-acquisition, sometimes reorders the input features, causing the buffer flush before all the values are received.
- The bug situation above is reproduced in the local; with burned CPU, this issue reproduced a few times in 100 shots. In the failed run, all the input features of `Aggregator` were preserving the order, and the debug outputs showed that the order was not preserved at the time of registering keys.

## What I've done
- Changed the `Aggregator` not to flush the buffer at every new key. A unit test is also added for this change.
- There are two more actions where buffers flush on a new key, namely `ConvexHullAccumulator` and `Dissolver`. Even though they do not cause the non-deterministic issue by itself as `num_threads()=1`, this PR fixes these two as well to absorb all the inputs before `finish()`, in order to make the accumulating processors consistent.
