### PR TITLE
feat(engine): implement Regex in FlowExpr and migrate FeatureFilter

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.375"
+version = "0.0.376"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -7031,6 +7031,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "logos",
+ "regex",
  "thiserror 2.0.18",
  "url",
 ]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.375"
+version = "0.0.376"
 
 [profile.dev]
 opt-level = 0

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -3121,6 +3121,28 @@ Filter Features Based on Custom Conditions
     }
   },
   "definitions": {
+    "Code": {
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/CodeType"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "CodeType": {
+      "type": "string",
+      "enum": [
+        "flowExpr",
+        "string"
+      ]
+    },
     "Condition": {
       "type": "object",
       "required": [
@@ -3132,7 +3154,7 @@ Filter Features Based on Custom Conditions
           "title": "Condition expression",
           "allOf": [
             {
-              "$ref": "#/definitions/Expr"
+              "$ref": "#/definitions/Code"
             }
           ]
         },
@@ -3145,9 +3167,6 @@ Filter Features Based on Custom Conditions
           ]
         }
       }
-    },
-    "Expr": {
-      "type": "string"
     },
     "Port": {
       "type": "string"

--- a/engine/runtime/action-processor/src/feature/filter.rs
+++ b/engine/runtime/action-processor/src/feature/filter.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, collections::HashSet, sync::Arc};
+use std::{collections::HashSet, sync::Arc};
 
 use once_cell::sync::Lazy;
 use reearth_flow_runtime::{
@@ -8,10 +8,11 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
 };
-use reearth_flow_types::Expr;
+use reearth_flow_types::{AttributeValue, Code, CompiledCode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashMap;
 
 use super::errors::FeatureProcessorError;
 
@@ -47,12 +48,12 @@ impl ProcessorFactory for FeatureFilterFactory {
 
     fn build(
         &self,
-        ctx: NodeContext,
+        _ctx: NodeContext,
         _event_hub: EventHub,
         _action: String,
         with: Option<HashMap<String, Value>>,
     ) -> Result<Box<dyn Processor>, BoxedError> {
-        let params: FeatureFilterParam = if let Some(with) = with.clone() {
+        let params: FeatureFilterParam = if let Some(with) = with {
             let value: Value = serde_json::to_value(with).map_err(|e| {
                 FeatureProcessorError::FilterFactory(format!(
                     "Failed to serialize `with` parameter: {e}"
@@ -86,30 +87,23 @@ impl ProcessorFactory for FeatureFilterFactory {
                 .into());
             }
         }
-        let expr_engine = Arc::clone(&ctx.expr_engine);
         let mut conditions = Vec::new();
         for condition in &params.conditions {
-            let expr = &condition.expr;
-            let template_ast = expr_engine
-                .compile(expr.as_ref())
+            let compiled = condition
+                .expr
+                .compile()
                 .map_err(|e| FeatureProcessorError::FilterFactory(format!("{e:?}")))?;
-            let output_port = &condition.output_port;
             conditions.push(CompiledCondition {
-                expr: template_ast,
-                output_port: output_port.clone(),
+                expr: compiled,
+                output_port: condition.output_port.clone(),
             });
         }
-        let process = FeatureFilter {
-            global_params: with,
-            conditions,
-        };
-        Ok(Box::new(process))
+        Ok(Box::new(FeatureFilter { conditions }))
     }
 }
 
 #[derive(Debug, Clone)]
 struct FeatureFilter {
-    global_params: Option<HashMap<String, serde_json::Value>>,
     conditions: Vec<CompiledCondition>,
 }
 
@@ -127,14 +121,14 @@ struct FeatureFilterParam {
 #[serde(rename_all = "camelCase")]
 struct Condition {
     /// # Condition expression
-    expr: Expr,
+    expr: Code,
     /// # Output port
     output_port: Port,
 }
 
 #[derive(Debug, Clone)]
 struct CompiledCondition {
-    expr: rhai::AST,
+    expr: CompiledCode,
     output_port: Port,
 }
 
@@ -144,14 +138,12 @@ impl Processor for FeatureFilter {
         ctx: ExecutorContext,
         fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
-        let expr_engine = Arc::clone(&ctx.expr_engine);
+        let env_vars = ctx.expr_engine.vars();
         let feature = &ctx.feature;
         let mut routing = false;
-        let scope = feature.new_scope(expr_engine.clone(), &self.global_params);
         for condition in &self.conditions {
-            let eval = scope.eval_ast::<bool>(&condition.expr);
-            match eval {
-                Ok(eval) if eval => {
+            match condition.expr.eval(feature, Arc::clone(&env_vars)) {
+                Ok(AttributeValue::Bool(true)) => {
                     fw.send(
                         ctx.new_with_feature_and_port(
                             feature.clone(),
@@ -166,7 +158,6 @@ impl Processor for FeatureFilter {
                         Some(ctx.error_span()),
                         format!("filter eval error = {err:?}"),
                     );
-                    continue;
                 }
             }
         }

--- a/engine/runtime/action-processor/src/feature/filter.rs
+++ b/engine/runtime/action-processor/src/feature/filter.rs
@@ -89,10 +89,12 @@ impl ProcessorFactory for FeatureFilterFactory {
         }
         let mut conditions = Vec::new();
         for condition in &params.conditions {
-            let compiled = condition
-                .expr
-                .compile()
-                .map_err(|e| FeatureProcessorError::FilterFactory(format!("{e:?}")))?;
+            let compiled = condition.expr.compile().map_err(|e| {
+                FeatureProcessorError::FilterFactory(format!(
+                    "failed to compile condition for port {:?}: {e:?}",
+                    condition.output_port
+                ))
+            })?;
             conditions.push(CompiledCondition {
                 expr: compiled,
                 output_port: condition.output_port.clone(),

--- a/engine/runtime/action-processor/src/feature/filter.rs
+++ b/engine/runtime/action-processor/src/feature/filter.rs
@@ -8,7 +8,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
 };
-use reearth_flow_types::{AttributeValue, Code, CompiledCode};
+use reearth_flow_types::{Code, CompiledCode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -142,8 +142,8 @@ impl Processor for FeatureFilter {
         let feature = &ctx.feature;
         let mut routing = false;
         for condition in &self.conditions {
-            match condition.expr.eval(feature, Arc::clone(&env_vars)) {
-                Ok(AttributeValue::Bool(true)) => {
+            match condition.expr.eval_bool(feature, Arc::clone(&env_vars)) {
+                Ok(true) => {
                     fw.send(
                         ctx.new_with_feature_and_port(
                             feature.clone(),
@@ -152,7 +152,7 @@ impl Processor for FeatureFilter {
                     );
                     routing = true;
                 }
-                Ok(_) => {}
+                Ok(false) => {}
                 Err(err) => {
                     ctx.event_hub.error_log(
                         Some(ctx.error_span()),

--- a/engine/runtime/examples/fixture/graphs/lod_splitter_with_dm.yml
+++ b/engine/runtime/examples/fixture/graphs/lod_splitter_with_dm.yml
@@ -14,8 +14,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+        - expr:
+            type: flowExpr
+            value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
           outputPort: DmGeometricAttribute
 
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
@@ -31,8 +32,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("exceptSplit") ?? false
+        - expr:
+            type: flowExpr
+            value: env.get("exceptSplit", false)
           outputPort: exceptSplit
 
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
@@ -46,20 +48,25 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").lod == "0"
+        - expr:
+            type: flowExpr
+            value: attributes["lod"] == "0"
           outputPort: lod0
-        - expr: |
-            env.get("__value").lod == "1"
+        - expr:
+            type: flowExpr
+            value: attributes["lod"] == "1"
           outputPort: lod1
-        - expr: |
-            env.get("__value").lod == "2"
+        - expr:
+            type: flowExpr
+            value: attributes["lod"] == "2"
           outputPort: lod2
-        - expr: |
-            env.get("__value").lod == "3"
+        - expr:
+            type: flowExpr
+            value: attributes["lod"] == "3"
           outputPort: lod3
-        - expr: |
-            env.get("__value").lod == "4"
+        - expr:
+            type: flowExpr
+            value: attributes["lod"] == "4"
           outputPort: lod4
 
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901

--- a/engine/runtime/examples/fixture/graphs/plateau4/domain_of_definition_validator.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/domain_of_definition_validator.yml
@@ -22,32 +22,41 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").flag == "Summary"
+        - expr:
+            type: flowExpr
+            value: attributes["flag"] == "Summary"
           outputPort: summary
-        - expr: |
-            env.get("__value").flag == "CodeValidation"
+        - expr:
+            type: flowExpr
+            value: attributes["flag"] == "CodeValidation"
           outputPort: codeValidation
-        - expr: |
-            env.get("__value").flag == "inCorrectCodeSpace"
+        - expr:
+            type: flowExpr
+            value: attributes["flag"] == "inCorrectCodeSpace"
           outputPort: inCorrectCodeSpace
-        - expr: |
-            env.get("__value").flag == "ExtentsValidation"
+        - expr:
+            type: flowExpr
+            value: attributes["flag"] == "ExtentsValidation"
           outputPort: extentsValidation
-        - expr: |
-            env.get("__value").flag == "GMLID_NotWellFormed"
+        - expr:
+            type: flowExpr
+            value: attributes["flag"] == "GMLID_NotWellFormed"
           outputPort: gmlIdNotWellFormed
-        - expr: |
-            env.get("__value").flag == "GMLID_NotUnique"
+        - expr:
+            type: flowExpr
+            value: attributes["flag"] == "GMLID_NotUnique"
           outputPort: gmlIdNotUnique
-        - expr: |
-            env.get("__value").flag == "XLink_NoReference"
+        - expr:
+            type: flowExpr
+            value: attributes["flag"] == "XLink_NoReference"
           outputPort: xlinkNoReference
-        - expr: |
-            env.get("__value").flag == "XLink_InvalidObjectType"
+        - expr:
+            type: flowExpr
+            value: attributes["flag"] == "XLink_InvalidObjectType"
           outputPort: xLinkInvalidObjectType
-        - expr: |
-            env.get("__value").flag == "InvalidLodXGeometry"
+        - expr:
+            type: flowExpr
+            value: attributes["flag"] == "InvalidLodXGeometry"
           outputPort: invalidLodXGeometry
 
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0

--- a/engine/runtime/examples/fixture/graphs/plateau4/folder_and_file_path_reader.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/folder_and_file_path_reader.yml
@@ -33,8 +33,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").extension == "gml"
+        - expr:
+            type: flowExpr
+            value: attributes["extension"] == "gml"
           outputPort: default
 
   - id: 712e4c72-950d-466d-9598-19f299668e7e

--- a/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
@@ -24,8 +24,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").extension == "gml"
+        - expr:
+            type: flowExpr
+            value: attributes["extension"] == "gml"
           outputPort: default
 
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e

--- a/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-02-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-02-common.yml
@@ -31,8 +31,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").extension == "gml"
+        - expr:
+            type: flowExpr
+            value: attributes["extension"] == "gml"
           outputPort: default
 
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e

--- a/engine/runtime/examples/fixture/graphs/surface_validator.yml
+++ b/engine/runtime/examples/fixture/graphs/surface_validator.yml
@@ -124,7 +124,7 @@ nodes:
       conditions:
         - expr:
             type: flowExpr
-            value: true
+            value: "true"
           outputPort: default
         - expr:
             type: flowExpr

--- a/engine/runtime/examples/fixture/graphs/surface_validator.yml
+++ b/engine/runtime/examples/fixture/graphs/surface_validator.yml
@@ -44,8 +44,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").outerOrientation != "counter_clockwise"
+        - expr:
+            type: flowExpr
+            value: attributes["outerOrientation"] != "counter_clockwise"
           outputPort: inCorrectOrientation
 
   - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
@@ -121,11 +122,13 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            true
+        - expr:
+            type: flowExpr
+            value: true
           outputPort: default
-        - expr: |
-            env.get("__value").holeCount > 0
+        - expr:
+            type: flowExpr
+            value: attributes["holeCount"] > 0
           outputPort: hole
 
   - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
@@ -262,8 +265,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").overlap > 1
+        - expr:
+            type: flowExpr
+            value: attributes["overlap"] > 1
           outputPort: intersectionInterior
 
   - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
@@ -303,8 +307,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").innerOrientation == env.get("__value").outerOrientation
+        - expr:
+            type: flowExpr
+            value: attributes["innerOrientation"] == attributes["outerOrientation"]
           outputPort: incorrectInterior
 
   - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
@@ -43,8 +43,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -149,8 +150,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 33e32a91-5ade-4265-8665-b061f552839c
     name: AttributeManagerForCityCodeAndCityName
@@ -410,10 +412,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let code = env.get("__value").cityCode;
-          let base = env.get("__value").baseCityCode;
-          code == base || env.get("__value").__wardParentCode == base
+      - expr:
+          type: flowExpr
+          value: attributes["cityCode"] == attributes["baseCityCode"] or attributes["__wardParentCode"] == attributes["baseCityCode"]
         outputPort: default
   - id: 4ffbb8a3-371e-4938-aa73-c142f11bb04b
     name: FeatureSorter

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
@@ -52,8 +52,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+            - expr:
+                type: flowExpr
+                value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
               outputPort: default
 
       - id: 33e32a91-5ade-4265-8665-b061f552839c
@@ -111,10 +112,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                let code = env.get("__value").cityCode;
-                let base = env.get("__value").baseCityCode;
-                code == base || env.get("__value").__wardParentCode == base
+            - expr:
+                type: flowExpr
+                value: attributes["cityCode"] == attributes["baseCityCode"] or attributes["__wardParentCode"] == attributes["baseCityCode"]
               outputPort: default
 
       - id: 4ffbb8a3-371e-4938-aa73-c142f11bb04b

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy.yml
@@ -48,8 +48,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -133,8 +134,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -148,8 +150,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -161,20 +164,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -309,8 +317,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6e
     name: AttributeManagerPreFlattener

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy/workflow.yml
@@ -59,8 +59,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+            - expr:
+                type: flowExpr
+                value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
               outputPort: default
 
       - id: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6e

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/03-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/03-frn-veg.yml
@@ -45,8 +45,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -130,8 +131,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -145,8 +147,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -158,20 +161,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -306,8 +314,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: ea263dcf-70c9-42a2-8385-07eb1d76270f
     name: VegPackageFilterDict
@@ -315,8 +324,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["featureType"].starts_with("veg:")
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"].starts_with("veg:")
         outputPort: veg_only
   - id: 7b83c850-7a02-44e0-ae6c-168bb7ef5206
     name: StripFeatureTypePrefixDict
@@ -402,14 +412,17 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").feature_type == "frn:CityFurniture"
+      - expr:
+          type: flowExpr
+          value: attributes["feature_type"] == "frn:CityFurniture"
         outputPort: frn_CityFurniture
-      - expr: |
-          env.get("__value").feature_type == "veg:SolitaryVegetationObject"
+      - expr:
+          type: flowExpr
+          value: attributes["feature_type"] == "veg:SolitaryVegetationObject"
         outputPort: veg_SolitaryVegetationObject
-      - expr: |
-          env.get("__value").feature_type == "veg:PlantCover"
+      - expr:
+          type: flowExpr
+          value: attributes["feature_type"] == "veg:PlantCover"
         outputPort: veg_PlantCover
   - id: 7d6d7fbb-c5c8-46e0-aed3-92e7ed03d660
     name: LodSplitterWithDM
@@ -421,8 +434,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["__citygml_feature_type"] == "frn:CityFurniture"
+      - expr:
+          type: flowExpr
+          value: attributes["__citygml_feature_type"] == "frn:CityFurniture"
         outputPort: frn_CityFurniture_schema
   - id: bbccddee-2222-3333-4444-555566667777
     name: SchemaAttributeMapperForFrn
@@ -643,8 +657,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["__citygml_feature_type"] == "veg:SolitaryVegetationObject"
+      - expr:
+          type: flowExpr
+          value: attributes["__citygml_feature_type"] == "veg:SolitaryVegetationObject"
         outputPort: veg_SolitaryVegetationObject_schema
   - id: 22bb33cc-4444-5555-6666-777788889999
     name: SchemaAttributeMapperForVeg1
@@ -904,8 +919,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["__citygml_feature_type"] == "veg:PlantCover"
+      - expr:
+          type: flowExpr
+          value: attributes["__citygml_feature_type"] == "veg:PlantCover"
         outputPort: veg_PlantCover_schema
   - id: 44dd55ee-6666-7777-8888-999900001111
     name: SchemaAttributeMapperForVeg2

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/03-frn-veg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/03-frn-veg/workflow.yml
@@ -56,8 +56,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+            - expr:
+                type: flowExpr
+                value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
               outputPort: default
 
       # Dictionary writer branch for veg
@@ -67,8 +68,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["featureType"].starts_with("veg:")
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"].starts_with("veg:")
               outputPort: veg_only
 
       - id: 7b83c850-7a02-44e0-ae6c-168bb7ef5206
@@ -161,14 +163,17 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").feature_type == "frn:CityFurniture"
+            - expr:
+                type: flowExpr
+                value: attributes["feature_type"] == "frn:CityFurniture"
               outputPort: frn_CityFurniture
-            - expr: |
-                env.get("__value").feature_type == "veg:SolitaryVegetationObject"
+            - expr:
+                type: flowExpr
+                value: attributes["feature_type"] == "veg:SolitaryVegetationObject"
               outputPort: veg_SolitaryVegetationObject
-            - expr: |
-                env.get("__value").feature_type == "veg:PlantCover"
+            - expr:
+                type: flowExpr
+                value: attributes["feature_type"] == "veg:PlantCover"
               outputPort: veg_PlantCover
 
       - id: 7d6d7fbb-c5c8-46e0-aed3-92e7ed03d660
@@ -183,8 +188,9 @@ graphs:
         with:
           conditions:
             # the feature_type is not part of the schema, get it from metadata
-            - expr: |
-                env.get("__value")["__citygml_feature_type"] == "frn:CityFurniture"
+            - expr:
+                type: flowExpr
+                value: attributes["__citygml_feature_type"] == "frn:CityFurniture"
               outputPort: frn_CityFurniture_schema
 
       - id: bbccddee-2222-3333-4444-555566667777
@@ -420,8 +426,9 @@ graphs:
         with:
           conditions:
             # the feature_type is not part of the schema, get it from metadata
-            - expr: |
-                env.get("__value")["__citygml_feature_type"] == "veg:SolitaryVegetationObject"
+            - expr:
+                type: flowExpr
+                value: attributes["__citygml_feature_type"] == "veg:SolitaryVegetationObject"
               outputPort: veg_SolitaryVegetationObject_schema
 
       - id: 22bb33cc-4444-5555-6666-777788889999
@@ -695,8 +702,9 @@ graphs:
         with:
           conditions:
             # the feature_type is not part of the schema, get it from metadata
-            - expr: |
-                env.get("__value")["__citygml_feature_type"] == "veg:PlantCover"
+            - expr:
+                type: flowExpr
+                value: attributes["__citygml_feature_type"] == "veg:PlantCover"
               outputPort: veg_PlantCover_schema
 
       - id: 44dd55ee-6666-7777-8888-999900001111

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld.yml
@@ -45,8 +45,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -150,8 +151,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 3820b7e2-a1ca-436b-acb0-72b907c8b246
     name: AttributeFlattener
@@ -167,11 +169,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["package"] == "luse"
+      - expr:
+          type: flowExpr
+          value: attributes["package"] == "luse"
         outputPort: luse
-      - expr: |
-          env.get("__value")["package"] == "lsld"
+      - expr:
+          type: flowExpr
+          value: attributes["package"] == "lsld"
         outputPort: lsld
   - id: 6e5ed9fc-006e-4dbe-8699-4663dba795cb
     name: AttributeMapperLuse

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld/workflow.yml
@@ -53,8 +53,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+            - expr:
+                type: flowExpr
+                value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
               outputPort: default
 
       - id: 3820b7e2-a1ca-436b-acb0-72b907c8b246
@@ -73,11 +74,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["package"] == "luse"
+            - expr:
+                type: flowExpr
+                value: attributes["package"] == "luse"
               outputPort: luse
-            - expr: |
-                env.get("__value")["package"] == "lsld"
+            - expr:
+                type: flowExpr
+                value: attributes["package"] == "lsld"
               outputPort: lsld
 
       # LUSE processing branch

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld.yml
@@ -48,8 +48,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -154,8 +155,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: e2441531-649a-4dcd-916f-ac59f7d56de3
     name: AttributeManagerPreFlattener

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld/workflow.yml
@@ -57,8 +57,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+            - expr:
+                type: flowExpr
+                value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
               outputPort: default
 
       - id: e2441531-649a-4dcd-916f-ac59f7d56de3

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/06-area-urf.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/06-area-urf.yml
@@ -45,8 +45,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -151,8 +152,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6e
     name: AttributeManagerPreFlattener
@@ -215,8 +217,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["package"] == "urf"
+      - expr:
+          type: flowExpr
+          value: attributes["package"] == "urf"
         outputPort: default
   - id: a3b4c5d6-e7f8-9a0b-1c2d-3e4f5a6b7c8d
     name: StripFeatureTypePrefix

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/06-area-urf/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/06-area-urf/workflow.yml
@@ -54,8 +54,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+            - expr:
+                type: flowExpr
+                value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
               outputPort: default
 
       - id: 1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6e
@@ -122,8 +123,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["package"] == "urf"
+            - expr:
+                type: flowExpr
+                value: attributes["package"] == "urf"
               outputPort: default
 
       - id: a3b4c5d6-e7f8-9a0b-1c2d-3e4f5a6b7c8d

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons.yml
@@ -45,8 +45,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -130,8 +131,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -145,8 +147,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -158,20 +161,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -307,8 +315,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 4ffbb8a3-371e-4938-aa73-c142f11bb04b
     name: FeatureSorter
@@ -629,9 +638,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let ft = env.get("__value").feature_type;
-          ft == "tun:Tunnel" || ft == "tun:TunnelPart"
+      - expr:
+          type: flowExpr
+          value: attributes["feature_type"] in ["tun:Tunnel", "tun:TunnelPart"]
         outputPort: tunnel
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d6
     name: VerticalReprojectorByLod4

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons/workflow.yml
@@ -56,8 +56,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+            - expr:
+                type: flowExpr
+                value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
               outputPort: default
 
       - id: 4ffbb8a3-371e-4938-aa73-c142f11bb04b
@@ -404,9 +405,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                let ft = env.get("__value").feature_type;
-                ft == "tun:Tunnel" || ft == "tun:TunnelPart"
+            - expr:
+                type: flowExpr
+                value: attributes["feature_type"] in ["tun:Tunnel", "tun:TunnelPart"]
               outputPort: tunnel
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d6

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/08-ubld.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/08-ubld.yml
@@ -44,8 +44,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -129,8 +130,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -144,8 +146,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -157,20 +160,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -305,8 +313,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: a04c645b-4651-4f7f-b6b5-0565428ef445
     name: AttributeManagerPreFlattener
@@ -347,9 +356,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let ft = env.get("__value").feature_type;
-          ft != "uro:UndergroundBuilding" && ft != "bldg:BuildingPart"
+      - expr:
+          type: flowExpr
+          value: attributes["feature_type"] not in ["uro:UndergroundBuilding", "bldg:BuildingPart"]
         outputPort: passed
   - id: 35fa118f-c8dd-456e-abc0-1fb6319c3931
     name: VerticalReprojector

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/08-ubld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/08-ubld/workflow.yml
@@ -55,8 +55,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+            - expr:
+                type: flowExpr
+                value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
               outputPort: default
 
       - id: a04c645b-4651-4f7f-b6b5-0565428ef445
@@ -101,9 +102,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                let ft = env.get("__value").feature_type;
-                ft != "uro:UndergroundBuilding" && ft != "bldg:BuildingPart"
+            - expr:
+                type: flowExpr
+                value: attributes["feature_type"] not in ["uro:UndergroundBuilding", "bldg:BuildingPart"]
               outputPort: passed
 
       - id: 35fa118f-c8dd-456e-abc0-1fb6319c3931

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/09-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/09-unf.yml
@@ -43,8 +43,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -128,8 +129,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -143,8 +145,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -156,20 +159,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -304,8 +312,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: d4f8a5b9-0e1c-2d3f-6a7b-c89012d1c701
     name: AttributeManagerDict

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/09-unf/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/09-unf/workflow.yml
@@ -54,8 +54,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+            - expr:
+                type: flowExpr
+                value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
               outputPort: default
 
       # Dictionary branch

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/10-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/10-wtr.yml
@@ -44,8 +44,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -129,8 +130,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -144,8 +146,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -157,20 +160,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -305,8 +313,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: e2441531-649a-4dcd-916f-ac59f7d56de3
     name: AttributeManagerPreFlattener

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/10-wtr/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/10-wtr/workflow.yml
@@ -55,8 +55,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+            - expr:
+                type: flowExpr
+                value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
               outputPort: default
 
       - id: e2441531-649a-4dcd-916f-ac59f7d56de3

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/11-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/11-gen.yml
@@ -44,8 +44,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -129,8 +130,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -144,8 +146,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -157,20 +160,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -305,8 +313,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 7bd12def-bc00-4340-adf5-1a2d68995dd7
     name: AttributeManagerPreFlattener

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/11-gen/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/11-gen/workflow.yml
@@ -55,8 +55,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+            - expr:
+                type: flowExpr
+                value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
               outputPort: default
 
       - id: 7bd12def-bc00-4340-adf5-1a2d68995dd7

--- a/engine/runtime/examples/fixture/workflow/examples/citygml3-reader/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/citygml3-reader/workflow.yml
@@ -50,8 +50,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: c1d2e3f4-a5b6-7890-cdef-1234567890ab

--- a/engine/runtime/examples/fixture/workflow/examples/zip-writer/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/zip-writer/workflow.yml
@@ -37,11 +37,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              env.get("__value").year == 2024
+          - expr:
+              type: flowExpr
+              value: attributes["year"] == 2024
             outputPort: year2024
-          - expr: |
-              env.get("__value").year == 2025
+          - expr:
+              type: flowExpr
+              value: attributes["year"] == 2025
             outputPort: year2025
 
       - id: f5e66920-24c0-4c70-ae16-6be1ed3b906c

--- a/engine/runtime/examples/fixture/workflow/executor-testing/feature-write/diamond.yml
+++ b/engine/runtime/examples/fixture/workflow/executor-testing/feature-write/diamond.yml
@@ -21,11 +21,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").category == "A"
+            - expr:
+                type: flowExpr
+                value: attributes["category"] == "A"
               outputPort: portA
-            - expr: |
-                env.get("__value").category == "B"
+            - expr:
+                type: flowExpr
+                value: attributes["category"] == "B"
               outputPort: portB
 
       - id: 40000000-0000-0000-0000-000000000033

--- a/engine/runtime/examples/fixture/workflow/executor-testing/feature-write/nested-subgraph.yml
+++ b/engine/runtime/examples/fixture/workflow/executor-testing/feature-write/nested-subgraph.yml
@@ -21,11 +21,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").category == "A"
+            - expr:
+                type: flowExpr
+                value: attributes["category"] == "A"
               outputPort: portA
-            - expr: |
-                env.get("__value").category == "B"
+            - expr:
+                type: flowExpr
+                value: attributes["category"] == "B"
               outputPort: portB
 
       - id: 20000000-0000-0000-0000-000000000033

--- a/engine/runtime/examples/fixture/workflow/executor-testing/feature-write/subgraph.yml
+++ b/engine/runtime/examples/fixture/workflow/executor-testing/feature-write/subgraph.yml
@@ -21,11 +21,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").category == "A"
+            - expr:
+                type: flowExpr
+                value: attributes["category"] == "A"
               outputPort: portA
-            - expr: |
-                env.get("__value").category == "B"
+            - expr:
+                type: flowExpr
+                value: attributes["category"] == "B"
               outputPort: portB
 
       - id: 10000000-0000-0000-0000-000000000023

--- a/engine/runtime/examples/fixture/workflow/executor-testing/feature-write/two-copies.yml
+++ b/engine/runtime/examples/fixture/workflow/executor-testing/feature-write/two-copies.yml
@@ -21,11 +21,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").category == "A"
+            - expr:
+                type: flowExpr
+                value: attributes["category"] == "A"
               outputPort: portA
-            - expr: |
-                env.get("__value").category == "B"
+            - expr:
+                type: flowExpr
+                value: attributes["category"] == "B"
               outputPort: portB
 
       - id: 30000000-0000-0000-0000-000000000023

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
@@ -160,32 +160,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -332,8 +341,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1226,8 +1236,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -1661,8 +1672,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e
     name: FileWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common/workflow.yml
@@ -81,8 +81,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       - id: b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -2691,7 +2691,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: attributes["gmlName"] == "bldg:Building" or attributes["gmlName"] == "bldg:BuildingPart"
+          value: attributes.get("gmlName") == "bldg:Building" or attributes.get("gmlName") == "bldg:BuildingPart"
         outputPort: default
   - id: b942f28a-3783-4672-8196-f124e8cc5f51
     name: BuildingUsageAttributeValidator

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -163,32 +163,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -335,8 +344,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1229,8 +1239,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -1620,8 +1631,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -1635,8 +1647,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -1648,20 +1661,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -1799,8 +1817,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").outerOrientation != "counter_clockwise"
+      - expr:
+          type: flowExpr
+          value: attributes["outerOrientation"] != "counter_clockwise"
         outputPort: inCorrectOrientation
   - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
     name: GeometryReplacer
@@ -1867,11 +1886,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          true
+      - expr:
+          type: flowExpr
+          value: true
         outputPort: default
-      - expr: |
-          env.get("__value").holeCount > 0
+      - expr:
+          type: flowExpr
+          value: attributes["holeCount"] > 0
         outputPort: hole
   - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
     name: GeometryValidatorSelfIntersection
@@ -1985,8 +2006,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionInterior
   - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
     name: AttributeManagerIntersectionInterior
@@ -2021,8 +2043,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").innerOrientation == env.get("__value").outerOrientation
+      - expr:
+          type: flowExpr
+          value: attributes["innerOrientation"] == attributes["outerOrientation"]
         outputPort: incorrectInterior
   - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
     name: AttributeManagerIncorrectInteriorOrientation
@@ -2330,8 +2353,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")._status != "full"
+      - expr:
+          type: flowExpr
+          value: attributes["_status"] != "full"
         outputPort: filtered
   - id: a6f7b8c9-0d1e-2f3a-4b5c-6d7e8f9a0b1c
     name: DeduplicateBuildingIds
@@ -2665,8 +2689,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["gmlName"] == "bldg:Building" || env.get("__value")["gmlName"] == "bldg:BuildingPart"
+      - expr:
+          type: flowExpr
+          value: attributes["gmlName"] == "bldg:Building" or attributes["gmlName"] == "bldg:BuildingPart"
         outputPort: default
   - id: b942f28a-3783-4672-8196-f124e8cc5f51
     name: BuildingUsageAttributeValidator
@@ -2771,29 +2796,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let attributes = env.get("__value").cityGmlAttributes ?? #{};
-          let building_id_attribute = (attributes["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-          let building_id = building_id_attribute["uro:buildingID"] ?? "";
-          let branch_id = building_id_attribute["uro:branchID"]  ?? "";
-          let part_id = building_id_attribute["uro:partID"] ?? "";
-          let gml_name = env.get("__value").gmlName ?? "";
-
-          // Condition 1: buildingID matches regex ^\d{5}-bldg-\d+$
-          let building_id_valid = str::matches(building_id, `^\d{5}-bldg-\d+$`);
-
-          // Condition 2: branchID is missing or integer type
-          let branch_id_valid = branch_id == "" || type_of(branch_id) == "i64";
-
-          // Condition 3: Building with missing partID, or BuildingPart with integer partID
-          let part_id_valid = false;
-          if gml_name == "bldg:Building" {
+      - expr:
+          type: flowExpr
+          value: |
+            attrs = attributes.get("cityGmlAttributes", {});
+            building_id_attr = attrs.get("uro:BuildingIDAttribute", []).get(0, {});
+            building_id = building_id_attr.get("uro:buildingID", "");
+            branch_id = building_id_attr.get("uro:branchID", "");
+            part_id = building_id_attr.get("uro:partID", "");
+            gml_name = attributes.get("gmlName", "");
+            building_id_valid = Regex(r"^\d{5}-bldg-\d+$").find(building_id);
+            branch_id_valid = branch_id == "" or type(branch_id) == "int";
+            if gml_name == "bldg:Building" {
               part_id_valid = part_id == "";
-          } else if gml_name == "bldg:BuildingPart" {
-              part_id_valid = type_of(part_id) == "i64";
-          }
-
-          building_id_valid && branch_id_valid && part_id_valid
+            } else if gml_name == "bldg:BuildingPart" {
+              part_id_valid = type(part_id) == "int";
+            } else {
+              part_id_valid = false;
+            }
+            building_id_valid and branch_id_valid and part_id_valid
         outputPort: goodUroFormatting
   - id: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
     name: AttributeMapper-invalid-building-id-format
@@ -2876,8 +2897,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").uroBuildingIdCount > 1
+      - expr:
+          type: flowExpr
+          value: attributes["uroBuildingIdCount"] > 1
         outputPort: multipleBuildingId
   - id: b6238f2d-e1d3-497b-a632-93d9d489ccfc
     name: AttributeMapper-c-bldg-01
@@ -3287,8 +3309,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          !(env.get("__value").geomTag in ["gml:MultiSurface", "gml:Solid"])
+      - expr:
+          type: flowExpr
+          value: attributes["geomTag"] not in ["gml:MultiSurface", "gml:Solid"]
         outputPort: default
   - id: 38b305d1-d716-48da-b578-419e15f66b4b
     name: AttributeMapperT-bldg-02
@@ -3728,8 +3751,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionSurface
   - id: ee1ff2aa-3bb4-4cc5-9dd6-7ee8ff3aa9bb
     name: ListIndexer1
@@ -3812,8 +3836,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          !env.get("__value").gmlFilename.starts_with(env.get("__value").meshcode)
+      - expr:
+          type: flowExpr
+          value: not attributes["gmlFilename"].starts_with(attributes["meshcode"])
         outputPort: failed
   - id: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e8f
     name: AttributeMapperIncorrectMeshCode
@@ -3896,9 +3921,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let issue = env.get("__value").solid_boundary_issues.issue;
-          issue == "NotA2Manifold"
+      - expr:
+          type: flowExpr
+          value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
         outputPort: notClosed
   - id: e57bec12-7e6e-4edf-8ce2-14fbd12a7f92
     name: AttributeMapperSolidBoundaryInvalidNotClosed
@@ -4086,8 +4111,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").gmlPropertyName.ends_with("Solid")
+      - expr:
+          type: flowExpr
+          value: attributes["gmlPropertyName"].ends_with("Solid")
         outputPort: solid
   - id: f1a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b5c
     name: GeometryExtractorSolidIntersection
@@ -4124,8 +4150,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: overlapping
   - id: 5e6a0a7a-5dfe-483b-9a45-7da7a5ea7641
     name: PLATEAU4.SolidIntersectionTestPairCreator
@@ -4828,8 +4855,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 151fbadf-1b40-4264-a003-f6f11f6af2d6
     name: FeatureCounterFileIndex
@@ -4853,8 +4881,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 7a561c34-2e94-4883-91e4-4026b09c2f8a
     name: ReferenceAndTypeChecker
@@ -4933,10 +4962,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: 'true'
+      - expr:
+          type: flowExpr
+          value: true
         outputPort: default
-      - expr: |
-          env.get("__value").featureType == "bldg:BuildingPart"
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "bldg:BuildingPart"
         outputPort: buildingPart
   - id: 7f3a8d2c-4e6b-4d9a-b1c5-3e8f2a7d9c4b
     name: FormatChecker
@@ -5218,8 +5250,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e
     name: FileWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -1888,7 +1888,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: true
+          value: 'true'
         outputPort: default
       - expr:
           type: flowExpr
@@ -4964,7 +4964,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: true
+          value: 'true'
         outputPort: default
       - expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/building_part_validation.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/building_part_validation.yml
@@ -79,8 +79,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value")._status != "full"
+        - expr:
+            type: flowExpr
+            value: attributes["_status"] != "full"
           outputPort: filtered
 
   # Deduplicate Building IDs

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/format_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/format_checks.yml
@@ -203,7 +203,7 @@ nodes:
       conditions:
       - expr:
           type: flowExpr
-          value: attributes["gmlName"] == "bldg:Building" or attributes["gmlName"] == "bldg:BuildingPart"
+          value: attributes.get("gmlName") == "bldg:Building" or attributes.get("gmlName") == "bldg:BuildingPart"
         outputPort: default
 
   # === Beginning of L-BLDG-04, 05, City Code Checks ===

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/format_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/format_checks.yml
@@ -201,8 +201,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["gmlName"] == "bldg:Building" || env.get("__value")["gmlName"] == "bldg:BuildingPart"
+      - expr:
+          type: flowExpr
+          value: attributes["gmlName"] == "bldg:Building" or attributes["gmlName"] == "bldg:BuildingPart"
         outputPort: default
 
   # === Beginning of L-BLDG-04, 05, City Code Checks ===
@@ -320,29 +321,25 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            let attributes = env.get("__value").cityGmlAttributes ?? #{};
-            let building_id_attribute = (attributes["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-            let building_id = building_id_attribute["uro:buildingID"] ?? "";
-            let branch_id = building_id_attribute["uro:branchID"]  ?? "";
-            let part_id = building_id_attribute["uro:partID"] ?? "";
-            let gml_name = env.get("__value").gmlName ?? "";
-            
-            // Condition 1: buildingID matches regex ^\d{5}-bldg-\d+$
-            let building_id_valid = str::matches(building_id, `^\d{5}-bldg-\d+$`);
-
-            // Condition 2: branchID is missing or integer type
-            let branch_id_valid = branch_id == "" || type_of(branch_id) == "i64";
-
-            // Condition 3: Building with missing partID, or BuildingPart with integer partID
-            let part_id_valid = false;
-            if gml_name == "bldg:Building" {
+        - expr:
+            type: flowExpr
+            value: |
+              attrs = attributes.get("cityGmlAttributes", {});
+              building_id_attr = attrs.get("uro:BuildingIDAttribute", []).get(0, {});
+              building_id = building_id_attr.get("uro:buildingID", "");
+              branch_id = building_id_attr.get("uro:branchID", "");
+              part_id = building_id_attr.get("uro:partID", "");
+              gml_name = attributes.get("gmlName", "");
+              building_id_valid = Regex(r"^\d{5}-bldg-\d+$").find(building_id);
+              branch_id_valid = branch_id == "" or type(branch_id) == "int";
+              if gml_name == "bldg:Building" {
                 part_id_valid = part_id == "";
-            } else if gml_name == "bldg:BuildingPart" {
-                part_id_valid = type_of(part_id) == "i64";
-            }
-            
-            building_id_valid && branch_id_valid && part_id_valid
+              } else if gml_name == "bldg:BuildingPart" {
+                part_id_valid = type(part_id) == "int";
+              } else {
+                part_id_valid = false;
+              }
+              building_id_valid and branch_id_valid and part_id_valid
           outputPort: goodUroFormatting
 
   - id: 3b4c5d6e-7f8a-9b0c-1d2e-3f4a5b6c7d8e
@@ -430,8 +427,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").uroBuildingIdCount > 1
+        - expr:
+            type: flowExpr
+            value: attributes["uroBuildingIdCount"] > 1
           outputPort: multipleBuildingId
 
   - id: b6238f2d-e1d3-497b-a632-93d9d489ccfc

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/ref_and_type_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/ref_and_type_checks.yml
@@ -140,8 +140,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            !(env.get("__value").geomTag in ["gml:MultiSurface", "gml:Solid"])
+        - expr:
+            type: flowExpr
+            value: attributes["geomTag"] not in ["gml:MultiSurface", "gml:Solid"]
           outputPort: default
 
   - id: 38b305d1-d716-48da-b578-419e15f66b4b

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/surface_validation.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/surface_validation.yml
@@ -284,8 +284,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").overlap > 1
+        - expr:
+            type: flowExpr
+            value: attributes["overlap"] > 1
           outputPort: intersectionSurface
 
   - id: ee1ff2aa-3bb4-4cc5-9dd6-7ee8ff3aa9bb
@@ -377,8 +378,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            !env.get("__value").gmlFilename.starts_with(env.get("__value").meshcode)
+        - expr:
+            type: flowExpr
+            value: not attributes["gmlFilename"].starts_with(attributes["meshcode"])
           outputPort: failed
 
   - id: 3c4d5e6f-7a8b-4c9d-0e1f-2a3b4c5d6e8f
@@ -472,9 +474,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            let issue = env.get("__value").solid_boundary_issues.issue;
-            issue == "NotA2Manifold"
+        - expr:
+            type: flowExpr
+            value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
           outputPort: notClosed
 
   - id: e57bec12-7e6e-4edf-8ce2-14fbd12a7f92
@@ -682,8 +684,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").gmlPropertyName.ends_with("Solid")
+        - expr:
+            type: flowExpr
+            value: attributes["gmlPropertyName"].ends_with("Solid")
           outputPort: solid
 
   - id: f1a2b3c4-d5e6-4f7a-8b9c-0d1e2f3a4b5c
@@ -731,8 +734,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").overlap > 1
+        - expr:
+            type: flowExpr
+            value: attributes["overlap"] > 1
           outputPort: overlapping
 
   - id: 5e6a0a7a-5dfe-483b-9a45-7da7a5ea7641

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
@@ -202,7 +202,7 @@ graphs:
           conditions:
             - expr:
                 type: flowExpr
-                value: true
+                value: "true"
               outputPort: default
             - expr:
                 type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
@@ -113,9 +113,7 @@ graphs:
           conditions:
           - expr:
               type: flowExpr
-              value: |
-                t = env.get("targetPackages", []);
-                len(t) == 0 or attributes["package"] in t
+              value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
             outputPort: default
 
       - id: 7a561c34-2e94-4883-91e4-4026b09c2f8a
@@ -521,8 +519,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       - id: b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
@@ -82,8 +82,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: 151fbadf-1b40-4264-a003-f6f11f6af2d6
@@ -110,8 +111,11 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+          - expr:
+              type: flowExpr
+              value: |
+                t = env.get("targetPackages", []);
+                len(t) == 0 or attributes["package"] in t
             outputPort: default
 
       - id: 7a561c34-2e94-4883-91e4-4026b09c2f8a
@@ -198,10 +202,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: "true"
+            - expr:
+                type: flowExpr
+                value: true
               outputPort: default
-            - expr: |
-                env.get("__value").featureType == "bldg:BuildingPart"
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "bldg:BuildingPart"
               outputPort: buildingPart
 
       - id: 7f3a8d2c-4e6b-4d9a-b1c5-3e8f2a7d9c4b

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -33,8 +33,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -48,8 +49,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -61,20 +63,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -212,8 +219,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").outerOrientation != "counter_clockwise"
+      - expr:
+          type: flowExpr
+          value: attributes["outerOrientation"] != "counter_clockwise"
         outputPort: inCorrectOrientation
   - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
     name: GeometryReplacer
@@ -280,11 +288,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          true
+      - expr:
+          type: flowExpr
+          value: true
         outputPort: default
-      - expr: |
-          env.get("__value").holeCount > 0
+      - expr:
+          type: flowExpr
+          value: attributes["holeCount"] > 0
         outputPort: hole
   - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
     name: GeometryValidatorSelfIntersection
@@ -398,8 +408,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionInterior
   - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
     name: AttributeManagerIntersectionInterior
@@ -434,8 +445,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").innerOrientation == env.get("__value").outerOrientation
+      - expr:
+          type: flowExpr
+          value: attributes["innerOrientation"] == attributes["outerOrientation"]
         outputPort: incorrectInterior
   - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
     name: AttributeManagerIncorrectInteriorOrientation
@@ -824,32 +836,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -996,8 +1017,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1890,8 +1912,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -2316,8 +2339,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: c29be788-be8d-43a2-97bf-3e15228a72a1
     name: FeatureCounterFileIndex
@@ -2341,8 +2365,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 242e339a-c7df-4be4-82f7-3223a6ed2145
     name: FeatureCityGmlReader
@@ -2459,8 +2484,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["orientation"] == "clockwise"
+      - expr:
+          type: flowExpr
+          value: attributes["orientation"] == "clockwise"
         outputPort: incorrectOrientation
   - id: 0740c8ce-3c27-416f-9a13-5b2086090426
     name: AttributeMapper
@@ -2509,8 +2535,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["package"] != "rwy"
+      - expr:
+          type: flowExpr
+          value: attributes["package"] != "rwy"
         outputPort: notRwy
   - id: b4d2d577-28a0-43a3-8a23-0ae562be1d04
     name: TwoDimensionForcer
@@ -2553,11 +2580,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["lod"] == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value")["lod"] == "2" || env.get("__value")["lod"] == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2" or attributes["lod"] == "3"
         outputPort: lod23
   - id: b684d916-5efe-4dfa-be20-fed9b101239d
     name: LineOnLineOverlayerLOD1
@@ -2583,8 +2612,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["overlayCount"] > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlayCount"] > 1
         outputPort: hasLineOverlap
   - id: db59af73-a1b7-49d3-92c3-e8485cb047bd
     name: OverlapCounter
@@ -2629,8 +2659,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["overlayCount"] > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlayCount"] > 1
         outputPort: hasAreaOverlap
   - id: ee3e5022-7f8c-4b9b-ab71-cba35cab287b
     name: AreaOverlapCounter
@@ -2854,8 +2885,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: 6f05d51b-3587-4625-8b9d-5f0ca614eed5
     name: FileWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -290,7 +290,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: true
+          value: 'true'
         outputPort: default
       - expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -82,8 +82,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: c29be788-be8d-43a2-97bf-3e15228a72a1
@@ -110,8 +111,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+          - expr:
+              type: flowExpr
+              value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
             outputPort: default
 
       - id: 242e339a-c7df-4be4-82f7-3223a6ed2145
@@ -247,8 +249,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["orientation"] == "clockwise"
+            - expr:
+                type: flowExpr
+                value: attributes["orientation"] == "clockwise"
               outputPort: incorrectOrientation
 
       # Map attributes for CSV output
@@ -308,8 +311,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["package"] != "rwy"
+            - expr:
+                type: flowExpr
+                value: attributes["package"] != "rwy"
               outputPort: notRwy
 
       # Convert surfaces to 2D for overlap detection
@@ -363,11 +367,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["lod"] == "1"
+            - expr:
+                type: flowExpr
+                value: attributes["lod"] == "1"
               outputPort: lod1
-            - expr: |
-                env.get("__value")["lod"] == "2" || env.get("__value")["lod"] == "3"
+            - expr:
+                type: flowExpr
+                value: attributes["lod"] == "2" or attributes["lod"] == "3"
               outputPort: lod23
 
       # Detect overlaps between different Road instances for LOD1
@@ -399,8 +405,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["overlayCount"] > 1
+            - expr:
+                type: flowExpr
+                value: attributes["overlayCount"] > 1
               outputPort: hasLineOverlap
 
       # Attach the overlap index
@@ -456,8 +463,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["overlayCount"] > 1
+            - expr:
+                type: flowExpr
+                value: attributes["overlayCount"] > 1
               outputPort: hasAreaOverlap
 
       # Attach area overlap index
@@ -722,8 +730,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       # Phase 10: Write qc_result_ok file

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
@@ -30,8 +30,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -45,8 +46,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -58,20 +60,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -209,8 +216,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").outerOrientation != "counter_clockwise"
+      - expr:
+          type: flowExpr
+          value: attributes["outerOrientation"] != "counter_clockwise"
         outputPort: inCorrectOrientation
   - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
     name: GeometryReplacer
@@ -277,11 +285,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          true
+      - expr:
+          type: flowExpr
+          value: true
         outputPort: default
-      - expr: |
-          env.get("__value").holeCount > 0
+      - expr:
+          type: flowExpr
+          value: attributes["holeCount"] > 0
         outputPort: hole
   - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
     name: GeometryValidatorSelfIntersection
@@ -395,8 +405,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionInterior
   - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
     name: AttributeManagerIntersectionInterior
@@ -431,8 +442,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").innerOrientation == env.get("__value").outerOrientation
+      - expr:
+          type: flowExpr
+          value: attributes["innerOrientation"] == attributes["outerOrientation"]
         outputPort: incorrectInterior
   - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
     name: AttributeManagerIncorrectInteriorOrientation
@@ -821,32 +833,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -993,8 +1014,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1887,8 +1909,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -2313,8 +2336,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 55c98a8e-b785-4e42-8217-b26610aa243f
     name: FeatureCounterFileIndex
@@ -2338,8 +2362,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 80f7b3d8-201b-4985-b512-c4b94690c16d
     name: FeatureCityGmlReader
@@ -2356,8 +2381,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").featureType != "CityModel"
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] != "CityModel"
         outputPort: default
   - id: 10df06f3-cafa-4abd-ba94-04ac71dae467
     name: HorizontalReprojector
@@ -2375,25 +2401,21 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let prop = env.get("__value").gmlPropertyName;
-          prop == "lod1MultiSurface" || prop == "lod2MultiSurface" || prop == "lod3MultiSurface"
+      - expr:
+          type: flowExpr
+          value: attributes["gmlPropertyName"] in ["lod1MultiSurface", "lod2MultiSurface", "lod3MultiSurface"]
         outputPort: multiSurface
-      - expr: |
-          let prop = env.get("__value").gmlPropertyName;
-          prop == "lod1MultiSolid" || prop == "lod2MultiSolid" || prop == "lod3MultiSolid"
+      - expr:
+          type: flowExpr
+          value: attributes["gmlPropertyName"] in ["lod1MultiSolid", "lod2MultiSolid", "lod3MultiSolid"]
         outputPort: multiSolid
-      - expr: |
-          let prop = env.get("__value").gmlPropertyName;
-          let is_geom = prop == "lod1Geometry" || prop == "lod2Geometry" || prop == "lod3Geometry";
-          let is_surface = env.get("__value").geometryName == "MultiSurface";
-          is_geom && is_surface
+      - expr:
+          type: flowExpr
+          value: attributes["gmlPropertyName"] in ["lod1Geometry", "lod2Geometry", "lod3Geometry"] and attributes["geometryName"] == "MultiSurface"
         outputPort: surfaceGeometry
-      - expr: |
-          let prop = env.get("__value").gmlPropertyName;
-          let is_geom = prop == "lod1Geometry" || prop == "lod2Geometry" || prop == "lod3Geometry";
-          let is_solid = env.get("__value").geometryName == "Solid";
-          is_geom && is_solid
+      - expr:
+          type: flowExpr
+          value: attributes["gmlPropertyName"] in ["lod1Geometry", "lod2Geometry", "lod3Geometry"] and attributes["geometryName"] == "Solid"
         outputPort: solidGeometry
   - id: 8cb3a0a3-4527-466a-a362-6fedddf6a15f
     name: FeatureSorter
@@ -2517,9 +2539,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let issue = env.get("__value").solid_boundary_issues.issue;
-          issue == "NotA2Manifold"
+      - expr:
+          type: flowExpr
+          value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
         outputPort: notClosed
   - id: e57bec12-7e6e-4edf-8ce2-14fbd12a7f92
     name: AttributeMapperSolidBoundaryInvalidNotClosed
@@ -2798,8 +2820,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: 734ebb2a-c2b0-429e-9363-5ccdd2a5b2ae
     name: JsonWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
@@ -287,7 +287,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: true
+          value: 'true'
         outputPort: default
       - expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg/workflow.yml
@@ -76,8 +76,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: 55c98a8e-b785-4e42-8217-b26610aa243f
@@ -104,8 +105,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+          - expr:
+              type: flowExpr
+              value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
             outputPort: default
 
       - id: 80f7b3d8-201b-4985-b512-c4b94690c16d
@@ -124,8 +126,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").featureType != "CityModel"
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] != "CityModel"
               outputPort: default
 
       - id: 10df06f3-cafa-4abd-ba94-04ac71dae467
@@ -146,25 +149,21 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                let prop = env.get("__value").gmlPropertyName;
-                prop == "lod1MultiSurface" || prop == "lod2MultiSurface" || prop == "lod3MultiSurface"
+            - expr:
+                type: flowExpr
+                value: attributes["gmlPropertyName"] in ["lod1MultiSurface", "lod2MultiSurface", "lod3MultiSurface"]
               outputPort: multiSurface
-            - expr: |
-                let prop = env.get("__value").gmlPropertyName;
-                prop == "lod1MultiSolid" || prop == "lod2MultiSolid" || prop == "lod3MultiSolid"
+            - expr:
+                type: flowExpr
+                value: attributes["gmlPropertyName"] in ["lod1MultiSolid", "lod2MultiSolid", "lod3MultiSolid"]
               outputPort: multiSolid
-            - expr: |
-                let prop = env.get("__value").gmlPropertyName;
-                let is_geom = prop == "lod1Geometry" || prop == "lod2Geometry" || prop == "lod3Geometry";
-                let is_surface = env.get("__value").geometryName == "MultiSurface";
-                is_geom && is_surface
+            - expr:
+                type: flowExpr
+                value: attributes["gmlPropertyName"] in ["lod1Geometry", "lod2Geometry", "lod3Geometry"] and attributes["geometryName"] == "MultiSurface"
               outputPort: surfaceGeometry
-            - expr: |
-                let prop = env.get("__value").gmlPropertyName;
-                let is_geom = prop == "lod1Geometry" || prop == "lod2Geometry" || prop == "lod3Geometry";
-                let is_solid = env.get("__value").geometryName == "Solid";
-                is_geom && is_solid
+            - expr:
+                type: flowExpr
+                value: attributes["gmlPropertyName"] in ["lod1Geometry", "lod2Geometry", "lod3Geometry"] and attributes["geometryName"] == "Solid"
               outputPort: solidGeometry
 
       # Instance Count
@@ -300,9 +299,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                let issue = env.get("__value").solid_boundary_issues.issue;
-                issue == "NotA2Manifold"
+            - expr:
+                type: flowExpr
+                value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
               outputPort: notClosed
 
       - id: e57bec12-7e6e-4edf-8ce2-14fbd12a7f92
@@ -613,8 +612,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       # Write qc_result_ok file

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
@@ -288,7 +288,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: true
+          value: 'true'
         outputPort: default
       - expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
@@ -31,8 +31,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -46,8 +47,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -59,20 +61,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -210,8 +217,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").outerOrientation != "counter_clockwise"
+      - expr:
+          type: flowExpr
+          value: attributes["outerOrientation"] != "counter_clockwise"
         outputPort: inCorrectOrientation
   - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
     name: GeometryReplacer
@@ -278,11 +286,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          true
+      - expr:
+          type: flowExpr
+          value: true
         outputPort: default
-      - expr: |
-          env.get("__value").holeCount > 0
+      - expr:
+          type: flowExpr
+          value: attributes["holeCount"] > 0
         outputPort: hole
   - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
     name: GeometryValidatorSelfIntersection
@@ -396,8 +406,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionInterior
   - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
     name: AttributeManagerIntersectionInterior
@@ -432,8 +443,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").innerOrientation == env.get("__value").outerOrientation
+      - expr:
+          type: flowExpr
+          value: attributes["innerOrientation"] == attributes["outerOrientation"]
         outputPort: incorrectInterior
   - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
     name: AttributeManagerIncorrectInteriorOrientation
@@ -822,32 +834,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -994,8 +1015,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1888,8 +1910,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -2314,8 +2337,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 55c98a8e-b785-4e42-8217-b26610aa243f
     name: FeatureCounterFileIndex
@@ -2339,8 +2363,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 80f7b3d8-201b-4985-b512-c4b94690c16d
     name: FeatureCityGmlReader
@@ -2357,8 +2382,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").featureType != "CityModel"
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] != "CityModel"
         outputPort: default
   - id: 10df06f3-cafa-4abd-ba94-04ac71dae467
     name: HorizontalReprojector
@@ -2635,8 +2661,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: 734ebb2a-c2b0-429e-9363-5ccdd2a5b2ae
     name: JsonWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area/workflow.yml
@@ -75,8 +75,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: 55c98a8e-b785-4e42-8217-b26610aa243f
@@ -103,8 +104,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+          - expr:
+              type: flowExpr
+              value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
             outputPort: default
 
       - id: 80f7b3d8-201b-4985-b512-c4b94690c16d
@@ -123,8 +125,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").featureType != "CityModel"
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] != "CityModel"
               outputPort: default
 
       - id: 10df06f3-cafa-4abd-ba94-04ac71dae467
@@ -432,8 +435,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       # Write qc_result_ok file

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
@@ -167,32 +167,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -339,8 +348,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1233,8 +1243,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -1658,8 +1669,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 30af8e4f-0d06-4b74-b99d-c23d7cb5c72e
     name: UDXFolderExtractor
@@ -1676,8 +1688,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 2f8e9d3a-1b2c-4d5e-6f7a-8b9c0d1e2f3a
     name: FldScaleExtractor
@@ -1955,8 +1968,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: 5a6b7c8d-9e0f-1a2b-3c4d-5e6f7a8b9c0d
     name: FileWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld/workflow.yml
@@ -74,8 +74,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       # UDX Folder Structure Extraction and _fld_scale Extraction
@@ -95,8 +96,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+          - expr:
+              type: flowExpr
+              value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
             outputPort: default
 
       # Extract _fld_scale (l1 or l2) from filename using pattern matching
@@ -427,8 +429,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       # Write qc_result_ok file when no errors

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
@@ -29,8 +29,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -44,8 +45,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -57,20 +59,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -208,8 +215,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").outerOrientation != "counter_clockwise"
+      - expr:
+          type: flowExpr
+          value: attributes["outerOrientation"] != "counter_clockwise"
         outputPort: inCorrectOrientation
   - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
     name: GeometryReplacer
@@ -276,11 +284,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          true
+      - expr:
+          type: flowExpr
+          value: true
         outputPort: default
-      - expr: |
-          env.get("__value").holeCount > 0
+      - expr:
+          type: flowExpr
+          value: attributes["holeCount"] > 0
         outputPort: hole
   - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
     name: GeometryValidatorSelfIntersection
@@ -394,8 +404,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionInterior
   - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
     name: AttributeManagerIntersectionInterior
@@ -430,8 +441,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").innerOrientation == env.get("__value").outerOrientation
+      - expr:
+          type: flowExpr
+          value: attributes["innerOrientation"] == attributes["outerOrientation"]
         outputPort: incorrectInterior
   - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
     name: AttributeManagerIncorrectInteriorOrientation
@@ -820,32 +832,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -992,8 +1013,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1886,8 +1908,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -2312,8 +2335,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 55c98a8e-b785-4e42-8217-b26610aa243f
     name: FeatureCounterFileIndex
@@ -2337,8 +2361,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 80f7b3d8-201b-4985-b512-c4b94690c16d
     name: FeatureCityGmlReader
@@ -2355,8 +2380,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").featureType != "CityModel"
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] != "CityModel"
         outputPort: default
   - id: 10df06f3-cafa-4abd-ba94-04ac71dae467
     name: HorizontalReprojector
@@ -2616,8 +2642,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: 734ebb2a-c2b0-429e-9363-5ccdd2a5b2ae
     name: JsonWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
@@ -286,7 +286,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: true
+          value: 'true'
         outputPort: default
       - expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld/workflow.yml
@@ -75,8 +75,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: 55c98a8e-b785-4e42-8217-b26610aa243f
@@ -103,8 +104,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+          - expr:
+              type: flowExpr
+              value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
             outputPort: default
 
       - id: 80f7b3d8-201b-4985-b512-c4b94690c16d
@@ -123,8 +125,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").featureType != "CityModel"
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] != "CityModel"
               outputPort: default
 
       - id: 10df06f3-cafa-4abd-ba94-04ac71dae467
@@ -415,8 +418,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       # Write qc_result_ok file

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
@@ -163,32 +163,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -335,8 +344,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1229,8 +1239,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -1655,8 +1666,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 6a08f964-a46d-4226-a4dc-2c283136e157
     name: FeatureCounterFileIndex
@@ -1680,8 +1692,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 7568f48a-0858-4244-b473-2a8a63909341
     name: PLATEAU4.CityGmlMeshBuilder
@@ -1869,8 +1882,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").boundaryIndex != 1 && env.get("__value").vertexCount < 50
+      - expr:
+          type: flowExpr
+          value: attributes["boundaryIndex"] != 1 and attributes["vertexCount"] < 50
         outputPort: default
   - id: 057a1995-8af0-4a8e-8699-cbb77e1ed374
     name: AttributeMapperInvalidBoundaries
@@ -2016,8 +2030,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: fc5b71bd-e34b-4381-b8f4-83919b5966df
     name: JsonWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem/workflow.yml
@@ -75,8 +75,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: 6a08f964-a46d-4226-a4dc-2c283136e157
@@ -103,8 +104,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+          - expr:
+              type: flowExpr
+              value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
             outputPort: default
 
       - id: 7568f48a-0858-4244-b473-2a8a63909341
@@ -318,8 +320,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").boundaryIndex != 1 && env.get("__value").vertexCount < 50
+            - expr:
+                type: flowExpr
+                value: attributes["boundaryIndex"] != 1 and attributes["vertexCount"] < 50
               outputPort: default
 
       - id: 057a1995-8af0-4a8e-8699-cbb77e1ed374
@@ -484,8 +487,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       # Write qc_result_ok file

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
@@ -288,7 +288,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: true
+          value: 'true'
         outputPort: default
       - expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
@@ -31,8 +31,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -46,8 +47,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -59,20 +61,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -210,8 +217,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").outerOrientation != "counter_clockwise"
+      - expr:
+          type: flowExpr
+          value: attributes["outerOrientation"] != "counter_clockwise"
         outputPort: inCorrectOrientation
   - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
     name: GeometryReplacer
@@ -278,11 +286,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          true
+      - expr:
+          type: flowExpr
+          value: true
         outputPort: default
-      - expr: |
-          env.get("__value").holeCount > 0
+      - expr:
+          type: flowExpr
+          value: attributes["holeCount"] > 0
         outputPort: hole
   - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
     name: GeometryValidatorSelfIntersection
@@ -396,8 +406,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionInterior
   - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
     name: AttributeManagerIntersectionInterior
@@ -432,8 +443,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").innerOrientation == env.get("__value").outerOrientation
+      - expr:
+          type: flowExpr
+          value: attributes["innerOrientation"] == attributes["outerOrientation"]
         outputPort: incorrectInterior
   - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
     name: AttributeManagerIncorrectInteriorOrientation
@@ -1125,8 +1137,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionSurface
   - id: ee1ff2aa-3bb4-4cc5-9dd6-7ee8ff3aa9bb
     name: ListIndexer1
@@ -1174,9 +1187,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let issue = env.get("__value").solid_boundary_issues.issue;
-          issue == "NotA2Manifold"
+      - expr:
+          type: flowExpr
+          value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
         outputPort: notClosed
   - id: e57bec12-7e6e-4edf-8ce2-14fbd12a7f92
     name: AttributeManagerSolidBoundaryInvalidNotClosed
@@ -1917,32 +1930,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -2089,8 +2111,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -2983,8 +3006,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -3409,8 +3433,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 151fbadf-1b40-4264-a003-f6f11f6af2d6
     name: FeatureCounterFileIndex
@@ -3434,8 +3459,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 3f7b2a9d-1c8e-4a6f-b5d3-9e2c7a4f8b1d
     name: FeatureCityGmlReader
@@ -3627,14 +3653,17 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").udxDirs == "brid"
+      - expr:
+          type: flowExpr
+          value: attributes["udxDirs"] == "brid"
         outputPort: brid
-      - expr: |
-          env.get("__value").udxDirs == "tun"
+      - expr:
+          type: flowExpr
+          value: attributes["udxDirs"] == "tun"
         outputPort: tun
-      - expr: |
-          env.get("__value").udxDirs == "ubld"
+      - expr:
+          type: flowExpr
+          value: attributes["udxDirs"] == "ubld"
         outputPort: ubld
   - id: 5cd2bea0-0723-4123-9df8-bc663f493744
     name: CsvWriterBridgeInstanceCounts
@@ -3861,8 +3890,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e
     name: FileWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld/surface_validation.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld/surface_validation.yml
@@ -450,8 +450,9 @@ nodes:
   action: FeatureFilter
   with:
     conditions:
-    - expr: |
-        env.get("__value").overlap > 1
+    - expr:
+        type: flowExpr
+        value: attributes["overlap"] > 1
       outputPort: intersectionSurface
 - id: ee1ff2aa-3bb4-4cc5-9dd6-7ee8ff3aa9bb
   name: ListIndexer1
@@ -499,9 +500,9 @@ nodes:
   action: FeatureFilter
   with:
     conditions:
-    - expr: |
-        let issue = env.get("__value").solid_boundary_issues.issue;
-        issue == "NotA2Manifold"
+    - expr:
+        type: flowExpr
+        value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
       outputPort: notClosed
 - id: e57bec12-7e6e-4edf-8ce2-14fbd12a7f92
   name: AttributeManagerSolidBoundaryInvalidNotClosed

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld/workflow.yml
@@ -71,8 +71,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 151fbadf-1b40-4264-a003-f6f11f6af2d6
     name: FeatureCounterFileIndex
@@ -96,8 +97,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: 3f7b2a9d-1c8e-4a6f-b5d3-9e2c7a4f8b1d
     name: FeatureCityGmlReader
@@ -289,14 +291,17 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").udxDirs == "brid"
+      - expr:
+          type: flowExpr
+          value: attributes["udxDirs"] == "brid"
         outputPort: brid
-      - expr: |
-          env.get("__value").udxDirs == "tun"
+      - expr:
+          type: flowExpr
+          value: attributes["udxDirs"] == "tun"
         outputPort: tun
-      - expr: |
-          env.get("__value").udxDirs == "ubld"
+      - expr:
+          type: flowExpr
+          value: attributes["udxDirs"] == "ubld"
         outputPort: ubld
   - id: 5cd2bea0-0723-4123-9df8-bc663f493744
     name: CsvWriterBridgeInstanceCounts
@@ -523,8 +528,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: b2c3d4e5-6f7a-8b9c-0d1e-2f3a4b5c6d7e
     name: FileWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
@@ -163,32 +163,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -335,8 +344,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1229,8 +1239,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -1620,8 +1631,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -1635,8 +1647,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -1648,20 +1661,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -1799,8 +1817,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").outerOrientation != "counter_clockwise"
+      - expr:
+          type: flowExpr
+          value: attributes["outerOrientation"] != "counter_clockwise"
         outputPort: inCorrectOrientation
   - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
     name: GeometryReplacer
@@ -1867,11 +1886,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          true
+      - expr:
+          type: flowExpr
+          value: true
         outputPort: default
-      - expr: |
-          env.get("__value").holeCount > 0
+      - expr:
+          type: flowExpr
+          value: attributes["holeCount"] > 0
         outputPort: hole
   - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
     name: GeometryValidatorSelfIntersection
@@ -1985,8 +2006,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionInterior
   - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
     name: AttributeManagerIntersectionInterior
@@ -2021,8 +2043,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").innerOrientation == env.get("__value").outerOrientation
+      - expr:
+          type: flowExpr
+          value: attributes["innerOrientation"] == attributes["outerOrientation"]
         outputPort: incorrectInterior
   - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
     name: AttributeManagerIncorrectInteriorOrientation
@@ -2385,9 +2408,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let issue = env.get("__value").solid_boundary_issues.issue;
-          issue == "NotA2Manifold"
+      - expr:
+          type: flowExpr
+          value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
         outputPort: notClosed
   - id: a103c4d5-e6f7-a8b9-c0d1-e2f3a4b5c6d7
     name: AttributeMapperNotClosed
@@ -2797,8 +2820,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c30
     name: FeatureCounterFileIndex
@@ -2822,8 +2846,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e50
     name: AttributeMapperGmlPathAndFilename
@@ -3084,8 +3109,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: b6c7d8e9-f0a1-2b3c-4d5e-6f7a8b9c0d20
     name: FileWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
@@ -1888,7 +1888,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: true
+          value: 'true'
         outputPort: default
       - expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/cons.yml
@@ -153,9 +153,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            let issue = env.get("__value").solid_boundary_issues.issue;
-            issue == "NotA2Manifold"
+        - expr:
+            type: flowExpr
+            value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
           outputPort: notClosed
 
   # AttributeMapper for NotClosed errors (lowercase format like wtr/bldg)

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/workflow.yml
@@ -80,8 +80,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c30
@@ -108,8 +109,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+          - expr:
+              type: flowExpr
+              value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
             outputPort: default
 
       - id: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e50
@@ -396,8 +398,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       - id: b6c7d8e9-f0a1-2b3c-4d5e-6f7a8b9c0d20

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
@@ -163,32 +163,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -335,8 +344,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1229,8 +1239,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -1620,8 +1631,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -1635,8 +1647,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -1648,20 +1661,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -1799,8 +1817,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").outerOrientation != "counter_clockwise"
+      - expr:
+          type: flowExpr
+          value: attributes["outerOrientation"] != "counter_clockwise"
         outputPort: inCorrectOrientation
   - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
     name: GeometryReplacer
@@ -1867,11 +1886,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          true
+      - expr:
+          type: flowExpr
+          value: true
         outputPort: default
-      - expr: |
-          env.get("__value").holeCount > 0
+      - expr:
+          type: flowExpr
+          value: attributes["holeCount"] > 0
         outputPort: hole
   - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
     name: GeometryValidatorSelfIntersection
@@ -1985,8 +2006,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionInterior
   - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
     name: AttributeManagerIntersectionInterior
@@ -2021,8 +2043,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").innerOrientation == env.get("__value").outerOrientation
+      - expr:
+          type: flowExpr
+          value: attributes["innerOrientation"] == attributes["outerOrientation"]
         outputPort: incorrectInterior
   - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
     name: AttributeManagerIncorrectInteriorOrientation
@@ -2421,9 +2444,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let issue = env.get("__value").solid_boundary_issues.issue;
-          issue == "NotA2Manifold"
+      - expr:
+          type: flowExpr
+          value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
         outputPort: notClosed
   - id: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b
     name: AttributeMapperNotClosed
@@ -2860,8 +2883,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d
     name: FeatureCounterFileIndex
@@ -2885,8 +2909,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e4f
     name: AttributeMapperGmlPathAndFilename
@@ -3124,8 +3149,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: b6c7d8e9-f0a1-2b3c-4d5e-6f7a8b9c0d1f
     name: FileWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
@@ -1888,7 +1888,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: true
+          value: 'true'
         outputPort: default
       - expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/workflow.yml
@@ -80,8 +80,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d
@@ -108,8 +109,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+          - expr:
+              type: flowExpr
+              value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
             outputPort: default
 
       - id: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e4f
@@ -369,8 +371,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       - id: b6c7d8e9-f0a1-2b3c-4d5e-6f7a8b9c0d1f

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/wtr.yml
@@ -182,9 +182,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            let issue = env.get("__value").solid_boundary_issues.issue;
-            issue == "NotA2Manifold"
+        - expr:
+            type: flowExpr
+            value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
           outputPort: notClosed
 
   # Non-watertight solid (NotA2Manifold) - following building workflow pattern

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
@@ -161,32 +161,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -333,8 +342,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1227,8 +1237,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -1618,8 +1629,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -1633,8 +1645,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -1646,20 +1659,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -1797,8 +1815,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").outerOrientation != "counter_clockwise"
+      - expr:
+          type: flowExpr
+          value: attributes["outerOrientation"] != "counter_clockwise"
         outputPort: inCorrectOrientation
   - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
     name: GeometryReplacer
@@ -1865,11 +1884,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          true
+      - expr:
+          type: flowExpr
+          value: true
         outputPort: default
-      - expr: |
-          env.get("__value").holeCount > 0
+      - expr:
+          type: flowExpr
+          value: attributes["holeCount"] > 0
         outputPort: hole
   - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
     name: GeometryValidatorSelfIntersection
@@ -1983,8 +2004,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionInterior
   - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
     name: AttributeManagerIntersectionInterior
@@ -2019,8 +2041,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").innerOrientation == env.get("__value").outerOrientation
+      - expr:
+          type: flowExpr
+          value: attributes["innerOrientation"] == attributes["outerOrientation"]
         outputPort: incorrectInterior
   - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
     name: AttributeManagerIncorrectInteriorOrientation
@@ -2388,9 +2411,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let issue = env.get("__value").solid_boundary_issues.issue;
-          issue == "NotA2Manifold"
+      - expr:
+          type: flowExpr
+          value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
         outputPort: notClosed
   - id: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6c
     name: AttributeMapperNotClosed
@@ -3037,8 +3060,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2f
     name: FeatureCounterFileIndex
@@ -3323,8 +3347,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: b6c7d8e9-f0a1-2b3c-4d5e-6f7a8b9c0d11
     name: FileWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
@@ -1886,7 +1886,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: true
+          value: 'true'
         outputPort: default
       - expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/unf.yml
@@ -148,9 +148,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            let issue = env.get("__value").solid_boundary_issues.issue;
-            issue == "NotA2Manifold"
+        - expr:
+            type: flowExpr
+            value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
           outputPort: notClosed
 
   # Non-watertight solid (NotA2Manifold)

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/workflow.yml
@@ -79,8 +79,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2f
@@ -393,8 +394,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       - id: b6c7d8e9-f0a1-2b3c-4d5e-6f7a8b9c0d11

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
@@ -163,32 +163,41 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").flag == "Summary"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "Summary"
         outputPort: summary
-      - expr: |
-          env.get("__value").flag == "CodeValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "CodeValidation"
         outputPort: codeValidation
-      - expr: |
-          env.get("__value").flag == "inCorrectCodeSpace"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "inCorrectCodeSpace"
         outputPort: inCorrectCodeSpace
-      - expr: |
-          env.get("__value").flag == "ExtentsValidation"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "ExtentsValidation"
         outputPort: extentsValidation
-      - expr: |
-          env.get("__value").flag == "GMLID_NotWellFormed"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotWellFormed"
         outputPort: gmlIdNotWellFormed
-      - expr: |
-          env.get("__value").flag == "GMLID_NotUnique"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "GMLID_NotUnique"
         outputPort: gmlIdNotUnique
-      - expr: |
-          env.get("__value").flag == "XLink_NoReference"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_NoReference"
         outputPort: xlinkNoReference
-      - expr: |
-          env.get("__value").flag == "XLink_InvalidObjectType"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "XLink_InvalidObjectType"
         outputPort: xLinkInvalidObjectType
-      - expr: |
-          env.get("__value").flag == "InvalidLodXGeometry"
+      - expr:
+          type: flowExpr
+          value: attributes["flag"] == "InvalidLodXGeometry"
         outputPort: invalidLodXGeometry
   - id: 0cf15acc-f7d1-4fbd-a502-97f766cff6d0
     name: SummaryRouter
@@ -335,8 +344,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 4b5c6d7e-8f9a-4b5c-9d0e-1f2a3b4c5d6e
     name: FeatureSorterByName
@@ -1229,8 +1239,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 740ac9e5-6eeb-439b-9860-23a125919a2e
     name: PLATEAU4.UDXFolderExtractor
@@ -1620,8 +1631,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["dm_feature_type"] == "DmGeometricAttribute"
+      - expr:
+          type: flowExpr
+          value: attributes.get("dm_feature_type") == "DmGeometricAttribute"
         outputPort: DmGeometricAttribute
   - id: 278ab965-ce22-473d-98c6-c7b381c38679
     name: GeometryFilter
@@ -1635,8 +1647,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("exceptSplit") ?? false
+      - expr:
+          type: flowExpr
+          value: env.get("exceptSplit", false)
         outputPort: exceptSplit
   - id: 8fe1a102-e3f3-40dd-b235-66e9c148830f
     name: GeometrySplitter
@@ -1648,20 +1661,25 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").lod == "0"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "0"
         outputPort: lod0
-      - expr: |
-          env.get("__value").lod == "1"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "1"
         outputPort: lod1
-      - expr: |
-          env.get("__value").lod == "2"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "2"
         outputPort: lod2
-      - expr: |
-          env.get("__value").lod == "3"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "3"
         outputPort: lod3
-      - expr: |
-          env.get("__value").lod == "4"
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] == "4"
         outputPort: lod4
   - id: b1c2d3e4-f5a6-7890-bcde-f12345678901
     name: DmGeometricAttributeRouter
@@ -1799,8 +1817,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").outerOrientation != "counter_clockwise"
+      - expr:
+          type: flowExpr
+          value: attributes["outerOrientation"] != "counter_clockwise"
         outputPort: inCorrectOrientation
   - id: 9e2b5f8a-1c4d-4a7e-f2b5-8a1e4b7c2f5d
     name: GeometryReplacer
@@ -1867,11 +1886,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          true
+      - expr:
+          type: flowExpr
+          value: true
         outputPort: default
-      - expr: |
-          env.get("__value").holeCount > 0
+      - expr:
+          type: flowExpr
+          value: attributes["holeCount"] > 0
         outputPort: hole
   - id: 5d2c7f4a-8b1e-4c6d-a9f2-4a7d2c5f8b1e
     name: GeometryValidatorSelfIntersection
@@ -1985,8 +2006,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").overlap > 1
+      - expr:
+          type: flowExpr
+          value: attributes["overlap"] > 1
         outputPort: intersectionInterior
   - id: 5a3b7e9c-2f4d-4a6e-b8c1-3e7a5b9c2f4d
     name: AttributeManagerIntersectionInterior
@@ -2021,8 +2043,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").innerOrientation == env.get("__value").outerOrientation
+      - expr:
+          type: flowExpr
+          value: attributes["innerOrientation"] == attributes["outerOrientation"]
         outputPort: incorrectInterior
   - id: 4b8e2a7d-3f6c-4a1e-b9d5-7a4b8e2d3f6c
     name: AttributeManagerIncorrectInteriorOrientation
@@ -2365,9 +2388,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let issue = env.get("__value").solid_boundary_issues.issue;
-          issue == "NotA2Manifold"
+      - expr:
+          type: flowExpr
+          value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
         outputPort: notClosed
   - id: a103c4d5-e6f7-a8b9-c0d1-e2f3a4b5c6d7
     name: AttributeMapperNotClosed
@@ -2825,8 +2848,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2e
     name: FeatureCounterFileIndex
@@ -2850,8 +2874,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+      - expr:
+          type: flowExpr
+          value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
         outputPort: default
   - id: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e40
     name: AttributeMapperGmlPathAndFilename
@@ -3089,8 +3114,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["totalErrorCount"] == 0
+      - expr:
+          type: flowExpr
+          value: attributes["totalErrorCount"] == 0
         outputPort: default
   - id: b6c7d8e9-f0a1-2b3c-4d5e-6f7a8b9c0d10
     name: FileWriterQcResultOk

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
@@ -1888,7 +1888,7 @@ graphs:
       conditions:
       - expr:
           type: flowExpr
-          value: true
+          value: 'true'
         outputPort: default
       - expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/gen.yml
@@ -129,9 +129,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            let issue = env.get("__value").solid_boundary_issues.issue;
-            issue == "NotA2Manifold"
+        - expr:
+            type: flowExpr
+            value: attributes["solid_boundary_issues"]["issue"] == "NotA2Manifold"
           outputPort: notClosed
 
   # AttributeMapper for NotClosed errors

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/workflow.yml
@@ -80,8 +80,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2e
@@ -108,8 +109,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              (env.get("targetPackages") ?? []).is_empty() || env.get("__value")["package"] in env.get("targetPackages")
+          - expr:
+              type: flowExpr
+              value: not env["targetPackages"] or attributes["package"] in env["targetPackages"]
             outputPort: default
 
       - id: c9d0e1f2-a3b4-5c6d-7e8f-9a0b1c2d3e40
@@ -369,8 +371,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["totalErrorCount"] == 0
+            - expr:
+                type: flowExpr
+                value: attributes["totalErrorCount"] == 0
               outputPort: default
 
       - id: b6c7d8e9-f0a1-2b3c-4d5e-6f7a8b9c0d10

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/plateau-data-to-surface/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/plateau-data-to-surface/workflow.yml
@@ -28,8 +28,9 @@ nodes:
     action: FeatureFilter
     with:
       conditions:
-        - expr: |
-            env.get("__value").featureType == "bldg:Building"
+        - expr:
+            type: flowExpr
+            value: attributes["featureType"] == "bldg:Building"
           outputPort: default
 
   # Step 1: Deaggregator equivalent - using geometry part extractor to decompose aggregate features

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
@@ -98,8 +98,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 712e4c72-950d-466d-9598-19f299668e7e
     name: PLATEAU4.UDXFolderExtractor
@@ -1603,8 +1604,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value").extension == "gml"
+      - expr:
+          type: flowExpr
+          value: attributes["extension"] == "gml"
         outputPort: default
   - id: 00000002-0000-0000-0000-000000000005
     name: DEMPLATEAU4UDXFolderExtractor
@@ -1638,21 +1640,21 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let lod = env.get("__value").lod;
-          lod == 1 || lod == "1";
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] in [1, "1"]
         outputPort: lod1
-      - expr: |
-          let lod = env.get("__value").lod;
-          lod == 2 || lod == "2";
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] in [2, "2"]
         outputPort: default
-      - expr: |
-          let lod = env.get("__value").lod;
-          lod == 3 || lod == "3";
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] in [3, "3"]
         outputPort: lod3
-      - expr: |
-          let lod = env.get("__value").lod;
-          lod == 4 || lod == "4";
+      - expr:
+          type: flowExpr
+          value: attributes["lod"] in [4, "4"]
         outputPort: lod4
   - id: 00000001-0000-0000-0000-00000000003b
     name: KeepFeatureType
@@ -1712,8 +1714,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["featureType"] != "bldg:Building";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] != "bldg:Building"
         outputPort: default
   - id: 00000001-0000-0000-0000-000000000006
     name: GeometrySplitter
@@ -1738,8 +1741,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["featureType"] == "bldg:RoofSurface";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "bldg:RoofSurface"
         outputPort: default
   - id: 00000001-0000-0000-0000-000000000029
     name: GridCellIdCounter
@@ -1899,8 +1903,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["column1"] == "9";
+      - expr:
+          type: flowExpr
+          value: attributes["column1"] == "9"
         outputPort: default
   - id: 00000003-0000-0000-0000-000000000003
     name: SnowAttributeMapper
@@ -2218,8 +2223,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["featureType"] != "bldg:Building";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] != "bldg:Building"
         outputPort: default
   - id: 00000001-0000-0000-0000-00000000006a
     name: FilterRoofForTexture
@@ -2227,8 +2233,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["featureType"] == "bldg:RoofSurface";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "bldg:RoofSurface"
         outputPort: default
   - id: 00000001-0000-0000-0000-000000000061
     name: ImageRasterizer
@@ -2305,9 +2312,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          let v = env.get("outputReflection");
-          v == true || v == "true";
+      - expr:
+          type: flowExpr
+          value: env["outputReflection"] == true or env["outputReflection"] == "true"
         outputPort: default
   - id: 00000001-0000-0000-0000-000000000013
     name: ComputeReflection
@@ -2743,8 +2750,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["featureType"] == "bldg:Building";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "bldg:Building"
         outputPort: default
   - id: 00000005-0000-0000-0000-000000000002
     name: BuildingAttrExtractor
@@ -2793,8 +2801,9 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("considerDEM") == true;
+      - expr:
+          type: flowExpr
+          value: env["considerDEM"] == true
         outputPort: default
   - id: 00000002-0000-0000-0000-000000000007
     name: DEMGeometrySplitter
@@ -2874,11 +2883,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["featureType"] == "bldg:RoofSurface";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "bldg:RoofSurface"
         outputPort: bldg
-      - expr: |
-          env.get("__value")["featureType"] == "dem:Triangle";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "dem:Triangle"
         outputPort: dem
   - id: 00000002-0000-0000-0000-00000000000a
     name: DEMGridDivider
@@ -2893,11 +2904,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["featureType"] == "bldg:RoofSurface";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "bldg:RoofSurface"
         outputPort: bldg
-      - expr: |
-          env.get("__value")["featureType"] == "dem:Triangle";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "dem:Triangle"
         outputPort: dem
   - id: 00000002-0000-0000-0000-00000000000d
     name: DEMGridKeyAssigner
@@ -2931,11 +2944,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["featureType"] == "bldg:RoofSurface";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "bldg:RoofSurface"
         outputPort: bldg
-      - expr: |
-          env.get("__value")["featureType"] == "dem:Triangle";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "dem:Triangle"
         outputPort: dem
   - id: 00000002-0000-0000-0000-000000000010
     name: DEMGridKeyAssigner2
@@ -2954,11 +2969,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["featureType"] == "bldg:RoofSurface";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "bldg:RoofSurface"
         outputPort: bldg
-      - expr: |
-          env.get("__value")["featureType"] == "dem:Triangle";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "dem:Triangle"
         outputPort: dem
   - id: 00000002-0000-0000-0000-000000000012
     name: DEMCellGeometryMerger
@@ -2975,11 +2992,13 @@ graphs:
     action: FeatureFilter
     with:
       conditions:
-      - expr: |
-          env.get("__value")["featureType"] == "dem:Triangle";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "dem:Triangle"
         outputPort: land
-      - expr: |
-          env.get("__value")["featureType"] == "bldg:RoofSurface";
+      - expr:
+          type: flowExpr
+          value: attributes["featureType"] == "bldg:RoofSurface"
         outputPort: default
   - id: 00000008-0000-0000-0000-000000000001
     name: AdequatePlaceJudgment

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/workflow.yml
@@ -143,8 +143,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").extension == "gml"
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
               outputPort: default
 
       - id: 00000002-0000-0000-0000-000000000005
@@ -183,21 +184,21 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                let lod = env.get("__value").lod;
-                lod == 1 || lod == "1";
+            - expr:
+                type: flowExpr
+                value: attributes["lod"] in [1, "1"]
               outputPort: lod1
-            - expr: |
-                let lod = env.get("__value").lod;
-                lod == 2 || lod == "2";
+            - expr:
+                type: flowExpr
+                value: attributes["lod"] in [2, "2"]
               outputPort: default
-            - expr: |
-                let lod = env.get("__value").lod;
-                lod == 3 || lod == "3";
+            - expr:
+                type: flowExpr
+                value: attributes["lod"] in [3, "3"]
               outputPort: lod3
-            - expr: |
-                let lod = env.get("__value").lod;
-                lod == 4 || lod == "4";
+            - expr:
+                type: flowExpr
+                value: attributes["lod"] in [4, "4"]
               outputPort: lod4
 
       # Keep only featureType attribute to reduce memory footprint
@@ -271,8 +272,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-          - expr: |
-              env.get("__value")["featureType"] != "bldg:Building";
+          - expr:
+              type: flowExpr
+              value: attributes["featureType"] != "bldg:Building"
             outputPort: default
 
       - id: 00000001-0000-0000-0000-000000000006
@@ -308,8 +310,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["featureType"] == "bldg:RoofSurface";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "bldg:RoofSurface"
               outputPort: default
 
       # Counter to assign stable cellId per physical grid cell (before timestep expansion)
@@ -495,8 +498,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["column1"] == "9";
+            - expr:
+                type: flowExpr
+                value: attributes["column1"] == "9"
               outputPort: default
 
       - id: 00000003-0000-0000-0000-000000000003
@@ -870,8 +874,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["featureType"] != "bldg:Building";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] != "bldg:Building"
               outputPort: default
 
       # Filter to keep only roof surfaces for texture assignment
@@ -881,8 +886,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["featureType"] == "bldg:RoofSurface";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "bldg:RoofSurface"
               outputPort: default
 
       # ImageRasterizer: creates texture from colored cells and assigns UV to roof geometry
@@ -976,9 +982,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                let v = env.get("outputReflection");
-                v == true || v == "true";
+            - expr:
+                type: flowExpr
+                value: env["outputReflection"] == true or env["outputReflection"] == "true"
               outputPort: default
 
       - id: 00000001-0000-0000-0000-000000000013
@@ -1500,8 +1506,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["featureType"] == "bldg:Building";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "bldg:Building"
               outputPort: default
 
       # Extract and preserve building-level CityGML attributes
@@ -1558,8 +1565,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("considerDEM") == true;
+            - expr:
+                type: flowExpr
+                value: env["considerDEM"] == true
               outputPort: default
 
       # Decompose DEM TriangularMesh → individual Polygon3D triangles
@@ -1655,11 +1663,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["featureType"] == "bldg:RoofSurface";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "bldg:RoofSurface"
               outputPort: bldg
-            - expr: |
-                env.get("__value")["featureType"] == "dem:Triangle";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "dem:Triangle"
               outputPort: dem
 
       # DEM-specific GridDivider: 5m cells, keepSquareOnly=false (partial cells kept)
@@ -1678,11 +1688,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["featureType"] == "bldg:RoofSurface";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "bldg:RoofSurface"
               outputPort: bldg
-            - expr: |
-                env.get("__value")["featureType"] == "dem:Triangle";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "dem:Triangle"
               outputPort: dem
 
       # Assign _dem_grid_key for DEM cells (before merging radiation across same-position pieces)
@@ -1722,11 +1734,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["featureType"] == "bldg:RoofSurface";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "bldg:RoofSurface"
               outputPort: bldg
-            - expr: |
-                env.get("__value")["featureType"] == "dem:Triangle";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "dem:Triangle"
               outputPort: dem
 
       # Assign _dem_grid_key to original DEM geometry pieces (for joining colors back)
@@ -1749,11 +1763,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["featureType"] == "bldg:RoofSurface";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "bldg:RoofSurface"
               outputPort: bldg
-            - expr: |
-                env.get("__value")["featureType"] == "dem:Triangle";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "dem:Triangle"
               outputPort: dem
 
       # Merge DEM colors back onto geometry pieces (requestor=geometry, supplier=colors)
@@ -1778,11 +1794,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value")["featureType"] == "dem:Triangle";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "dem:Triangle"
               outputPort: land
-            - expr: |
-                env.get("__value")["featureType"] == "bldg:RoofSurface";
+            - expr:
+                type: flowExpr
+                value: attributes["featureType"] == "bldg:RoofSurface"
               outputPort: default
 
       # ========================================

--- a/engine/runtime/expr/Cargo.toml
+++ b/engine/runtime/expr/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 indexmap.workspace = true
 lalrpop-util = "0.22"
 logos = "0.15"
+regex.workspace = true
 thiserror.workspace = true
 url.workspace = true
 

--- a/engine/runtime/expr/src/core/builtins.rs
+++ b/engine/runtime/expr/src/core/builtins.rs
@@ -1,10 +1,12 @@
 pub mod array;
 pub mod map;
 pub mod math;
+mod regex;
 pub mod str;
 mod url;
 
 pub use math::builtin_math;
+pub use regex::builtin_regex;
 pub use url::builtin_url;
 
 use crate::core::error::InnerResult;

--- a/engine/runtime/expr/src/core/builtins/array.rs
+++ b/engine/runtime/expr/src/core/builtins/array.rs
@@ -88,7 +88,15 @@ mod tests {
         assert_eval("arr.get(-3)", &[("arr", arr.clone())], Value::from(10i64));
         assert_eval("arr.get(5)", &[("arr", arr.clone())], Value::Null);
         assert_eval("arr.get(-5)", &[("arr", arr.clone())], Value::Null);
-        assert_eval("arr.get(5, 99)", &[("arr", arr.clone())], Value::from(99i64));
-        assert_eval("arr.get(1, 99)", &[("arr", arr.clone())], Value::from(20i64));
+        assert_eval(
+            "arr.get(5, 99)",
+            &[("arr", arr.clone())],
+            Value::from(99i64),
+        );
+        assert_eval(
+            "arr.get(1, 99)",
+            &[("arr", arr.clone())],
+            Value::from(20i64),
+        );
     }
 }

--- a/engine/runtime/expr/src/core/builtins/array.rs
+++ b/engine/runtime/expr/src/core/builtins/array.rs
@@ -9,7 +9,8 @@ use crate::core::value::{NativeFn, Value};
 
 use super::MethodFn;
 
-static METHODS: LazyLock<HashMap<&'static str, MethodFn>> = LazyLock::new(|| HashMap::from([]));
+static METHODS: LazyLock<HashMap<&'static str, MethodFn>> =
+    LazyLock::new(|| HashMap::from([("get", get as MethodFn)]));
 
 pub fn resolve_method(recv: Value, method: &str) -> InnerResult<NativeFn> {
     let f = METHODS
@@ -21,6 +22,33 @@ pub fn resolve_method(recv: Value, method: &str) -> InnerResult<NativeFn> {
         a.extend_from_slice(args);
         f(&a)
     }))
+}
+
+/// Resolves a possibly-negative index into a concrete `usize`, or `None` if out of bounds.
+pub fn resolve_index(i: i64, len: usize) -> Option<usize> {
+    let pos = if i >= 0 {
+        i as usize
+    } else {
+        len.checked_sub(i.unsigned_abs() as usize)?
+    };
+    (pos < len).then_some(pos)
+}
+
+fn get(args: &[Value]) -> InnerResult<Value> {
+    let (recv, idx, fallback) = match args {
+        [recv, idx] => (recv, idx, None),
+        [recv, idx, fallback] => (recv, idx, Some(fallback)),
+        _ => return Err(InnerError::new("array.get() requires 1 or 2 arguments")),
+    };
+    let Value::Array(rc) = recv else {
+        return Err(InnerError::new("expected array receiver"));
+    };
+    let Value::Int(i) = idx else {
+        return Err(InnerError::new("array.get() index must be an integer"));
+    };
+    let arr = rc.borrow();
+    let elem = resolve_index(*i, arr.len()).map(|pos| arr[pos].clone());
+    Ok(elem.unwrap_or_else(|| fallback.cloned().unwrap_or(Value::Null)))
 }
 
 pub fn eq_inner(a: &Rc<RefCell<Vec<Value>>>, b: &Rc<RefCell<Vec<Value>>>) -> InnerResult<bool> {
@@ -49,5 +77,18 @@ mod tests {
     fn test_len() {
         let arr = Value::from(vec![1i64, 2i64, 3i64]);
         assert_eval("len(arr)", &[("arr", arr)], Value::from(3i64));
+    }
+
+    #[test]
+    fn test_get() {
+        let arr = Value::from(vec![10i64, 20i64, 30i64]);
+        assert_eval("arr.get(0)", &[("arr", arr.clone())], Value::from(10i64));
+        assert_eval("arr.get(2)", &[("arr", arr.clone())], Value::from(30i64));
+        assert_eval("arr.get(-1)", &[("arr", arr.clone())], Value::from(30i64));
+        assert_eval("arr.get(-3)", &[("arr", arr.clone())], Value::from(10i64));
+        assert_eval("arr.get(5)", &[("arr", arr.clone())], Value::Null);
+        assert_eval("arr.get(-5)", &[("arr", arr.clone())], Value::Null);
+        assert_eval("arr.get(5, 99)", &[("arr", arr.clone())], Value::from(99i64));
+        assert_eval("arr.get(1, 99)", &[("arr", arr.clone())], Value::from(20i64));
     }
 }

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -25,14 +25,16 @@ impl ImmutableObject for RegexObject {
                 let Value::String(s) = s else {
                     return Err(InnerError::new("Regex.find() requires a string argument"));
                 };
-                Ok(regex_find(&self.regex, &s))
+                Ok(regex_find(&self.regex, s))
             }
             "findall" => {
                 unpack_args!(args => s);
                 let Value::String(s) = s else {
-                    return Err(InnerError::new("Regex.findall() requires a string argument"));
+                    return Err(InnerError::new(
+                        "Regex.findall() requires a string argument",
+                    ));
                 };
-                Ok(Value::array(regex_findall(&self.regex, &s)))
+                Ok(Value::array(regex_findall(&self.regex, s)))
             }
             m => Err(InnerError::new(format!("Regex has no method '{m}'"))),
         }

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -27,14 +27,14 @@ impl ImmutableObject for RegexObject {
                 };
                 Ok(regex_find(&self.regex, s))
             }
-            "findall" => {
+            "find_all" => {
                 unpack_args!(args => s);
                 let Value::String(s) = s else {
                     return Err(InnerError::new(
-                        "Regex.findall() requires a string argument",
+                        "Regex.find_all() requires a string argument",
                     ));
                 };
-                Ok(Value::array(regex_findall(&self.regex, s)))
+                Ok(Value::array(regex_find_all(&self.regex, s)))
             }
             m => Err(InnerError::new(format!("Regex has no method '{m}'"))),
         }
@@ -49,18 +49,27 @@ impl ImmutableObject for RegexObject {
     }
 }
 
+// follow Python re.findall element type convention
 fn capture_to_value(cap: &regex::Captures, num_groups: usize) -> Value {
     if num_groups == 1 {
-        Value::String(cap.get(1).map(|m| m.as_str()).unwrap_or("").to_string())
+        cap.get(1)
+            .map(|m| Value::String(m.as_str().to_string()))
+            .unwrap_or(Value::Null)
     } else {
         Value::array(
             (1..=num_groups)
-                .map(|i| Value::String(cap.get(i).map(|m| m.as_str()).unwrap_or("").to_string()))
+                .map(|i| {
+                    cap.get(i)
+                        .map(|m| Value::String(m.as_str().to_string()))
+                        .unwrap_or(Value::Null)
+                })
                 .collect(),
         )
     }
 }
 
+// note that `if Regex(".*").find("1")` does not match, although constructing patterns that match empty string is considered bad practice
+// Still, for dynamic/user input pattern, it is safer to test with `== null`
 fn regex_find(regex: &Regex, s: &str) -> Value {
     let num_groups = regex.captures_len() - 1;
     if num_groups == 0 {
@@ -76,7 +85,7 @@ fn regex_find(regex: &Regex, s: &str) -> Value {
     }
 }
 
-fn regex_findall(regex: &Regex, s: &str) -> Vec<Value> {
+fn regex_find_all(regex: &Regex, s: &str) -> Vec<Value> {
     let num_groups = regex.captures_len() - 1;
     if num_groups == 0 {
         regex
@@ -107,6 +116,8 @@ pub fn builtin_regex(args: &[Value]) -> InnerResult<Value> {
             )))
         }
     };
+    // FlowExpr is general-purpose. Do not do implicit caching for Regex patterns here.
+    // Compile-time constant folding might be a proper future solution, but currently it is overkill.
     let regex = Regex::new(&pattern).map_err(|e| InnerError::new(format!("invalid regex: {e}")))?;
     Ok(Value::object(RegexObject { pattern, regex }))
 }
@@ -133,24 +144,48 @@ mod tests {
     }
 
     #[test]
-    fn test_regex_findall() {
+    fn test_regex_optional_group_null() {
+        // single optional group that did not participate → Null, not ""
+        assert_val(&run(r#"Regex(r"a(b)?c").find("ac")"#, &[]), &Value::Null);
+        // single optional group that did participate → String
         assert_val(
-            &run(r#"Regex(r"\d+").findall("abc 123 def 456")"#, &[]),
+            &run(r#"Regex(r"a(b)?c").find("abc")"#, &[]),
+            &Value::from("b"),
+        );
+        // multi-group: second optional group absent → Null in that slot
+        assert_val(
+            &run(r#"Regex(r"(\d+)(x)?").find("123")"#, &[]),
+            &Value::array(vec![Value::from("123"), Value::Null]),
+        );
+        // find_all: optional group absent → Null per match
+        assert_val(
+            &run(r#"Regex(r"(\d+)(x)?").find_all("123 456x")"#, &[]),
+            &Value::array(vec![
+                Value::array(vec![Value::from("123"), Value::Null]),
+                Value::array(vec![Value::from("456"), Value::from("x")]),
+            ]),
+        );
+    }
+
+    #[test]
+    fn test_regex_find_all() {
+        assert_val(
+            &run(r#"Regex(r"\d+").find_all("abc 123 def 456")"#, &[]),
             &Value::array(vec![Value::from("123"), Value::from("456")]),
         );
         assert_val(
-            &run(r#"Regex(r"(\d+)").findall("abc 123 def 456")"#, &[]),
+            &run(r#"Regex(r"(\d+)").find_all("abc 123 def 456")"#, &[]),
             &Value::array(vec![Value::from("123"), Value::from("456")]),
         );
         assert_val(
-            &run(r#"Regex(r"(\w+)@(\w+)").findall("a@b x@y")"#, &[]),
+            &run(r#"Regex(r"(\w+)@(\w+)").find_all("a@b x@y")"#, &[]),
             &Value::array(vec![
                 Value::array(vec![Value::from("a"), Value::from("b")]),
                 Value::array(vec![Value::from("x"), Value::from("y")]),
             ]),
         );
         assert_val(
-            &run(r#"Regex(r"\d+").findall("no digits here")"#, &[]),
+            &run(r#"Regex(r"\d+").find_all("no digits here")"#, &[]),
             &Value::array(vec![]),
         );
     }

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -68,7 +68,7 @@ fn capture_to_value(cap: &regex::Captures, num_groups: usize) -> Value {
     }
 }
 
-// note that `if Regex(".*").find("1")` does not match, although constructing patterns that match empty string is considered bad practice
+// note that `if Regex(".*").find("1")` is falsy even though constructing patterns that match empty string is considered bad practice
 // Still, for dynamic/user input pattern, it is safer to test with `== null`
 fn regex_find(regex: &Regex, s: &str) -> Value {
     let num_groups = regex.captures_len() - 1;

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -1,0 +1,155 @@
+use crate::core::error::{InnerError, InnerResult};
+use crate::core::value::{ImmutableObject, Value};
+use crate::unpack_args;
+use regex::Regex;
+
+#[derive(Debug, Clone)]
+pub struct RegexObject {
+    pattern: String,
+    regex: Regex,
+}
+
+impl ImmutableObject for RegexObject {
+    fn type_name(&self) -> &'static str {
+        "Regex"
+    }
+
+    fn get_property(&self, _name: &str) -> Option<InnerResult<Value>> {
+        None
+    }
+
+    fn call_method(&self, method: &str, args: &[Value]) -> InnerResult<Value> {
+        match method {
+            "find" => {
+                unpack_args!(args => s);
+                let Value::String(s) = s else {
+                    return Err(InnerError::new("Regex.find() requires a string argument"));
+                };
+                Ok(regex_find(&self.regex, &s))
+            }
+            "findall" => {
+                unpack_args!(args => s);
+                let Value::String(s) = s else {
+                    return Err(InnerError::new("Regex.findall() requires a string argument"));
+                };
+                Ok(Value::array(regex_findall(&self.regex, &s)))
+            }
+            m => Err(InnerError::new(format!("Regex has no method '{m}'"))),
+        }
+    }
+
+    fn display(&self) -> String {
+        self.pattern.clone()
+    }
+
+    fn serialize(&self) -> Option<Value> {
+        Some(Value::String(self.pattern.clone()))
+    }
+}
+
+fn capture_to_value(cap: &regex::Captures, num_groups: usize) -> Value {
+    if num_groups == 1 {
+        Value::String(cap.get(1).map(|m| m.as_str()).unwrap_or("").to_string())
+    } else {
+        Value::array(
+            (1..=num_groups)
+                .map(|i| Value::String(cap.get(i).map(|m| m.as_str()).unwrap_or("").to_string()))
+                .collect(),
+        )
+    }
+}
+
+fn regex_find(regex: &Regex, s: &str) -> Value {
+    let num_groups = regex.captures_len() - 1;
+    if num_groups == 0 {
+        regex
+            .find(s)
+            .map(|m| Value::String(m.as_str().to_string()))
+            .unwrap_or(Value::Null)
+    } else {
+        regex
+            .captures(s)
+            .map(|cap| capture_to_value(&cap, num_groups))
+            .unwrap_or(Value::Null)
+    }
+}
+
+fn regex_findall(regex: &Regex, s: &str) -> Vec<Value> {
+    let num_groups = regex.captures_len() - 1;
+    if num_groups == 0 {
+        regex
+            .find_iter(s)
+            .map(|m| Value::String(m.as_str().to_string()))
+            .collect()
+    } else {
+        regex
+            .captures_iter(s)
+            .map(|cap| capture_to_value(&cap, num_groups))
+            .collect()
+    }
+}
+
+pub fn builtin_regex(args: &[Value]) -> InnerResult<Value> {
+    if args.len() != 1 {
+        return Err(InnerError::new(format!(
+            "Regex() expected 1 argument, got {}",
+            args.len()
+        )));
+    }
+    let pattern = match &args[0] {
+        Value::String(s) => s.clone(),
+        v => {
+            return Err(InnerError::new(format!(
+                "Regex() expects a string, got {}",
+                v.type_name()
+            )))
+        }
+    };
+    let regex = Regex::new(&pattern).map_err(|e| InnerError::new(format!("invalid regex: {e}")))?;
+    Ok(Value::object(RegexObject { pattern, regex }))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::test_utils::{assert_val, run};
+    use crate::core::value::Value;
+
+    #[test]
+    fn test_regex_find() {
+        assert_val(
+            &run(r#"Regex(r"\d+").find("abc 123 def 456")"#, &[]),
+            &Value::from("123"),
+        );
+        assert_val(
+            &run(r#"Regex(r"(\d+)").find("abc 123")"#, &[]),
+            &Value::from("123"),
+        );
+        assert_val(
+            &run(r#"Regex(r"\d+").find("no digits")"#, &[]),
+            &Value::Null,
+        );
+    }
+
+    #[test]
+    fn test_regex_findall() {
+        assert_val(
+            &run(r#"Regex(r"\d+").findall("abc 123 def 456")"#, &[]),
+            &Value::array(vec![Value::from("123"), Value::from("456")]),
+        );
+        assert_val(
+            &run(r#"Regex(r"(\d+)").findall("abc 123 def 456")"#, &[]),
+            &Value::array(vec![Value::from("123"), Value::from("456")]),
+        );
+        assert_val(
+            &run(r#"Regex(r"(\w+)@(\w+)").findall("a@b x@y")"#, &[]),
+            &Value::array(vec![
+                Value::array(vec![Value::from("a"), Value::from("b")]),
+                Value::array(vec![Value::from("x"), Value::from("y")]),
+            ]),
+        );
+        assert_val(
+            &run(r#"Regex(r"\d+").findall("no digits here")"#, &[]),
+            &Value::array(vec![]),
+        );
+    }
+}

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -971,7 +971,11 @@ fn is_truthy(v: &Value) -> bool {
     }
 }
 
-pub(crate) fn str_cast(v: Value) -> InnerResult<String> {
+pub fn bool_cast(v: Value) -> bool {
+    is_truthy(&v)
+}
+
+pub fn str_cast(v: Value) -> InnerResult<String> {
     match builtin_str(std::slice::from_ref(&v))? {
         Value::String(s) => Ok(s),
         _ => unreachable!(),

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -785,7 +785,9 @@ fn eval_index(target: Value, key: Value) -> InnerResult<Value> {
             let len = chars.len();
             array_methods::resolve_index(i, len)
                 .map(|pos| Value::String(chars[pos].to_string()))
-                .ok_or_else(|| InnerError::new(format!("string index {i} out of range (len {len})")))
+                .ok_or_else(|| {
+                    InnerError::new(format!("string index {i} out of range (len {len})"))
+                })
         }
         (Value::Object(rc), key) => rc.call_method("__getitem__", &[key]),
         (target, key) => Err(InnerError::new(format!(

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 
 use super::ast::{BinOp, Expr, ExprKind, UnaryOp};
 use super::builtins::{array as array_methods, map as map_methods, str as str_methods};
-use super::builtins::{builtin_math, builtin_url};
+use super::builtins::{builtin_math, builtin_regex, builtin_url};
 use super::error::{Error, InnerError, InnerResult, Result};
 use super::value::{format_float, NativeFn, Value};
 use crate::unpack_args;
@@ -66,6 +66,7 @@ pub fn default_env() -> Env {
     env.insert("list".into(), Value::Fn(NativeFn::new(builtin_list)));
     env.insert("map".into(), Value::Fn(NativeFn::new(builtin_map)));
     env.insert("Url".into(), Value::Fn(NativeFn::new(builtin_url)));
+    env.insert("Regex".into(), Value::Fn(NativeFn::new(builtin_regex)));
     env.insert("math".into(), builtin_math());
     env.insert("print".into(), Value::Fn(NativeFn::new(builtin_print)));
     env.insert("type".into(), Value::Fn(NativeFn::new(builtin_type)));
@@ -678,15 +679,12 @@ fn eval_assign_lvalue(lvalue: &Expr, value: Value, env: &mut Env) -> Result<()> 
             let key_val = eval_inner(key, env)?;
             match (container, &key_val) {
                 (Value::Array(rc), Value::Int(i)) => {
-                    let len = rc.borrow().len() as i64;
-                    let idx = if *i < 0 { len + i } else { *i };
-                    if idx < 0 || idx as usize >= len as usize {
-                        return Err(Error::Eval {
-                            pos,
-                            msg: format!("array index {} out of range (len {})", i, len),
-                        });
-                    }
-                    rc.borrow_mut()[idx as usize] = value;
+                    let len = rc.borrow().len();
+                    let idx = array_methods::resolve_index(*i, len).ok_or_else(|| Error::Eval {
+                        pos,
+                        msg: format!("array index {} out of range (len {})", i, len),
+                    })?;
+                    rc.borrow_mut()[idx] = value;
                 }
                 (Value::Map(rc), Value::String(k)) => {
                     rc.borrow_mut().insert(k.clone(), value);
@@ -735,17 +733,14 @@ fn eval_compound_assign(
             let key_val = eval_inner(key, env)?;
             match (container, &key_val) {
                 (Value::Array(rc), Value::Int(i)) => {
-                    let len = rc.borrow().len() as i64;
-                    let idx = if *i < 0 { len + i } else { *i };
-                    if idx < 0 || idx as usize >= len as usize {
-                        return Err(Error::Eval {
-                            pos,
-                            msg: format!("array index {} out of range (len {})", i, len),
-                        });
-                    }
-                    let current = rc.borrow()[idx as usize].clone();
+                    let len = rc.borrow().len();
+                    let idx = array_methods::resolve_index(*i, len).ok_or_else(|| Error::Eval {
+                        pos,
+                        msg: format!("array index {} out of range (len {})", i, len),
+                    })?;
+                    let current = rc.borrow()[idx].clone();
                     let new_val = call_func(&f, &[current, rhs_val], pos)?;
-                    rc.borrow_mut()[idx as usize] = new_val.clone();
+                    rc.borrow_mut()[idx] = new_val.clone();
                     Ok(new_val)
                 }
                 (Value::Map(rc), Value::String(k)) => {
@@ -780,25 +775,17 @@ fn eval_index(target: Value, key: Value) -> InnerResult<Value> {
             .ok_or_else(|| InnerError::new(format!("map key '{k}' not found"))),
         (Value::Array(arr), Value::Int(i)) => {
             let arr = arr.borrow();
-            let len = arr.len() as i64;
-            let i = if i < 0 { len + i } else { i };
-            if i < 0 || i >= len {
-                return Err(InnerError::new(format!(
-                    "array index {i} out of range (len {len})"
-                )));
-            }
-            Ok(arr[i as usize].clone())
+            let len = arr.len();
+            array_methods::resolve_index(i, len)
+                .map(|pos| arr[pos].clone())
+                .ok_or_else(|| InnerError::new(format!("array index {i} out of range (len {len})")))
         }
         (Value::String(s), Value::Int(i)) => {
             let chars: Vec<char> = s.chars().collect();
-            let len = chars.len() as i64;
-            let i = if i < 0 { len + i } else { i };
-            if i < 0 || i >= len {
-                return Err(InnerError::new(format!(
-                    "string index {i} out of range (len {len})"
-                )));
-            }
-            Ok(Value::String(chars[i as usize].to_string()))
+            let len = chars.len();
+            array_methods::resolve_index(i, len)
+                .map(|pos| Value::String(chars[pos].to_string()))
+                .ok_or_else(|| InnerError::new(format!("string index {i} out of range (len {len})")))
         }
         (Value::Object(rc), key) => rc.call_method("__getitem__", &[key]),
         (target, key) => Err(InnerError::new(format!(

--- a/engine/runtime/expr/src/core/lexer.rs
+++ b/engine/runtime/expr/src/core/lexer.rs
@@ -2,6 +2,12 @@ use logos::Logos;
 
 use super::error::Error;
 
+fn lex_raw_string<'src>(lex: &mut logos::Lexer<'src, Token>) -> Option<String> {
+    let raw = lex.slice();
+    // strip leading r" and trailing "
+    Some(raw[2..raw.len() - 1].to_string())
+}
+
 fn lex_string<'src>(lex: &mut logos::Lexer<'src, Token>) -> Option<String> {
     let raw = lex.slice();
     let quote = raw.chars().next()?;
@@ -39,6 +45,7 @@ pub enum Token {
     Int(i64),
 
     #[regex(r#""([^"\\]|\\.)*""#, lex_string)]
+    #[regex(r#"r"[^"]*""#, lex_raw_string)]
     Str(String),
 
     // keywords — must be defined before Ident so logos gives them priority
@@ -372,6 +379,20 @@ mod tests {
         assert_eq!(
             tokenize(r#""foo#bar" # strip this"#),
             vec![Token::Str("foo#bar".into())]
+        );
+    }
+
+    #[test]
+    fn test_raw_string() {
+        // backslashes are literal, not escape sequences
+        assert_eq!(
+            tokenize(r#"r"\n\t""#),
+            vec![Token::Str(r"\n\t".into())]
+        );
+        // regular content works too
+        assert_eq!(
+            tokenize(r#"r"hello world""#),
+            vec![Token::Str("hello world".into())]
         );
     }
 

--- a/engine/runtime/expr/src/core/lexer.rs
+++ b/engine/runtime/expr/src/core/lexer.rs
@@ -385,10 +385,7 @@ mod tests {
     #[test]
     fn test_raw_string() {
         // backslashes are literal, not escape sequences
-        assert_eq!(
-            tokenize(r#"r"\n\t""#),
-            vec![Token::Str(r"\n\t".into())]
-        );
+        assert_eq!(tokenize(r#"r"\n\t""#), vec![Token::Str(r"\n\t".into())]);
         // regular content works too
         assert_eq!(
             tokenize(r#"r"hello world""#),

--- a/engine/runtime/expr/src/lib.rs
+++ b/engine/runtime/expr/src/lib.rs
@@ -30,7 +30,7 @@ macro_rules! unpack_args {
 }
 
 pub use core::error::{Error, InnerError, InnerResult, Result};
-pub use core::eval::{default_env, Env};
+pub use core::eval::{bool_cast, default_env, str_cast, Env};
 pub use core::value::{ImmutableObject, NativeFn, Value};
 
 /// Compile an expression string into an opaque [`CompiledExpr`].
@@ -41,12 +41,6 @@ pub fn compile(input: &str) -> Result<CompiledExpr> {
 /// Evaluate a compiled expression against an [`Env`].
 pub fn eval(expr: &CompiledExpr, env: &mut Env) -> Result<Value> {
     core::eval::eval(&expr.0, env)
-}
-
-/// Evaluate and coerce the result to a `String` via the `str()` builtin.
-pub fn eval_string(expr: &CompiledExpr, env: &mut Env) -> Result<String> {
-    let value = eval(expr, env)?;
-    core::eval::str_cast(value).map_err(|e| Error::EvalString { msg: e.msg })
 }
 
 /// Opaque handle to a compiled expression. Internals are not part of the public API.

--- a/engine/runtime/tests/fixture/workflow/feature/filter.yaml
+++ b/engine/runtime/tests/fixture/workflow/feature/filter.yaml
@@ -19,8 +19,9 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").city in ["Tokyo", "Osaka"]
+            - expr:
+                type: flowExpr
+                value: attributes["city"] in ["Tokyo", "Osaka"]
               outputPort: default
 
     edges:

--- a/engine/runtime/tests/fixture/workflow/geometry/neighbor_finder/proximity_search_with_geojson.yaml
+++ b/engine/runtime/tests/fixture/workflow/geometry/neighbor_finder/proximity_search_with_geojson.yaml
@@ -28,11 +28,13 @@ graphs:
         action: FeatureFilter
         with:
           conditions:
-            - expr: |
-                env.get("__value").type == "candidate"
+            - expr:
+                type: flowExpr
+                value: attributes["type"] == "candidate"
               outputPort: candidate
-            - expr: |
-                env.get("__value").type == "base"
+            - expr:
+                type: flowExpr
+                value: attributes["type"] == "base"
               outputPort: base
 
       - id: c3d4e5f6-a7b8-9012-cdef-345678901234

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -5,7 +5,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use reearth_flow_expr::{
-    compile, eval, eval_string, Error as ExprError, InnerError, InnerResult, Value as ExprValue,
+    bool_cast, compile, eval, str_cast, Error as ExprError, InnerError, InnerResult,
+    Value as ExprValue,
 };
 
 use crate::attribute::{Attribute, AttributeValue};
@@ -80,13 +81,27 @@ impl CompiledCode {
         attribute_value_from_eval(v)
     }
 
+    pub fn eval_bool(
+        &self,
+        feature: &Feature,
+        env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
+    ) -> reearth_flow_expr::Result<bool> {
+        match self {
+            CompiledCode::Expr(e) => {
+                eval(e, &mut env_from_feature(feature, env_vars)).map(bool_cast)
+            }
+            CompiledCode::Literal(s) => Ok(!s.is_empty()),
+        }
+    }
+
     pub fn eval_string(
         &self,
         feature: &Feature,
         env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
     ) -> reearth_flow_expr::Result<String> {
         match self {
-            CompiledCode::Expr(e) => eval_string(e, &mut env_from_feature(feature, env_vars)),
+            CompiledCode::Expr(e) => eval(e, &mut env_from_feature(feature, env_vars))
+                .and_then(|v| str_cast(v).map_err(|e| ExprError::EvalString { msg: e.msg })),
             CompiledCode::Literal(s) => Ok(s.clone()),
         }
     }

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -3214,6 +3214,28 @@
           }
         },
         "definitions": {
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
+          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3225,7 +3247,7 @@
                 "title": "Condition expression",
                 "allOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   }
                 ]
               },
@@ -3238,9 +3260,6 @@
                 ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           },
           "Port": {
             "type": "string"

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -3214,6 +3214,28 @@
           }
         },
         "definitions": {
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
+          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3225,7 +3247,7 @@
                 "title": "Condition expression",
                 "allOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   }
                 ]
               },
@@ -3238,9 +3260,6 @@
                 ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           },
           "Port": {
             "type": "string"

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -3214,6 +3214,28 @@
           }
         },
         "definitions": {
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
+          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3225,7 +3247,7 @@
                 "title": "Condition expression",
                 "allOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   }
                 ]
               },
@@ -3238,9 +3260,6 @@
                 ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           },
           "Port": {
             "type": "string"

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -3214,6 +3214,28 @@
           }
         },
         "definitions": {
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
+          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3225,7 +3247,7 @@
                 "title": "Condition expression",
                 "allOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   }
                 ]
               },
@@ -3238,9 +3260,6 @@
                 ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           },
           "Port": {
             "type": "string"

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -3217,6 +3217,28 @@
           }
         },
         "definitions": {
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
+          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3228,7 +3250,7 @@
                 "title": "条件式",
                 "allOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   }
                 ]
               },
@@ -3241,9 +3263,6 @@
                 ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           },
           "Port": {
             "type": "string"

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -3214,6 +3214,28 @@
           }
         },
         "definitions": {
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
+          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3225,7 +3247,7 @@
                 "title": "Condition expression",
                 "allOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   }
                 ]
               },
@@ -3238,9 +3260,6 @@
                 ]
               }
             }
-          },
-          "Expr": {
-            "type": "string"
           },
           "Port": {
             "type": "string"

--- a/engine/schema/i18n/actions/en.json
+++ b/engine/schema/i18n/actions/en.json
@@ -1103,6 +1103,10 @@
         }
       },
       "definitionI18n": {
+        "Code": {
+          "type": {},
+          "value": {}
+        },
         "Condition": {
           "expr": {
             "title": "Condition expression"

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -1115,6 +1115,10 @@
         }
       },
       "definitionI18n": {
+        "Code": {
+          "type": {},
+          "value": {}
+        },
         "Condition": {
           "expr": {
             "title": "Condition expression"

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -1115,6 +1115,10 @@
         }
       },
       "definitionI18n": {
+        "Code": {
+          "type": {},
+          "value": {}
+        },
         "Condition": {
           "expr": {
             "title": "Condition expression"

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -1118,6 +1118,10 @@
         }
       },
       "definitionI18n": {
+        "Code": {
+          "type": {},
+          "value": {}
+        },
         "Condition": {
           "expr": {
             "title": "条件式"

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -1115,6 +1115,10 @@
         }
       },
       "definitionI18n": {
+        "Code": {
+          "type": {},
+          "value": {}
+        },
         "Condition": {
           "expr": {
             "title": "Condition expression"


### PR DESCRIPTION
# Overview

Continuing #2030, #2087, #2109, migrating FeatureFilter and update FlowExpr implementation.

## Changes

- add Regex(pattern) to construct/compile regular expressions providing `find` and `find_all` methods
- add `.get` on list to simplify out of range fallback on list
- migrate FeatureFilter in all workflows to use FlowExpr (except for deprecated workflows listed in #2089)

## Notes

Currently condition expression accepts both code and string types which is a known problem. Schema generation for the new code fields are not determined. The fix will be implemented in another PR.