### PR TITLE
chore(ui): remove deprecated dev:secure script [FLOW-DEV-136]

### DIFF
--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -25,8 +25,6 @@ cd server/websocket && cargo run
 
 # Terminal 4: Start UI Development Server
 cd ui && yarn start
-# or, to inject secrets via 1Password CLI:
-cd ui && yarn dev:secure
 ```
 
 ## Cross-Component Workflows

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -7,7 +7,6 @@ React/TypeScript visual workflow builder frontend. See [../AGENTS.md](../AGENTS.
 ```bash
 # Development
 yarn start          # Start dev server on port 3000
-yarn dev:secure     # Start dev server with secrets injected via 1Password CLI (op run)
 yarn test           # Run unit tests with Vitest
 yarn coverage       # Run tests with coverage
 yarn storybook      # Start Storybook on port 6006

--- a/ui/README.md
+++ b/ui/README.md
@@ -25,8 +25,7 @@ yarn
 yarn start
 // or
 yarn storybook
-// or
-yarn dev:secure
+
 ```
 
 For an optimal development experience, make sure you use these vscode settings ([reference]("https://github.com/reearth/eslint-config-reearth/blob/main/.vscode/settings.json")):

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,6 @@
   "private": true,
   "scripts": {
     "start": "yarn && vite",
-    "dev:secure": "op run --env-file=.env -- yarn vite",
     "serve": "vite preview",
     "storybook": "storybook dev -p 6006 --no-open",
     "build": "tsc && vite build",


### PR DESCRIPTION
# Overview
Removes the deprecated `dev:secure` yarn script and its references from documentation.
## What I've done
- Removed `dev:secure` script from `ui/package.json`
- Removed `dev:secure` references from `ui/README.md` and `ui/AGENTS.md`
- Removed `dev:secure` references from `docs/development-guidelines.md`
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
