### PR TITLE
fix(ui): prevent node dialog opening on double click and node selection on single click for intermediate data [FLOW-DEV-142]

### DIFF
--- a/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/CustomHandle/Port/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/CustomHandle/Port/index.tsx
@@ -39,7 +39,13 @@ const Port: React.FC<Props> = ({ nodeId, nodeData, portName, readonly }) => {
       <div className="group flex w-full min-w-0 -translate-x-0.5 items-center justify-end gap-1">
         <div
           className={`flex items-center gap-1 rounded-sm  px-0.5 ${hasData ? "group-hover:cursor-pointer group-hover:bg-success/20 " : ""}${isSelected ? "bg-success/20" : ""}`}
-          onClick={hasData ? handleClick : undefined}>
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (hasData) handleClick();
+          }}>
           <p
             className={`min-w-0 text-end text-[10px] ${getBreakClass(portName)} italic dark:font-thin ${
               hasData && isSelected


### PR DESCRIPTION
# Overview
This PR adjusts click handling in the GeneralNode port UI to avoid unintended ReactFlow node interactions when users interact with intermediate-data ports.
## What I've done
- Stops event propagation on port `click`/`doubleClick` to prevent ReactFlow node-level handlers from triggering.
- Routes port clicks to the intermediate-data selection handler when data is available.

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
