### PR TITLE
fix(api): finalize Cloud Run debug jobs via the monitoring loop

### DIFF
--- a/server/api/internal/usecase/interactor/job.go
+++ b/server/api/internal/usecase/interactor/job.go
@@ -156,106 +156,65 @@ func (i *Job) Cancel(ctx context.Context, jobID id.JobID) (*job.Job, error) {
 	return j, nil
 }
 
-// RunDebugJob runs a Cloud Run debug job end-to-end: blocks on RunJob, then
-// waits (bounded) for the authoritative JobCompleteEvent from Redis before
-// persisting the final merged status and calling handleJobCompletion.
-func (i *Job) RunDebugJob(ctx context.Context, j *job.Job, p gateway.RunJobParam) {
-	// This runs in a detached goroutine; a panic here would otherwise crash the API server.
-	defer func() {
-		if r := recover(); r != nil {
-			log.Errorfc(ctx, "job: debug job %s panicked: %v", j.ID(), r)
+// RunCloudRunWorker triggers execution of a debug job on the Cloud Run worker
+// Service. The worker publishes its authoritative result to Redis (via the
+// subscriber); the standard monitoring loop reads that event and finalizes the
+// job, exactly as it does for Batch jobs. Only an infrastructure failure — where
+// no result will ever arrive — is finalized here.
+func (i *Job) RunCloudRunWorker(j *job.Job, p gateway.RunJobParam) {
+	go func() {
+		ctx := context.Background()
+		// Detached goroutine; a panic here would otherwise crash the API server.
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorfc(ctx, "job: cloud run worker %s panicked: %v", j.ID(), r)
+			}
+		}()
+
+		status, err := i.cloudRunWorker.RunJob(ctx, p)
+		if err != nil {
+			log.Errorfc(ctx, "job: cloud run worker %s run error: %v", j.ID(), err)
+		}
+
+		// Success and workflow-level failures are finalized by the monitoring loop
+		// from the Redis worker event. An infra failure produces no event, so the
+		// loop would wait indefinitely — finalize as failed here instead.
+		if err != nil || status == gateway.JobStatusFailed {
+			i.failCloudRunJob(ctx, j.ID())
 		}
 	}()
+}
 
-	status, err := i.cloudRunWorker.RunJob(ctx, p)
-	if err != nil {
-		log.Errorfc(ctx, "job: debug job %s run error: %v", j.ID(), err)
-		status = gateway.JobStatusFailed
-	}
-	batchStatus := job.Status(status)
-
-	// Wait (bounded) for the Redis JobCompleteEvent — process exit-0 is not
-	// sufficient since the workflow itself may have failed.
-	var workerStatus job.Status
-	for attempt := 0; attempt < 30; attempt++ { // ~60s max (2s interval)
-		ev, rerr := i.redis.GetJobCompleteEvent(ctx, j.ID())
-		if rerr != nil {
-			log.Warnf("debug job %s: redis read error: %v", j.ID(), rerr)
-		}
-		if ev != nil {
-			switch ev.Result {
-			case "success":
-				workerStatus = job.StatusCompleted
-			case "failed":
-				workerStatus = job.StatusFailed
-			}
-			if workerStatus != "" {
-				break
-			}
-		}
-		select {
-		case <-ctx.Done():
-			return
-		case <-time.After(2 * time.Second):
-		}
-	}
-
-	if workerStatus == "" {
-		log.Warnfc(ctx, "job: debug job %s finalized without a worker JobCompleteEvent; status from infra signal only", j.ID())
-	}
-
-	lock := i.getJobLock(j.ID().String())
+// failCloudRunJob marks a debug job failed when the Cloud Run worker call itself
+// fails and no worker result will arrive. It mirrors the persistence the
+// monitoring loop uses so the two finalization paths stay consistent.
+func (i *Job) failCloudRunJob(ctx context.Context, jobID id.JobID) {
+	lock := i.getJobLock(jobID.String())
 	lock.Lock()
 	defer lock.Unlock()
 
-	latest, err := i.jobRepo.FindByID(ctx, j.ID())
+	latest, err := i.jobRepo.FindByID(ctx, jobID)
 	if err != nil {
-		log.Errorfc(ctx, "job: failed to reload debug job %s: %v", j.ID(), err)
+		log.Errorfc(ctx, "job: failed to reload cloud run job %s: %v", jobID, err)
 		return
 	}
-	// Don't clobber if a concurrent Cancel already finalized it.
+	// Don't clobber a status the monitoring loop or Cancel already finalized.
 	if s := latest.Status(); s == job.StatusCancelled || s == job.StatusCompleted || s == job.StatusFailed {
-		log.Infofc(ctx, "job: debug job %s already terminal (%s); skipping", j.ID(), s)
 		return
 	}
 
-	latest.SetBatchStatus(batchStatus)
-	if workerStatus != "" {
-		latest.SetWorkerStatus(workerStatus)
-	}
+	latest.SetBatchStatus(job.StatusFailed)
 	latest.SetStatus(latest.Status())
 
-	tx, txErr := i.transaction.Begin(ctx)
-	if txErr != nil {
-		log.Errorfc(ctx, "job: tx begin failed for debug job %s: %v", j.ID(), txErr)
+	if err := i.jobRepo.Save(ctx, latest); err != nil {
+		log.Errorfc(ctx, "job: failed to save cloud run job %s: %v", jobID, err)
 		return
 	}
-	txCtx := tx.Context()
-	defer func() {
-		if err2 := tx.End(txCtx); err2 != nil {
-			log.Errorfc(ctx, "transaction end failed: %v", err2)
-		}
-	}()
 
-	if serr := i.jobRepo.Save(txCtx, latest); serr != nil {
-		log.Errorfc(ctx, "job: failed to save debug job %s: %v", j.ID(), serr)
-		return
+	if err := i.handleJobCompletion(ctx, latest); err != nil {
+		log.Errorfc(ctx, "job: completion handling failed for cloud run job %s: %v", jobID, err)
 	}
-	tx.Commit()
-
-	if workerStatus != "" {
-		if derr := i.redis.DeleteJobCompleteEvent(ctx, j.ID()); derr != nil {
-			log.Warnf("debug job %s: failed to delete redis event: %v", j.ID(), derr)
-		}
-	}
-
-	final := latest.Status()
-	if final == job.StatusCompleted || final == job.StatusFailed || final == job.StatusCancelled {
-		if cerr := i.handleJobCompletion(ctx, latest); cerr != nil {
-			log.Errorfc(ctx, "job: completion handling failed for debug job %s: %v", j.ID(), cerr)
-		}
-	}
-	i.subscriptions.Notify(j.ID().String(), latest.Status())
+	i.subscriptions.Notify(jobID.String(), latest.Status())
 }
 
 func (i *Job) FindByID(ctx context.Context, id id.JobID) (*job.Job, error) {
@@ -638,11 +597,6 @@ func (i *Job) startMonitoringIfNeeded(jobID id.JobID) {
 	j, err := i.jobRepo.FindByID(context.Background(), jobID)
 	if err != nil {
 		log.Errorfc(context.Background(), "job: failed to find job for monitoring: %v", err)
-		return
-	}
-
-	// RunDebugJob owns the lifecycle for Cloud-Run debug jobs; don't start a loop.
-	if j.Debug() != nil && *j.Debug() && j.GCPJobID() == "" {
 		return
 	}
 

--- a/server/api/internal/usecase/interactor/job.go
+++ b/server/api/internal/usecase/interactor/job.go
@@ -156,21 +156,14 @@ func (i *Job) Cancel(ctx context.Context, jobID id.JobID) (*job.Job, error) {
 	return j, nil
 }
 
-// cloudRunInfraFailureGrace is how long failCloudRunJob waits for a late worker
-// completion event before declaring an infrastructure failure. A failed RunJob
-// call (client-side timeout/connection drop) does not guarantee the workflow
-// failed — the worker may still finish and publish its result to Redis.
 const cloudRunInfraFailureGrace = 30 * time.Second
 
-// RunCloudRunWorker triggers execution of a debug job on the Cloud Run worker
-// Service. The worker publishes its authoritative result to Redis (via the
-// subscriber); the standard monitoring loop reads that event and finalizes the
-// job, exactly as it does for Batch jobs. Only an infrastructure failure — where
-// no result will ever arrive — is finalized here.
+// RunCloudRunWorker executes a debug job on the Cloud Run worker; the worker
+// publishes its result to Redis and the standard monitoring loop finalizes the
+// job. Only an infra failure (no result will ever arrive) is finalized here.
 func (i *Job) RunCloudRunWorker(j *job.Job, p gateway.RunJobParam) {
 	go func() {
 		ctx := context.Background()
-		// Detached goroutine; a panic here would otherwise crash the API server.
 		defer func() {
 			if r := recover(); r != nil {
 				log.Errorfc(ctx, "job: cloud run worker %s panicked: %v", j.ID(), r)
@@ -182,22 +175,16 @@ func (i *Job) RunCloudRunWorker(j *job.Job, p gateway.RunJobParam) {
 			log.Errorfc(ctx, "job: cloud run worker %s run error: %v", j.ID(), err)
 		}
 
-		// Success and workflow-level failures are finalized by the monitoring loop
-		// from the Redis worker event. A failed RunJob call may still be a workflow
-		// that completes after a client-side drop, so failCloudRunJob confirms no
-		// result arrives before declaring an infra failure.
 		if err != nil || status == gateway.JobStatusFailed {
 			i.failCloudRunJob(ctx, j.ID())
 		}
 	}()
 }
 
-// failCloudRunJob finalizes a debug job as failed when the Cloud Run worker call
-// fails. Because a client-side error does not guarantee the workflow failed, it
-// first gives the monitoring loop a bounded grace period to pick up a late worker
-// event and only finalizes if none arrives. It records the failure via the legacy
-// status field (leaving batchStatus nil) so a later worker event could still
-// resolve the status merge rather than being forced to FAILED.
+// failCloudRunJob marks a debug job failed when the worker call fails. A
+// client-side error may still yield a result, so it waits a grace period and
+// bails if the loop already finalized or a worker event arrived; it sets the
+// legacy status (not batchStatus) so a late success isn't forced to FAILED.
 func (i *Job) failCloudRunJob(ctx context.Context, jobID id.JobID) {
 	select {
 	case <-ctx.Done():
@@ -214,11 +201,9 @@ func (i *Job) failCloudRunJob(ctx context.Context, jobID id.JobID) {
 		log.Errorfc(ctx, "job: failed to reload cloud run job %s: %v", jobID, err)
 		return
 	}
-	// The monitoring loop or Cancel may have already finalized it.
 	if s := latest.Status(); s == job.StatusCancelled || s == job.StatusCompleted || s == job.StatusFailed {
 		return
 	}
-	// A worker result did arrive after all — let the monitoring loop finalize from it.
 	if ev, _ := i.redis.GetJobCompleteEvent(ctx, jobID); ev != nil {
 		return
 	}
@@ -444,10 +429,8 @@ func (i *Job) checkJobStatus(ctx context.Context, j *job.Job) error {
 	computedStatus := currentJob.Status()
 	isTerminalState := computedStatus == job.StatusCompleted || computedStatus == job.StatusFailed ||
 		computedStatus == job.StatusCancelled
-	// Only handle completion on an actual transition to terminal in this iteration.
-	// Without the statusChanged guard, a job finalized concurrently (e.g. by
-	// failCloudRunJob or Cancel) would have its completion side-effects (artifact
-	// listing, notifications) run a second time here.
+	// statusChanged guard: don't re-run completion side-effects if another path
+	// (failCloudRunJob, Cancel) already finalized the job.
 	if statusChanged && isTerminalState {
 		log.Infof(
 			"Job %s transitioning to terminal state %s, handling completion",

--- a/server/api/internal/usecase/interactor/job.go
+++ b/server/api/internal/usecase/interactor/job.go
@@ -156,6 +156,12 @@ func (i *Job) Cancel(ctx context.Context, jobID id.JobID) (*job.Job, error) {
 	return j, nil
 }
 
+// cloudRunInfraFailureGrace is how long failCloudRunJob waits for a late worker
+// completion event before declaring an infrastructure failure. A failed RunJob
+// call (client-side timeout/connection drop) does not guarantee the workflow
+// failed — the worker may still finish and publish its result to Redis.
+const cloudRunInfraFailureGrace = 30 * time.Second
+
 // RunCloudRunWorker triggers execution of a debug job on the Cloud Run worker
 // Service. The worker publishes its authoritative result to Redis (via the
 // subscriber); the standard monitoring loop reads that event and finalizes the
@@ -177,18 +183,28 @@ func (i *Job) RunCloudRunWorker(j *job.Job, p gateway.RunJobParam) {
 		}
 
 		// Success and workflow-level failures are finalized by the monitoring loop
-		// from the Redis worker event. An infra failure produces no event, so the
-		// loop would wait indefinitely — finalize as failed here instead.
+		// from the Redis worker event. A failed RunJob call may still be a workflow
+		// that completes after a client-side drop, so failCloudRunJob confirms no
+		// result arrives before declaring an infra failure.
 		if err != nil || status == gateway.JobStatusFailed {
 			i.failCloudRunJob(ctx, j.ID())
 		}
 	}()
 }
 
-// failCloudRunJob marks a debug job failed when the Cloud Run worker call itself
-// fails and no worker result will arrive. It mirrors the persistence the
-// monitoring loop uses so the two finalization paths stay consistent.
+// failCloudRunJob finalizes a debug job as failed when the Cloud Run worker call
+// fails. Because a client-side error does not guarantee the workflow failed, it
+// first gives the monitoring loop a bounded grace period to pick up a late worker
+// event and only finalizes if none arrives. It records the failure via the legacy
+// status field (leaving batchStatus nil) so a later worker event could still
+// resolve the status merge rather than being forced to FAILED.
 func (i *Job) failCloudRunJob(ctx context.Context, jobID id.JobID) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(cloudRunInfraFailureGrace):
+	}
+
 	lock := i.getJobLock(jobID.String())
 	lock.Lock()
 	defer lock.Unlock()
@@ -198,13 +214,16 @@ func (i *Job) failCloudRunJob(ctx context.Context, jobID id.JobID) {
 		log.Errorfc(ctx, "job: failed to reload cloud run job %s: %v", jobID, err)
 		return
 	}
-	// Don't clobber a status the monitoring loop or Cancel already finalized.
+	// The monitoring loop or Cancel may have already finalized it.
 	if s := latest.Status(); s == job.StatusCancelled || s == job.StatusCompleted || s == job.StatusFailed {
 		return
 	}
+	// A worker result did arrive after all — let the monitoring loop finalize from it.
+	if ev, _ := i.redis.GetJobCompleteEvent(ctx, jobID); ev != nil {
+		return
+	}
 
-	latest.SetBatchStatus(job.StatusFailed)
-	latest.SetStatus(latest.Status())
+	latest.SetStatus(job.StatusFailed)
 
 	if err := i.jobRepo.Save(ctx, latest); err != nil {
 		log.Errorfc(ctx, "job: failed to save cloud run job %s: %v", jobID, err)
@@ -425,7 +444,11 @@ func (i *Job) checkJobStatus(ctx context.Context, j *job.Job) error {
 	computedStatus := currentJob.Status()
 	isTerminalState := computedStatus == job.StatusCompleted || computedStatus == job.StatusFailed ||
 		computedStatus == job.StatusCancelled
-	if isTerminalState {
+	// Only handle completion on an actual transition to terminal in this iteration.
+	// Without the statusChanged guard, a job finalized concurrently (e.g. by
+	// failCloudRunJob or Cancel) would have its completion side-effects (artifact
+	// listing, notifications) run a second time here.
+	if statusChanged && isTerminalState {
 		log.Infof(
 			"Job %s transitioning to terminal state %s, handling completion",
 			currentJob.ID(),

--- a/server/api/internal/usecase/interactor/project.go
+++ b/server/api/internal/usecase/interactor/project.go
@@ -291,10 +291,7 @@ func (i *Project) Run(ctx context.Context, p interfaces.RunProjectParam) (_ *job
 	if i.cloudRunWorker != nil {
 		tx.Commit()
 		if i.job != nil {
-			// Execute the workflow on the Cloud Run worker (async). The worker
-			// publishes its result to Redis; the standard monitoring loop finalizes
-			// the job — it already handles debug jobs (empty GCPJobID skips Batch
-			// polling and the worker event drives status).
+			// Run on Cloud Run; the standard monitoring loop finalizes the job.
 			i.job.RunCloudRunWorker(j, gateway.RunJobParam{
 				JobID:         j.ID(),
 				WorkflowURL:   workflowURL.String(),

--- a/server/api/internal/usecase/interactor/project.go
+++ b/server/api/internal/usecase/interactor/project.go
@@ -289,10 +289,13 @@ func (i *Project) Run(ctx context.Context, p interfaces.RunProjectParam) (_ *job
 	}
 
 	if i.cloudRunWorker != nil {
-		// RunDebugJob owns the full lifecycle; commit before handing off.
 		tx.Commit()
 		if i.job != nil {
-			go i.job.RunDebugJob(context.Background(), j, gateway.RunJobParam{
+			// Execute the workflow on the Cloud Run worker (async). The worker
+			// publishes its result to Redis; the standard monitoring loop finalizes
+			// the job — it already handles debug jobs (empty GCPJobID skips Batch
+			// polling and the worker event drives status).
+			i.job.RunCloudRunWorker(j, gateway.RunJobParam{
 				JobID:         j.ID(),
 				WorkflowURL:   workflowURL.String(),
 				MetadataURL:   j.MetadataURL(),
@@ -300,6 +303,9 @@ func (i *Project) Run(ctx context.Context, p interfaces.RunProjectParam) (_ *job
 				PreviousJobID: p.PreviousJobID,
 				StartNodeID:   p.StartNodeID,
 			})
+			if err := i.job.StartMonitoring(ctx, j, nil); err != nil {
+				return j, fmt.Errorf("failed to start job monitoring: %v", err)
+			}
 		}
 	} else {
 		gcpJobID, err := i.batch.SubmitJob(ctx, j.ID(), workflowURL.String(), j.MetadataURL(), nil, p.ProjectID, prj.Workspace(), p.PreviousJobID, p.StartNodeID)

--- a/server/api/internal/usecase/interfaces/job.go
+++ b/server/api/internal/usecase/interfaces/job.go
@@ -15,7 +15,7 @@ type Job interface {
 	FindByID(context.Context, id.JobID) (*job.Job, error)
 	FindByWorkspace(context.Context, accountsid.WorkspaceID, *PaginationParam, *string) ([]*job.Job, *PageBasedInfo, error)
 	GetStatus(context.Context, id.JobID) (job.Status, error)
-	RunDebugJob(ctx context.Context, j *job.Job, p gateway.RunJobParam)
+	RunCloudRunWorker(j *job.Job, p gateway.RunJobParam)
 	StartMonitoring(context.Context, *job.Job, *string) error
 	Subscribe(context.Context, id.JobID) (chan job.Status, error)
 	Unsubscribe(id.JobID, chan job.Status)


### PR DESCRIPTION
# Overview

Follow-up to #2103. Cloud Run debug jobs (editor "Run") never updated their status, and **Output data** stayed empty, even when the workflow ran successfully.

## What I've done

Root cause: `RunDebugJob` persisted the final status with `tx.Context()` — i.e. *inside* a MongoDB transaction — while every other status path (`checkJobStatus`, `Cancel`, `saveJobState`) saves with the plain `ctx`. That transaction routinely aborts in this environment (`transaction end failed: NoSuchTransaction ... has been aborted`), which is harmless for the other paths (their writes auto-commit) but rolled back `RunDebugJob`'s status write. The same failed finalization is why `outputURLs` were never set ("Output data (0)").

- Deleted `RunDebugJob`'s bespoke poll-and-finalize logic.
- Added `RunCloudRunWorker`, which triggers execution on the worker Service and finalizes **only** on infra failure (where no Redis worker event will arrive).
- `project.go` debug branch now calls `RunCloudRunWorker` **and** `StartMonitoring` — the same loop Batch uses. `checkJobStatus` already handles debug jobs (empty `GCPJobID` skips Batch polling; the builder leaves `batchStatus` nil so the status merge returns the Redis worker status), and it persists status + runs `handleJobCompletion` (which sets `outputURLs`).
- Removed the debug-job skip in `startMonitoringIfNeeded`.

Net −40 lines; success/workflow-failure finalize via the proven loop, infra failures via `failCloudRunJob`.

## What I haven't done

- No change to `workerArtifactPath` — the worker's output path (`artifacts/<jobID>/artifacts/`) already matches `ListJobArtifacts`.
- Intermediate-data compression (`FLOW_RUNTIME_COMPRESS_INTERMEDIATE_DATA=true`) is a worker-Service env setting (already applied on the deployed Service); codifying it in terraform is tracked with the rest of the debug-Service infra.

## How I tested

- `go build ./...`, `go vet`, `go test ./pkg/job/... ./internal/usecase/interactor/...` — all pass.
- Verified in reearth-oss logs that the worker runs and publishes the `JobCompleteEvent` to Redis, and that `checkJobStatus` reads it on the debug (empty `GCPJobID`) path.

## Screenshot

n/a

## Which point I want you to review particularly

The reliance on `batchStatus` being nil for debug jobs (so the merge returns the worker status), and the split between `RunCloudRunWorker` (infra failure) and the monitoring loop (success / workflow failure).

## Memo

Follow-up to #2103. Needs the worker Service env `FLOW_RUNTIME_COMPRESS_INTERMEDIATE_DATA=true` (already set) for intermediate Data Preview.