### PR TITLE
chore(github): Update CODEOWNERS for UI and server ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 *                   @reearth/flow-admin
 /engine/            @n4to4 @asrcpq @shunski
-/ui/                @KaWaite @billcookie
+/ui/                @billcookie
 /server/            @pyshx
-/server/api/        @akiyatomohiro @pyshx
-/server/subscriber/ @akiyatomohiro @pyshx
-/go.work*           @akiyatomohiro @pyshx
+/server/api/        @pyshx
+/server/subscriber/ @pyshx
+/go.work*           @pyshx


### PR DESCRIPTION
Removed @KaWaite from the UI ownership and consolidated @pyshx as the sole owner for several server directories.

# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
