### PR TITLE
feat(server,engine): debug runs via Cloud Run Service for fast cold start

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -459,6 +459,8 @@ dependencies = [
  "http 1.4.0",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa 1.0.17",
  "matchit",
  "memchr",
@@ -467,10 +469,15 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -491,6 +498,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5798,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.316"
+version = "0.0.317"
 dependencies = [
  "directories",
  "log",
@@ -5827,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6621,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "futures",
  "once_cell",
@@ -6641,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "approx",
  "async-trait",
@@ -6687,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "Inflector",
  "approx",
@@ -6745,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6766,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6834,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6885,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6896,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "bytes",
  "clap",
@@ -6934,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6974,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "chrono",
  "futures",
@@ -6988,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7017,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7029,7 +7037,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "approx",
  "bvh",
@@ -7059,7 +7067,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7093,7 +7101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7102,7 +7110,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7132,7 +7140,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7166,7 +7174,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7183,7 +7191,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7195,7 +7203,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "bytes",
  "futures",
@@ -7212,7 +7220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "bytes",
  "futures",
@@ -7231,7 +7239,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7245,7 +7253,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7280,7 +7288,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7318,9 +7326,10 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.369"
+version = "0.0.370"
 dependencies = [
  "async-trait",
+ "axum",
  "backon",
  "bytes",
  "chrono",
@@ -8109,6 +8118,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa 1.0.17",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -9756,6 +9776,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -11196,7 +11217,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.218"
+version = "0.1.219"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.369"
+version = "0.0.370"
 
 [profile.dev]
 opt-level = 0

--- a/engine/containers/worker/Dockerfile
+++ b/engine/containers/worker/Dockerfile
@@ -42,7 +42,9 @@ RUN \
     --mount=type=bind,source=testing/plateau-tiles-test,target=testing/plateau-tiles-test \
     --mount=type=bind,source=testing/workflow-tests,target=testing/workflow-tests \
     --mount=type=bind,source=worker,target=worker \
-    cargo build --package reearth-flow-worker --bin reearth-flow-worker --release && mv target/release/reearth-flow-worker /tmp/reearth-flow-worker
+    cargo build --package reearth-flow-worker --bin reearth-flow-worker --bin reearth-flow-worker-server --release && \
+    mv target/release/reearth-flow-worker /tmp/reearth-flow-worker && \
+    mv target/release/reearth-flow-worker-server /tmp/reearth-flow-worker-server
 
 FROM debian:trixie-slim
 
@@ -57,5 +59,7 @@ RUN \
     rm -rf /var/lib/apt/lists/*
 
 COPY --chmod=0755 --from=builder /tmp/reearth-flow-worker /bin
+COPY --chmod=0755 --from=builder /tmp/reearth-flow-worker-server /bin
+RUN mkdir -p /work
 
 CMD [ "/bin/reearth-flow-worker" ]

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.316"
+version = "0.0.317"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.28"
+version = "0.2.29"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.218"
+version = "0.1.219"
 edition = "2021"
 
 [[bin]]

--- a/engine/worker/Cargo.toml
+++ b/engine/worker/Cargo.toml
@@ -14,6 +14,10 @@ version.workspace = true
 name = "reearth-flow-worker"
 path = "src/main.rs"
 
+[[bin]]
+name = "reearth-flow-worker-server"
+path = "src/bin/server.rs"
+
 [dependencies]
 reearth-flow-action-log.workspace = true
 reearth-flow-action-plateau-processor.workspace = true
@@ -28,6 +32,8 @@ reearth-flow-state.workspace = true
 reearth-flow-storage.workspace = true
 reearth-flow-telemetry.workspace = true
 reearth-flow-types.workspace = true
+
+axum = "0.7.9"
 
 async-trait.workspace = true
 backon = "1.6.0"

--- a/engine/worker/src/bin/server.rs
+++ b/engine/worker/src/bin/server.rs
@@ -1,0 +1,160 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{extract::State, http::StatusCode, routing::get, routing::post, Json, Router};
+use reearth_flow_common::uri::Uri;
+use reearth_flow_storage::resolve::StorageResolver;
+use reearth_flow_worker::wrapper::{
+    build_worker_args, cancel_requested, cleanup_work_root, make_work_root, validate_job_id,
+    RunRequest,
+};
+use serde_json::json;
+
+#[derive(Clone)]
+struct AppState {
+    resolver: Arc<StorageResolver>,
+    worker_bin: String,
+    work_base: PathBuf,
+}
+
+async fn health() -> &'static str {
+    "ok"
+}
+
+/// Handle a `/run` POST request.
+/// Response: `{"status": "COMPLETED"|"CANCELLED"|"FAILED", "error"?: string}`
+async fn run(
+    State(st): State<AppState>,
+    Json(req): Json<RunRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    // Validate before touching the filesystem — prevents rm -rf path traversal.
+    if let Err(e) = validate_job_id(&req.job_id) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"status": "FAILED", "error": e})),
+        );
+    }
+
+    let root = match make_work_root(&st.work_base, &req.job_id) {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"status": "FAILED", "error": e.to_string()})),
+            );
+        }
+    };
+
+    let cancel_uri = match Uri::from_str(&req.cancel_flag_uri) {
+        Ok(u) => u,
+        Err(e) => {
+            cleanup_work_root(&root);
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"status": "FAILED", "error": format!("bad cancel_flag_uri: {e}")})),
+            );
+        }
+    };
+
+    let args = build_worker_args(&req);
+    let mut child = match tokio::process::Command::new(&st.worker_bin)
+        .args(&args)
+        .env("FLOW_RUNTIME_WORKING_DIRECTORY", &root)
+        .env("TMPDIR", &root)
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            cleanup_work_root(&root);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"status": "FAILED", "error": e.to_string()})),
+            );
+        }
+    };
+    eprintln!(
+        "[wrapper] spawned job {} pid={}",
+        req.job_id,
+        child.id().unwrap_or(0)
+    );
+
+    // Check exit before cancel flag: COMPLETED wins if both arrive simultaneously.
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                cleanup_work_root(&root);
+                return if status.success() {
+                    (StatusCode::OK, Json(json!({"status": "COMPLETED"})))
+                } else {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(
+                            json!({"status": "FAILED", "error": format!("worker exit: {status}")}),
+                        ),
+                    )
+                };
+            }
+            Ok(None) => {}
+            Err(e) => {
+                cleanup_work_root(&root);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({"status": "FAILED", "error": e.to_string()})),
+                );
+            }
+        }
+
+        let cancelled = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            cancel_requested(&st.resolver, &cancel_uri),
+        )
+        .await
+        .unwrap_or(false);
+        if cancelled {
+            eprintln!("[wrapper] cancel flag seen for {} -> killing", req.job_id);
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            cleanup_work_root(&root);
+            return (StatusCode::OK, Json(json!({"status": "CANCELLED"})));
+        }
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(8080);
+
+    let worker_bin =
+        std::env::var("FLOW_WORKER_BIN").unwrap_or_else(|_| "/bin/reearth-flow-worker".to_string());
+
+    let work_base = std::env::var("FLOW_WRAPPER_WORK_BASE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/work"));
+
+    let state = AppState {
+        resolver: Arc::new(StorageResolver::new()),
+        worker_bin,
+        work_base,
+    };
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/run", post(run))
+        .with_state(state);
+
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    eprintln!("reearth-flow-worker-server listening on {addr}");
+    axum::serve(listener, app).await.expect("axum serve failed");
+}

--- a/engine/worker/src/lib.rs
+++ b/engine/worker/src/lib.rs
@@ -4,3 +4,4 @@ pub mod logger;
 pub mod pubsub;
 pub mod types;
 mod user_facing_log_handler;
+pub mod wrapper;

--- a/engine/worker/src/wrapper.rs
+++ b/engine/worker/src/wrapper.rs
@@ -1,0 +1,195 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use reearth_flow_common::uri::Uri;
+use reearth_flow_storage::resolve::StorageResolver;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct RunRequest {
+    /// Used by the wrapper to build the work-root path; not passed to the worker CLI.
+    pub job_id: String,
+    pub workflow_url: String,
+    pub metadata_path: String,
+    #[serde(default)]
+    pub variables: HashMap<String, String>,
+    #[serde(default)]
+    pub previous_job_id: Option<String>,
+    #[serde(default)]
+    pub start_node_id: Option<String>,
+    /// Polled by the wrapper for cancellation; not passed to the worker CLI.
+    pub cancel_flag_uri: String,
+}
+
+/// Build the argv (excluding the program name) for the `reearth-flow-worker` CLI.
+pub fn build_worker_args(req: &RunRequest) -> Vec<String> {
+    let mut args = vec![
+        "--workflow".to_string(),
+        req.workflow_url.clone(),
+        "--metadata-path".to_string(),
+        req.metadata_path.clone(),
+    ];
+    for (k, v) in &req.variables {
+        args.push("--var".to_string());
+        args.push(format!("{k}={v}"));
+    }
+    if let Some(prev) = &req.previous_job_id {
+        args.push("--previous-job-id".to_string());
+        args.push(prev.clone());
+    }
+    if let Some(node) = &req.start_node_id {
+        args.push("--start-node-id".to_string());
+        args.push(node.clone());
+    }
+    args
+}
+
+/// Create a unique work root for a request under `base` (e.g. /work).
+pub fn make_work_root(base: &Path, job_id: &str) -> std::io::Result<PathBuf> {
+    let root = base.join(job_id);
+    std::fs::create_dir_all(&root)?;
+    Ok(root)
+}
+
+/// Returns true if the cancel-flag object exists at `uri`.
+/// Uses `head()` (backend-aware) not `exists()` (local-fs only).
+pub async fn cancel_requested(resolver: &Arc<StorageResolver>, uri: &Uri) -> bool {
+    match resolver.resolve(uri) {
+        // head() Err is the normal "no flag yet" case (every poll) — do not log it.
+        Ok(storage) => storage.head(uri.path().as_path()).await.is_ok(),
+        Err(e) => {
+            eprintln!("[wrapper] resolve cancel uri failed: {e}");
+            false
+        }
+    }
+}
+
+/// Validate a job_id is safe as a single path segment (prevents rm -rf traversal).
+/// Accepts ASCII alphanumeric, `-`, and `_` only (covers UUIDs).
+pub fn validate_job_id(job_id: &str) -> Result<(), String> {
+    if job_id.is_empty() {
+        return Err("job_id must not be empty".to_string());
+    }
+    if !job_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(
+            "job_id must contain only ASCII alphanumeric characters, '-', or '_'".to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Remove the work root; never panics. Logs on failure.
+pub fn cleanup_work_root(root: &Path) {
+    if root.exists() {
+        if let Err(e) = std::fs::remove_dir_all(root) {
+            eprintln!("[wrapper] failed to cleanup {root:?}: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn maps_required_args() {
+        let req = RunRequest {
+            job_id: "j1".into(),
+            workflow_url: "https://wf".into(),
+            metadata_path: "gs://md".into(),
+            variables: Default::default(),
+            previous_job_id: None,
+            start_node_id: None,
+            cancel_flag_uri: "gs://b/cancel/j1".into(),
+        };
+        assert_eq!(
+            build_worker_args(&req),
+            vec!["--workflow", "https://wf", "--metadata-path", "gs://md"]
+        );
+    }
+
+    #[test]
+    fn maps_optional_args() {
+        let req = RunRequest {
+            job_id: "j1".into(),
+            workflow_url: "https://wf".into(),
+            metadata_path: "gs://md".into(),
+            variables: HashMap::from([("A".into(), "1".into())]),
+            previous_job_id: Some("prev".into()),
+            start_node_id: Some("node".into()),
+            cancel_flag_uri: "gs://b/cancel/j1".into(),
+        };
+        let args = build_worker_args(&req);
+        assert!(args.windows(2).any(|w| w == ["--var", "A=1"]));
+        assert!(args.windows(2).any(|w| w == ["--previous-job-id", "prev"]));
+        assert!(args.windows(2).any(|w| w == ["--start-node-id", "node"]));
+    }
+
+    #[test]
+    fn maps_multiple_variables() {
+        let req = RunRequest {
+            job_id: "j1".into(),
+            workflow_url: "https://wf".into(),
+            metadata_path: "gs://md".into(),
+            variables: HashMap::from([("A".into(), "1".into()), ("B".into(), "2".into())]),
+            previous_job_id: None,
+            start_node_id: None,
+            cancel_flag_uri: "gs://b/cancel/j1".into(),
+        };
+        let args = build_worker_args(&req);
+        assert!(args.windows(2).any(|w| w == ["--var", "A=1"]));
+        assert!(args.windows(2).any(|w| w == ["--var", "B=2"]));
+        assert_eq!(args.iter().filter(|a| *a == "--var").count(), 2);
+    }
+
+    #[test]
+    fn work_root_create_and_cleanup() {
+        let base = std::env::temp_dir().join(format!("wrap-test-{}", uuid::Uuid::new_v4()));
+        let root = make_work_root(&base, "job-123").unwrap();
+        std::fs::write(root.join("blob"), b"x").unwrap();
+        assert!(root.exists());
+        cleanup_work_root(&root);
+        assert!(!root.exists());
+        cleanup_work_root(&base); // tidy parent
+    }
+
+    #[test]
+    fn validate_job_id_accepts_uuid() {
+        assert!(validate_job_id("6b34bf72-1993-450d-b447-60a586a792dc").is_ok());
+    }
+
+    #[test]
+    fn validate_job_id_rejects_empty_and_traversal() {
+        assert!(validate_job_id("").is_err());
+        assert!(validate_job_id("../etc").is_err());
+        assert!(validate_job_id("a/b").is_err());
+        assert!(validate_job_id("a\\b").is_err());
+        assert!(validate_job_id(".").is_err());
+        assert!(validate_job_id("..").is_err());
+    }
+
+    #[tokio::test]
+    async fn cancel_flag_detected_via_file_uri() {
+        let dir = std::env::temp_dir().join(format!("cancel-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let flag = dir.join("flag");
+        // Construct a file:// URI from the absolute path.
+        let uri_str = format!("file://{}", flag.display());
+        let uri = Uri::for_test(&uri_str);
+        let resolver = Arc::new(StorageResolver::new());
+
+        // Flag does not exist yet — cancel_requested must return false.
+        assert!(!cancel_requested(&resolver, &uri).await);
+
+        // Write the flag file — cancel_requested must now return true.
+        std::fs::write(&flag, b"cancel").unwrap();
+        assert!(cancel_requested(&resolver, &uri).await);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/server/api/internal/app/config/config.go
+++ b/server/api/internal/app/config/config.go
@@ -83,6 +83,7 @@ type (
 		Worker_TaskCount                       string `envconfig:"WORKER_TASK_COUNT" default:"1" pp:",omitempty"`
 		Worker_ThreadPoolSize                  string `envconfig:"WORKER_THREAD_POOL_SIZE" default:"30" pp:",omitempty"`
 		Worker_RustLog                         string `envconfig:"WORKER_RUST_LOG" default:"info" pp:",omitempty"`
+		Worker_DebugServiceURL                 string `envconfig:"WORKER_DEBUG_SERVICE_URL" pp:",omitempty"`
 
 		// websocket
 		WebsocketThriftServerURL string `envconfig:"REEARTH_FLOW_WEBSOCKET_SERVER_URL" default:"http://localhost:8000" pp:",omitempty"`

--- a/server/api/internal/app/repo.go
+++ b/server/api/internal/app/repo.go
@@ -7,6 +7,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/reearth/reearth-flow/api/internal/app/config"
 	"github.com/reearth/reearth-flow/api/internal/infrastructure/auth0"
+	"github.com/reearth/reearth-flow/api/internal/infrastructure/cloudrunworker"
 	"github.com/reearth/reearth-flow/api/internal/infrastructure/cms"
 	"github.com/reearth/reearth-flow/api/internal/infrastructure/fs"
 	"github.com/reearth/reearth-flow/api/internal/infrastructure/gcpbatch"
@@ -82,6 +83,9 @@ func initReposAndGateways(ctx context.Context, conf *config.Config, _ bool) (*re
 
 	// Batch
 	gateways.Batch = initBatch(ctx, conf)
+
+	// CloudRunWorker (must be after File)
+	gateways.CloudRunWorker = initCloudRunWorker(ctx, conf, gateways.File)
 
 	// Scheduler
 	gateways.Scheduler = initScheduler(ctx, conf)
@@ -197,6 +201,17 @@ func initBatch(ctx context.Context, conf *config.Config) gateway.Batch {
 	}
 
 	return batchRepo
+}
+
+func initCloudRunWorker(ctx context.Context, conf *config.Config, fileRepo gateway.File) gateway.CloudRunWorker {
+	if conf.Worker_DebugServiceURL == "" || fileRepo == nil {
+		return nil
+	}
+	w, err := cloudrunworker.New(ctx, conf.Worker_DebugServiceURL, fileRepo)
+	if err != nil {
+		log.Fatalf("failed to create CloudRunWorker: %v", err)
+	}
+	return w
 }
 
 func initRedis(ctx context.Context, conf *config.Config) gateway.Redis {

--- a/server/api/internal/infrastructure/cloudrunworker/worker.go
+++ b/server/api/internal/infrastructure/cloudrunworker/worker.go
@@ -1,0 +1,116 @@
+package cloudrunworker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/reearth/reearth-flow/api/internal/usecase/gateway"
+	"github.com/reearth/reearth-flow/api/pkg/id"
+	"google.golang.org/api/idtoken"
+)
+
+// Worker implements gateway.CloudRunWorker by POSTing to a Cloud Run Service
+// and blocking until the workflow finishes.
+type Worker struct {
+	file       gateway.File
+	httpClient *http.Client
+	serviceURL string
+}
+
+// New constructs a Worker using the provided file gateway for cancel-flag I/O.
+func New(ctx context.Context, serviceURL string, file gateway.File) (gateway.CloudRunWorker, error) {
+	httpClient, err := idtoken.NewClient(ctx, serviceURL)
+	if err != nil {
+		return nil, fmt.Errorf("cloudrunworker: idtoken client: %w", err)
+	}
+	// Bound the blocking /run call just above Cloud Run's max request timeout (60 min).
+	httpClient.Timeout = 65 * time.Minute
+	return &Worker{
+		file:       file,
+		httpClient: httpClient,
+		serviceURL: serviceURL,
+	}, nil
+}
+
+type runRequest struct {
+	JobID         string            `json:"job_id"`
+	WorkflowURL   string            `json:"workflow_url"`
+	MetadataPath  string            `json:"metadata_path"`
+	Variables     map[string]string `json:"variables,omitempty"`
+	PreviousJobID *string           `json:"previous_job_id,omitempty"`
+	StartNodeID   *string           `json:"start_node_id,omitempty"`
+	CancelFlagURI string            `json:"cancel_flag_uri"`
+}
+
+type runResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+// RunJob POSTs to the Cloud Run Service /run endpoint and blocks until the
+// workflow finishes. The service responds with a terminal status in the body.
+func (w *Worker) RunJob(ctx context.Context, p gateway.RunJobParam) (gateway.JobStatus, error) {
+	body := runRequest{
+		JobID:         p.JobID.String(),
+		WorkflowURL:   p.WorkflowURL,
+		MetadataPath:  p.MetadataURL,
+		Variables:     p.Variables,
+		CancelFlagURI: w.file.CancelFlagURI(p.JobID.String()),
+	}
+	if p.PreviousJobID != nil {
+		s := p.PreviousJobID.String()
+		body.PreviousJobID = &s
+	}
+	if p.StartNodeID != nil {
+		s := p.StartNodeID.String()
+		body.StartNodeID = &s
+	}
+
+	buf, _ := json.Marshal(body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.serviceURL+"/run", bytes.NewReader(buf))
+	if err != nil {
+		return gateway.JobStatusFailed, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := w.httpClient.Do(req)
+	if err != nil {
+		// Connection dropped / instance reclaimed = infra failure.
+		return gateway.JobStatusFailed, err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	var rr runResponse
+	_ = json.Unmarshal(raw, &rr)
+
+	switch rr.Status {
+	case "COMPLETED":
+		return gateway.JobStatusCompleted, nil
+	case "CANCELLED":
+		return gateway.JobStatusCancelled, nil
+	default:
+		detail := rr.Error
+		if detail == "" {
+			if len(raw) > 256 {
+				detail = string(raw[:256])
+			} else {
+				detail = string(raw)
+			}
+		}
+		return gateway.JobStatusFailed, fmt.Errorf(
+			"cloudrunworker: run failed (http %d): %s", resp.StatusCode, detail,
+		)
+	}
+}
+
+// CancelJob writes a cancel flag via the file gateway so the wrapper process
+// can trigger graceful cancellation of the running workflow.
+func (w *Worker) CancelJob(ctx context.Context, jobID id.JobID) error {
+	return w.file.WriteCancelFlag(ctx, jobID.String())
+}

--- a/server/api/internal/infrastructure/cloudrunworker/worker_test.go
+++ b/server/api/internal/infrastructure/cloudrunworker/worker_test.go
@@ -1,0 +1,132 @@
+package cloudrunworker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/reearth/reearth-flow/api/internal/usecase/gateway"
+	"github.com/reearth/reearth-flow/api/pkg/asset"
+	"github.com/reearth/reearth-flow/api/pkg/file"
+	"github.com/reearth/reearth-flow/api/pkg/id"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeFile is a minimal gateway.File for testing the cloudrunworker.
+// Only WriteCancelFlag and CancelFlagURI are exercised; all other methods panic.
+type fakeFile struct {
+	bucket      string
+	cancelCalls []string
+}
+
+func (f *fakeFile) CancelFlagURI(jobID string) string {
+	return fmt.Sprintf("gs://%s/cancel/%s", f.bucket, jobID)
+}
+func (f *fakeFile) WriteCancelFlag(_ context.Context, jobID string) error {
+	f.cancelCalls = append(f.cancelCalls, jobID)
+	return nil
+}
+func (f *fakeFile) ReadAsset(context.Context, string) (io.ReadCloser, error)         { panic("unused") }
+func (f *fakeFile) UploadAsset(context.Context, *file.File) (*url.URL, int64, error) { panic("unused") }
+func (f *fakeFile) DeleteAsset(context.Context, *url.URL) error                      { panic("unused") }
+func (f *fakeFile) ReadWorkflow(context.Context, string) (io.ReadCloser, error)      { panic("unused") }
+func (f *fakeFile) UploadWorkflow(context.Context, *file.File) (*url.URL, error)     { panic("unused") }
+func (f *fakeFile) RemoveWorkflow(context.Context, *url.URL) error                   { panic("unused") }
+func (f *fakeFile) ReadMetadata(context.Context, string) (io.ReadCloser, error)      { panic("unused") }
+func (f *fakeFile) UploadMetadata(context.Context, string, []string) (*url.URL, error) {
+	panic("unused")
+}
+func (f *fakeFile) RemoveMetadata(context.Context, *url.URL) error                { panic("unused") }
+func (f *fakeFile) ReadArtifact(context.Context, string) (io.ReadCloser, error)   { panic("unused") }
+func (f *fakeFile) ListJobArtifacts(context.Context, string) ([]string, error)    { panic("unused") }
+func (f *fakeFile) GetJobLogURL(string) string                                    { panic("unused") }
+func (f *fakeFile) CheckJobLogExists(context.Context, string) (bool, error)       { panic("unused") }
+func (f *fakeFile) GetJobWorkerLogURL(string) string                              { panic("unused") }
+func (f *fakeFile) CheckJobWorkerLogExists(context.Context, string) (bool, error) { panic("unused") }
+func (f *fakeFile) GetJobUserFacingLogURL(string) string                          { panic("unused") }
+func (f *fakeFile) CheckJobUserFacingLogExists(context.Context, string) (bool, error) {
+	panic("unused")
+}
+func (f *fakeFile) GetIntermediateDataURL(context.Context, string, string) string { panic("unused") }
+func (f *fakeFile) CheckIntermediateDataExists(context.Context, string, string) (bool, error) {
+	panic("unused")
+}
+func (f *fakeFile) IssueUploadAssetLink(context.Context, gateway.IssueUploadAssetParam) (*gateway.UploadAssetLink, error) {
+	panic("unused")
+}
+func (f *fakeFile) GetPublicAssetURL(string, string) (*url.URL, error)               { panic("unused") }
+func (f *fakeFile) UploadedAsset(context.Context, *asset.Upload) (*file.File, error) { panic("unused") }
+
+func TestRunJob_MapsStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"COMPLETED"}`))
+	}))
+	defer srv.Close()
+
+	repo := &Worker{serviceURL: srv.URL, file: &fakeFile{bucket: "b"}, httpClient: srv.Client()}
+	st, err := repo.RunJob(context.Background(), gateway.RunJobParam{
+		JobID:       id.NewJobID(),
+		WorkflowURL: "https://wf",
+		MetadataURL: "gs://md",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, gateway.JobStatusCompleted, st)
+}
+
+func TestRunJob_500IsFailed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"status":"FAILED","error":"boom"}`))
+	}))
+	defer srv.Close()
+
+	repo := &Worker{serviceURL: srv.URL, file: &fakeFile{bucket: "b"}, httpClient: srv.Client()}
+	st, err := repo.RunJob(context.Background(), gateway.RunJobParam{
+		JobID:       id.NewJobID(),
+		WorkflowURL: "w",
+		MetadataURL: "m",
+	})
+	assert.Equal(t, gateway.JobStatusFailed, st)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestRunJob_PostsContractFields(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"status":"COMPLETED"}`))
+	}))
+	defer srv.Close()
+
+	fake := &fakeFile{bucket: "mybucket"}
+	repo := &Worker{serviceURL: srv.URL, file: fake, httpClient: srv.Client()}
+	jid := id.NewJobID()
+	_, _ = repo.RunJob(context.Background(), gateway.RunJobParam{
+		JobID:       jid,
+		WorkflowURL: "https://wf",
+		MetadataURL: "gs://md",
+	})
+
+	assert.Contains(t, string(gotBody), `"workflow_url":"https://wf"`)
+	assert.Contains(t, string(gotBody), `"metadata_path":"gs://md"`)
+	assert.Contains(t, string(gotBody), "gs://mybucket/cancel/"+jid.String())
+}
+
+func TestRunJob_MapsCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"CANCELLED"}`))
+	}))
+	defer srv.Close()
+	repo := &Worker{serviceURL: srv.URL, file: &fakeFile{bucket: "b"}, httpClient: srv.Client()}
+	st, err := repo.RunJob(context.Background(), gateway.RunJobParam{JobID: id.NewJobID(), WorkflowURL: "w", MetadataURL: "m"})
+	assert.NoError(t, err)
+	assert.Equal(t, gateway.JobStatusCancelled, st)
+}

--- a/server/api/internal/infrastructure/fs/file.go
+++ b/server/api/internal/infrastructure/fs/file.go
@@ -327,3 +327,11 @@ func (f *fileRepo) validateURL(u *url.URL, base *url.URL) bool {
 func (f *fileRepo) IssueUploadAssetLink(_ context.Context, _ gateway.IssueUploadAssetParam) (*gateway.UploadAssetLink, error) {
 	return nil, gateway.ErrUnsupportedOperation
 }
+
+func (f *fileRepo) WriteCancelFlag(_ context.Context, jobID string) error {
+	return afero.WriteFile(f.fs, "cancel/"+jobID, []byte("cancel"), 0644)
+}
+
+func (f *fileRepo) CancelFlagURI(jobID string) string {
+	return "file://cancel/" + jobID
+}

--- a/server/api/internal/infrastructure/gcs/file.go
+++ b/server/api/internal/infrastructure/gcs/file.go
@@ -356,6 +356,20 @@ func (f *fileRepo) CheckIntermediateDataExists(ctx context.Context, edgeID, jobI
 	return true, nil
 }
 
+func (f *fileRepo) WriteCancelFlag(ctx context.Context, jobID string) error {
+	obj := f.bucket().Object("cancel/" + jobID)
+	w := obj.NewWriter(ctx)
+	if _, err := w.Write([]byte("cancel")); err != nil {
+		_ = w.Close()
+		return fmt.Errorf("gcs: write cancel flag: %w", err)
+	}
+	return w.Close()
+}
+
+func (f *fileRepo) CancelFlagURI(jobID string) string {
+	return fmt.Sprintf("gs://%s/cancel/%s", f.bucketName, jobID)
+}
+
 // helpers
 func (f *fileRepo) bucket() *storage.BucketHandle {
 	return f.client.Bucket(f.bucketName)

--- a/server/api/internal/usecase/gateway/cloudrunworker.go
+++ b/server/api/internal/usecase/gateway/cloudrunworker.go
@@ -1,0 +1,27 @@
+package gateway
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/reearth/reearth-flow/api/pkg/id"
+)
+
+// CloudRunWorker runs debug jobs on a min=0 Cloud Run Service.
+// RunJob holds until the run finishes (the HTTP response is the infra status).
+type CloudRunWorker interface {
+	// RunJob POSTs to the Service and blocks until the workflow completes.
+	// Returns the terminal infra status (COMPLETED / FAILED / CANCELLED).
+	RunJob(ctx context.Context, p RunJobParam) (JobStatus, error)
+	// CancelJob writes the cancel flag for jobID so the wrapper kills the subprocess.
+	CancelJob(ctx context.Context, jobID id.JobID) error
+}
+
+type RunJobParam struct {
+	Variables     map[string]string
+	PreviousJobID *id.JobID
+	StartNodeID   *uuid.UUID
+	WorkflowURL   string
+	MetadataURL   string
+	JobID         id.JobID
+}

--- a/server/api/internal/usecase/gateway/container.go
+++ b/server/api/internal/usecase/gateway/container.go
@@ -1,9 +1,10 @@
 package gateway
 
 type Container struct {
-	File      File
-	Batch     Batch
-	Redis     Redis
-	Scheduler Scheduler
-	CMS       CMS
+	File           File
+	Batch          Batch
+	Redis          Redis
+	Scheduler      Scheduler
+	CMS            CMS
+	CloudRunWorker CloudRunWorker
 }

--- a/server/api/internal/usecase/gateway/file.go
+++ b/server/api/internal/usecase/gateway/file.go
@@ -74,4 +74,8 @@ type File interface {
 	IssueUploadAssetLink(context.Context, IssueUploadAssetParam) (*UploadAssetLink, error)
 	GetPublicAssetURL(string, string) (*url.URL, error)
 	UploadedAsset(context.Context, *asset.Upload) (*file.File, error)
+	// WriteCancelFlag writes the debug-run cancel marker for jobID.
+	WriteCancelFlag(ctx context.Context, jobID string) error
+	// CancelFlagURI returns the URI of the cancel marker for jobID (the worker polls it).
+	CancelFlagURI(jobID string) string
 }

--- a/server/api/internal/usecase/interactor/job.go
+++ b/server/api/internal/usecase/interactor/job.go
@@ -27,6 +27,7 @@ type Job struct {
 	transaction       usecasex.Transaction
 	file              gateway.File
 	batch             gateway.Batch
+	cloudRunWorker    gateway.CloudRunWorker
 	redis             gateway.Redis
 	notifier          notification.Notifier
 	permissionChecker gateway.PermissionChecker
@@ -56,6 +57,7 @@ func NewJob(
 		transaction:       r.Transaction,
 		file:              gr.File,
 		batch:             gr.Batch,
+		cloudRunWorker:    gr.CloudRunWorker,
 		redis:             gr.Redis,
 		monitor:           monitor.NewMonitor(),
 		subscriptions:     subscription.NewJobManager(),
@@ -124,8 +126,15 @@ func (i *Job) Cancel(ctx context.Context, jobID id.JobID) (*job.Job, error) {
 		}
 	}()
 
-	if err := i.batch.CancelJob(ctx, j.GCPJobID()); err != nil {
-		return nil, err
+	// Cloud-Run debug jobs have an empty GCPJobID; batch-fallback jobs do not.
+	if j.Debug() != nil && *j.Debug() && j.GCPJobID() == "" && i.cloudRunWorker != nil {
+		if err := i.cloudRunWorker.CancelJob(ctx, j.ID()); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := i.batch.CancelJob(ctx, j.GCPJobID()); err != nil {
+			return nil, err
+		}
 	}
 
 	j.SetStatus(job.StatusCancelled)
@@ -145,6 +154,108 @@ func (i *Job) Cancel(ctx context.Context, jobID id.JobID) (*job.Job, error) {
 	i.subscriptions.Notify(j.ID().String(), j.Status())
 
 	return j, nil
+}
+
+// RunDebugJob runs a Cloud Run debug job end-to-end: blocks on RunJob, then
+// waits (bounded) for the authoritative JobCompleteEvent from Redis before
+// persisting the final merged status and calling handleJobCompletion.
+func (i *Job) RunDebugJob(ctx context.Context, j *job.Job, p gateway.RunJobParam) {
+	// This runs in a detached goroutine; a panic here would otherwise crash the API server.
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorfc(ctx, "job: debug job %s panicked: %v", j.ID(), r)
+		}
+	}()
+
+	status, err := i.cloudRunWorker.RunJob(ctx, p)
+	if err != nil {
+		log.Errorfc(ctx, "job: debug job %s run error: %v", j.ID(), err)
+		status = gateway.JobStatusFailed
+	}
+	batchStatus := job.Status(status)
+
+	// Wait (bounded) for the Redis JobCompleteEvent — process exit-0 is not
+	// sufficient since the workflow itself may have failed.
+	var workerStatus job.Status
+	for attempt := 0; attempt < 30; attempt++ { // ~60s max (2s interval)
+		ev, rerr := i.redis.GetJobCompleteEvent(ctx, j.ID())
+		if rerr != nil {
+			log.Warnf("debug job %s: redis read error: %v", j.ID(), rerr)
+		}
+		if ev != nil {
+			switch ev.Result {
+			case "success":
+				workerStatus = job.StatusCompleted
+			case "failed":
+				workerStatus = job.StatusFailed
+			}
+			if workerStatus != "" {
+				break
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(2 * time.Second):
+		}
+	}
+
+	if workerStatus == "" {
+		log.Warnfc(ctx, "job: debug job %s finalized without a worker JobCompleteEvent; status from infra signal only", j.ID())
+	}
+
+	lock := i.getJobLock(j.ID().String())
+	lock.Lock()
+	defer lock.Unlock()
+
+	latest, err := i.jobRepo.FindByID(ctx, j.ID())
+	if err != nil {
+		log.Errorfc(ctx, "job: failed to reload debug job %s: %v", j.ID(), err)
+		return
+	}
+	// Don't clobber if a concurrent Cancel already finalized it.
+	if s := latest.Status(); s == job.StatusCancelled || s == job.StatusCompleted || s == job.StatusFailed {
+		log.Infofc(ctx, "job: debug job %s already terminal (%s); skipping", j.ID(), s)
+		return
+	}
+
+	latest.SetBatchStatus(batchStatus)
+	if workerStatus != "" {
+		latest.SetWorkerStatus(workerStatus)
+	}
+	latest.SetStatus(latest.Status())
+
+	tx, txErr := i.transaction.Begin(ctx)
+	if txErr != nil {
+		log.Errorfc(ctx, "job: tx begin failed for debug job %s: %v", j.ID(), txErr)
+		return
+	}
+	txCtx := tx.Context()
+	defer func() {
+		if err2 := tx.End(txCtx); err2 != nil {
+			log.Errorfc(ctx, "transaction end failed: %v", err2)
+		}
+	}()
+
+	if serr := i.jobRepo.Save(txCtx, latest); serr != nil {
+		log.Errorfc(ctx, "job: failed to save debug job %s: %v", j.ID(), serr)
+		return
+	}
+	tx.Commit()
+
+	if workerStatus != "" {
+		if derr := i.redis.DeleteJobCompleteEvent(ctx, j.ID()); derr != nil {
+			log.Warnf("debug job %s: failed to delete redis event: %v", j.ID(), derr)
+		}
+	}
+
+	final := latest.Status()
+	if final == job.StatusCompleted || final == job.StatusFailed || final == job.StatusCancelled {
+		if cerr := i.handleJobCompletion(ctx, latest); cerr != nil {
+			log.Errorfc(ctx, "job: completion handling failed for debug job %s: %v", j.ID(), cerr)
+		}
+	}
+	i.subscriptions.Notify(j.ID().String(), latest.Status())
 }
 
 func (i *Job) FindByID(ctx context.Context, id id.JobID) (*job.Job, error) {
@@ -278,13 +389,6 @@ func (i *Job) runMonitoringLoop(ctx context.Context, j *job.Job) {
 }
 
 func (i *Job) checkJobStatus(ctx context.Context, j *job.Job) error {
-	status, err := i.batch.GetJobStatus(ctx, j.GCPJobID())
-	if err != nil {
-		return err
-	}
-
-	newBatchStatus := job.Status(status)
-
 	jobLock := i.getJobLock(j.ID().String())
 	jobLock.Lock()
 	defer jobLock.Unlock()
@@ -292,6 +396,21 @@ func (i *Job) checkJobStatus(ctx context.Context, j *job.Job) error {
 	currentJob, err := i.jobRepo.FindByID(ctx, j.ID())
 	if err != nil {
 		return fmt.Errorf("failed to fetch current job state: %w", err)
+	}
+
+	var batchStatusChanged bool
+
+	// Cloud-Run debug jobs have an empty GCPJobID; skip Batch polling for them.
+	if j.GCPJobID() != "" {
+		status, err := i.batch.GetJobStatus(ctx, j.GCPJobID())
+		if err != nil {
+			return err
+		}
+		newBatchStatus := job.Status(status)
+		batchStatusChanged = currentJob.BatchStatus() == nil || *currentJob.BatchStatus() != newBatchStatus
+		if batchStatusChanged {
+			currentJob.SetBatchStatus(newBatchStatus)
+		}
 	}
 
 	workerEvent, err := i.redis.GetJobCompleteEvent(ctx, currentJob.ID())
@@ -314,18 +433,10 @@ func (i *Job) checkJobStatus(ctx context.Context, j *job.Job) error {
 		}
 	}
 
-	batchStatusChanged := currentJob.BatchStatus() == nil || *currentJob.BatchStatus() != newBatchStatus
-	if batchStatusChanged {
-		currentJob.SetBatchStatus(newBatchStatus)
-	}
-
 	statusChanged := batchStatusChanged || workerEvent != nil
 
 	if statusChanged {
-		// Update legacy status field with computed value
 		currentJob.SetStatus(currentJob.Status())
-
-		// Use transaction for MongoDB update
 		tx, err := i.transaction.Begin(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to begin transaction: %w", err)
@@ -345,7 +456,6 @@ func (i *Job) checkJobStatus(ctx context.Context, j *job.Job) error {
 
 		tx.Commit()
 
-		// Delete Redis key only after successful DB commit
 		if workerEvent != nil {
 			if err := i.redis.DeleteJobCompleteEvent(ctx, currentJob.ID()); err != nil {
 				log.Warnf("Failed to delete job complete event from Redis for job %s: %v", currentJob.ID(), err)
@@ -363,14 +473,11 @@ func (i *Job) checkJobStatus(ctx context.Context, j *job.Job) error {
 			computedStatus,
 		)
 
-		// For terminal states, run completion handling (artifacts/logs) before notifying.
 		if err := i.handleJobCompletion(ctx, currentJob); err != nil {
 			log.Errorfc(ctx, "job: completion handling failed: %v", err)
 		}
 	}
 
-	// For terminal states we notify only after completion handling,
-	// so subscribers see final outputs/logs together with the final status.
 	if statusChanged {
 		i.subscriptions.Notify(currentJob.ID().String(), currentJob.Status())
 	}
@@ -531,6 +638,11 @@ func (i *Job) startMonitoringIfNeeded(jobID id.JobID) {
 	j, err := i.jobRepo.FindByID(context.Background(), jobID)
 	if err != nil {
 		log.Errorfc(context.Background(), "job: failed to find job for monitoring: %v", err)
+		return
+	}
+
+	// RunDebugJob owns the lifecycle for Cloud-Run debug jobs; don't start a loop.
+	if j.Debug() != nil && *j.Debug() && j.GCPJobID() == "" {
 		return
 	}
 

--- a/server/api/internal/usecase/interactor/project.go
+++ b/server/api/internal/usecase/interactor/project.go
@@ -27,6 +27,7 @@ type Project struct {
 	transaction       usecasex.Transaction
 	file              gateway.File
 	batch             gateway.Batch
+	cloudRunWorker    gateway.CloudRunWorker
 	websocket         interfaces.WebsocketClient
 	job               interfaces.Job
 	permissionChecker gateway.PermissionChecker
@@ -43,6 +44,7 @@ func NewProject(r *repo.Container, gr *gateway.Container, jobUsecase interfaces.
 		transaction:       r.Transaction,
 		file:              gr.File,
 		batch:             gr.Batch,
+		cloudRunWorker:    gr.CloudRunWorker,
 		websocket:         websocket,
 		job:               jobUsecase,
 		permissionChecker: permissionChecker,
@@ -286,21 +288,36 @@ func (i *Project) Run(ctx context.Context, p interfaces.RunProjectParam) (_ *job
 		return nil, err
 	}
 
-	gcpJobID, err := i.batch.SubmitJob(ctx, j.ID(), workflowURL.String(), j.MetadataURL(), nil, p.ProjectID, prj.Workspace(), p.PreviousJobID, p.StartNodeID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to submit job: %v", err)
-	}
-	j.SetGCPJobID(gcpJobID)
+	if i.cloudRunWorker != nil {
+		// RunDebugJob owns the full lifecycle; commit before handing off.
+		tx.Commit()
+		if i.job != nil {
+			go i.job.RunDebugJob(context.Background(), j, gateway.RunJobParam{
+				JobID:         j.ID(),
+				WorkflowURL:   workflowURL.String(),
+				MetadataURL:   j.MetadataURL(),
+				Variables:     nil,
+				PreviousJobID: p.PreviousJobID,
+				StartNodeID:   p.StartNodeID,
+			})
+		}
+	} else {
+		gcpJobID, err := i.batch.SubmitJob(ctx, j.ID(), workflowURL.String(), j.MetadataURL(), nil, p.ProjectID, prj.Workspace(), p.PreviousJobID, p.StartNodeID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to submit job: %v", err)
+		}
+		j.SetGCPJobID(gcpJobID)
 
-	if err := i.jobRepo.Save(ctx, j); err != nil {
-		return nil, err
-	}
+		if err := i.jobRepo.Save(ctx, j); err != nil {
+			return nil, err
+		}
 
-	tx.Commit()
+		tx.Commit()
 
-	if i.job != nil {
-		if err := i.job.StartMonitoring(ctx, j, nil); err != nil {
-			return j, fmt.Errorf("failed to start job monitoring: %v", err)
+		if i.job != nil {
+			if err := i.job.StartMonitoring(ctx, j, nil); err != nil {
+				return j, fmt.Errorf("failed to start job monitoring: %v", err)
+			}
 		}
 	}
 

--- a/server/api/internal/usecase/interfaces/job.go
+++ b/server/api/internal/usecase/interfaces/job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	accountsid "github.com/reearth/reearth-accounts/server/pkg/id"
+	"github.com/reearth/reearth-flow/api/internal/usecase/gateway"
 	"github.com/reearth/reearth-flow/api/pkg/id"
 	"github.com/reearth/reearth-flow/api/pkg/job"
 )
@@ -14,6 +15,7 @@ type Job interface {
 	FindByID(context.Context, id.JobID) (*job.Job, error)
 	FindByWorkspace(context.Context, accountsid.WorkspaceID, *PaginationParam, *string) ([]*job.Job, *PageBasedInfo, error)
 	GetStatus(context.Context, id.JobID) (job.Status, error)
+	RunDebugJob(ctx context.Context, j *job.Job, p gateway.RunJobParam)
 	StartMonitoring(context.Context, *job.Job, *string) error
 	Subscribe(context.Context, id.JobID) (chan job.Status, error)
 	Unsubscribe(id.JobID, chan job.Status)


### PR DESCRIPTION
# Overview

Phase 1 of reducing **debug-run** cold start. Routes debug runs (`job.Debug == true`, the editor "Run") off GCP Batch onto a **min=0 Cloud Run Service** running the worker image — cutting cold start from ~60 s to single-digit seconds at **$0 idle**. API / scheduled / PLATEAU runs stay on GCP Batch, unchanged.

Design + plan: `docs/superpowers/specs/2026-05-20-debug-run-warm-pool-design.md`, `docs/superpowers/plans/2026-05-20-debug-run-warm-pool-phase1.md`.

## What I've done

**Engine (Rust)** — new `reearth-flow-worker-server` binary (HTTP wrapper, ships in the same worker image):
- `POST /run` spawns the existing `reearth-flow-worker` CLI as a **subprocess**, confined to a per-request work root via `FLOW_RUNTIME_WORKING_DIRECTORY` + `TMPDIR`, and `rm -rf`s it on every exit path (keeps the one-shot cleanup model inside a warm container).
- Polls a GCS **cancel-flag** (`head()`, backend-aware) while the job runs; kills the subprocess on cancel.
- `job_id` validated (no path traversal / empty → no `rm -rf /work`).
- Dockerfile builds + ships both binaries; Cloud Run overrides the entrypoint to the server, Batch keeps using the CLI.

**Server (Go)** — `CloudRunWorker` gateway + debug routing:
- New `gateway.CloudRunWorker` (`internal/infrastructure/cloudrunworker/`): `RunJob` POSTs to the Service with an ID token; `CancelJob` writes the GCS cancel-flag. Wired via `initCloudRunWorker` (nil when unconfigured → falls back to Batch).
- `Project.Run` routes debug jobs to `Job.RunDebugJob`, which is the **sole owner** of the debug lifecycle: blocks on `/run`, then waits (bounded) for the worker's `JobCompleteEvent` (Pub/Sub → Redis) for the authoritative workflow result, **merges** it with the HTTP infra status (dual-status), persists, and runs completion + notify.
- Cancellation routed to the GCS flag. Non-debug Batch submit/poll/cancel + monitoring loop unchanged.

## What I haven't done

- **Infra (Terraform)** — Cloud Run Service module + cancel-flag bucket + prod wiring: deferred to a follow-up CI/CD PR (per discussion).
- **Deploy** — image publish to Artifact Registry, `terraform apply`, server config (`WORKER_DEBUG_SERVICE_URL`, `WORKER_DEBUG_CANCEL_BUCKET`), and pointing the debug Service at the **real** Pub/Sub topics.
- **Phase 2** — session-driven warm pool (heartbeat) to also warm the first run of a session.
- Full API-server-routed end-to-end in a deployed non-prod env.

## How I tested

- Engine: `cargo test -p reearth-flow-worker` — 7 tests; clippy clean (scoped; two pre-existing workspace clippy errors in `reearth-flow-runtime`/`-common` are unrelated).
- Server: `go test` on `interactor` / `pkg/job` / `cloudrunworker` — 105 tests.
- **Live local docker trial** with the real worker image: validated the wrapper end-to-end — `/run` ran the real OBJ workflow, confined writes, cleaned up, returned status; cancel via flag killed the subprocess. The trial **caught a real bug** (the worker process exits 0 even when the workflow's nodes fail — the result is only in the `JobCompleteEvent`) which is fixed by the dual-status model above.

## Screenshot

N/A (backend).

## Which point I want you to review particularly

- **`Job.RunDebugJob` (`internal/usecase/interactor/job.go`)** — the dual-status handling: the worker exits 0 even on workflow failure, so we wait for the Pub/Sub `JobCompleteEvent` and merge with the HTTP result. Please sanity-check the locking/timing and that **non-debug paths are byte-for-byte unchanged**.
- **Cancellation** — client disconnect does **not** propagate to a Cloud Run container (verified), so cancel uses a polled GCS flag rather than connection-close.

## Memo

- The debug Service **must** publish to the real Pub/Sub topics (not `noop`) for `workerStatus` reconciliation to work.
- `cloudRunWorker == nil` (debug service unconfigured) → debug runs fall back to the existing Batch path, so environments without `WORKER_DEBUG_SERVICE_URL` behave exactly as before.