### PR TITLE
refactor(engine/sink): introduce SinkOutput abstraction

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7037,7 +7037,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "approx",
  "bvh",
@@ -7067,7 +7067,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7101,7 +7101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7110,7 +7110,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7140,7 +7140,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7174,7 +7174,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7191,7 +7191,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7203,7 +7203,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "bytes",
  "futures",
@@ -7220,7 +7220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "bytes",
  "futures",
@@ -7239,7 +7239,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7253,7 +7253,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7288,7 +7288,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7326,7 +7326,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.370"
+version = "0.0.371"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.370"
+version = "0.0.371"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/pipeline.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/pipeline.rs
@@ -2,7 +2,6 @@ use std::{
     convert::Infallible,
     fs,
     io::BufWriter,
-    path::Path,
     sync::{
         mpsc::{self},
         Arc, Mutex,
@@ -18,6 +17,7 @@ use nusamai_projection::cartesian::geodetic_to_geocentric;
 use rayon::prelude::*;
 use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::executor_operation::Context;
+use reearth_flow_runtime::executor_operation::NodeContext;
 use reearth_flow_types::Feature;
 use tempfile::tempdir;
 
@@ -372,6 +372,10 @@ pub(super) fn tile_writing_stage(
 ) -> crate::errors::Result<()> {
     let contents: Arc<Mutex<Vec<TileContent>>> = Default::default();
 
+    let node_ctx = NodeContext::from(ctx.clone());
+    let sink_out = crate::SinkOutput::from_path(&node_ctx, output_path.as_str())
+        .map_err(crate::errors::SinkError::cesium3dtiles_writer)?;
+
     // Pre-initialize property_stats from schema to preserve attribute order
     let property_stats: Arc<Mutex<IndexMap<String, PropertyMetadata>>> = {
         let mut stats = IndexMap::new();
@@ -463,13 +467,9 @@ pub(super) fn tile_writing_stage(
             )
             .map_err(crate::errors::SinkError::cesium3dtiles_writer)?;
 
-            let storage = ctx
-                .storage_resolver
-                .resolve(&output_path)
-                .map_err(crate::errors::SinkError::cesium3dtiles_writer)?;
-            let output_file_path = output_path.path().join(Path::new(&content_path));
-            storage
-                .put_sync(Path::new(&output_file_path), bytes::Bytes::from(buffer))
+            sink_out
+                .join(&content_path)
+                .and_then(|tile_out| tile_out.write(bytes::Bytes::from(buffer)))
                 .map_err(crate::errors::SinkError::cesium3dtiles_writer)?;
 
             Ok::<(), crate::errors::SinkError>(())
@@ -525,18 +525,11 @@ pub(super) fn tile_writing_stage(
         ..Default::default()
     };
 
-    let storage = ctx
-        .storage_resolver
-        .resolve(&output_path)
-        .map_err(crate::errors::SinkError::cesium3dtiles_writer)?;
-
-    let root_tileset_path = output_path
-        .join(Path::new("tileset.json"))
-        .map_err(crate::errors::SinkError::cesium3dtiles_writer)?;
     let tileset_json = serde_json::to_string_pretty(&tileset)
         .map_err(crate::errors::SinkError::cesium3dtiles_writer)?;
-    storage
-        .put_sync(Path::new(&root_tileset_path.path()), tileset_json.into())
+    sink_out
+        .join("tileset.json")
+        .and_then(|manifest_out| manifest_out.write(tileset_json.into()))
         .map_err(crate::errors::SinkError::cesium3dtiles_writer)?;
 
     Ok(())

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     io::{BufWriter, Cursor},
+    str::FromStr,
     sync::Arc,
     time, vec,
 };
@@ -216,18 +217,14 @@ impl Cesium3DTilesWriter {
         let path = scope
             .eval_ast::<String>(&output)
             .map_err(|e| SinkError::Cesium3DTilesWriter(format!("{e:?}")))?;
-        let node_ctx = NodeContext::from(ctx.clone());
-        let output_sink = crate::SinkOutput::from_path(&node_ctx, path.as_str())
-            .map_err(SinkError::cesium3dtiles_writer)?;
-        let output = output_sink.uri().clone();
+        // URI parse only; SinkOutput is constructed once at write time in pipeline.rs (see MVT pattern).
+        let output = Uri::from_str(path.as_str()).map_err(SinkError::cesium3dtiles_writer)?;
         let compress_output = if let Some(compress_output) = &self.params.compress_output {
             let compress_output = compress_output.clone();
             let path = scope
                 .eval_ast::<String>(&compress_output)
                 .map_err(|e| SinkError::Cesium3DTilesWriter(format!("{e:?}")))?;
-            let compress_sink = crate::SinkOutput::from_path(&node_ctx, path.as_str())
-                .map_err(SinkError::cesium3dtiles_writer)?;
-            Some(compress_sink.uri().clone())
+            Some(Uri::from_str(path.as_str()).map_err(SinkError::cesium3dtiles_writer)?)
         } else {
             None
         };

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::HashMap,
     io::{BufWriter, Cursor},
-    str::FromStr,
     sync::Arc,
     time, vec,
 };
@@ -217,13 +216,18 @@ impl Cesium3DTilesWriter {
         let path = scope
             .eval_ast::<String>(&output)
             .map_err(|e| SinkError::Cesium3DTilesWriter(format!("{e:?}")))?;
-        let output = Uri::from_str(path.as_str()).map_err(SinkError::cesium3dtiles_writer)?;
+        let node_ctx = NodeContext::from(ctx.clone());
+        let output_sink = crate::SinkOutput::from_path(&node_ctx, path.as_str())
+            .map_err(SinkError::cesium3dtiles_writer)?;
+        let output = output_sink.uri().clone();
         let compress_output = if let Some(compress_output) = &self.params.compress_output {
             let compress_output = compress_output.clone();
             let path = scope
                 .eval_ast::<String>(&compress_output)
                 .map_err(|e| SinkError::Cesium3DTilesWriter(format!("{e:?}")))?;
-            Some(Uri::from_str(path.as_str()).map_err(SinkError::cesium3dtiles_writer)?)
+            let compress_sink = crate::SinkOutput::from_path(&node_ctx, path.as_str())
+                .map_err(SinkError::cesium3dtiles_writer)?;
+            Some(compress_sink.uri().clone())
         } else {
             None
         };
@@ -423,67 +427,86 @@ impl Cesium3DTilesWriter {
                         );
 
                         if let Some(compress_output) = compress_output {
-                            if let Ok(storage) = ctx.storage_resolver.resolve(compress_output) {
-                                let now = time::Instant::now();
-                                let buffer = Vec::new();
-                                let mut cursor = Cursor::new(buffer);
-                                let writer = BufWriter::new(&mut cursor);
-                                let zip_result = reearth_flow_common::zip::write(
-                                    writer,
-                                    output.path().as_path(),
-                                )
-                                .map_err(|e| {
-                                    crate::errors::SinkError::cesium3dtiles_writer(e.to_string())
-                                });
-                                match zip_result {
-                                    Ok(_) => {
-                                        match storage
-                                            .put_sync(
-                                                compress_output.path().as_path(),
-                                                bytes::Bytes::from(cursor.into_inner()),
-                                            )
-                                            .map_err(crate::errors::SinkError::cesium3dtiles_writer)
-                                        {
-                                            Ok(_) => {
-                                                match std::fs::remove_dir_all(
-                                                    output.path().as_path(),
-                                                ) {
-                                                    Ok(_) => {}
-                                                    Err(e) => {
-                                                        ctx.event_hub.error_log(
-                                                            None,
-                                                            format!(
-                                                    "Failed to remove directory with error = {e:?}"
-                                                ),
-                                                        );
+                            let compress_node_ctx = NodeContext::from(ctx.clone());
+                            match crate::SinkOutput::from_path(
+                                &compress_node_ctx,
+                                compress_output.as_str(),
+                            ) {
+                                Ok(compress_sink_out) => {
+                                    let now = time::Instant::now();
+                                    let buffer = Vec::new();
+                                    let mut cursor = Cursor::new(buffer);
+                                    let writer = BufWriter::new(&mut cursor);
+                                    let zip_result = reearth_flow_common::zip::write(
+                                        writer,
+                                        output.path().as_path(),
+                                    )
+                                    .map_err(|e| {
+                                        crate::errors::SinkError::cesium3dtiles_writer(
+                                            e.to_string(),
+                                        )
+                                    });
+                                    match zip_result {
+                                        Ok(_) => {
+                                            match compress_sink_out
+                                                .write(bytes::Bytes::from(cursor.into_inner()))
+                                                .map_err(|e| {
+                                                    crate::errors::SinkError::cesium3dtiles_writer(
+                                                        e.to_string(),
+                                                    )
+                                                })
+                                            {
+                                                Ok(_) => {
+                                                    match std::fs::remove_dir_all(
+                                                        output.path().as_path(),
+                                                    ) {
+                                                        Ok(_) => {}
+                                                        Err(e) => {
+                                                            ctx.event_hub.error_log(
+                                                                None,
+                                                                format!(
+                                                        "Failed to remove directory with error = {e:?}"
+                                                    ),
+                                                            );
+                                                        }
                                                     }
                                                 }
-                                            }
-                                            Err(e) => {
-                                                ctx.event_hub.error_log(
-                                                    None,
-                                                    format!(
-                                                    "Failed to write zip file with error = {e:?}"
-                                                ),
-                                                );
+                                                Err(e) => {
+                                                    ctx.event_hub.error_log(
+                                                        None,
+                                                        format!(
+                                                        "Failed to write zip file with error = {e:?}"
+                                                    ),
+                                                    );
+                                                }
                                             }
                                         }
+                                        Err(e) => {
+                                            ctx.event_hub.error_log(
+                                                None,
+                                                format!(
+                                                    "Failed to write zip file with error = {e:?}"
+                                                ),
+                                            );
+                                        }
                                     }
-                                    Err(e) => {
-                                        ctx.event_hub.error_log(
-                                            None,
-                                            format!("Failed to write zip file with error = {e:?}"),
-                                        );
-                                    }
+                                    ctx.event_hub.info_log(
+                                        None,
+                                        format!(
+                                            "Finish write zip file. elapsed = {:?}, output = {}",
+                                            now.elapsed(),
+                                            output
+                                        ),
+                                    );
                                 }
-                                ctx.event_hub.info_log(
-                                    None,
-                                    format!(
-                                        "Finish write zip file. elapsed = {:?}, output = {}",
-                                        now.elapsed(),
-                                        output
-                                    ),
-                                );
+                                Err(e) => {
+                                    ctx.event_hub.error_log(
+                                        None,
+                                        format!(
+                                            "Failed to resolve compress output with error = {e:?}"
+                                        ),
+                                    );
+                                }
                             }
                         }
                     });

--- a/engine/runtime/action-sink/src/file/citygml.rs
+++ b/engine/runtime/action-sink/src/file/citygml.rs
@@ -339,16 +339,11 @@ impl Sink for CityGmlWriterSink {
     }
 
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let expr_engine = Arc::clone(&ctx.expr_engine);
-        let scope = expr_engine.new_scope();
-
-        let path = scope
-            .eval::<String>(self.params.output.as_ref())
-            .unwrap_or_else(|_| self.params.output.as_ref().to_string());
-        let output_uri = Uri::from_str(&path)?;
+        let out = crate::SinkOutput::from_expr(&ctx, &self.params.output)
+            .map_err(|e| SinkError::CityGmlWriter(e.to_string()))?;
 
         write_citygml_to_storage(
-            &output_uri,
+            out.uri(),
             &self.buffer,
             &self.lod_mask,
             self.params.epsg_code,

--- a/engine/runtime/action-sink/src/file/citygml.rs
+++ b/engine/runtime/action-sink/src/file/citygml.rs
@@ -339,7 +339,11 @@ impl Sink for CityGmlWriterSink {
     }
 
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let out = crate::SinkOutput::from_expr(&ctx, &self.params.output)
+        let scope = ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(self.params.output.as_ref())
+            .unwrap_or_else(|_| self.params.output.as_ref().to_string());
+        let out = crate::SinkOutput::from_path(&ctx, &path)
             .map_err(|e| SinkError::CityGmlWriter(e.to_string()))?;
 
         write_citygml_to_storage(

--- a/engine/runtime/action-sink/src/file/csv.rs
+++ b/engine/runtime/action-sink/src/file/csv.rs
@@ -120,13 +120,20 @@ impl Sink for CsvWriter {
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let node_ctx: NodeContext = ctx.clone().into();
-        let out = SinkOutput::from_expr(&node_ctx, &self.params.output)
+        let (path, uri) = crate::SinkOutput::evaluate_uri(&node_ctx, &self.params.output)
             .map_err(|e| SinkError::CsvWriter(e.to_string()))?;
-        self.buffer
-            .entry(out.uri().clone())
-            .or_insert_with(|| (out, Vec::new()))
-            .1
-            .push(ctx.feature);
+        let feature = ctx.feature.clone();
+        use std::collections::hash_map::Entry;
+        match self.buffer.entry(uri) {
+            Entry::Occupied(mut e) => {
+                e.get_mut().1.push(feature);
+            }
+            Entry::Vacant(e) => {
+                let out = crate::SinkOutput::from_path(&node_ctx, &path)
+                    .map_err(|e| SinkError::CsvWriter(e.to_string()))?;
+                e.insert((out, vec![feature]));
+            }
+        }
         Ok(())
     }
 

--- a/engine/runtime/action-sink/src/file/csv.rs
+++ b/engine/runtime/action-sink/src/file/csv.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use bytes::Bytes;
 use reearth_flow_common::csv::Delimiter;
@@ -120,8 +121,12 @@ impl Sink for CsvWriter {
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let node_ctx: NodeContext = ctx.clone().into();
-        let (path, uri) = crate::SinkOutput::evaluate_uri(&node_ctx, &self.params.output)
-            .map_err(|e| SinkError::CsvWriter(e.to_string()))?;
+        let scope = node_ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(self.params.output.as_ref())
+            .unwrap_or_else(|_| self.params.output.as_ref().to_string());
+        let uri = Uri::from_str(&path)
+            .map_err(|e| SinkError::CsvWriter(format!("invalid path {:?}: {e}", path)))?;
         let feature = ctx.feature.clone();
         use std::collections::hash_map::Entry;
         match self.buffer.entry(uri) {

--- a/engine/runtime/action-sink/src/file/csv.rs
+++ b/engine/runtime/action-sink/src/file/csv.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::str::FromStr;
-use std::sync::Arc;
 
 use bytes::Bytes;
 use reearth_flow_common::csv::Delimiter;
@@ -9,13 +7,13 @@ use reearth_flow_runtime::errors::BoxedError;
 use reearth_flow_runtime::event::EventHub;
 use reearth_flow_runtime::executor_operation::{ExecutorContext, NodeContext};
 use reearth_flow_runtime::node::{Port, Sink, SinkFactory, DEFAULT_PORT};
-use reearth_flow_storage::resolve::StorageResolver;
 use reearth_flow_types::{AttributeValue, Expr, Feature};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::errors::SinkError;
+use crate::SinkOutput;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct CsvWriterFactory;
@@ -76,7 +74,7 @@ impl SinkFactory for CsvWriterFactory {
 #[derive(Debug, Clone)]
 pub(super) struct CsvWriter {
     pub(super) params: CsvWriterParam,
-    pub(super) buffer: HashMap<Uri, Vec<Feature>>,
+    pub(super) buffer: HashMap<Uri, (SinkOutput, Vec<Feature>)>,
 }
 
 /// # CsvWriter Parameters
@@ -121,26 +119,24 @@ impl Sink for CsvWriter {
     }
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
-        let expr_engine = Arc::clone(&ctx.expr_engine);
-        let scope = expr_engine.new_scope();
-        let output = &self.params.output;
-        let path = scope
-            .eval::<String>(output.as_ref())
-            .unwrap_or_else(|_| output.as_ref().to_string());
-        let uri = Uri::from_str(&path)?;
-        self.buffer.entry(uri).or_default().push(ctx.feature);
+        let node_ctx: NodeContext = ctx.clone().into();
+        let out = SinkOutput::from_expr(&node_ctx, &self.params.output)
+            .map_err(|e| SinkError::CsvWriter(e.to_string()))?;
+        self.buffer
+            .entry(out.uri().clone())
+            .or_insert_with(|| (out, Vec::new()))
+            .1
+            .push(ctx.feature);
         Ok(())
     }
 
-    fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let storage_resolver = Arc::clone(&ctx.storage_resolver);
+    fn finish(&self, _ctx: NodeContext) -> Result<(), BoxedError> {
         let delimiter = self.params.format.delimiter();
-        for (uri, features) in &self.buffer {
+        for (out, features) in self.buffer.values() {
             write_csv(
-                uri,
+                out,
                 features,
                 delimiter.clone(),
-                &storage_resolver,
                 self.params.geometry.as_ref(),
             )?;
         }
@@ -149,10 +145,9 @@ impl Sink for CsvWriter {
 }
 
 fn write_csv(
-    output: &Uri,
+    out: &SinkOutput,
     features: &[Feature],
     delimiter: Delimiter,
-    storage_resolver: &Arc<StorageResolver>,
     geometry_config: Option<&super::writer_geometry::GeometryExportConfig>,
 ) -> Result<(), crate::errors::SinkError> {
     if features.is_empty() {
@@ -264,11 +259,7 @@ fn write_csv(
             .map_err(|e| crate::errors::SinkError::CsvWriter(format!("{e:?}")))?,
     )
     .map_err(|e| crate::errors::SinkError::CsvWriter(format!("{e:?}")))?;
-    let storage = storage_resolver
-        .resolve(output)
-        .map_err(|e| crate::errors::SinkError::CsvWriter(format!("{e:?}")))?;
-    storage
-        .put_sync(output.path().as_path(), Bytes::from(data))
+    out.write(Bytes::from(data))
         .map_err(|e| crate::errors::SinkError::CsvWriter(format!("{e:?}")))?;
     Ok(())
 }

--- a/engine/runtime/action-sink/src/file/czml.rs
+++ b/engine/runtime/action-sink/src/file/czml.rs
@@ -302,7 +302,11 @@ impl Sink for CzmlWriter {
         Ok(())
     }
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let base = crate::SinkOutput::from_expr(&ctx, &self.params.output)
+        let scope = ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(self.params.output.as_ref())
+            .unwrap_or_else(|_| self.params.output.as_ref().to_string());
+        let base = crate::SinkOutput::from_path(&ctx, &path)
             .map_err(crate::errors::SinkError::czml_writer)?;
 
         for (key, features) in self.buffer.iter() {

--- a/engine/runtime/action-sink/src/file/czml.rs
+++ b/engine/runtime/action-sink/src/file/czml.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::io::Write;
-use std::str::FromStr;
-use std::sync::Arc;
 use std::vec;
 
 use bytes::Bytes;
@@ -13,7 +11,6 @@ use nusamai_czml::{
 };
 use rayon::iter::{ParallelBridge, ParallelIterator};
 use reearth_flow_common::str::to_hash;
-use reearth_flow_common::uri::Uri;
 use reearth_flow_geometry::types::geometry::{Geometry2D, Geometry3D};
 use reearth_flow_geometry::types::polygon::Polygon3D;
 use reearth_flow_runtime::errors::BoxedError;
@@ -305,24 +302,16 @@ impl Sink for CzmlWriter {
         Ok(())
     }
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let storage_resolver = Arc::clone(&ctx.storage_resolver);
-        let expr_engine = Arc::clone(&ctx.expr_engine);
-        let output = self.params.output.clone();
-        let scope = expr_engine.new_scope();
-        let path = scope
-            .eval::<String>(output.as_ref())
-            .unwrap_or_else(|_| output.as_ref().to_string());
-        let output = Uri::from_str(path.as_str())?;
+        let base = crate::SinkOutput::from_expr(&ctx, &self.params.output)
+            .map_err(crate::errors::SinkError::czml_writer)?;
 
         for (key, features) in self.buffer.iter() {
-            let file_path = if *key == AttributeValue::Null {
-                output.clone()
+            let out = if *key == AttributeValue::Null {
+                base.clone()
             } else {
-                output.join(format!("{}.json", to_hash(key.to_string().as_str())))?
+                base.join(&format!("{}.json", to_hash(key.to_string().as_str())))
+                    .map_err(crate::errors::SinkError::czml_writer)?
             };
-            let storage = storage_resolver
-                .resolve(&file_path)
-                .map_err(crate::errors::SinkError::czml_writer)?;
 
             let is_grouped_timeseries =
                 self.params.group_timeseries_by.is_some() && self.params.time_field.is_some();
@@ -332,8 +321,7 @@ impl Sink for CzmlWriter {
 
             if is_grouped_timeseries {
                 let buffer = build_timeseries_czml(features, &self.params, &ctx)?;
-                storage
-                    .put_sync(file_path.path().as_path(), Bytes::from(buffer))
+                out.write(Bytes::from(buffer))
                     .map_err(crate::errors::SinkError::czml_writer)?;
             } else if has_citygml {
                 let (sender, receiver) = std::sync::mpsc::sync_channel(1000);
@@ -381,8 +369,7 @@ impl Sink for CzmlWriter {
                         buffer
                             .write(b"]\n")
                             .map_err(crate::errors::SinkError::czml_writer)?;
-                        storage
-                            .put_sync(file_path.path().as_path(), Bytes::from(buffer))
+                        out.write(Bytes::from(buffer))
                             .map_err(crate::errors::SinkError::czml_writer)
                     },
                 );
@@ -390,8 +377,7 @@ impl Sink for CzmlWriter {
                 rb?;
             } else {
                 let buffer = build_embedded_czml(features, &self.params)?;
-                storage
-                    .put_sync(file_path.path().as_path(), Bytes::from(buffer))
+                out.write(Bytes::from(buffer))
                     .map_err(crate::errors::SinkError::czml_writer)?;
             }
         }

--- a/engine/runtime/action-sink/src/file/excel.rs
+++ b/engine/runtime/action-sink/src/file/excel.rs
@@ -1,13 +1,6 @@
-use std::path::Path;
-use std::sync::Arc;
-
 use indexmap::IndexMap;
 use reearth_flow_types::Attribute;
 use rust_xlsxwriter::{Format, FormatAlign, FormatUnderline, Formula, Url, Workbook, Worksheet};
-
-use reearth_flow_storage::resolve::StorageResolver;
-
-use reearth_flow_common::uri::Uri;
 
 use reearth_flow_types::{AttributeValue, Feature};
 use schemars::JsonSchema;
@@ -23,10 +16,9 @@ pub struct ExcelWriterParam {
 }
 
 pub(super) fn write_excel(
-    output: &Uri,
+    output: &crate::SinkOutput,
     params: &ExcelWriterParam,
     features: &[Feature],
-    storage_resolver: &Arc<StorageResolver>,
 ) -> Result<(), crate::errors::SinkError> {
     let mut workbook = Workbook::new();
     let worksheet = workbook.add_worksheet();
@@ -95,14 +87,8 @@ pub(super) fn write_excel(
         .save_to_buffer()
         .map_err(crate::errors::SinkError::excel_writer)?;
 
-    let storage = storage_resolver
-        .resolve(output)
-        .map_err(crate::errors::SinkError::excel_writer)?;
-    let uri_path = output.path();
-    let path = Path::new(&uri_path);
-
-    storage
-        .put_sync(path, bytes::Bytes::from(buf))
+    output
+        .write(bytes::Bytes::from(buf))
         .map_err(crate::errors::SinkError::excel_writer)?;
 
     Ok(())

--- a/engine/runtime/action-sink/src/file/excel_writer.rs
+++ b/engine/runtime/action-sink/src/file/excel_writer.rs
@@ -97,13 +97,20 @@ impl Sink for ExcelWriter {
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let node_ctx: NodeContext = ctx.clone().into();
-        let out = crate::SinkOutput::from_expr(&node_ctx, &self.params.output)
+        let (path, uri) = crate::SinkOutput::evaluate_uri(&node_ctx, &self.params.output)
             .map_err(|e| SinkError::ExcelWriterFactory(e.to_string()))?;
-        self.buffer
-            .entry(out.uri().clone())
-            .or_insert_with(|| (out, Vec::new()))
-            .1
-            .push(ctx.feature);
+        let feature = ctx.feature.clone();
+        use std::collections::hash_map::Entry;
+        match self.buffer.entry(uri) {
+            Entry::Occupied(mut e) => {
+                e.get_mut().1.push(feature);
+            }
+            Entry::Vacant(e) => {
+                let out = crate::SinkOutput::from_path(&node_ctx, &path)
+                    .map_err(|e| SinkError::ExcelWriterFactory(e.to_string()))?;
+                e.insert((out, vec![feature]));
+            }
+        }
         Ok(())
     }
 

--- a/engine/runtime/action-sink/src/file/excel_writer.rs
+++ b/engine/runtime/action-sink/src/file/excel_writer.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::str::FromStr;
-use std::sync::Arc;
 
 use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::errors::BoxedError;
@@ -77,7 +75,7 @@ impl SinkFactory for ExcelWriterFactory {
 #[derive(Debug, Clone)]
 pub(super) struct ExcelWriter {
     pub(super) params: ExcelWriterParam,
-    pub(super) buffer: HashMap<Uri, Vec<Feature>>,
+    pub(super) buffer: HashMap<Uri, (crate::SinkOutput, Vec<Feature>)>,
 }
 
 /// # ExcelWriter Parameters
@@ -98,24 +96,23 @@ impl Sink for ExcelWriter {
     }
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
-        let expr_engine = Arc::clone(&ctx.expr_engine);
-        let scope = expr_engine.new_scope();
-        let output = &self.params.output;
-        let path = scope
-            .eval::<String>(output.as_ref())
-            .unwrap_or_else(|_| output.as_ref().to_string());
-        let uri = Uri::from_str(&path)?;
-        self.buffer.entry(uri).or_default().push(ctx.feature);
+        let node_ctx: NodeContext = ctx.clone().into();
+        let out = crate::SinkOutput::from_expr(&node_ctx, &self.params.output)
+            .map_err(|e| SinkError::ExcelWriterFactory(e.to_string()))?;
+        self.buffer
+            .entry(out.uri().clone())
+            .or_insert_with(|| (out, Vec::new()))
+            .1
+            .push(ctx.feature);
         Ok(())
     }
 
-    fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let storage_resolver = Arc::clone(&ctx.storage_resolver);
-        for (uri, features) in &self.buffer {
+    fn finish(&self, _ctx: NodeContext) -> Result<(), BoxedError> {
+        for (out, features) in self.buffer.values() {
             let old_params = OldExcelWriterParam {
                 sheet_name: self.params.sheet_name.clone(),
             };
-            write_excel(uri, &old_params, features, &storage_resolver)?;
+            write_excel(out, &old_params, features)?;
         }
         Ok(())
     }

--- a/engine/runtime/action-sink/src/file/excel_writer.rs
+++ b/engine/runtime/action-sink/src/file/excel_writer.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::errors::BoxedError;
@@ -97,8 +98,12 @@ impl Sink for ExcelWriter {
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let node_ctx: NodeContext = ctx.clone().into();
-        let (path, uri) = crate::SinkOutput::evaluate_uri(&node_ctx, &self.params.output)
-            .map_err(|e| SinkError::ExcelWriterFactory(e.to_string()))?;
+        let scope = node_ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(self.params.output.as_ref())
+            .unwrap_or_else(|_| self.params.output.as_ref().to_string());
+        let uri = Uri::from_str(&path)
+            .map_err(|e| SinkError::ExcelWriterFactory(format!("invalid path {:?}: {e}", path)))?;
         let feature = ctx.feature.clone();
         use std::collections::hash_map::Entry;
         match self.buffer.entry(uri) {

--- a/engine/runtime/action-sink/src/file/geojson.rs
+++ b/engine/runtime/action-sink/src/file/geojson.rs
@@ -118,7 +118,11 @@ impl Sink for GeoJsonWriter {
         Ok(())
     }
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let base = crate::SinkOutput::from_expr(&ctx, &self.params.output)
+        let scope = ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(self.params.output.as_ref())
+            .unwrap_or_else(|_| self.params.output.as_ref().to_string());
+        let base = crate::SinkOutput::from_path(&ctx, &path)
             .map_err(crate::errors::SinkError::geojson_writer)?;
 
         for (key, features) in self.buffer.iter() {

--- a/engine/runtime/action-sink/src/file/geojson.rs
+++ b/engine/runtime/action-sink/src/file/geojson.rs
@@ -1,11 +1,8 @@
 use std::collections::HashMap;
-use std::str::FromStr;
-use std::sync::Arc;
 use std::vec;
 
 use bytes::Bytes;
 use reearth_flow_common::str::to_hash;
-use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::errors::BoxedError;
 use reearth_flow_runtime::event::EventHub;
 use reearth_flow_runtime::executor_operation::{ExecutorContext, NodeContext};
@@ -121,24 +118,17 @@ impl Sink for GeoJsonWriter {
         Ok(())
     }
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let storage_resolver = Arc::clone(&ctx.storage_resolver);
-        let expr_engine = Arc::clone(&ctx.expr_engine);
-        let output = self.params.output.clone();
-        let scope = expr_engine.new_scope();
-        let path = scope
-            .eval::<String>(output.as_ref())
-            .unwrap_or_else(|_| output.as_ref().to_string());
-        let output = Uri::from_str(path.as_str())?;
+        let base = crate::SinkOutput::from_expr(&ctx, &self.params.output)
+            .map_err(crate::errors::SinkError::geojson_writer)?;
 
         for (key, features) in self.buffer.iter() {
-            let file_path = if *key == AttributeValue::Null {
-                output.clone()
+            let out = if *key == AttributeValue::Null {
+                base.clone()
             } else {
-                output.join(format!("{}.geojson", to_hash(key.to_string().as_str())))?
+                base.join(&format!("{}.geojson", to_hash(key.to_string().as_str())))
+                    .map_err(crate::errors::SinkError::geojson_writer)?
             };
-            let storage = storage_resolver
-                .resolve(&file_path)
-                .map_err(crate::errors::SinkError::geojson_writer)?;
+
             let mut buffer = Vec::from(b"{\"type\":\"FeatureCollection\",\"features\":[");
 
             let geojsons: Vec<geojson::Feature> = features
@@ -158,7 +148,8 @@ impl Sink for GeoJsonWriter {
                 buffer.extend(bytes);
             }
             buffer.extend(Vec::from(b"]}\n"));
-            storage.put_sync(file_path.path().as_path(), Bytes::from(buffer))?;
+            out.write(Bytes::from(buffer))
+                .map_err(crate::errors::SinkError::geojson_writer)?;
         }
         Ok(())
     }

--- a/engine/runtime/action-sink/src/file/geopackage.rs
+++ b/engine/runtime/action-sink/src/file/geopackage.rs
@@ -1,11 +1,7 @@
 use std::collections::HashMap;
-use std::str::FromStr;
-use std::sync::Arc;
 
 use byteorder::{LittleEndian, WriteBytesExt};
-use bytes::Bytes;
 use indexmap::IndexMap;
-use reearth_flow_common::uri::Uri;
 use reearth_flow_geometry::types::geometry::{Geometry2D, Geometry3D};
 use reearth_flow_runtime::errors::BoxedError;
 use reearth_flow_runtime::event::EventHub;
@@ -206,25 +202,19 @@ impl Sink for GeoPackageWriter {
             return Ok(());
         }
 
-        let storage_resolver = Arc::clone(&ctx.storage_resolver);
-        let expr_engine = Arc::clone(&ctx.expr_engine);
-        let output = self.params.output.clone();
-        let scope = expr_engine.new_scope();
-        let path = scope
-            .eval::<String>(output.as_ref())
-            .unwrap_or_else(|_| output.as_ref().to_string());
-        let output_uri = Uri::from_str(path.as_str())?;
+        let out = crate::SinkOutput::from_expr(&ctx, &self.params.output)
+            .map_err(|e| crate::errors::SinkError::GeoPackageWriter(e.to_string()))?;
 
         // Check if file exists
-        let storage = storage_resolver
-            .resolve(&output_uri)
-            .map_err(SinkError::geopackage_writer)?;
-
         if !self.params.overwrite {
-            if let Ok(true) = storage.exists_sync(output_uri.path().as_path()) {
+            let storage = ctx
+                .storage_resolver
+                .resolve(out.uri())
+                .map_err(SinkError::geopackage_writer)?;
+            if let Ok(true) = storage.exists_sync(out.uri().path().as_path()) {
                 return Err(SinkError::GeoPackageWriter(format!(
                     "File already exists: {}. Set overwrite=true to replace it.",
-                    path
+                    out.uri()
                 ))
                 .into());
             }
@@ -234,7 +224,8 @@ impl Sink for GeoPackageWriter {
         let gpkg_data = self.create_geopackage()?;
 
         // Write to storage
-        storage.put_sync(output_uri.path().as_path(), Bytes::from(gpkg_data))?;
+        out.write(bytes::Bytes::from(gpkg_data))
+            .map_err(|e| crate::errors::SinkError::GeoPackageWriter(e.to_string()))?;
 
         Ok(())
     }

--- a/engine/runtime/action-sink/src/file/geopackage.rs
+++ b/engine/runtime/action-sink/src/file/geopackage.rs
@@ -202,7 +202,11 @@ impl Sink for GeoPackageWriter {
             return Ok(());
         }
 
-        let out = crate::SinkOutput::from_expr(&ctx, &self.params.output)
+        let scope = ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(self.params.output.as_ref())
+            .unwrap_or_else(|_| self.params.output.as_ref().to_string());
+        let out = crate::SinkOutput::from_path(&ctx, &path)
             .map_err(|e| crate::errors::SinkError::GeoPackageWriter(e.to_string()))?;
 
         // Check if file exists

--- a/engine/runtime/action-sink/src/file/gltf.rs
+++ b/engine/runtime/action-sink/src/file/gltf.rs
@@ -1,13 +1,15 @@
 use std::collections::HashMap;
 use std::f64::consts::FRAC_PI_2;
 use std::io::BufWriter;
-use std::sync::Mutex;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
 
 use flatgeom::{Polygon2, Polygon3};
 use glam::{DMat4, DVec3, DVec4};
 use indexmap::IndexSet;
 use nusamai_projection::cartesian::geodetic_to_geocentric;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use reearth_flow_common::uri::Uri;
 use reearth_flow_gltf::{BoundingVolume, MetadataEncoder};
 use reearth_flow_runtime::errors::BoxedError;
 use reearth_flow_runtime::event::EventHub;
@@ -55,7 +57,7 @@ impl SinkFactory for GltfWriterSinkFactory {
 
     fn build(
         &self,
-        _ctx: NodeContext,
+        ctx: NodeContext,
         _event_hub: EventHub,
         _action: String,
         with: Option<HashMap<String, Value>>,
@@ -72,8 +74,19 @@ impl SinkFactory for GltfWriterSinkFactory {
                 SinkError::BuildFactory("Missing required parameter `with`".to_string()).into(),
             );
         };
+        let expr_engine = Arc::clone(&ctx.expr_engine);
+        let scope = expr_engine.new_scope();
+        if let Some(with) = with {
+            for (k, v) in with {
+                scope.set(k.as_str(), v);
+            }
+        }
+        let output = scope
+            .eval::<String>(params.output.to_string().as_str())
+            .map_err(|e| SinkError::BuildFactory(e.to_string()))?;
+        let output = Uri::from_str(output.as_str())?;
         let sink = GltfWriter {
-            output: params.output,
+            output,
             attach_texture: params.attach_texture.unwrap_or(true),
             classified_features: Default::default(),
             draco_compression: params.draco_compression.unwrap_or(false),
@@ -128,7 +141,7 @@ impl TryFrom<&ClassFeatures> for Schema {
 
 #[derive(Debug, Clone)]
 pub struct GltfWriter {
-    output: Expr,
+    output: Uri,
     classified_features: ClassifiedFeatures,
     attach_texture: bool,
     draco_compression: bool,
@@ -188,11 +201,7 @@ impl Sink for GltfWriter {
         let transform_matrix = compute_transform_matrix(&global_bvol, &ellipsoid);
         let _ = transform_matrix.inverse();
 
-        let scope = ctx.expr_engine.new_scope();
-        let path = scope
-            .eval::<String>(self.output.as_ref())
-            .unwrap_or_else(|_| self.output.as_ref().to_string());
-        let base = crate::SinkOutput::from_path(&ctx, &path)
+        let base = crate::SinkOutput::from_path(&ctx, &self.output.to_string())
             .map_err(|e| crate::errors::SinkError::GltfWriter(e.to_string()))?;
 
         let tileset_content_files = Mutex::new(Vec::new());

--- a/engine/runtime/action-sink/src/file/gltf.rs
+++ b/engine/runtime/action-sink/src/file/gltf.rs
@@ -201,7 +201,7 @@ impl Sink for GltfWriter {
         let transform_matrix = compute_transform_matrix(&global_bvol, &ellipsoid);
         let _ = transform_matrix.inverse();
 
-        let base = crate::SinkOutput::from_path(&ctx, &self.output.to_string())
+        let base = crate::SinkOutput::from_path(&ctx, self.output.as_ref())
             .map_err(|e| crate::errors::SinkError::GltfWriter(e.to_string()))?;
 
         let tileset_content_files = Mutex::new(Vec::new());

--- a/engine/runtime/action-sink/src/file/gltf.rs
+++ b/engine/runtime/action-sink/src/file/gltf.rs
@@ -2,14 +2,12 @@ use std::collections::HashMap;
 use std::f64::consts::FRAC_PI_2;
 use std::io::BufWriter;
 use std::sync::Mutex;
-use std::{str::FromStr, sync::Arc};
 
 use flatgeom::{Polygon2, Polygon3};
 use glam::{DMat4, DVec3, DVec4};
 use indexmap::IndexSet;
 use nusamai_projection::cartesian::geodetic_to_geocentric;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use reearth_flow_common::uri::Uri;
 use reearth_flow_gltf::{BoundingVolume, MetadataEncoder};
 use reearth_flow_runtime::errors::BoxedError;
 use reearth_flow_runtime::event::EventHub;
@@ -57,7 +55,7 @@ impl SinkFactory for GltfWriterSinkFactory {
 
     fn build(
         &self,
-        ctx: NodeContext,
+        _ctx: NodeContext,
         _event_hub: EventHub,
         _action: String,
         with: Option<HashMap<String, Value>>,
@@ -74,19 +72,8 @@ impl SinkFactory for GltfWriterSinkFactory {
                 SinkError::BuildFactory("Missing required parameter `with`".to_string()).into(),
             );
         };
-        let expr_engine = Arc::clone(&ctx.expr_engine);
-        let scope = expr_engine.new_scope();
-        if let Some(with) = with {
-            for (k, v) in with {
-                scope.set(k.as_str(), v);
-            }
-        }
-        let output = scope
-            .eval::<String>(params.output.to_string().as_str())
-            .map_err(|e| SinkError::BuildFactory(e.to_string()))?;
-        let output = Uri::from_str(output.as_str())?;
         let sink = GltfWriter {
-            output,
+            output: params.output,
             attach_texture: params.attach_texture.unwrap_or(true),
             classified_features: Default::default(),
             draco_compression: params.draco_compression.unwrap_or(false),
@@ -141,7 +128,7 @@ impl TryFrom<&ClassFeatures> for Schema {
 
 #[derive(Debug, Clone)]
 pub struct GltfWriter {
-    output: Uri,
+    output: Expr,
     classified_features: ClassifiedFeatures,
     attach_texture: bool,
     draco_compression: bool,
@@ -201,6 +188,9 @@ impl Sink for GltfWriter {
         let transform_matrix = compute_transform_matrix(&global_bvol, &ellipsoid);
         let _ = transform_matrix.inverse();
 
+        let base = crate::SinkOutput::from_expr(&ctx, &self.output)
+            .map_err(|e| crate::errors::SinkError::GltfWriter(e.to_string()))?;
+
         let tileset_content_files = Mutex::new(Vec::new());
 
         self.classified_features
@@ -252,17 +242,17 @@ impl Sink for GltfWriter {
                     &mut vertices,
                 )?;
 
-                let file_path = match typename {
+                let out = match typename {
                     Some(f) => {
                         let name = format!("{}.glb", f.replace(':', "_"));
                         tileset_content_files.lock().unwrap().push(name.clone());
-                        self.output.join(name).map_err(|e| {
+                        base.join(&name).map_err(|e| {
                             crate::errors::SinkError::GltfWriter(format!(
                                 "Failed to join uri with {e:?}"
                             ))
                         })?
                     }
-                    None => self.output.clone(),
+                    None => base.clone(),
                 };
 
                 let mut buffer = Vec::new();
@@ -283,12 +273,7 @@ impl Sink for GltfWriter {
                     ))
                 })?;
 
-                let storage = ctx
-                    .storage_resolver
-                    .resolve(&file_path)
-                    .map_err(crate::errors::SinkError::gltf_writer)?;
-                storage
-                    .put_sync(file_path.as_path().as_path(), bytes::Bytes::from(buffer))
+                out.write(bytes::Bytes::from(buffer))
                     .map_err(crate::errors::SinkError::gltf_writer)?;
 
                 Ok::<(), crate::errors::SinkError>(())

--- a/engine/runtime/action-sink/src/file/gltf.rs
+++ b/engine/runtime/action-sink/src/file/gltf.rs
@@ -188,7 +188,11 @@ impl Sink for GltfWriter {
         let transform_matrix = compute_transform_matrix(&global_bvol, &ellipsoid);
         let _ = transform_matrix.inverse();
 
-        let base = crate::SinkOutput::from_expr(&ctx, &self.output)
+        let scope = ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(self.output.as_ref())
+            .unwrap_or_else(|_| self.output.as_ref().to_string());
+        let base = crate::SinkOutput::from_path(&ctx, &path)
             .map_err(|e| crate::errors::SinkError::GltfWriter(e.to_string()))?;
 
         let tileset_content_files = Mutex::new(Vec::new());

--- a/engine/runtime/action-sink/src/file/gltf.rs
+++ b/engine/runtime/action-sink/src/file/gltf.rs
@@ -670,3 +670,76 @@ impl GltfWriter {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reearth_flow_runtime::event::EventHub;
+    use serde_json::json;
+
+    fn make_with(entries: &[(&str, serde_json::Value)]) -> HashMap<String, serde_json::Value> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    // Regression: with-params must be injected into the eval scope at build time
+    // so the output expression can reference them via `env.get(...)`. If this
+    // breaks, workflows using `env.get("some_with_param")` in their output
+    // silently fail to resolve.
+    #[test]
+    fn build_resolves_output_expression_referencing_with_param() {
+        let ctx = NodeContext::default();
+        // The expression throws if `output_dir` is missing from scope — that
+        // way the test fails loudly if the with-injection regresses, instead
+        // of letting `env.get` return Dynamic::UNIT and silently coercing to
+        // an empty string in the concat.
+        let with = make_with(&[
+            (
+                "output",
+                json!(
+                    r#"let dir = env.get("output_dir"); if type_of(dir) != "string" { throw "output_dir not injected into scope" }; dir + "/feature.glb""#
+                ),
+            ),
+            ("output_dir", json!("file:///tmp/gltf_regression_test")),
+        ]);
+
+        let result = GltfWriterSinkFactory.build(
+            ctx,
+            EventHub::new(10),
+            "GltfWriter".to_string(),
+            Some(with),
+        );
+
+        assert!(
+            result.is_ok(),
+            "build must succeed when output expression references an injected with-param via env.get; got error: {:?}",
+            result.err(),
+        );
+    }
+
+    // Regression: eval failure at build() must surface as SinkError::BuildFactory,
+    // not silently fall through to a literal path. If this breaks, malformed
+    // output expressions produce garbage paths at write time with no signal.
+    #[test]
+    fn build_fails_when_output_expression_cannot_evaluate() {
+        let ctx = NodeContext::default();
+        let with = make_with(&[
+            // References a variable not present in `with` — Rhai eval will fail.
+            ("output", json!(r#"undefined_variable + "/x.glb""#)),
+        ]);
+
+        let result = GltfWriterSinkFactory.build(
+            ctx,
+            EventHub::new(10),
+            "GltfWriter".to_string(),
+            Some(with),
+        );
+
+        assert!(
+            result.is_err(),
+            "build must error when output expression cannot evaluate; silent fallback would mask this",
+        );
+    }
+}

--- a/engine/runtime/action-sink/src/file/json.rs
+++ b/engine/runtime/action-sink/src/file/json.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -10,7 +9,6 @@ use reearth_flow_runtime::errors::BoxedError;
 use reearth_flow_runtime::event::EventHub;
 use reearth_flow_runtime::executor_operation::{ExecutorContext, NodeContext};
 use reearth_flow_runtime::node::{Port, Sink, SinkFactory, DEFAULT_PORT};
-use reearth_flow_storage::resolve::StorageResolver;
 use reearth_flow_types::{Expr, Feature};
 use rhai::Dynamic;
 use schemars::JsonSchema;
@@ -18,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::errors::SinkError;
+use crate::SinkOutput;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct JsonWriterFactory;
@@ -78,7 +77,7 @@ impl SinkFactory for JsonWriterFactory {
 #[derive(Debug, Clone)]
 pub(super) struct JsonWriter {
     pub(super) params: JsonWriterParam,
-    pub(super) buffer: HashMap<Uri, Vec<Feature>>,
+    pub(super) buffer: HashMap<Uri, (SinkOutput, Vec<Feature>)>,
 }
 
 /// # JsonWriter Parameters
@@ -99,38 +98,30 @@ impl Sink for JsonWriter {
     }
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
-        let expr_engine = Arc::clone(&ctx.expr_engine);
-        let scope = expr_engine.new_scope();
-        let output = &self.params.output;
-        let path = scope
-            .eval::<String>(output.as_ref())
-            .unwrap_or_else(|_| output.as_ref().to_string());
-        let uri = Uri::from_str(&path)?;
-        self.buffer.entry(uri).or_default().push(ctx.feature);
+        let node_ctx: NodeContext = ctx.clone().into();
+        let out = SinkOutput::from_expr(&node_ctx, &self.params.output)
+            .map_err(|e| SinkError::JsonWriter(e.to_string()))?;
+        self.buffer
+            .entry(out.uri().clone())
+            .or_insert_with(|| (out, Vec::new()))
+            .1
+            .push(ctx.feature);
         Ok(())
     }
 
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let storage_resolver = Arc::clone(&ctx.storage_resolver);
-        for (uri, features) in &self.buffer {
-            write_json(
-                uri,
-                &self.params,
-                features,
-                &ctx.expr_engine,
-                &storage_resolver,
-            )?;
+        for (out, features) in self.buffer.values() {
+            write_json(out, &self.params, features, &ctx.expr_engine)?;
         }
         Ok(())
     }
 }
 
 fn write_json(
-    output: &Uri,
+    out: &SinkOutput,
     params: &JsonWriterParam,
     features: &[Feature],
     expr_engine: &Arc<Engine>,
-    storage_resolver: &Arc<StorageResolver>,
 ) -> Result<(), crate::errors::SinkError> {
     let json_value: serde_json::Value = if let Some(converter) = &params.converter {
         let scope = expr_engine.new_scope();
@@ -167,11 +158,7 @@ fn write_json(
             .collect::<Vec<serde_json::Value>>();
         serde_json::Value::Array(attributes)
     };
-    let storage = storage_resolver
-        .resolve(output)
-        .map_err(|e| crate::errors::SinkError::JsonWriter(format!("{e:?}")))?;
-    storage
-        .put_sync(output.path().as_path(), Bytes::from(json_value.to_string()))
+    out.write(Bytes::from(json_value.to_string()))
         .map_err(|e| crate::errors::SinkError::JsonWriter(format!("{e:?}")))?;
     Ok(())
 }

--- a/engine/runtime/action-sink/src/file/json.rs
+++ b/engine/runtime/action-sink/src/file/json.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -99,8 +100,12 @@ impl Sink for JsonWriter {
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let node_ctx: NodeContext = ctx.clone().into();
-        let (path, uri) = SinkOutput::evaluate_uri(&node_ctx, &self.params.output)
-            .map_err(|e| SinkError::JsonWriter(e.to_string()))?;
+        let scope = node_ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(self.params.output.as_ref())
+            .unwrap_or_else(|_| self.params.output.as_ref().to_string());
+        let uri = Uri::from_str(&path)
+            .map_err(|e| SinkError::JsonWriter(format!("invalid path {:?}: {e}", path)))?;
         let feature = ctx.feature.clone();
         use std::collections::hash_map::Entry;
         match self.buffer.entry(uri) {

--- a/engine/runtime/action-sink/src/file/json.rs
+++ b/engine/runtime/action-sink/src/file/json.rs
@@ -99,13 +99,20 @@ impl Sink for JsonWriter {
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let node_ctx: NodeContext = ctx.clone().into();
-        let out = SinkOutput::from_expr(&node_ctx, &self.params.output)
+        let (path, uri) = SinkOutput::evaluate_uri(&node_ctx, &self.params.output)
             .map_err(|e| SinkError::JsonWriter(e.to_string()))?;
-        self.buffer
-            .entry(out.uri().clone())
-            .or_insert_with(|| (out, Vec::new()))
-            .1
-            .push(ctx.feature);
+        let feature = ctx.feature.clone();
+        use std::collections::hash_map::Entry;
+        match self.buffer.entry(uri) {
+            Entry::Occupied(mut e) => {
+                e.get_mut().1.push(feature);
+            }
+            Entry::Vacant(e) => {
+                let out = SinkOutput::from_path(&node_ctx, &path)
+                    .map_err(|e| SinkError::JsonWriter(e.to_string()))?;
+                e.insert((out, vec![feature]));
+            }
+        }
         Ok(())
     }
 

--- a/engine/runtime/action-sink/src/file/mvt/pipeline.rs
+++ b/engine/runtime/action-sink/src/file/mvt/pipeline.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::io::Write;
-use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -19,6 +18,7 @@ use rayon::iter::ParallelBridge;
 use rayon::iter::ParallelIterator;
 use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::executor_operation::Context;
+use reearth_flow_runtime::executor_operation::NodeContext;
 use reearth_flow_types::Feature;
 use tinymvt::geometry::GeometryEncoder;
 use tinymvt::tag::TagsEncoder;
@@ -53,9 +53,8 @@ pub(super) fn geometry_slicing_stage(
 ) -> crate::errors::Result<()> {
     let tile_contents = Arc::new(Mutex::new(Vec::new()));
     let layer_names = Arc::new(Mutex::new(std::collections::HashSet::new()));
-    let storage = ctx
-        .storage_resolver
-        .resolve(output_path)
+    let node_ctx = NodeContext::from(ctx.clone());
+    let sink_out = crate::SinkOutput::from_path(&node_ctx, output_path.as_str())
         .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))?;
 
     // Convert CityObjects to sliced features
@@ -208,14 +207,9 @@ pub(super) fn geometry_slicing_stage(
     serde_json::to_string_pretty(&metadata)
         .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))
         .and_then(|metadata| {
-            storage
-                .put_sync(
-                    &output_path
-                        .join(Path::new("tilejson.json"))
-                        .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))?
-                        .path(),
-                    bytes::Bytes::from(metadata),
-                )
+            sink_out
+                .join("tilejson.json")
+                .and_then(|out| out.write(bytes::Bytes::from(metadata)))
                 .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))
         })?;
 
@@ -279,9 +273,8 @@ pub(super) fn tile_writing_stage(
 ) -> crate::errors::Result<()> {
     let min_extent: i32 = 512;
 
-    let storage = ctx
-        .storage_resolver
-        .resolve(output_path)
+    let node_ctx = NodeContext::from(ctx);
+    let sink_out = crate::SinkOutput::from_path(&node_ctx, output_path.as_str())
         .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))?;
 
     receiver_sorted
@@ -290,9 +283,6 @@ pub(super) fn tile_writing_stage(
         .try_for_each(|(tile_id, serialized_feats)| {
             let (zoom, x, y) = tile_id_conv.id_to_zxy(tile_id);
 
-            let path = output_path
-                .join(Path::new(&format!("{zoom}/{x}/{y}.mvt")))
-                .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))?;
             let mut extent = default_extent;
             while extent >= min_extent {
                 let bytes = make_tile(
@@ -316,8 +306,9 @@ pub(super) fn tile_writing_stage(
                     extent /= 2;
                     continue;
                 }
-                storage
-                    .put_sync(&path.path(), bytes::Bytes::from(bytes))
+                sink_out
+                    .join(&format!("{zoom}/{x}/{y}.mvt"))
+                    .and_then(|tile_out| tile_out.write(bytes::Bytes::from(bytes)))
                     .map_err(|e| crate::errors::SinkError::MvtWriter(format!("{e:?}")))?;
                 break;
             }

--- a/engine/runtime/action-sink/src/file/mvt/sink.rs
+++ b/engine/runtime/action-sink/src/file/mvt/sink.rs
@@ -409,48 +409,65 @@ impl MVTWriter {
                 }
 
                 if let Some(compress_output) = compress_output {
-                    if let Ok(storage) = gctx.storage_resolver.resolve(&compress_output) {
-                        let buffer = Vec::new();
-                        let mut cursor = Cursor::new(buffer);
-                        let writer = BufWriter::new(&mut cursor);
-                        let zip_result =
-                            reearth_flow_common::zip::write(writer, out.path().as_path()).map_err(
-                                |e| crate::errors::SinkError::cesium3dtiles_writer(e.to_string()),
-                            );
-                        match zip_result {
-                            Ok(_) => {
-                                match storage
-                                    .put_sync(
-                                        compress_output.path().as_path(),
-                                        bytes::Bytes::from(cursor.into_inner()),
-                                    )
-                                    .map_err(crate::errors::SinkError::cesium3dtiles_writer)
-                                {
-                                    Ok(_) => match std::fs::remove_dir_all(out.path().as_path()) {
-                                        Ok(_) => {}
+                    let compress_node_ctx = NodeContext::from(gctx.clone());
+                    match crate::SinkOutput::from_path(
+                        &compress_node_ctx,
+                        compress_output.as_str(),
+                    ) {
+                        Ok(compress_sink_out) => {
+                            let buffer = Vec::new();
+                            let mut cursor = Cursor::new(buffer);
+                            let writer = BufWriter::new(&mut cursor);
+                            let zip_result = reearth_flow_common::zip::write(
+                                writer,
+                                out.path().as_path(),
+                            )
+                            .map_err(|e| {
+                                crate::errors::SinkError::MvtWriter(e.to_string())
+                            });
+                            match zip_result {
+                                Ok(_) => {
+                                    match compress_sink_out
+                                        .write(bytes::Bytes::from(cursor.into_inner()))
+                                        .map_err(|e| {
+                                            crate::errors::SinkError::MvtWriter(e.to_string())
+                                        }) {
+                                        Ok(_) => {
+                                            match std::fs::remove_dir_all(out.path().as_path()) {
+                                                Ok(_) => {}
+                                                Err(e) => {
+                                                    gctx.event_hub.error_log(
+                                                        None,
+                                                        format!(
+                                                            "Failed to remove directory with error = {e:?}"
+                                                        ),
+                                                    );
+                                                }
+                                            }
+                                        }
                                         Err(e) => {
                                             gctx.event_hub.error_log(
                                                 None,
                                                 format!(
-                                                    "Failed to remove directory with error = {e:?}"
+                                                    "Failed to write zip file with error = {e:?}"
                                                 ),
                                             );
                                         }
-                                    },
-                                    Err(e) => {
-                                        gctx.event_hub.error_log(
-                                            None,
-                                            format!("Failed to write zip file with error = {e:?}"),
-                                        );
                                     }
                                 }
+                                Err(e) => {
+                                    gctx.event_hub.error_log(
+                                        None,
+                                        format!("Failed to write zip file with error = {e:?}"),
+                                    );
+                                }
                             }
-                            Err(e) => {
-                                gctx.event_hub.error_log(
-                                    None,
-                                    format!("Failed to write zip file with error = {e:?}"),
-                                );
-                            }
+                        }
+                        Err(e) => {
+                            gctx.event_hub.error_log(
+                                None,
+                                format!("Failed to resolve compress output with error = {e:?}"),
+                            );
                         }
                     }
                 }

--- a/engine/runtime/action-sink/src/file/obj.rs
+++ b/engine/runtime/action-sink/src/file/obj.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use bytes::Bytes;
 use indexmap::IndexMap;
-use reearth_flow_common::uri::Uri;
 use reearth_flow_geometry::types::geometry::Geometry3D as FlowGeometry3D;
 use reearth_flow_runtime::errors::BoxedError;
 use reearth_flow_runtime::event::EventHub;
@@ -127,7 +125,6 @@ impl Sink for ObjWriter {
 
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
         let expr_engine = Arc::clone(&ctx.expr_engine);
-        let storage_resolver = Arc::clone(&ctx.storage_resolver);
 
         let scope = expr_engine.new_scope();
         if let Some(ref params) = self.global_params {
@@ -139,26 +136,22 @@ impl Sink for ObjWriter {
         let path = scope
             .eval_ast::<String>(&self.output)
             .map_err(|e| SinkError::ObjWriter(e.to_string()))?;
-        let output = Uri::from_str(path.as_str())?;
 
         let (obj_content, mtl_content) = features_to_obj(&self.buffer, self, &path)?;
 
-        let storage = storage_resolver
-            .resolve(&output)
-            .map_err(|e| SinkError::ObjWriter(format!("Failed to resolve storage: {e}")))?;
-        storage
-            .put_sync(output.path().as_path(), Bytes::from(obj_content))
-            .map_err(|e| SinkError::ObjWriter(format!("Failed to write OBJ file: {e}")))?;
+        let obj_out = crate::SinkOutput::from_path(&ctx, &path)
+            .map_err(|e| SinkError::ObjWriter(e.to_string()))?;
+        obj_out
+            .write(Bytes::from(obj_content))
+            .map_err(|e| SinkError::ObjWriter(e.to_string()))?;
 
         if self.write_materials && !mtl_content.is_empty() {
-            let mtl_path = output.to_string().replace(".obj", ".mtl");
-            let mtl_uri = Uri::from_str(&mtl_path)?;
-            let mtl_storage = storage_resolver
-                .resolve(&mtl_uri)
-                .map_err(|e| SinkError::ObjWriter(format!("Failed to resolve MTL storage: {e}")))?;
-            mtl_storage
-                .put_sync(mtl_uri.path().as_path(), Bytes::from(mtl_content))
-                .map_err(|e| SinkError::ObjWriter(format!("Failed to write MTL file: {e}")))?;
+            let mtl_path = path.replace(".obj", ".mtl");
+            let mtl_out = crate::SinkOutput::from_path(&ctx, &mtl_path)
+                .map_err(|e| SinkError::ObjWriter(e.to_string()))?;
+            mtl_out
+                .write(Bytes::from(mtl_content))
+                .map_err(|e| SinkError::ObjWriter(e.to_string()))?;
         }
 
         Ok(())

--- a/engine/runtime/action-sink/src/file/shapefile/pipeline.rs
+++ b/engine/runtime/action-sink/src/file/shapefile/pipeline.rs
@@ -2,7 +2,6 @@ use std::io::BufWriter;
 
 use itertools::Itertools;
 use rayon::iter::{ParallelBridge, ParallelIterator};
-use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::executor_operation::Context;
 use reearth_flow_types::{AttributeValue, Feature};
 
@@ -14,7 +13,7 @@ use super::{
 
 pub(super) fn pipeline(
     ctx: &Context,
-    output: &Uri,
+    output: &crate::SinkOutput,
     key: &AttributeValue,
     upstream: &[Feature],
 ) -> crate::errors::Result<()> {
@@ -29,7 +28,7 @@ pub(super) fn pipeline(
             "No EPSG code".to_string(),
         ));
     };
-    std::fs::create_dir_all(output.as_path())
+    std::fs::create_dir_all(output.uri().as_path())
         .map_err(crate::errors::SinkError::ShapefileWriterIo)?;
 
     let (table_builder, fields_default) = make_table_builder(&feature.attributes)?;
@@ -58,11 +57,11 @@ pub(super) fn pipeline(
             let shapes = receiver.into_iter().collect_vec();
 
             // Create all the files needed for the shapefile to be complete (.shp, .shx, .dbf)
-            let shp_path = output
-                .join(format!("{}.shp", key.to_string().replace('/', "-")))
-                .map_err(|err| {
-                    crate::errors::SinkError::ShapefileWriter(format!("Failed to join path: {err}"))
-                })?;
+            let key_stem = key.to_string().replace('/', "-");
+            let shp_out = output.join(&format!("{key_stem}.shp")).map_err(|err| {
+                crate::errors::SinkError::ShapefileWriter(format!("Failed to join path: {err}"))
+            })?;
+            let shp_path = shp_out.uri();
             let feature_count = shapes.len();
             let has_no_geometry = shapes
                 .iter()
@@ -110,37 +109,38 @@ pub(super) fn pipeline(
                 }
             }
 
-            let storage = ctx
-                .storage_resolver
-                .resolve(&shp_path)
+            let shx_out = output
+                .join(&format!("{key_stem}.shx"))
                 .map_err(|e| crate::errors::SinkError::ShapefileWriter(e.to_string()))?;
 
             if has_no_geometry {
-                let _ = storage.delete_sync(shp_path.as_path().as_path());
-                let shx_path = shp_path.as_path().with_extension("shx");
-                let _ = storage.delete_sync(shp_path.as_path().as_path());
+                // Remove the files written by shapefile::Writer and replace with null-shape bytes
+                let _ = std::fs::remove_file(shp_path.as_path());
+                let _ = std::fs::remove_file(shx_out.uri().as_path());
                 let mut buffer = Vec::new();
                 null_shape::write_shp(BufWriter::new(&mut buffer), feature_count)
                     .map_err(|e| crate::errors::SinkError::ShapefileWriter(e.to_string()))?;
-                storage
-                    .put_sync(shp_path.as_path().as_path(), bytes::Bytes::from(buffer))
+                shp_out
+                    .write(bytes::Bytes::from(buffer))
                     .map_err(|e| crate::errors::SinkError::ShapefileWriter(e.to_string()))?;
 
                 let mut buffer = Vec::new();
                 null_shape::write_shx(BufWriter::new(&mut buffer), feature_count)
                     .map_err(|e| crate::errors::SinkError::ShapefileWriter(e.to_string()))?;
-                storage
-                    .put_sync(shx_path.as_path(), bytes::Bytes::from(buffer))
+                shx_out
+                    .write(bytes::Bytes::from(buffer))
                     .map_err(|e| crate::errors::SinkError::ShapefileWriter(e.to_string()))?;
             } else {
                 // write .prj file if this type has geometry
                 let repo = ProjectionRepository::new();
-                let prj_path = &shp_path.as_path().with_extension("prj");
+                let prj_out = output
+                    .join(&format!("{key_stem}.prj"))
+                    .map_err(|e| crate::errors::SinkError::ShapefileWriter(e.to_string()))?;
                 let mut buffer = Vec::new();
                 crs::write_prj(BufWriter::new(&mut buffer), &repo, epsg)
                     .map_err(|e| crate::errors::SinkError::ShapefileWriter(e.to_string()))?;
-                storage
-                    .put_sync(prj_path.as_path(), bytes::Bytes::from(buffer))
+                prj_out
+                    .write(bytes::Bytes::from(buffer))
                     .map_err(|e| crate::errors::SinkError::ShapefileWriter(e.to_string()))?;
             }
             Ok::<(), crate::errors::SinkError>(())

--- a/engine/runtime/action-sink/src/file/shapefile/sink.rs
+++ b/engine/runtime/action-sink/src/file/shapefile/sink.rs
@@ -118,7 +118,11 @@ impl Sink for ShapefileWriter {
         Ok(())
     }
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let base = crate::SinkOutput::from_expr(&ctx, &self.params.output)
+        let scope = ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(self.params.output.as_ref())
+            .unwrap_or_else(|_| self.params.output.as_ref().to_string());
+        let base = crate::SinkOutput::from_path(&ctx, &path)
             .map_err(|e| SinkError::ShapefileWriter(e.to_string()))?;
         for (key, features) in self.buffer.iter() {
             pipeline::pipeline(&ctx.as_context(), &base, key, features)?;

--- a/engine/runtime/action-sink/src/file/shapefile/sink.rs
+++ b/engine/runtime/action-sink/src/file/shapefile/sink.rs
@@ -1,9 +1,6 @@
 use std::collections::HashMap;
-use std::str::FromStr;
-use std::sync::Arc;
 use std::vec;
 
-use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::errors::BoxedError;
 use reearth_flow_runtime::event::EventHub;
 use reearth_flow_runtime::executor_operation::{ExecutorContext, NodeContext};
@@ -121,15 +118,10 @@ impl Sink for ShapefileWriter {
         Ok(())
     }
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let expr_engine = Arc::clone(&ctx.expr_engine);
-        let output = self.params.output.clone();
-        let scope = expr_engine.new_scope();
-        let path = scope
-            .eval::<String>(output.as_ref())
-            .unwrap_or_else(|_| output.as_ref().to_string());
-        let output = Uri::from_str(path.as_str())?;
+        let base = crate::SinkOutput::from_expr(&ctx, &self.params.output)
+            .map_err(|e| SinkError::ShapefileWriter(e.to_string()))?;
         for (key, features) in self.buffer.iter() {
-            pipeline::pipeline(&ctx.as_context(), &output, key, features)?;
+            pipeline::pipeline(&ctx.as_context(), &base, key, features)?;
         }
         Ok(())
     }

--- a/engine/runtime/action-sink/src/file/xml.rs
+++ b/engine/runtime/action-sink/src/file/xml.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::str::FromStr;
-use std::sync::Arc;
 
 use bytes::Bytes;
 use quick_xml::events::{BytesDecl, BytesStart, Event};
@@ -16,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::errors::SinkError;
-use reearth_flow_storage::resolve::StorageResolver;
+use crate::SinkOutput;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct XmlWriterFactory;
@@ -77,7 +75,7 @@ impl SinkFactory for XmlWriterFactory {
 #[derive(Debug, Clone)]
 pub(super) struct XmlWriter {
     pub(super) params: XmlWriterParam,
-    pub(super) buffer: HashMap<Uri, Vec<Feature>>,
+    pub(super) buffer: HashMap<Uri, (SinkOutput, Vec<Feature>)>,
 }
 
 /// # XmlWriter Parameters
@@ -96,30 +94,28 @@ impl Sink for XmlWriter {
     }
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
-        let expr_engine = Arc::clone(&ctx.expr_engine);
-        let scope = expr_engine.new_scope();
-        let output = &self.params.output;
-        let path = scope
-            .eval::<String>(output.as_ref())
-            .unwrap_or_else(|_| output.as_ref().to_string());
-        let uri = Uri::from_str(&path)?;
-        self.buffer.entry(uri).or_default().push(ctx.feature);
+        let node_ctx: NodeContext = ctx.clone().into();
+        let out = SinkOutput::from_expr(&node_ctx, &self.params.output)
+            .map_err(|e| SinkError::XmlWriter(e.to_string()))?;
+        self.buffer
+            .entry(out.uri().clone())
+            .or_insert_with(|| (out, Vec::new()))
+            .1
+            .push(ctx.feature);
         Ok(())
     }
 
-    fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let storage_resolver = Arc::clone(&ctx.storage_resolver);
-        for (uri, features) in &self.buffer {
-            write_xml(uri, features, &storage_resolver)?;
+    fn finish(&self, _ctx: NodeContext) -> Result<(), BoxedError> {
+        for (out, features) in self.buffer.values() {
+            write_xml(out, features)?;
         }
         Ok(())
     }
 }
 
 pub(super) fn write_xml(
-    output: &Uri,
+    out: &SinkOutput,
     features: &[Feature],
-    storage_resolver: &Arc<StorageResolver>,
 ) -> Result<(), crate::errors::SinkError> {
     let attributes = features
         .iter()
@@ -147,11 +143,7 @@ pub(super) fn write_xml(
     let result = writer.into_inner();
     let xml = String::from_utf8(result)
         .map_err(|e| crate::errors::SinkError::XmlWriter(format!("{e:?}")))?;
-    let storage = storage_resolver
-        .resolve(output)
-        .map_err(|e| crate::errors::SinkError::XmlWriter(format!("{e:?}")))?;
-    storage
-        .put_sync(output.path().as_path(), Bytes::from(xml))
+    out.write(Bytes::from(xml))
         .map_err(|e| crate::errors::SinkError::XmlWriter(format!("{e:?}")))?;
     Ok(())
 }

--- a/engine/runtime/action-sink/src/file/xml.rs
+++ b/engine/runtime/action-sink/src/file/xml.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use bytes::Bytes;
 use quick_xml::events::{BytesDecl, BytesStart, Event};
@@ -95,8 +96,12 @@ impl Sink for XmlWriter {
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let node_ctx: NodeContext = ctx.clone().into();
-        let (path, uri) = SinkOutput::evaluate_uri(&node_ctx, &self.params.output)
-            .map_err(|e| SinkError::XmlWriter(e.to_string()))?;
+        let scope = node_ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(self.params.output.as_ref())
+            .unwrap_or_else(|_| self.params.output.as_ref().to_string());
+        let uri = Uri::from_str(&path)
+            .map_err(|e| SinkError::XmlWriter(format!("invalid path {:?}: {e}", path)))?;
         let feature = ctx.feature.clone();
         use std::collections::hash_map::Entry;
         match self.buffer.entry(uri) {

--- a/engine/runtime/action-sink/src/file/xml.rs
+++ b/engine/runtime/action-sink/src/file/xml.rs
@@ -95,13 +95,20 @@ impl Sink for XmlWriter {
 
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let node_ctx: NodeContext = ctx.clone().into();
-        let out = SinkOutput::from_expr(&node_ctx, &self.params.output)
+        let (path, uri) = SinkOutput::evaluate_uri(&node_ctx, &self.params.output)
             .map_err(|e| SinkError::XmlWriter(e.to_string()))?;
-        self.buffer
-            .entry(out.uri().clone())
-            .or_insert_with(|| (out, Vec::new()))
-            .1
-            .push(ctx.feature);
+        let feature = ctx.feature.clone();
+        use std::collections::hash_map::Entry;
+        match self.buffer.entry(uri) {
+            Entry::Occupied(mut e) => {
+                e.get_mut().1.push(feature);
+            }
+            Entry::Vacant(e) => {
+                let out = SinkOutput::from_path(&node_ctx, &path)
+                    .map_err(|e| SinkError::XmlWriter(e.to_string()))?;
+                e.insert((out, vec![feature]));
+            }
+        }
         Ok(())
     }
 

--- a/engine/runtime/action-sink/src/file/zip.rs
+++ b/engine/runtime/action-sink/src/file/zip.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::io::{BufWriter, Cursor};
 use std::str::FromStr;
-use std::sync::Arc;
 use std::vec;
 
 use reearth_flow_common::uri::Uri;
@@ -112,14 +111,8 @@ impl Sink for ZipFileWriter {
         if self.buffer.is_empty() {
             return Ok(());
         }
-        let storage_resolver = Arc::clone(&ctx.storage_resolver);
-        let expr_engine = Arc::clone(&ctx.expr_engine);
-        let output = self.output.clone();
-        let scope = expr_engine.new_scope();
-        let path = scope
-            .eval::<String>(output.as_ref())
-            .unwrap_or_else(|_| output.as_ref().to_string());
-        let output = Uri::from_str(path.as_str())?;
+        let out = crate::SinkOutput::from_expr(&ctx, &self.output)
+            .map_err(|e| crate::errors::SinkError::ZipFileWriter(e.to_string()))?;
         let temp_dir_path = dir::project_temp_dir(uuid::Uuid::new_v4().to_string().as_str())?;
         dir::move_files_with_structure(&temp_dir_path, &self.buffer)?;
         let buffer = Vec::new();
@@ -127,15 +120,8 @@ impl Sink for ZipFileWriter {
         let writer = BufWriter::new(&mut cursor);
         zip::write(writer, temp_dir_path.as_path())
             .map_err(|e| crate::errors::SinkError::ZipFileWriter(e.to_string()))?;
-        let storage = storage_resolver.resolve(&output).map_err(|e| {
-            crate::errors::SinkError::ZipFileWriter(format!(
-                "Failed to resolve storage for {output}: {e}"
-            ))
-        })?;
-        storage.put_sync(
-            output.path().as_path(),
-            bytes::Bytes::from(cursor.into_inner()),
-        )?;
+        out.write(bytes::Bytes::from(cursor.into_inner()))
+            .map_err(|e| crate::errors::SinkError::ZipFileWriter(e.to_string()))?;
         Ok(())
     }
 }

--- a/engine/runtime/action-sink/src/file/zip.rs
+++ b/engine/runtime/action-sink/src/file/zip.rs
@@ -111,7 +111,11 @@ impl Sink for ZipFileWriter {
         if self.buffer.is_empty() {
             return Ok(());
         }
-        let out = crate::SinkOutput::from_expr(&ctx, &self.output)
+        let scope = ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(self.output.as_ref())
+            .unwrap_or_else(|_| self.output.as_ref().to_string());
+        let out = crate::SinkOutput::from_path(&ctx, &path)
             .map_err(|e| crate::errors::SinkError::ZipFileWriter(e.to_string()))?;
         let temp_dir_path = dir::project_temp_dir(uuid::Uuid::new_v4().to_string().as_str())?;
         dir::move_files_with_structure(&temp_dir_path, &self.buffer)?;

--- a/engine/runtime/action-sink/src/lib.rs
+++ b/engine/runtime/action-sink/src/lib.rs
@@ -4,5 +4,8 @@ pub mod errors;
 pub mod file;
 pub mod mapping;
 pub mod noop;
+mod output;
 pub mod schema;
 mod zip_eq_logged;
+
+pub use output::SinkOutput;

--- a/engine/runtime/action-sink/src/output.rs
+++ b/engine/runtime/action-sink/src/output.rs
@@ -17,22 +17,24 @@ pub struct SinkOutput {
 }
 
 impl SinkOutput {
+    /// Construct a `SinkOutput` from a fully-formed path string.
+    ///
+    /// The string must parse as a valid URI (`file://...`, `gs://...`, etc.).
+    /// Resolves the storage backend eagerly. Used by sinks that pre-compile
+    /// Rhai expression ASTs and evaluate them at write time.
     pub fn from_path(ctx: &NodeContext, path: &str) -> Result<Self, BoxedError> {
-        let resolved = Uri::from_str(path)?;
+        let resolved = Uri::from_str(path).map_err(|e| -> BoxedError {
+            format!("SinkOutput: invalid path {:?}: {e}", path).into()
+        })?;
         let storage = ctx.storage_resolver.resolve(&resolved)?;
         Ok(Self { resolved, storage })
     }
 
-    pub fn uri(&self) -> &Uri {
-        &self.resolved
-    }
-
-    pub fn write(&self, bytes: Bytes) -> Result<(), BoxedError> {
-        self.storage
-            .put_sync(self.resolved.path().as_path(), bytes)?;
-        Ok(())
-    }
-
+    /// Construct a `SinkOutput` by evaluating a Rhai expression to a path string.
+    ///
+    /// If evaluation fails, the raw expression text is used as the path —
+    /// this matches the historical per-sink behavior so literal paths work
+    /// without writing them as `"\"file://...\""`.
     pub fn from_expr(ctx: &NodeContext, expr: &Expr) -> Result<Self, BoxedError> {
         let scope = ctx.expr_engine.new_scope();
         let path = scope
@@ -41,6 +43,25 @@ impl SinkOutput {
         Self::from_path(ctx, &path)
     }
 
+    /// Return the resolved URI this output writes to.
+    pub fn uri(&self) -> &Uri {
+        &self.resolved
+    }
+
+    /// Write bytes to the resolved URI via the eagerly-acquired storage backend.
+    ///
+    /// Semantics are "put" (full overwrite), not append.
+    pub fn write(&self, bytes: Bytes) -> Result<(), BoxedError> {
+        self.storage
+            .put_sync(self.resolved.path().as_path(), bytes)?;
+        Ok(())
+    }
+
+    /// Derive a child `SinkOutput` whose URI is `self.uri()` joined with `sub`.
+    ///
+    /// `sub` must be a relative path. Absolute sub-paths will return an error
+    /// from `Uri::join`. The storage backend is reused (scheme+authority cannot
+    /// change via join).
     pub fn join(&self, sub: &str) -> Result<Self, BoxedError> {
         let joined = self.resolved.join(sub)?;
         // join preserves scheme+authority, so the storage backend is the same
@@ -90,6 +111,19 @@ mod tests {
         let out = SinkOutput::from_expr(&ctx, &expr).unwrap();
         out.write(Bytes::from_static(b"x")).unwrap();
         assert!(target.exists());
+    }
+
+    #[test]
+    fn from_expr_evaluates_rhai_concat_expression() {
+        let tmp = tempdir().unwrap();
+        // A Rhai expression that concatenates strings — must successfully evaluate
+        let dir = tmp.path().display().to_string();
+        let expr_src = format!(r#""file://{dir}/" + "concat_out.bin""#);
+        let expr = Expr::new(&expr_src);
+        let ctx = NodeContext::default();
+        let out = SinkOutput::from_expr(&ctx, &expr).unwrap();
+        out.write(Bytes::from_static(b"y")).unwrap();
+        assert!(tmp.path().join("concat_out.bin").exists());
     }
 
     #[test]

--- a/engine/runtime/action-sink/src/output.rs
+++ b/engine/runtime/action-sink/src/output.rs
@@ -6,10 +6,9 @@ use reearth_flow_common::uri::Uri;
 use reearth_flow_runtime::errors::BoxedError;
 use reearth_flow_runtime::executor_operation::NodeContext;
 use reearth_flow_storage::storage::Storage;
-use reearth_flow_types::Expr;
 
-/// Owns expression evaluation, URI parsing, storage backend acquisition,
-/// and bytes write for sink output handling.
+/// Owns URI parsing, storage backend acquisition, and bytes write for sink
+/// output handling. Expression evaluation is the responsibility of the caller.
 #[derive(Clone, Debug)]
 pub struct SinkOutput {
     resolved: Uri,
@@ -21,8 +20,7 @@ impl SinkOutput {
     ///
     /// Accepts either a URI (`file://...`, `gs://...`, etc.) or a plain
     /// filesystem path (treated as `file://` by `Uri::from_str`). Resolves
-    /// the storage backend eagerly. Used by sinks that pre-compile Rhai
-    /// expression ASTs and evaluate them at write time.
+    /// the storage backend eagerly.
     pub fn from_path(ctx: &NodeContext, path: &str) -> Result<Self, BoxedError> {
         let resolved = Uri::from_str(path).map_err(|e| -> BoxedError {
             format!("SinkOutput: invalid path {:?}: {e}", path).into()
@@ -34,36 +32,6 @@ impl SinkOutput {
                 format!("SinkOutput: failed to resolve storage for {resolved}: {e}").into()
             })?;
         Ok(Self { resolved, storage })
-    }
-
-    /// Construct a `SinkOutput` by evaluating a Rhai expression to a path string.
-    ///
-    /// If evaluation fails, the raw expression text is used as the path —
-    /// this matches the historical per-sink behavior so literal paths work
-    /// without writing them as `"\"file://...\""`.
-    pub fn from_expr(ctx: &NodeContext, expr: &Expr) -> Result<Self, BoxedError> {
-        let scope = ctx.expr_engine.new_scope();
-        let path = scope
-            .eval::<String>(expr.as_ref())
-            .unwrap_or_else(|_| expr.as_ref().to_string());
-        Self::from_path(ctx, &path)
-    }
-
-    /// Evaluate an `Expr` to its `(path_string, Uri)` pair without acquiring
-    /// a storage backend.
-    ///
-    /// Useful for buffered sinks that want to key a `HashMap` by `Uri` and
-    /// only construct a full `SinkOutput` (which calls
-    /// `storage_resolver.resolve`) when the entry is vacant.
-    pub fn evaluate_uri(ctx: &NodeContext, expr: &Expr) -> Result<(String, Uri), BoxedError> {
-        let scope = ctx.expr_engine.new_scope();
-        let path = scope
-            .eval::<String>(expr.as_ref())
-            .unwrap_or_else(|_| expr.as_ref().to_string());
-        let uri = Uri::from_str(&path).map_err(|e| -> BoxedError {
-            format!("SinkOutput: invalid path {:?}: {e}", path).into()
-        })?;
-        Ok((path, uri))
     }
 
     /// Return the resolved URI this output writes to.
@@ -123,30 +91,6 @@ mod tests {
         out.write(Bytes::from_static(b"hello")).unwrap();
         let content = std::fs::read(&target).unwrap();
         assert_eq!(content, b"hello");
-    }
-
-    #[test]
-    fn from_expr_evaluates_then_resolves() {
-        let tmp = tempdir().unwrap();
-        let target = tmp.path().join("expr_target.bin");
-        let ctx = NodeContext::default();
-        let expr = Expr::new(file_uri(&target));
-        let out = SinkOutput::from_expr(&ctx, &expr).unwrap();
-        out.write(Bytes::from_static(b"x")).unwrap();
-        assert!(target.exists());
-    }
-
-    #[test]
-    fn from_expr_evaluates_rhai_concat_expression() {
-        let tmp = tempdir().unwrap();
-        // A Rhai expression that concatenates strings — must successfully evaluate
-        let dir = tmp.path().display().to_string();
-        let expr_src = format!(r#""file://{dir}/" + "concat_out.bin""#);
-        let expr = Expr::new(&expr_src);
-        let ctx = NodeContext::default();
-        let out = SinkOutput::from_expr(&ctx, &expr).unwrap();
-        out.write(Bytes::from_static(b"y")).unwrap();
-        assert!(tmp.path().join("concat_out.bin").exists());
     }
 
     #[test]
@@ -222,17 +166,6 @@ mod tests {
             Arc::ptr_eq(&original.storage, &cloned.storage),
             "clone must share the same storage Arc, not create a new one"
         );
-    }
-
-    #[test]
-    fn evaluate_uri_returns_path_and_parsed_uri() {
-        let tmp = tempdir().unwrap();
-        let target = tmp.path().join("eval.bin");
-        let ctx = NodeContext::default();
-        let expr = Expr::new(file_uri(&target));
-        let (path, uri) = SinkOutput::evaluate_uri(&ctx, &expr).unwrap();
-        assert_eq!(path, file_uri(&target));
-        assert_eq!(uri.path().as_path(), target.as_path());
     }
 
     #[test]

--- a/engine/runtime/action-sink/src/output.rs
+++ b/engine/runtime/action-sink/src/output.rs
@@ -1,0 +1,108 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use reearth_flow_common::uri::Uri;
+use reearth_flow_runtime::errors::BoxedError;
+use reearth_flow_runtime::executor_operation::NodeContext;
+use reearth_flow_storage::storage::Storage;
+use reearth_flow_types::Expr;
+
+/// Owns expression evaluation, URI parsing, storage backend acquisition,
+/// and bytes write for sink output handling.
+#[derive(Clone)]
+pub struct SinkOutput {
+    resolved: Uri,
+    storage: Arc<Storage>,
+}
+
+impl SinkOutput {
+    pub fn from_path(ctx: &NodeContext, path: &str) -> Result<Self, BoxedError> {
+        let resolved = Uri::from_str(path)?;
+        let storage = ctx.storage_resolver.resolve(&resolved)?;
+        Ok(Self { resolved, storage })
+    }
+
+    pub fn uri(&self) -> &Uri {
+        &self.resolved
+    }
+
+    pub fn write(&self, bytes: Bytes) -> Result<(), BoxedError> {
+        self.storage
+            .put_sync(self.resolved.path().as_path(), bytes)?;
+        Ok(())
+    }
+
+    pub fn from_expr(ctx: &NodeContext, expr: &Expr) -> Result<Self, BoxedError> {
+        let scope = ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(expr.as_ref())
+            .unwrap_or_else(|_| expr.as_ref().to_string());
+        Self::from_path(ctx, &path)
+    }
+
+    pub fn join(&self, sub: &str) -> Result<Self, BoxedError> {
+        let joined = self.resolved.join(sub)?;
+        // join preserves scheme+authority, so the storage backend is the same
+        Ok(Self {
+            resolved: joined,
+            storage: self.storage.clone(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reearth_flow_runtime::executor_operation::NodeContext;
+    use tempfile::tempdir;
+
+    fn file_uri(path: &std::path::Path) -> String {
+        format!("file://{}", path.display())
+    }
+
+    #[test]
+    fn from_path_resolves_file_uri() {
+        let tmp = tempdir().unwrap();
+        let target = tmp.path().join("out.bin");
+        let ctx = NodeContext::default();
+        let out = SinkOutput::from_path(&ctx, &file_uri(&target)).unwrap();
+        assert_eq!(out.uri().path().as_path(), target.as_path());
+    }
+
+    #[test]
+    fn write_persists_bytes_to_resolved_uri() {
+        let tmp = tempdir().unwrap();
+        let target = tmp.path().join("write_target.bin");
+        let ctx = NodeContext::default();
+        let out = SinkOutput::from_path(&ctx, &file_uri(&target)).unwrap();
+        out.write(Bytes::from_static(b"hello")).unwrap();
+        let content = std::fs::read(&target).unwrap();
+        assert_eq!(content, b"hello");
+    }
+
+    #[test]
+    fn from_expr_evaluates_then_resolves() {
+        let tmp = tempdir().unwrap();
+        let target = tmp.path().join("expr_target.bin");
+        let ctx = NodeContext::default();
+        let expr = Expr::new(file_uri(&target));
+        let out = SinkOutput::from_expr(&ctx, &expr).unwrap();
+        out.write(Bytes::from_static(b"x")).unwrap();
+        assert!(target.exists());
+    }
+
+    #[test]
+    fn join_composes_subpath_under_base() {
+        let tmp = tempdir().unwrap();
+        let ctx = NodeContext::default();
+        let base = SinkOutput::from_path(&ctx, &file_uri(tmp.path())).unwrap();
+        let sub = base.join("group/a.geojson").unwrap();
+        assert_eq!(
+            sub.uri().path().as_path(),
+            tmp.path().join("group/a.geojson")
+        );
+        sub.write(Bytes::from_static(b"{}")).unwrap();
+        assert!(tmp.path().join("group/a.geojson").exists());
+    }
+}

--- a/engine/runtime/action-sink/src/output.rs
+++ b/engine/runtime/action-sink/src/output.rs
@@ -49,6 +49,23 @@ impl SinkOutput {
         Self::from_path(ctx, &path)
     }
 
+    /// Evaluate an `Expr` to its `(path_string, Uri)` pair without acquiring
+    /// a storage backend.
+    ///
+    /// Useful for buffered sinks that want to key a `HashMap` by `Uri` and
+    /// only construct a full `SinkOutput` (which calls
+    /// `storage_resolver.resolve`) when the entry is vacant.
+    pub fn evaluate_uri(ctx: &NodeContext, expr: &Expr) -> Result<(String, Uri), BoxedError> {
+        let scope = ctx.expr_engine.new_scope();
+        let path = scope
+            .eval::<String>(expr.as_ref())
+            .unwrap_or_else(|_| expr.as_ref().to_string());
+        let uri = Uri::from_str(&path).map_err(|e| -> BoxedError {
+            format!("SinkOutput: invalid path {:?}: {e}", path).into()
+        })?;
+        Ok((path, uri))
+    }
+
     /// Return the resolved URI this output writes to.
     pub fn uri(&self) -> &Uri {
         &self.resolved
@@ -205,6 +222,17 @@ mod tests {
             Arc::ptr_eq(&original.storage, &cloned.storage),
             "clone must share the same storage Arc, not create a new one"
         );
+    }
+
+    #[test]
+    fn evaluate_uri_returns_path_and_parsed_uri() {
+        let tmp = tempdir().unwrap();
+        let target = tmp.path().join("eval.bin");
+        let ctx = NodeContext::default();
+        let expr = Expr::new(file_uri(&target));
+        let (path, uri) = SinkOutput::evaluate_uri(&ctx, &expr).unwrap();
+        assert_eq!(path, file_uri(&target));
+        assert_eq!(uri.path().as_path(), target.as_path());
     }
 
     #[test]

--- a/engine/runtime/action-sink/src/output.rs
+++ b/engine/runtime/action-sink/src/output.rs
@@ -139,4 +139,82 @@ mod tests {
         sub.write(Bytes::from_static(b"{}")).unwrap();
         assert!(tmp.path().join("group/a.geojson").exists());
     }
+
+    #[test]
+    fn from_path_rejects_invalid_uri() {
+        let ctx = NodeContext::default();
+        // An empty string and a bare token are not valid URIs in this codebase's `Uri` type.
+        // Try empty first; if `Uri::from_str("")` somehow succeeds, also test a clearly malformed input.
+        let result = SinkOutput::from_path(&ctx, "");
+        assert!(result.is_err(), "empty string should fail to parse");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("SinkOutput: invalid path"),
+            "error should include the context wrapper, got: {err_msg}"
+        );
+    }
+
+    #[test]
+    fn join_rejects_absolute_subpath() {
+        let tmp = tempdir().unwrap();
+        let ctx = NodeContext::default();
+        let base = SinkOutput::from_path(&ctx, &file_uri(tmp.path())).unwrap();
+        // Absolute sub paths are not allowed by `Uri::join` and must error.
+        let result = base.join("/etc/passwd");
+        assert!(
+            result.is_err(),
+            "join should reject absolute subpath, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn join_with_dotdot_pins_current_behavior() {
+        let tmp = tempdir().unwrap();
+        let nested = tmp.path().join("subdir");
+        std::fs::create_dir(&nested).unwrap();
+        let ctx = NodeContext::default();
+        let base = SinkOutput::from_path(&ctx, &file_uri(&nested)).unwrap();
+        // Document current behavior of `base.join("../sibling.txt")`.
+        // If `Uri::join` resolves `..` and the result escapes the base, this test pins that.
+        // PR2's sandbox check will replace this with a rejection assertion.
+        let result = base.join("../sibling.txt");
+        // Run the test once locally to see whether result is Ok or Err, then write the matching assertion below.
+        // Acceptable forms:
+        //   - assert!(result.is_ok(), "..."); + path check
+        //   - assert!(result.is_err(), "...");
+        match result {
+            Ok(sub) => {
+                // Today: join resolves traversal; pin the resolved path so PR2 sees the change.
+                let expected = tmp.path().join("sibling.txt");
+                assert_eq!(
+                    sub.uri().path().as_path(),
+                    expected.as_path(),
+                    "traversal currently resolves to parent — PR2 will block this"
+                );
+            }
+            Err(e) => {
+                // Today: Uri::join rejects `..` segments outright.
+                let _ = e; // pin that traversal is rejected at the Uri layer
+            }
+        }
+    }
+
+    #[test]
+    fn clone_shares_storage_backend() {
+        let tmp = tempdir().unwrap();
+        let ctx = NodeContext::default();
+        let original = SinkOutput::from_path(&ctx, &file_uri(tmp.path())).unwrap();
+        let cloned = original.clone();
+        // `Arc::ptr_eq` confirms both SinkOutputs point at the same underlying storage handle.
+        assert!(
+            Arc::ptr_eq(&original.storage, &cloned.storage),
+            "clone must share the same storage Arc, not create a new one"
+        );
+    }
+
+    #[test]
+    fn sink_output_is_send_sync_clone_debug() {
+        fn assert_send_sync_clone_debug<T: Send + Sync + Clone + std::fmt::Debug>() {}
+        assert_send_sync_clone_debug::<SinkOutput>();
+    }
 }

--- a/engine/runtime/action-sink/src/output.rs
+++ b/engine/runtime/action-sink/src/output.rs
@@ -10,7 +10,7 @@ use reearth_flow_types::Expr;
 
 /// Owns expression evaluation, URI parsing, storage backend acquisition,
 /// and bytes write for sink output handling.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SinkOutput {
     resolved: Uri,
     storage: Arc<Storage>,

--- a/engine/runtime/action-sink/src/output.rs
+++ b/engine/runtime/action-sink/src/output.rs
@@ -17,16 +17,22 @@ pub struct SinkOutput {
 }
 
 impl SinkOutput {
-    /// Construct a `SinkOutput` from a fully-formed path string.
+    /// Construct a `SinkOutput` from a path string.
     ///
-    /// The string must parse as a valid URI (`file://...`, `gs://...`, etc.).
-    /// Resolves the storage backend eagerly. Used by sinks that pre-compile
-    /// Rhai expression ASTs and evaluate them at write time.
+    /// Accepts either a URI (`file://...`, `gs://...`, etc.) or a plain
+    /// filesystem path (treated as `file://` by `Uri::from_str`). Resolves
+    /// the storage backend eagerly. Used by sinks that pre-compile Rhai
+    /// expression ASTs and evaluate them at write time.
     pub fn from_path(ctx: &NodeContext, path: &str) -> Result<Self, BoxedError> {
         let resolved = Uri::from_str(path).map_err(|e| -> BoxedError {
             format!("SinkOutput: invalid path {:?}: {e}", path).into()
         })?;
-        let storage = ctx.storage_resolver.resolve(&resolved)?;
+        let storage = ctx
+            .storage_resolver
+            .resolve(&resolved)
+            .map_err(|e| -> BoxedError {
+                format!("SinkOutput: failed to resolve storage for {resolved}: {e}").into()
+            })?;
         Ok(Self { resolved, storage })
     }
 
@@ -174,29 +180,18 @@ mod tests {
         std::fs::create_dir(&nested).unwrap();
         let ctx = NodeContext::default();
         let base = SinkOutput::from_path(&ctx, &file_uri(&nested)).unwrap();
-        // Document current behavior of `base.join("../sibling.txt")`.
-        // If `Uri::join` resolves `..` and the result escapes the base, this test pins that.
-        // PR2's sandbox check will replace this with a rejection assertion.
-        let result = base.join("../sibling.txt");
-        // Run the test once locally to see whether result is Ok or Err, then write the matching assertion below.
-        // Acceptable forms:
-        //   - assert!(result.is_ok(), "..."); + path check
-        //   - assert!(result.is_err(), "...");
-        match result {
-            Ok(sub) => {
-                // Today: join resolves traversal; pin the resolved path so PR2 sees the change.
-                let expected = tmp.path().join("sibling.txt");
-                assert_eq!(
-                    sub.uri().path().as_path(),
-                    expected.as_path(),
-                    "traversal currently resolves to parent — PR2 will block this"
-                );
-            }
-            Err(e) => {
-                // Today: Uri::join rejects `..` segments outright.
-                let _ = e; // pin that traversal is rejected at the Uri layer
-            }
-        }
+        // Pin current behavior: `Uri::join` normalizes `..` and the result
+        // escapes the base directory. PR2 will replace this with a rejection
+        // assertion once sandboxing lands.
+        let sub = base
+            .join("../sibling.txt")
+            .expect("Uri::join currently resolves `..` segments");
+        let expected = tmp.path().join("sibling.txt");
+        assert_eq!(
+            sub.uri().path().as_path(),
+            expected.as_path(),
+            "traversal currently resolves to parent — PR2 will block this"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# refactor(engine/sink): introduce SinkOutput abstraction

> **Branch:** `chore/engine-sink-output-abstraction` (22 commits ahead of `main`)
> **Companion future work:** PR2 will add the sandbox security check inside `SinkOutput::from_path` (designed but not started).

## Why

Every sink writer in `engine/runtime/action-sink/src/file/` duplicated the same boilerplate for URI parsing, storage backend acquisition, and bytes write inside its `finish()` (and sometimes `process()`) method:

1. `Uri::from_str(path)` → URI
2. `storage_resolver.resolve(&uri)` → storage backend
3. **Format-specific serialization** (the only step that varies)
4. `storage.put_sync(path, bytes)`

14 sinks × 3-of-4 identical steps = duplicated code with no single chokepoint. This PR extracts steps 1, 2, and 4 into one type, `SinkOutput`, and migrates every sink to it. Each sink now only owns its serialization logic and its own expression evaluation.

## What changes

**New type:** `engine/runtime/action-sink/src/output.rs` — `SinkOutput`. **Storage-focused only**, no knowledge of expression evaluation:

- `from_path(&NodeContext, &str) -> Result<Self, BoxedError>` — parses URI, eagerly acquires storage backend.
- `uri(&self) -> &Uri` — read the resolved URI.
- `write(&self, Bytes) -> Result<(), BoxedError>` — write via the backend.
- `join(&self, &str) -> Result<Self, BoxedError>` — derive child URIs (for groups, tiles, sidecars). Reuses the parent's storage `Arc`.

`Clone + Debug` are derived so sinks can store instances in their buffers.

**Expression evaluation stays in each sink.** The `scope.eval::<String>(...).unwrap_or_else(...)` dance lives at each call site — same place it did before the refactor began. This is a deliberate choice (see "Updates from review" below).

**14 sink migrations** — one commit per sink, simplest → most complex (Zip, Geopackage, CityGml, Json, Xml, Csv, Excel, GeoJson, Czml, Obj, Shapefile, Gltf, Mvt, Cesium3DTiles). Each commit is independently CI-green.

## What does NOT change

- **No new workflow features.** Same `output:` param semantics for every sink.
- **No fixture / YAML edits.** All 83 workflow fixtures referencing `workerArtifactPath` are untouched (`git diff main -- engine/runtime/examples/fixture engine/runtime/tests/fixture engine/testing/data` is empty).
- **No sandbox / security check.** That's the explicit PR2 scope.
- **No Cesium3DTiles `output`/`compressedOutput` consolidation.** Cesium keeps two independent `SinkOutput` instances. PR2 collapses them.
- **No cross-crate signature changes** in `action-processor`. Where a `pub fn` is shared between sink and processor crates, only the sink-local caller migrated (see CityGML below).
- **Expression evaluation semantics unchanged** — same Rhai eval with silent-string fallback in each sink, just no longer abstracted into `SinkOutput`.

## Tests

| Suite | Before | After |
| --- | --- | --- |
| `cargo test -p reearth-flow-action-sink --lib` | 48 | 56 (48 prior + 8 new `SinkOutput` tests: 3 happy paths + 5 edge cases) |
| `cargo make test-rs` (full workspace) | passes | passes |
| Fixture YAML diff vs main | — | empty |

Every existing sink test passes **unmodified**. That's the load-bearing claim of a pure-refactor PR.

The 5 edge-case tests cover: invalid URI rejection with error context, absolute-subpath rejection in `join`, current `..` traversal behavior (pinned for PR2 to verify the sandbox change), `Clone` sharing the storage `Arc`, and a compile-time `Send + Sync + Clone + Debug` assertion that guards future field additions to `SinkOutput`.

**Notable finding from the edge-case tests:** `base.join("../escape.txt")` **currently succeeds and resolves outside the base directory**. This is the exact traversal vulnerability PR2's sandbox check exists to close. The pinned test in this PR makes PR2's behavior change visible.

---

## Updates from review

- **Narrowed `SinkOutput` to URI + storage only.** An earlier iteration had `from_expr` and `evaluate_uri` methods that owned the eval-fallback dance. Per reviewer feedback, those were removed so the type stays decoupled from the expression system — different sinks can evolve their expression handling independently (e.g., when the silent-string fallback is eventually deprecated in favor of an explicit literal-path type, individual sinks can migrate without touching the shared abstraction).
- **Hot-path optimization preserved.** Dynamic-per-feature sinks (JSON/XML/CSV/Excel) use `Entry::Occupied`/`Vacant` so `SinkOutput::from_path` (with its `storage_resolver.resolve` call) only fires when a new output URI appears in the buffer, not on every feature.
- **GLTF regression caught and fixed.** An early iteration moved GltfWriter's output evaluation from `build()` to `finish()`, which silently broke two things: (1) `with:` workflow parameters were no longer injected into the eval scope, so any expression referencing a `with` variable would fail to resolve, and (2) eval failures changed from a build-time `SinkError::BuildFactory` (workflow startup abort) to a silent fallback to the raw expression string. Both reverted — GltfWriter is back to its original semantics, with `SinkOutput::from_path` called in `finish()` from the already-resolved `Uri`.

## Editorial improvements worth calling out

While migrating, a few sinks got small improvements beyond a byte-exact swap. Worth reading so reviewers don't miss them.

### 1. CityGML — partial migration

`write_citygml_to_storage` is a `pub fn` shared between the sink crate and the `action-processor` crate. Migrating its signature would touch a second crate, out of scope here. Only the sink-internal callsite was migrated; the function still receives `&Uri` + `&Arc<StorageResolver>` as before. **Texture sidecar writes still go through the old direct-storage path** and will need PR2 to migrate them when the sandbox check lands.

### 2. Shapefile — `storage.delete_sync` → `std::fs::remove_file`

In the null-shape overwrite cleanup, two `storage.delete_sync(...)` calls were replaced with `std::fs::remove_file(...)`. Rationale: the shapefile sink is **local-filesystem-only by design** — `shapefile::Writer::from_path` is hard-coded to local paths, so the rest of the sink can never see a non-`file://` URI. The two paths are equivalent in practice.

### 3. MVT and Cesium3DTiles — silent `if let Ok` on compress resolve → logged `match`

The compress-output write block originally swallowed storage-resolver failures silently via `if let Ok(storage) = ctx.storage_resolver.resolve(...)`. The refactor changed this to an explicit `match` that emits a `tracing` warn via `event_hub` on the `Err` arm. Upstream behavior preserved — errors are still non-fatal, the sink continues. Operators will see a log line in monitoring when compress resolve fails. Net: latent bug surfacing, no functional regression.

---

## Why this PR is the foundation for PR2

PR2's sandbox security check (rejecting writes outside a per-job allowed root) needs **one place** to attach. Before this PR, that one place didn't exist — every sink had its own copy of the URI → storage acquisition logic, and a sandbox check would need to be duplicated 14 times.

After this PR, the sandbox check is a single conditional inside `SinkOutput::from_path`. Every sink that routes through `SinkOutput` inherits it the moment it lands. That's why the refactor is worth its size.

---

## Reviewer checklist

- [ ] Read `output.rs` first — it's the foundational API everything else routes through. ~80 lines.
- [ ] Spot-check one of the simpler sink migrations (`zip.rs` is good) to see the typical shape.
- [ ] Spot-check one of the dynamic per-feature ones (`json.rs`) to see the `Entry::Occupied`/`Vacant` buffer pattern.
- [ ] Read the "Editorial improvements" notes above and confirm you're comfortable with the small deviations.
- [ ] Verify `git diff main -- engine/runtime/examples/fixture engine/runtime/tests/fixture engine/testing/data` is empty (no fixture changes).
- [ ] Optional: run `cargo make test-qc` and `cargo make test-conv` locally — these exercise sinks end-to-end through real workflow fixtures.
