### PR TITLE
feat(ui): add user focused element handling in various components [FLOW-DEV-133]

### DIFF
--- a/ui/src/features/Canvas/components/Awareness/MultiCursor/index.tsx
+++ b/ui/src/features/Canvas/components/Awareness/MultiCursor/index.tsx
@@ -7,6 +7,9 @@ type MultiCursorProps = {
 };
 
 const MultiCursor: React.FC<MultiCursorProps> = ({ user }) => {
+  if (user.focusedElement) {
+    return null;
+  }
   return (
     <div
       className="pointer-events-none absolute"

--- a/ui/src/features/Editor/components/OverlayUI/components/DebugActionBar/hooks.ts
+++ b/ui/src/features/Editor/components/OverlayUI/components/DebugActionBar/hooks.ts
@@ -10,11 +10,12 @@ export default ({
   onDebugRunStart,
   onDebugRunStop,
   refetchWorkflowVariables,
-
+  onUserFocusedElement,
   customDebugRunWorkflowVariables,
 }: {
   onDebugRunStart: () => Promise<void>;
   onDebugRunStop: () => Promise<void>;
+  onUserFocusedElement?: (isOpen: boolean) => void;
   refetchWorkflowVariables: () => void;
   customDebugRunWorkflowVariables: AnyWorkflowVariable[] | undefined;
 }) => {
@@ -27,15 +28,26 @@ export default ({
     | undefined
   >(undefined);
 
-  const handleShowDebugStartPopover = () => setshowOverlayElement("debugStart");
-  const handleShowDebugStopPopover = () => setshowOverlayElement("debugStop");
-  const handleShowDebugActiveRunsPopover = () =>
+  const handleShowDebugStartPopover = () => {
+    onUserFocusedElement?.(true);
+    setshowOverlayElement("debugStart");
+  };
+  const handleShowDebugStopPopover = () => {
+    onUserFocusedElement?.(true);
+    setshowOverlayElement("debugStop");
+  };
+  const handleShowDebugActiveRunsPopover = () => {
+    onUserFocusedElement?.(true);
     setshowOverlayElement("debugRuns");
+  };
   const handleShowDebugWorkflowVariablesDialog = () => {
     refetchWorkflowVariables();
     setshowOverlayElement("debugWorkflowVariables");
   };
-  const handlePopoverClose = () => setshowOverlayElement(undefined);
+  const handlePopoverClose = () => {
+    onUserFocusedElement?.(false);
+    setshowOverlayElement(undefined);
+  };
   const [debugRunStarted, setDebugRunStarted] = useState(false);
 
   const { useGetJob } = useJob();

--- a/ui/src/features/Editor/components/OverlayUI/components/DebugActionBar/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/DebugActionBar/index.tsx
@@ -19,8 +19,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@flow/components";
-import { useSubscription } from "@flow/lib/gql/subscriptions/useSubscription";
 import { useEditorContext } from "@flow/features/Editor/editorContext";
+import { useSubscription } from "@flow/lib/gql/subscriptions/useSubscription";
 import { useT } from "@flow/lib/i18n";
 import { useIndexedDB } from "@flow/lib/indexedDB";
 import { JobState, useCurrentProject } from "@flow/stores";
@@ -51,6 +51,7 @@ type Props = {
   customDebugRunWorkflowVariables?: AnyWorkflowVariable[];
   onDebugRunVariableValueChange: (index: number, newValue: any) => void;
   refetchWorkflowVariables: () => void;
+  onUserFocusedElement?: (isOpen: boolean) => void;
 };
 
 const DebugActionBar: React.FC<Props> = ({
@@ -64,6 +65,7 @@ const DebugActionBar: React.FC<Props> = ({
   onDebugRunStartFromSelectedNode,
   onDebugRunStop,
   onDebugRunVariableValueChange,
+  onUserFocusedElement,
   refetchWorkflowVariables,
 }) => {
   const t = useT();
@@ -83,6 +85,7 @@ const DebugActionBar: React.FC<Props> = ({
   } = useHooks({
     onDebugRunStart,
     onDebugRunStop,
+    onUserFocusedElement,
     refetchWorkflowVariables,
     customDebugRunWorkflowVariables,
   });

--- a/ui/src/features/Editor/components/OverlayUI/components/Homebar/hooks.ts
+++ b/ui/src/features/Editor/components/OverlayUI/components/Homebar/hooks.ts
@@ -9,7 +9,11 @@ import {
 
 import { DialogOptions } from "../../types";
 
-export default () => {
+export default ({
+  onUserFocusedElement,
+}: {
+  onUserFocusedElement?: (isOpen: boolean) => void;
+}) => {
   const [showDialog, setShowDialog] = useState<DialogOptions>(undefined);
 
   const {
@@ -33,9 +37,13 @@ export default () => {
       refetchWorkflowVariables();
     }
     setShowDialog(dialog);
+    onUserFocusedElement?.(true);
   };
 
-  const handleDialogClose = () => setShowDialog(undefined);
+  const handleDialogClose = () => {
+    setShowDialog(undefined);
+    onUserFocusedElement?.(false);
+  };
 
   const handleWorkflowVariableAdd = useCallback(
     async (workflowVariable: WorkflowVariableType) => {

--- a/ui/src/features/Editor/components/OverlayUI/components/Homebar/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/Homebar/index.tsx
@@ -29,6 +29,7 @@ type Props = {
   onSpotlightUserDeselect: () => void;
   onWorkflowClose: (workflowId: string) => void;
   onWorkflowChange: (workflowId?: string) => void;
+  onUserFocusedElement?: (isOpen: boolean) => void;
 };
 
 const Homebar: React.FC<Props> = ({
@@ -42,6 +43,7 @@ const Homebar: React.FC<Props> = ({
   onSpotlightUserDeselect,
   onWorkflowChange,
   onWorkflowClose,
+  onUserFocusedElement,
 }) => {
   const t = useT();
 
@@ -56,7 +58,9 @@ const Homebar: React.FC<Props> = ({
     handleWorkflowVariablesBatchDelete,
     handleDialogOpen,
     handleDialogClose,
-  } = useHooks();
+  } = useHooks({
+    onUserFocusedElement,
+  });
 
   return (
     <div

--- a/ui/src/features/Editor/components/OverlayUI/components/LayoutOptionsDialog/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/LayoutOptionsDialog/index.tsx
@@ -18,10 +18,7 @@ import {
 import { useT } from "@flow/lib/i18n";
 import type { Algorithm, Direction } from "@flow/types";
 
-import { DialogOptions } from "../../types";
-
 type Props = {
-  showDialog: DialogOptions;
   onClose: () => void;
   onLayoutChange: (
     algorithm: Algorithm,
@@ -30,11 +27,7 @@ type Props = {
   ) => void;
 };
 
-const LayoutOptionsDialog: React.FC<Props> = ({
-  showDialog,
-  onClose,
-  onLayoutChange,
-}) => {
+const LayoutOptionsDialog: React.FC<Props> = ({ onClose, onLayoutChange }) => {
   const t = useT();
 
   const [layoutDirection, setLayoutDirection] =
@@ -65,7 +58,7 @@ const LayoutOptionsDialog: React.FC<Props> = ({
   };
 
   return (
-    <Dialog open={!!showDialog} onOpenChange={(o) => !o && onClose()}>
+    <Dialog open={true} onOpenChange={(o) => !o && onClose()}>
       <DialogContent size="sm" position="top" overlayBgClass="bg-opacity-0">
         <DialogTitle>{t("Layout Options")}</DialogTitle>
         <DialogContentWrapper>

--- a/ui/src/features/Editor/components/OverlayUI/components/LayoutOptionsDialog/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/LayoutOptionsDialog/index.tsx
@@ -18,8 +18,10 @@ import {
 import { useT } from "@flow/lib/i18n";
 import type { Algorithm, Direction } from "@flow/types";
 
+import { DialogOptions } from "../../types";
+
 type Props = {
-  isOpen: boolean;
+  showDialog: DialogOptions;
   onClose: () => void;
   onLayoutChange: (
     algorithm: Algorithm,
@@ -29,7 +31,7 @@ type Props = {
 };
 
 const LayoutOptionsDialog: React.FC<Props> = ({
-  isOpen,
+  showDialog,
   onClose,
   onLayoutChange,
 }) => {
@@ -63,7 +65,7 @@ const LayoutOptionsDialog: React.FC<Props> = ({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+    <Dialog open={!!showDialog} onOpenChange={(o) => !o && onClose()}>
       <DialogContent size="sm" position="top" overlayBgClass="bg-opacity-0">
         <DialogTitle>{t("Layout Options")}</DialogTitle>
         <DialogContentWrapper>

--- a/ui/src/features/Editor/components/OverlayUI/hooks.ts
+++ b/ui/src/features/Editor/components/OverlayUI/hooks.ts
@@ -2,10 +2,20 @@ import { useState } from "react";
 
 import { DialogOptions } from "./types";
 
-export default () => {
+export default ({
+  onUserFocusedElement,
+}: {
+  onUserFocusedElement?: (isOpen: boolean) => void;
+}) => {
   const [showDialog, setShowDialog] = useState<DialogOptions>(undefined);
-  const handleDialogOpen = (dialog: DialogOptions) => setShowDialog(dialog);
-  const handleDialogClose = () => setShowDialog(undefined);
+  const handleDialogOpen = (dialog: DialogOptions) => {
+    setShowDialog(dialog);
+    onUserFocusedElement?.(true);
+  };
+  const handleDialogClose = () => {
+    setShowDialog(undefined);
+    onUserFocusedElement?.(false);
+  };
 
   return {
     showDialog,

--- a/ui/src/features/Editor/components/OverlayUI/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/index.tsx
@@ -224,6 +224,7 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
               onDebugRunStop={onDebugRunStop}
               customDebugRunWorkflowVariables={customDebugRunWorkflowVariables}
               onDebugRunVariableValueChange={onDebugRunVariableValueChange}
+              onUserFocusedElement={onUserFocusedElement}
               refetchWorkflowVariables={refetchWorkflowVariables}
             />
             <div className="h-4/5 border-r" />

--- a/ui/src/features/Editor/components/OverlayUI/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/index.tsx
@@ -277,7 +277,6 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
       </div>
       {showDialog === "layout" && (
         <LayoutOptionsDialog
-          showDialog={showDialog}
           onLayoutChange={onLayoutChange}
           onClose={handleDialogClose}
         />

--- a/ui/src/features/Editor/components/OverlayUI/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/index.tsx
@@ -1,6 +1,6 @@
 import { LockIcon } from "@phosphor-icons/react";
 import { Edge, EdgeChange, NodeChange, type XYPosition } from "@xyflow/react";
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback } from "react";
 import { Doc } from "yjs";
 
 import { useEditorContext } from "@flow/features/Editor/editorContext";
@@ -150,14 +150,18 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
   onUserFocusedElement,
 }) => {
   const { isLocked } = useEditorContext();
-  const [showLayoutOptions, setShowLayoutOptions] = useState(false);
   const { showDialog, handleDialogOpen, handleDialogClose } = useHooks({
     onUserFocusedElement,
   });
 
   const handleLayoutOptionsToggle = useCallback(() => {
-    setShowLayoutOptions((prev) => !prev);
-  }, []);
+    if (showDialog === "layout") {
+      handleDialogClose();
+      return;
+    } else {
+      handleDialogOpen("layout");
+    }
+  }, [showDialog, handleDialogOpen, handleDialogClose]);
 
   const t = useT();
 
@@ -270,11 +274,13 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
           </div>
         </div>
       </div>
-      <LayoutOptionsDialog
-        isOpen={showLayoutOptions}
-        onLayoutChange={onLayoutChange}
-        onClose={handleLayoutOptionsToggle}
-      />
+      {showDialog === "layout" && (
+        <LayoutOptionsDialog
+          showDialog={showDialog}
+          onLayoutChange={onLayoutChange}
+          onClose={handleDialogClose}
+        />
+      )}
       {nodePickerOpen && (
         <ActionPickerDialog
           openedActionType={nodePickerOpen}

--- a/ui/src/features/Editor/components/OverlayUI/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/index.tsx
@@ -95,6 +95,7 @@ type OverlayUIProps = {
   children?: React.ReactNode;
   showSearchPanel: boolean;
   onShowSearchPanel: (open: boolean) => void;
+  onUserFocusedElement?: (isOpen: boolean) => void;
 };
 
 const OverlayUI: React.FC<OverlayUIProps> = ({
@@ -146,10 +147,13 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
   activeUsersDebugRuns,
   showSearchPanel,
   onShowSearchPanel,
+  onUserFocusedElement,
 }) => {
   const { isLocked } = useEditorContext();
   const [showLayoutOptions, setShowLayoutOptions] = useState(false);
-  const { showDialog, handleDialogOpen, handleDialogClose } = useHooks();
+  const { showDialog, handleDialogOpen, handleDialogClose } = useHooks({
+    onUserFocusedElement,
+  });
 
   const handleLayoutOptionsToggle = useCallback(() => {
     setShowLayoutOptions((prev) => !prev);
@@ -199,6 +203,7 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
             onWorkflowClose={onWorkflowClose}
             onSpotlightUserSelect={onSpotlightUserSelect}
             onSpotlightUserDeselect={onSpotlightUserDeselect}
+            onUserFocusedElement={onUserFocusedElement}
           />
         </div>
         <div id="right-top" className="absolute top-2 right-2 h-[42px]">

--- a/ui/src/features/Editor/components/OverlayUI/types.ts
+++ b/ui/src/features/Editor/components/OverlayUI/types.ts
@@ -6,4 +6,5 @@ export type DialogOptions =
   | "debugStop"
   | "workflowVariables"
   | "collaboration"
+  | "layout"
   | undefined;

--- a/ui/src/features/Editor/components/ParamsDialog/index.tsx
+++ b/ui/src/features/Editor/components/ParamsDialog/index.tsx
@@ -43,7 +43,6 @@ type Props = {
   ) => void;
   onWorkflowRename?: (id: string, name: string) => void;
   onParamFieldFocus?: (fieldId: string | null) => void;
-  onUserFocusedElement?: (isOpen: boolean) => void;
 };
 
 const ParamsDialog: React.FC<Props> = ({
@@ -54,7 +53,6 @@ const ParamsDialog: React.FC<Props> = ({
   onDataSubmit,
   onWorkflowRename,
   onParamFieldFocus,
-  onUserFocusedElement,
 }) => {
   const t = useT();
   const { isLocked } = useEditorContext();
@@ -135,11 +133,6 @@ const ParamsDialog: React.FC<Props> = ({
     },
     [setMyDraft],
   );
-
-  useEffect(() => {
-    onUserFocusedElement?.(true);
-    return () => onUserFocusedElement?.(false);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleUpdate = useCallback(
     async (

--- a/ui/src/features/Editor/components/ParamsDialog/index.tsx
+++ b/ui/src/features/Editor/components/ParamsDialog/index.tsx
@@ -136,14 +136,10 @@ const ParamsDialog: React.FC<Props> = ({
     [setMyDraft],
   );
 
-  const onUserFocusedElementRef = useRef(onUserFocusedElement);
-  onUserFocusedElementRef.current = onUserFocusedElement;
   useEffect(() => {
-    onUserFocusedElementRef.current?.(true);
-    return () => {
-      onUserFocusedElementRef.current?.(false);
-    };
-  }, []);
+    onUserFocusedElement?.(true);
+    return () => onUserFocusedElement?.(false);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleUpdate = useCallback(
     async (

--- a/ui/src/features/Editor/components/ParamsDialog/index.tsx
+++ b/ui/src/features/Editor/components/ParamsDialog/index.tsx
@@ -136,9 +136,14 @@ const ParamsDialog: React.FC<Props> = ({
     [setMyDraft],
   );
 
+  const onUserFocusedElementRef = useRef(onUserFocusedElement);
+  onUserFocusedElementRef.current = onUserFocusedElement;
   useEffect(() => {
-    onUserFocusedElement?.(!!openNode);
-  }, [openNode, onUserFocusedElement]);
+    onUserFocusedElementRef.current?.(true);
+    return () => {
+      onUserFocusedElementRef.current?.(false);
+    };
+  }, []);
 
   const handleUpdate = useCallback(
     async (
@@ -175,18 +180,9 @@ const ParamsDialog: React.FC<Props> = ({
       }, "params");
 
       removeMyDraft(id);
-      onUserFocusedElement?.(false);
       onOpenNode();
     },
-    [
-      openNode,
-      rawDrafts,
-      onDataSubmit,
-      yDoc,
-      removeMyDraft,
-      onOpenNode,
-      onUserFocusedElement,
-    ],
+    [openNode, rawDrafts, onDataSubmit, yDoc, removeMyDraft, onOpenNode],
   );
 
   const handleMigrate = useCallback(
@@ -318,9 +314,8 @@ const ParamsDialog: React.FC<Props> = ({
   };
 
   const handleOpenNode = useCallback(() => {
-    onUserFocusedElement?.(false);
     onOpenNode();
-  }, [onOpenNode, onUserFocusedElement]);
+  }, [onOpenNode]);
 
   return (
     <>

--- a/ui/src/features/Editor/components/ParamsDialog/index.tsx
+++ b/ui/src/features/Editor/components/ParamsDialog/index.tsx
@@ -1,5 +1,5 @@
-import { RJSFSchema } from "@rjsf/utils";
 import { GearFineIcon } from "@phosphor-icons/react";
+import { RJSFSchema } from "@rjsf/utils";
 import { useReactFlow } from "@xyflow/react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useY } from "react-yjs";
@@ -43,6 +43,7 @@ type Props = {
   ) => void;
   onWorkflowRename?: (id: string, name: string) => void;
   onParamFieldFocus?: (fieldId: string | null) => void;
+  onUserFocusedElement?: (isOpen: boolean) => void;
 };
 
 const ParamsDialog: React.FC<Props> = ({
@@ -53,6 +54,7 @@ const ParamsDialog: React.FC<Props> = ({
   onDataSubmit,
   onWorkflowRename,
   onParamFieldFocus,
+  onUserFocusedElement,
 }) => {
   const t = useT();
   const { isLocked } = useEditorContext();
@@ -134,6 +136,10 @@ const ParamsDialog: React.FC<Props> = ({
     [setMyDraft],
   );
 
+  useEffect(() => {
+    onUserFocusedElement?.(!!openNode);
+  }, [openNode, onUserFocusedElement]);
+
   const handleUpdate = useCallback(
     async (
       id: string,
@@ -169,9 +175,18 @@ const ParamsDialog: React.FC<Props> = ({
       }, "params");
 
       removeMyDraft(id);
+      onUserFocusedElement?.(false);
       onOpenNode();
     },
-    [openNode, rawDrafts, onDataSubmit, yDoc, removeMyDraft, onOpenNode],
+    [
+      openNode,
+      rawDrafts,
+      onDataSubmit,
+      yDoc,
+      removeMyDraft,
+      onOpenNode,
+      onUserFocusedElement,
+    ],
   );
 
   const handleMigrate = useCallback(
@@ -302,9 +317,14 @@ const ParamsDialog: React.FC<Props> = ({
     updateMyFieldPatch(openNode.id, "paramsPatch", path, value);
   };
 
+  const handleOpenNode = useCallback(() => {
+    onUserFocusedElement?.(false);
+    onOpenNode();
+  }, [onOpenNode, onUserFocusedElement]);
+
   return (
     <>
-      <Dialog open={!!openNode} onOpenChange={() => onOpenNode()}>
+      <Dialog open={!!openNode} onOpenChange={handleOpenNode}>
         <DialogContent size="2xl">
           <DialogHeader>
             <DialogTitle>

--- a/ui/src/features/Editor/hooks.ts
+++ b/ui/src/features/Editor/hooks.ts
@@ -315,8 +315,8 @@ export default ({
           if (hasModifier) handleProjectLockChange?.(!isLocked);
           break;
         case "k":
-          if (hasModifier && !showSearchPanel) setShowSearchPanel(true);
-          if (hasModifier && showSearchPanel) setShowSearchPanel(false);
+          if (hasModifier && !showSearchPanel) handleShowSearchPanel(true);
+          if (hasModifier && showSearchPanel) handleShowSearchPanel(false);
 
           break;
         case "z":
@@ -358,6 +358,14 @@ export default ({
     openNode,
     yAwareness,
   });
+
+  const handleShowSearchPanel = useCallback(
+    (open: boolean) => {
+      setShowSearchPanel(open);
+      handleUserFocusedElement?.(open);
+    },
+    [setShowSearchPanel, handleUserFocusedElement],
+  );
 
   const {
     nodePickerOpen,
@@ -490,7 +498,7 @@ export default ({
     handleSpotlightUserDeselect,
     handlePaneClick,
     selectedNodeIds,
-    setShowSearchPanel,
+    handleShowSearchPanel,
     handlePointerDown,
     handleConnectStart,
     handleConnectEnd,

--- a/ui/src/features/Editor/hooks.ts
+++ b/ui/src/features/Editor/hooks.ts
@@ -305,7 +305,9 @@ export default ({
 
   const handleOpenNode = useCallback(
     (nodeId?: string) => {
-      setOpenNodeId((prev) => (!nodeId || prev === nodeId ? undefined : nodeId));
+      setOpenNodeId((prev) =>
+        !nodeId || prev === nodeId ? undefined : nodeId,
+      );
       handleUserFocusedElement(!!nodeId);
     },
     [handleUserFocusedElement],

--- a/ui/src/features/Editor/hooks.ts
+++ b/ui/src/features/Editor/hooks.ts
@@ -298,6 +298,29 @@ export default ({
   const handleDeleteDialogClose = () => setShowBeforeDeleteDialog(false);
   const [showSearchPanel, setShowSearchPanel] = useState<boolean>(false);
 
+  const {
+    self,
+    users,
+    awarenessSelectionsMap,
+    handlePointerDown,
+    handleParamFieldFocus,
+    handleUserFocusedElement,
+    setDraggingEdge,
+    clearDraggingEdge,
+  } = useAwarenessPresence({
+    selectedNodeIds,
+    openNode,
+    yAwareness,
+  });
+
+  const handleShowSearchPanel = useCallback(
+    (open: boolean) => {
+      setShowSearchPanel(open);
+      handleUserFocusedElement?.(open);
+    },
+    [setShowSearchPanel, handleUserFocusedElement],
+  );
+
   useHotkeys(
     EDITOR_HOT_KEYS,
     (event, handler) => {
@@ -343,29 +366,6 @@ export default ({
       handleProjectExport({ yDoc, project: currentProject });
     }
   };
-
-  const {
-    self,
-    users,
-    awarenessSelectionsMap,
-    handlePointerDown,
-    handleParamFieldFocus,
-    handleUserFocusedElement,
-    setDraggingEdge,
-    clearDraggingEdge,
-  } = useAwarenessPresence({
-    selectedNodeIds,
-    openNode,
-    yAwareness,
-  });
-
-  const handleShowSearchPanel = useCallback(
-    (open: boolean) => {
-      setShowSearchPanel(open);
-      handleUserFocusedElement?.(open);
-    },
-    [setShowSearchPanel, handleUserFocusedElement],
-  );
 
   const {
     nodePickerOpen,

--- a/ui/src/features/Editor/hooks.ts
+++ b/ui/src/features/Editor/hooks.ts
@@ -180,19 +180,9 @@ export default ({
     setCurrentWorkflowId,
   });
 
-  const handleOpenNode = useCallback((nodeId?: string) => {
-    setOpenNodeId((prev) => (!nodeId || prev === nodeId ? undefined : nodeId));
-  }, []);
-
   // Passed to editor context so needs to be a ref
   const handleNodeSettingsClickRef =
     useRef<(e: MouseEvent | undefined, nodeId: string) => void>(undefined);
-  handleNodeSettingsClickRef.current = (
-    _e: MouseEvent | undefined,
-    nodeId: string,
-  ) => {
-    handleOpenNode(nodeId);
-  };
 
   const handleNodeSettings = useCallback(
     (e: MouseEvent | undefined, nodeId: string) =>
@@ -312,6 +302,21 @@ export default ({
     openNode,
     yAwareness,
   });
+
+  const handleOpenNode = useCallback(
+    (nodeId?: string) => {
+      setOpenNodeId((prev) => (!nodeId || prev === nodeId ? undefined : nodeId));
+      handleUserFocusedElement(!!nodeId);
+    },
+    [handleUserFocusedElement],
+  );
+
+  handleNodeSettingsClickRef.current = (
+    _e: MouseEvent | undefined,
+    nodeId: string,
+  ) => {
+    handleOpenNode(nodeId);
+  };
 
   const handleShowSearchPanel = useCallback(
     (open: boolean) => {

--- a/ui/src/features/Editor/hooks.ts
+++ b/ui/src/features/Editor/hooks.ts
@@ -213,13 +213,6 @@ export default ({
     handleEdgesChange: handleYEdgesChange,
   });
 
-  const {
-    nodePickerOpen,
-    openNodePickerViaShortcut,
-    handleNodePickerOpen,
-    handleNodePickerClose,
-  } = useUIState();
-
   const { allowedToDeploy, handleWorkflowDeployment } = useDeployment({
     currentNodes: nodes,
     yWorkflows,
@@ -357,6 +350,7 @@ export default ({
     awarenessSelectionsMap,
     handlePointerDown,
     handleParamFieldFocus,
+    handleUserFocusedElement,
     setDraggingEdge,
     clearDraggingEdge,
   } = useAwarenessPresence({
@@ -364,6 +358,13 @@ export default ({
     openNode,
     yAwareness,
   });
+
+  const {
+    nodePickerOpen,
+    openNodePickerViaShortcut,
+    handleNodePickerOpen,
+    handleNodePickerClose,
+  } = useUIState({ onUserFocusedElement: handleUserFocusedElement });
 
   const {
     spotlightUser,
@@ -495,5 +496,6 @@ export default ({
     handleConnectEnd,
     awarenessSelectionsMap,
     handleParamFieldFocus,
+    handleUserFocusedElement,
   };
 };

--- a/ui/src/features/Editor/index.tsx
+++ b/ui/src/features/Editor/index.tsx
@@ -98,7 +98,7 @@ export default function Editor({
     handleParamFieldFocus,
     handleUserFocusedElement,
     awarenessSelectionsMap,
-    setShowSearchPanel,
+    handleShowSearchPanel,
     selectedNodeIds,
   } = useHooks({
     yDoc,
@@ -182,7 +182,7 @@ export default function Editor({
             onDebugRunJoin={loadExternalDebugJob}
             activeUsersDebugRuns={activeUsersDebugRuns}
             showSearchPanel={showSearchPanel}
-            onShowSearchPanel={setShowSearchPanel}
+            onShowSearchPanel={handleShowSearchPanel}
             onUserFocusedElement={handleUserFocusedElement}>
             <Canvas
               nodes={nodes}

--- a/ui/src/features/Editor/index.tsx
+++ b/ui/src/features/Editor/index.tsx
@@ -224,7 +224,6 @@ export default function Editor({
               onDataSubmit={handleNodesDataUpdate}
               onWorkflowRename={handleWorkflowRename}
               onParamFieldFocus={handleParamFieldFocus}
-              onUserFocusedElement={handleUserFocusedElement}
             />
           )}
           {showBeforeDeleteDialog && (

--- a/ui/src/features/Editor/index.tsx
+++ b/ui/src/features/Editor/index.tsx
@@ -96,6 +96,7 @@ export default function Editor({
     handleConnectStart,
     handleConnectEnd,
     handleParamFieldFocus,
+    handleUserFocusedElement,
     awarenessSelectionsMap,
     setShowSearchPanel,
     selectedNodeIds,
@@ -181,7 +182,8 @@ export default function Editor({
             onDebugRunJoin={loadExternalDebugJob}
             activeUsersDebugRuns={activeUsersDebugRuns}
             showSearchPanel={showSearchPanel}
-            onShowSearchPanel={setShowSearchPanel}>
+            onShowSearchPanel={setShowSearchPanel}
+            onUserFocusedElement={handleUserFocusedElement}>
             <Canvas
               nodes={nodes}
               edges={edges}
@@ -222,6 +224,7 @@ export default function Editor({
               onDataSubmit={handleNodesDataUpdate}
               onWorkflowRename={handleWorkflowRename}
               onParamFieldFocus={handleParamFieldFocus}
+              onUserFocusedElement={handleUserFocusedElement}
             />
           )}
           {showBeforeDeleteDialog && (

--- a/ui/src/features/Editor/useUIState.ts
+++ b/ui/src/features/Editor/useUIState.ts
@@ -3,7 +3,11 @@ import { useCallback, useState } from "react";
 
 import type { ActionNodeType } from "@flow/types";
 
-export default () => {
+export default ({
+  onUserFocusedElement,
+}: {
+  onUserFocusedElement?: (isOpen: boolean) => void;
+}) => {
   const [nodePickerOpen, setNodePickerOpen] = useState<
     { position: XYPosition; nodeType: ActionNodeType } | undefined
   >(undefined);
@@ -21,14 +25,16 @@ export default () => {
       if (openViaShortcut) {
         setOpenNodePickerViaShortcut(true);
       }
+      onUserFocusedElement?.(true);
     },
-    [],
+    [onUserFocusedElement],
   );
 
   const handleNodePickerClose = useCallback(() => {
     setNodePickerOpen(undefined);
     setOpenNodePickerViaShortcut(false);
-  }, []);
+    onUserFocusedElement?.(false);
+  }, [onUserFocusedElement]);
 
   return {
     nodePickerOpen,

--- a/ui/src/lib/yjs/useAwarenessPresence.test.ts
+++ b/ui/src/lib/yjs/useAwarenessPresence.test.ts
@@ -219,6 +219,65 @@ describe("useAwarenessPresence", () => {
     );
   });
 
+  it("skips cursor updates when focusedElement is true", () => {
+    const { result } = renderHook(() =>
+      useAwarenessPresence({
+        yAwareness: awareness,
+        selectedNodeIds: [],
+        openNode: undefined,
+      }),
+    );
+
+    act(() => {
+      result.current.handleUserFocusedElement(true);
+    });
+
+    vi.mocked(awareness.setLocalStateField).mockClear();
+
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent("pointermove", { clientX: 50, clientY: 60 }),
+      );
+    });
+
+    expect(awareness.setLocalStateField).not.toHaveBeenCalledWith(
+      "cursor",
+      expect.anything(),
+    );
+    expect(awareness.setLocalStateField).not.toHaveBeenCalledWith(
+      "viewport",
+      expect.anything(),
+    );
+  });
+
+  it("resumes cursor updates after focusedElement becomes false", () => {
+    const { result } = renderHook(() =>
+      useAwarenessPresence({
+        yAwareness: awareness,
+        selectedNodeIds: [],
+        openNode: undefined,
+      }),
+    );
+
+    act(() => {
+      result.current.handleUserFocusedElement(true);
+      result.current.handleUserFocusedElement(false);
+    });
+
+    vi.mocked(awareness.setLocalStateField).mockClear();
+
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent("pointermove", { clientX: 50, clientY: 60 }),
+      );
+    });
+
+    expect(awareness.setLocalStateField).toHaveBeenCalledWith("cursor", {
+      x: 50,
+      y: 60,
+    });
+  });
+
   it("syncs openNode prop to awareness field and clears focusedParamField when closed", () => {
     const { rerender } = renderHook(
       ({ openNode }: { openNode: Node | undefined }) =>

--- a/ui/src/lib/yjs/useAwarenessPresence.ts
+++ b/ui/src/lib/yjs/useAwarenessPresence.ts
@@ -179,6 +179,13 @@ export default function useAwarenessPresence({
     [yAwareness],
   );
 
+  const handleUserFocusedElement = useCallback(
+    (isOpen: boolean) => {
+      yAwareness.setLocalStateField("focusedElement", isOpen);
+    },
+    [yAwareness],
+  );
+
   useEffect(() => {
     const handleWindowPointerMove = (event: PointerEvent) => {
       throttledPresenceUpdate(event.clientX, event.clientY);
@@ -243,6 +250,7 @@ export default function useAwarenessPresence({
     awarenessSelectionsMap,
     handlePointerDown,
     handleParamFieldFocus,
+    handleUserFocusedElement,
     setDraggingEdge,
     clearDraggingEdge,
   };

--- a/ui/src/lib/yjs/useAwarenessPresence.ts
+++ b/ui/src/lib/yjs/useAwarenessPresence.ts
@@ -188,6 +188,8 @@ export default function useAwarenessPresence({
 
   useEffect(() => {
     const handleWindowPointerMove = (event: PointerEvent) => {
+      if (yAwareness.getLocalState()?.focusedElement) return;
+      console.log("TEST: pointer move", { x: event.clientX, y: event.clientY });
       throttledPresenceUpdate(event.clientX, event.clientY);
       const awarenessStates = yAwareness.getStates();
       if (awarenessStates.size > 1) {

--- a/ui/src/lib/yjs/useAwarenessPresence.ts
+++ b/ui/src/lib/yjs/useAwarenessPresence.ts
@@ -189,7 +189,6 @@ export default function useAwarenessPresence({
   useEffect(() => {
     const handleWindowPointerMove = (event: PointerEvent) => {
       if (yAwareness.getLocalState()?.focusedElement) return;
-      console.log("TEST: pointer move", { x: event.clientX, y: event.clientY });
       throttledPresenceUpdate(event.clientX, event.clientY);
       const awarenessStates = yAwareness.getStates();
       if (awarenessStates.size > 1) {

--- a/ui/src/types/user.ts
+++ b/ui/src/types/user.ts
@@ -53,6 +53,7 @@ export type AwarenessUser = {
     y: number;
     zoom: number;
   };
+  focusedElement?: boolean;
   openNodeId?: string | null;
   focusedParamField?: string | null;
   color: string;


### PR DESCRIPTION
# Overview
Adds a `focusedElement` field to the Yjs awareness state so collaborators' cursors can be suppressed while they're interacting with modal/popover UI (action picker, params dialog, layout options, debug popovers, search panel, homebar dialogs). A new `handleUserFocusedElement` awareness setter is threaded through the Editor, OverlayUI, Homebar, DebugActionBar, ParamsDialog and `useUIState` hook, and `MultiCursor` hides remote cursors when the remote user has `focusedElement` set.

The general trend with the PR is that essentially if a user is either in a dialog or a popover then their cursor will no longer show for other users.
## What I've done
- Add `focusedElement?: boolean` to `AwarenessUser` and a `handleUserFocusedElement` setter in `useAwarenessPresence`.
- Propagate `onUserFocusedElement` callbacks through Editor → OverlayUI / ParamsDialog / Homebar / DebugActionBar / `useUIState`, and call it from open/close handlers (including a new `handleShowSearchPanel` wrapper and refactor of `LayoutOptionsDialog` to use the shared `DialogOptions` state).
- `MultiCursor` returns null when the remote `user.focusedElement` is true.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo