### PR TITLE
fix(ui): make grid view primary view for assets and add icons to asset list [FLOW-DEV-132]

### DIFF
--- a/ui/src/features/AssetsDialog/components/AssetCard.tsx
+++ b/ui/src/features/AssetsDialog/components/AssetCard.tsx
@@ -6,7 +6,7 @@ import {
   PencilLineIcon,
   TrashIcon,
 } from "@phosphor-icons/react";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 import {
   Card,
@@ -20,9 +20,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@flow/components";
-import { Icon, IconName } from "@flow/components/Icon";
+import { Icon } from "@flow/components/Icon";
 import { useT } from "@flow/lib/i18n";
 import { Asset } from "@flow/types";
+
+import { getIconFileType } from "./utils";
 
 type Props = {
   asset: Asset;
@@ -58,48 +60,7 @@ const AssetCard: React.FC<Props> = ({
       onDoubleClick(asset);
     }
   };
-  const iconType = useMemo((): IconName | undefined => {
-    switch (ext) {
-      case "csv":
-        return "fileCSV";
-      case "czml":
-        return "fileCzml";
-      case "geojson":
-        return "fileGeoJSON";
-      case "glb":
-        return "fileGlb";
-      case "gltf":
-        return "fileGltf";
-      case "gml":
-        return "fileGml";
-      case "gpkg":
-        return "fileGpkg";
-      case "jpg":
-        return "fileJpg";
-      case "jpeg":
-        return "fileJpeg";
-      case "json":
-        return "fileJson";
-      case "mtl":
-        return "fileMtl";
-      case "obj":
-        return "fileObj";
-      case "png":
-        return "filePng";
-      case "py":
-        return "filePy";
-      case "tif":
-        return "fileTif";
-      case "tiff":
-        return "fileTiff";
-      case "tsv":
-        return "fileTsv";
-      case "zip":
-        return "fileZip";
-      default:
-        return undefined;
-    }
-  }, [ext]);
+  const fileIcon = getIconFileType(ext);
 
   return (
     <Card
@@ -107,9 +68,9 @@ const AssetCard: React.FC<Props> = ({
       key={id}
       onDoubleClick={handleDoubleClick}>
       <CardContent className="flex items-start justify-center p-2">
-        {iconType ? (
+        {fileIcon ? (
           <Icon
-            icon={iconType}
+            icon={fileIcon}
             size={70}
             className="opacity-50 group-hover:opacity-90"
           />

--- a/ui/src/features/AssetsDialog/components/AssetsListView.tsx
+++ b/ui/src/features/AssetsDialog/components/AssetsListView.tsx
@@ -6,11 +6,13 @@ import {
 } from "@phosphor-icons/react";
 import { ColumnDef } from "@tanstack/react-table";
 
-import { IconButton, LoadingSkeleton } from "@flow/components";
+import { Icon, IconButton, LoadingSkeleton } from "@flow/components";
 import { DataTable as Table } from "@flow/components/DataTable";
 import { ASSET_FETCH_RATE } from "@flow/lib/gql/assets/useQueries";
 import { useT } from "@flow/lib/i18n";
 import type { Asset } from "@flow/types";
+
+import { getIconFileType } from "./utils";
 
 type Props = {
   assets?: Asset[];
@@ -51,6 +53,22 @@ const AssetsListView: React.FC<Props> = ({
     {
       accessorKey: "name",
       header: t("Name"),
+      cell: ({ row }) => {
+        const ext = row.original.fileName.split(".").pop()?.toLowerCase();
+        const icon = getIconFileType(ext);
+        return (
+          <div className="flex items-center gap-1.5">
+            {icon && (
+              <Icon
+                icon={icon}
+                size={25}
+                className="opacity-50 group-hover:opacity-90"
+              />
+            )}
+            <strong>{row.original.name}</strong>
+          </div>
+        );
+      },
     },
     {
       accessorKey: "createdAt",

--- a/ui/src/features/AssetsDialog/components/AssetsListView.tsx
+++ b/ui/src/features/AssetsDialog/components/AssetsListView.tsx
@@ -58,13 +58,7 @@ const AssetsListView: React.FC<Props> = ({
         const icon = getIconFileType(ext);
         return (
           <div className="flex items-center gap-1.5">
-            {icon && (
-              <Icon
-                icon={icon}
-                size={25}
-                className="opacity-50 group-hover:opacity-90"
-              />
-            )}
+            {icon && <Icon icon={icon} size={25} className="opacity-50" />}
             <strong>{row.original.name}</strong>
           </div>
         );

--- a/ui/src/features/AssetsDialog/components/utils.ts
+++ b/ui/src/features/AssetsDialog/components/utils.ts
@@ -1,0 +1,46 @@
+import { IconName } from "@flow/components";
+
+export const getIconFileType = (
+  ext: string | undefined,
+): IconName | undefined => {
+  switch (ext) {
+    case "csv":
+      return "fileCSV";
+    case "czml":
+      return "fileCzml";
+    case "geojson":
+      return "fileGeoJSON";
+    case "glb":
+      return "fileGlb";
+    case "gltf":
+      return "fileGltf";
+    case "gml":
+      return "fileGml";
+    case "gpkg":
+      return "fileGpkg";
+    case "jpg":
+      return "fileJpg";
+    case "jpeg":
+      return "fileJpeg";
+    case "json":
+      return "fileJson";
+    case "mtl":
+      return "fileMtl";
+    case "obj":
+      return "fileObj";
+    case "png":
+      return "filePng";
+    case "py":
+      return "filePy";
+    case "tif":
+      return "fileTif";
+    case "tiff":
+      return "fileTiff";
+    case "tsv":
+      return "fileTsv";
+    case "zip":
+      return "fileZip";
+    default:
+      return undefined;
+  }
+};

--- a/ui/src/features/AssetsDialog/index.tsx
+++ b/ui/src/features/AssetsDialog/index.tsx
@@ -113,15 +113,6 @@ const AssetsDialog: React.FC<Props> = ({ onDialogClose, onAssetSelect }) => {
                   </SelectContent>
                 </Select>
               </div>
-
-              <IconButton
-                size="icon"
-                variant="outline"
-                className={layoutView === "list" ? "bg-accent" : ""}
-                tooltipText={t("List Layout")}
-                onClick={handleListView}
-                icon={<ListIcon size={"18px"} />}
-              />
               <IconButton
                 size="icon"
                 variant="outline"
@@ -130,8 +121,15 @@ const AssetsDialog: React.FC<Props> = ({ onDialogClose, onAssetSelect }) => {
                 onClick={handleGridView}
                 icon={<SquaresFourIcon size={"18px"} />}
               />
+              <IconButton
+                size="icon"
+                variant="outline"
+                className={layoutView === "list" ? "bg-accent" : ""}
+                tooltipText={t("List Layout")}
+                onClick={handleListView}
+                icon={<ListIcon size={"18px"} />}
+              />
             </div>
-
             <Button
               variant="default"
               onClick={handleAssetUploadClick}

--- a/ui/src/features/WorkspaceAssets/index.tsx
+++ b/ui/src/features/WorkspaceAssets/index.tsx
@@ -109,18 +109,18 @@ const AssetsManager: React.FC = () => {
             <IconButton
               size="icon"
               variant="outline"
-              className={layoutView === "list" ? "bg-accent" : ""}
-              tooltipText={t("List Layout")}
-              onClick={handleListView}
-              icon={<ListIcon size={"18px"} />}
-            />
-            <IconButton
-              size="icon"
-              variant="outline"
               className={layoutView === "grid" ? "bg-accent" : ""}
               tooltipText={t("Grid Layout")}
               onClick={handleGridView}
               icon={<SquaresFourIcon size={"18px"} />}
+            />
+            <IconButton
+              size="icon"
+              variant="outline"
+              className={layoutView === "list" ? "bg-accent" : ""}
+              tooltipText={t("List Layout")}
+              onClick={handleListView}
+              icon={<ListIcon size={"18px"} />}
             />
           </div>
         </div>

--- a/ui/src/hooks/useAssets.ts
+++ b/ui/src/hooks/useAssets.ts
@@ -50,7 +50,7 @@ export default ({ workspaceId }: { workspaceId: string }) => {
     undefined,
   );
 
-  const [layoutView, setLayoutView] = useState<"list" | "grid">("list");
+  const [layoutView, setLayoutView] = useState<"list" | "grid">("grid");
 
   const { page, refetch, isFetching } = useGetAssets(workspaceId, searchTerm, {
     page: currentPage,


### PR DESCRIPTION
# Overview
This PR makes the assets grid the default view and updates asset list rows to show file-type icons using shared icon mapping.
## What I've done
- Defaults asset layout state to grid.
- Reorders grid/list toggle buttons so grid appears first.
- Extracts file-extension-to-icon mapping and reuses it in grid cards and list rows.
## What I haven't done

## How I tested

## Screenshot
<img width="1509" height="855" alt="Screenshot 2026-05-19 at 11 08 20" src="https://github.com/user-attachments/assets/a2402e4a-5fa5-46f6-9014-dd059d37ebc8" />
<img width="1510" height="858" alt="Screenshot 2026-05-19 at 11 08 31" src="https://github.com/user-attachments/assets/6dd33923-3f31-4650-8284-9c6ef01816fb" />
<img width="1508" height="850" alt="Screenshot 2026-05-19 at 11 08 43" src="https://github.com/user-attachments/assets/75d72bd2-c9f7-45ac-911b-246c22c4d29a" />
<img width="1511" height="855" alt="Screenshot 2026-05-19 at 11 08 54" src="https://github.com/user-attachments/assets/b1d6e85c-22f8-4495-9421-6de081061cec" />

## Which point I want you to review particularly

## Memo
