### PR TITLE
fix(ui): update Port component to conditionally handle click events based on data availability

### DIFF
--- a/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/CustomHandle/Port/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/CustomHandle/Port/index.tsx
@@ -38,8 +38,8 @@ const Port: React.FC<Props> = ({ nodeId, nodeData, portName, readonly }) => {
       />
       <div className="group flex w-full min-w-0 -translate-x-0.5 items-center justify-end gap-1">
         <div
-          className={`flex items-center gap-1 rounded-sm  px-0.5 group-hover:cursor-pointer group-hover:bg-success/20 ${isSelected ? "bg-success/20" : ""}`}
-          onClick={handleClick}>
+          className={`flex items-center gap-1 rounded-sm  px-0.5 ${hasData ? "group-hover:cursor-pointer group-hover:bg-success/20 " : ""}${isSelected ? "bg-success/20" : ""}`}
+          onClick={hasData ? handleClick : undefined}>
           <p
             className={`min-w-0 text-end text-[10px] ${getBreakClass(portName)} italic dark:font-thin ${
               hasData && isSelected


### PR DESCRIPTION
# Overview
Updates the ReactFlow GeneralNode Port UI so that ports only present hover affordances and respond to clicks when intermediate data is actually available (and the debug job has completed), preventing “dead” click interactions.
## What I've done
- Conditionally applies hover cursor/background styling only when `hasData` is true.
- Conditionally attaches the `onClick` handler only when `hasData` is true.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
