### PR TITLE
ci(worker): deploy reearth-flow-worker-debug Cloud Run Service on nightly

### DIFF
--- a/.github/workflows/build_docker_push_worker.yml
+++ b/.github/workflows/build_docker_push_worker.yml
@@ -184,8 +184,7 @@ jobs:
 
       - name: Deploy to Cloud Run
         run: |
-          gcloud run deploy ${{ env.CLOUD_RUN_SERVICE }} \
+          gcloud run services update ${{ env.CLOUD_RUN_SERVICE }} \
             --image ${{ env.IMAGE }} \
-            --region us-central1 \
-            --platform managed \
+            --region ${{ secrets.GC_REGION }} \
             --quiet

--- a/.github/workflows/build_docker_push_worker.yml
+++ b/.github/workflows/build_docker_push_worker.yml
@@ -165,7 +165,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      IMAGE: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-flow-worker:nightly
+      IMAGE: ${{ secrets.GC_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-flow-worker:nightly
       CLOUD_RUN_SERVICE: reearth-flow-worker-debug
     steps:
       - name: Harden Runner

--- a/.github/workflows/build_docker_push_worker.yml
+++ b/.github/workflows/build_docker_push_worker.yml
@@ -155,3 +155,37 @@ jobs:
           docker pull $IMAGE_NAME:${{ inputs.name }}
           docker tag $IMAGE_NAME:${{ inputs.name }} $IMAGE_GCP:${{ inputs.name }}
           docker push $IMAGE_GCP:${{ inputs.name }}
+
+  deploy-worker-debug-to-cloud-run:
+    name: Deploy Worker Debug to Cloud Run (Nightly)
+    needs: build-docker-image
+    runs-on: ubuntu-latest
+    if: ${{ inputs.name == 'nightly' }}
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/reearth/reearth-flow-worker:nightly
+      CLOUD_RUN_SERVICE: reearth-flow-worker-debug
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          service_account: ${{ secrets.GC_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy ${{ env.CLOUD_RUN_SERVICE }} \
+            --image ${{ env.IMAGE }} \
+            --region us-central1 \
+            --platform managed \
+            --quiet

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.318"
+version = "0.0.319"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7037,7 +7037,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "approx",
  "bvh",
@@ -7067,7 +7067,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7101,7 +7101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7110,7 +7110,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7140,7 +7140,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7174,7 +7174,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7191,7 +7191,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7203,7 +7203,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "bytes",
  "futures",
@@ -7220,7 +7220,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "bytes",
  "futures",
@@ -7239,7 +7239,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7253,7 +7253,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7288,7 +7288,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7326,7 +7326,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-trait",
  "axum",
@@ -11217,7 +11217,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.220"
+version = "0.1.221"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.375"
+version = "0.0.376"
 
 [profile.dev]
 opt-level = 0

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.318"
+version = "0.0.319"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.30"
+version = "0.2.31"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.220"
+version = "0.1.221"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Overview

Adds CI deployment for the **reearth-flow-worker-debug** Cloud Run Service (introduced behind the editor "Run" path in #2103 + #2107). Currently the Service's image is updated by hand — this workflow keeps it in sync with the nightly worker image, the same image that already gets pushed by this workflow for Batch.

## Changes

- New \`deploy-worker-debug-to-cloud-run\` job in \`.github/workflows/build_docker_push_worker.yml\`:
  - \`needs: build-docker-image\` — runs after the existing image push.
  - \`if: \${{ inputs.name == 'nightly' }}\` — only on nightly, mirroring how \`build_deploy_subscriber.yml\` gates its deploy job.
  - Auths via the same Workload Identity convention used by every other \`build_deploy_*\` deploy step (\`GC_SA_EMAIL\` / \`GC_WORKLOAD_IDENTITY_PROVIDER\`).
  - Runs \`gcloud run deploy reearth-flow-worker-debug --image us-central1-docker.pkg.dev/\${GCP_PROJECT_ID}/reearth/reearth-flow-worker:nightly --region us-central1 --platform managed --quiet\`.

The Service itself (resource definition + IAM + env vars) is managed by terraform in [eukarya-inc/infrastructure#2533](https://github.com/eukarya-inc/infrastructure/pull/2533); this workflow only updates its image. The TF resource has \`lifecycle.ignore_changes = [..., template[0].containers[0].image, ...]\` so terraform won't fight the CI deploys.

## Notes

- The Service runs the wrapper binary (\`/bin/reearth-flow-worker-server\`); the shared worker image already builds both binaries (Dockerfile line 45) — Cloud Run's container \`command\` overrides the default CMD.
- The deploy job will start succeeding after the infra PR merges and the manual Service is replaced by the terraform-managed one in reearth-oss.

## Test plan

- [ ] Merge the infra PR (eukarya-inc/infrastructure#2533) and apply.
- [ ] Manually trigger / wait for the next nightly run of this workflow.
- [ ] Confirm the \`reearth-flow-worker-debug\` Service in reearth-oss gets a fresh revision with the new image.
- [ ] Run a debug job from the editor and confirm status / Output / Data Preview still work.