### PR TITLE
fix(ui): simplify schema fingerprint computation by removing deep sorting [FLOW-DEV-148]

### DIFF
--- a/ui/src/features/Editor/components/ParamsDialog/components/ParamEditor/index.tsx
+++ b/ui/src/features/Editor/components/ParamsDialog/components/ParamEditor/index.tsx
@@ -28,7 +28,7 @@ import type { AwarenessUser, NodeData, NodeParams } from "@flow/types";
 
 import { extractDescriptions } from "../../utils/extractDescriptions";
 import { FieldContext } from "../../utils/fieldUtils";
-import { schemasMatch } from "../../utils/schemaFingerprint";
+import { schemaKeysMatch } from "../../utils/schemaFingerprint";
 
 import SchemaMigrationView from "./SchemaMigrationView";
 
@@ -92,7 +92,7 @@ const ParamEditor: React.FC<Props> = ({
 
   const needsMigration =
     !!createdAction?.parameter &&
-    !schemasMatch(nodeMeta.paramsSchema, createdAction.parameter);
+    !schemaKeysMatch(nodeMeta.paramsSchema, createdAction.parameter);
 
   const [migrationComplete, setMigrationComplete] = useState(false);
 

--- a/ui/src/features/Editor/components/ParamsDialog/utils/schemaFingerprint.test.ts
+++ b/ui/src/features/Editor/components/ParamsDialog/utils/schemaFingerprint.test.ts
@@ -1,13 +1,10 @@
 import { RJSFSchema } from "@rjsf/utils";
 import { describe, it, expect } from "vitest";
 
-import {
-  computeSchemaFingerprint,
-  schemaKeysMatch,
-} from "./schemaFingerprint";
+import { computeSchemaFingerprint, schemaKeysMatch } from "./schemaFingerprint";
 
 const s = (properties: Record<string, object>): RJSFSchema =>
-  ({ properties } as RJSFSchema);
+  ({ properties }) as RJSFSchema;
 
 describe("computeSchemaFingerprint", () => {
   it("returns undefined when schema is undefined", () => {

--- a/ui/src/features/Editor/components/ParamsDialog/utils/schemaFingerprint.test.ts
+++ b/ui/src/features/Editor/components/ParamsDialog/utils/schemaFingerprint.test.ts
@@ -1,0 +1,101 @@
+import { RJSFSchema } from "@rjsf/utils";
+import { describe, it, expect } from "vitest";
+
+import {
+  computeSchemaFingerprint,
+  schemaKeysMatch,
+} from "./schemaFingerprint";
+
+const s = (properties: Record<string, object>): RJSFSchema =>
+  ({ properties } as RJSFSchema);
+
+describe("computeSchemaFingerprint", () => {
+  it("returns undefined when schema is undefined", () => {
+    expect(computeSchemaFingerprint(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when schema has no properties", () => {
+    expect(computeSchemaFingerprint({ type: "object" })).toBeUndefined();
+  });
+
+  it("returns a string for a valid schema", () => {
+    expect(typeof computeSchemaFingerprint(s({ a: { type: "string" } }))).toBe(
+      "string",
+    );
+  });
+
+  it("is invariant to property definition order (same keys, same fingerprint)", () => {
+    const a = s({ alpha: { type: "string" }, beta: { type: "number" } });
+    const b = s({ beta: { type: "number" }, alpha: { type: "string" } });
+    expect(computeSchemaFingerprint(a)).toBe(computeSchemaFingerprint(b));
+  });
+
+  it("produces different fingerprints when keys differ", () => {
+    const a = s({ a: { type: "string" } });
+    const b = s({ b: { type: "string" } });
+    expect(computeSchemaFingerprint(a)).not.toBe(computeSchemaFingerprint(b));
+  });
+
+  it("produces the same fingerprint when only values change (type)", () => {
+    const a = s({ a: { type: "string" } });
+    const b = s({ a: { type: "number" } });
+    expect(computeSchemaFingerprint(a)).toBe(computeSchemaFingerprint(b));
+  });
+
+  it("produces the same fingerprint when only values change (description)", () => {
+    const a = s({ a: { type: "string", description: "old" } });
+    const b = s({ a: { type: "string", description: "new" } });
+    expect(computeSchemaFingerprint(a)).toBe(computeSchemaFingerprint(b));
+  });
+
+  it("produces the same fingerprint when only values change (enum values)", () => {
+    const a = s({ mode: { type: "string", enum: ["a", "b"] } });
+    const b = s({ mode: { type: "string", enum: ["a", "b", "c"] } });
+    expect(computeSchemaFingerprint(a)).toBe(computeSchemaFingerprint(b));
+  });
+});
+
+describe("schemaKeysMatch", () => {
+  it("returns true when storedSchema is undefined (first-time node)", () => {
+    expect(schemaKeysMatch(undefined, s({ a: { type: "string" } }))).toBe(true);
+  });
+
+  it("returns true when keys are identical", () => {
+    const stored = s({ a: { type: "string" }, b: { type: "number" } });
+    const current = s({ a: { type: "string" }, b: { type: "number" } });
+    expect(schemaKeysMatch(stored, current)).toBe(true);
+  });
+
+  it("returns true when key order differs between stored and current", () => {
+    const stored = s({ a: { type: "string" }, b: { type: "number" } });
+    const current = s({ b: { type: "number" }, a: { type: "string" } });
+    expect(schemaKeysMatch(stored, current)).toBe(true);
+  });
+
+  it("returns true when property values change but keys are the same", () => {
+    const stored = s({ url: { type: "string" }, count: { type: "string" } });
+    const current = s({
+      url: { type: "string", description: "The endpoint URL" },
+      count: { type: "number", default: 10 },
+    });
+    expect(schemaKeysMatch(stored, current)).toBe(true);
+  });
+
+  it("returns false when a property is added", () => {
+    const stored = s({ a: { type: "string" } });
+    const current = s({ a: { type: "string" }, b: { type: "number" } });
+    expect(schemaKeysMatch(stored, current)).toBe(false);
+  });
+
+  it("returns false when a property is removed", () => {
+    const stored = s({ a: { type: "string" }, b: { type: "number" } });
+    const current = s({ a: { type: "string" } });
+    expect(schemaKeysMatch(stored, current)).toBe(false);
+  });
+
+  it("returns false when a property is renamed", () => {
+    const stored = s({ oldName: { type: "string" } });
+    const current = s({ newName: { type: "string" } });
+    expect(schemaKeysMatch(stored, current)).toBe(false);
+  });
+});

--- a/ui/src/features/Editor/components/ParamsDialog/utils/schemaFingerprint.ts
+++ b/ui/src/features/Editor/components/ParamsDialog/utils/schemaFingerprint.ts
@@ -20,7 +20,7 @@ export function computeSchemaFingerprint(
 // Returns true (no migration needed) when:
 // - storedSchema is undefined (first-time node, never been saved with a schema)
 // - schemas produce the same fingerprint
-export function schemasMatch(
+export function schemaKeysMatch(
   storedSchema: RJSFSchema | undefined,
   currentSchema: RJSFSchema,
 ): boolean {

--- a/ui/src/features/Editor/components/ParamsDialog/utils/schemaFingerprint.ts
+++ b/ui/src/features/Editor/components/ParamsDialog/utils/schemaFingerprint.ts
@@ -10,27 +10,11 @@ function simpleHash(str: string): string {
   return hash.toString(36);
 }
 
-function sortDeep(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(sortDeep);
-  if (value !== null && typeof value === "object") {
-    return Object.keys(value as object)
-      .sort()
-      .reduce(
-        (acc, key) => {
-          acc[key] = sortDeep((value as Record<string, unknown>)[key]);
-          return acc;
-        },
-        {} as Record<string, unknown>,
-      );
-  }
-  return value;
-}
-
 export function computeSchemaFingerprint(
   schema?: RJSFSchema,
 ): string | undefined {
   if (!schema?.properties) return undefined;
-  return simpleHash(JSON.stringify(sortDeep(schema.properties)));
+  return simpleHash(JSON.stringify(Object.keys(schema.properties).sort()));
 }
 
 // Returns true (no migration needed) when:


### PR DESCRIPTION
# Overview
This PR updates the Params Dialog schema-change detection logic by simplifying how a schema “fingerprint” is computed, aiming to avoid the previous deep-sorting approach.
## What I've done
- Removed the deep recursive sorting helper previously used to normalize schema objects.
- Changed schema fingerprinting to hash only the sorted list of top-level `schema.properties` keys.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
