### PR TITLE
refactor(engine): code language allowlist in schema definition

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.403"
+version = "0.0.404"
 
 [profile.dev]
 opt-level = 0

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -686,28 +686,6 @@ Transform Feature Attributes Using Expressions and Mappings
     }
   },
   "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
-    },
     "Mapper": {
       "type": "object",
       "properties": {
@@ -727,25 +705,51 @@ Transform Feature Attributes Using Expressions and Mappings
         },
         "expr": {
           "title": "Expression to evaluate",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Code"
+          "type": [
+            "object",
+            "null"
+          ],
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
             },
-            {
-              "type": "null"
+            "value": {
+              "type": "string"
             }
-          ]
+          }
         },
         "multipleExpr": {
           "title": "Expression to evaluate multiple attributes",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Code"
+          "type": [
+            "object",
+            "null"
+          ],
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
             },
-            {
-              "type": "null"
+            "value": {
+              "type": "string"
             }
-          ]
+          }
         },
         "parentAttribute": {
           "title": "Parent attribute name",
@@ -1482,14 +1486,27 @@ Reads 3D city models from CityGML files.
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "flatten": {
       "type": [
@@ -1500,38 +1517,27 @@ Reads 3D city models from CityGML files.
     "inline": {
       "title": "Inline Content",
       "description": "Expression that returns the file content as text instead of reading from a file path",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
     }
   }
 }
@@ -1582,11 +1588,24 @@ Writes features to CityGML 2.0 files
     },
     "output": {
       "description": "Output file path expression",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "prettyPrint": {
       "description": "Whether to format output with indentation (default: true)",
@@ -1594,30 +1613,6 @@ Writes features to CityGML 2.0 files
       "type": [
         "boolean",
         "null"
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
       ]
     }
   }
@@ -1851,14 +1846,27 @@ Read Features from CSV or TSV File
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "encoding": {
       "title": "Character Encoding",
@@ -1902,14 +1910,27 @@ Read Features from CSV or TSV File
     "inline": {
       "title": "Inline Content",
       "description": "Expression that returns the file content as text instead of reading from a file path",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "offset": {
       "title": "Header Row Offset",
@@ -1923,28 +1944,6 @@ Read Features from CSV or TSV File
     }
   },
   "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
-    },
     "CsvFormat": {
       "oneOf": [
         {
@@ -2076,36 +2075,27 @@ Writes features to CSV or TSV files.
     },
     "output": {
       "description": "Output path or expression for the CSV/TSV file to create",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
-    },
+    }
+  },
+  "definitions": {
     "CsvFormat": {
       "oneOf": [
         {
@@ -2202,14 +2192,27 @@ Reads geographic features from CZML (Cesium Language) files for 3D visualization
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "force2d": {
       "title": "Force 2D",
@@ -2220,14 +2223,27 @@ Reads geographic features from CZML (Cesium Language) files for 3D visualization
     "inline": {
       "title": "Inline Content",
       "description": "Expression that returns the file content as text instead of reading from a file path",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "skipDocumentPacket": {
       "title": "Skip Document Packet",
@@ -2247,28 +2263,6 @@ Reads geographic features from CZML (Cesium Language) files for 3D visualization
     }
   },
   "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
-    },
     "TimeSamplingStrategy": {
       "description": "Strategy for handling time-dynamic CZML properties.",
       "oneOf": [
@@ -2404,11 +2398,24 @@ Export features as CZML for Cesium visualization. Supports static entities and t
     "output": {
       "title": "Output File Path",
       "description": "Path where the CZML file will be written",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "timeField": {
       "title": "Time Field",
@@ -2426,28 +2433,6 @@ Export features as CZML for Cesium visualization. Supports static entities and t
   "definitions": {
     "Attribute": {
       "type": "string"
-    },
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
     },
     "InterpolationAlgorithm": {
       "description": "Interpolation algorithm for Cesium time-dynamic properties.",
@@ -2883,41 +2868,30 @@ Writes features to Microsoft Excel format (.xlsx files).
   "properties": {
     "output": {
       "description": "Output path or expression for the Excel file to create",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    },
-    "sheetName": {
-      "description": "Sheet name (defaults to \"Sheet1\")",
-      "type": [
-        "string",
-        "null"
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
     },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
+    "sheetName": {
+      "description": "Sheet name (defaults to \"Sheet1\")",
+      "type": [
+        "string",
+        "null"
       ]
     }
   }
@@ -2987,11 +2961,24 @@ Reads CityGML 3.0 files: resolves gml:id references and xlink:href links across 
     "dataset": {
       "title": "Dataset",
       "description": "Path expression resolving to the CityGML 3.0 file to read.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "extractTags": {
       "title": "Extract Tags",
@@ -3001,30 +2988,6 @@ Reads CityGML 3.0 files: resolves gml:id references and xlink:href links across 
       "items": {
         "type": "string"
       }
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
     }
   }
 }
@@ -3055,23 +3018,49 @@ Reads and processes features from CityGML files with optional flattening
     "codelistsPath": {
       "title": "Codelists Path",
       "description": "Optional path to the codelists directory for resolving codelist values",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "dataset": {
       "title": "Dataset",
       "description": "Path or expression to the CityGML dataset file to be read",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "flatten": {
       "title": "Flatten",
@@ -3079,30 +3068,6 @@ Reads and processes features from CityGML files with optional flattening
       "type": [
         "boolean",
         "null"
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
       ]
     }
   }
@@ -3189,35 +3154,24 @@ Generate Custom Features Using Scripts
     "creator": {
       "title": "Script Expression",
       "description": "Write a script expression that returns a map (single feature) or array of maps (multiple features). Each map represents feature attributes as key-value pairs.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
     }
   }
 }
@@ -3663,11 +3617,24 @@ Reads features from various file formats (CSV, TSV, JSON) with configurable pars
         "dataset": {
           "title": "Dataset",
           "description": "Path or expression to the dataset file to be read",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Code"
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          ]
+          }
         },
         "encoding": {
           "title": "Character Encoding",
@@ -3716,11 +3683,24 @@ Reads features from various file formats (CSV, TSV, JSON) with configurable pars
         "dataset": {
           "title": "Dataset",
           "description": "Path or expression to the dataset file to be read",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Code"
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          ]
+          }
         },
         "encoding": {
           "title": "Character Encoding",
@@ -3769,11 +3749,24 @@ Reads features from various file formats (CSV, TSV, JSON) with configurable pars
         "dataset": {
           "title": "Dataset",
           "description": "Path or expression to the dataset file to be read",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Code"
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          ]
+          }
         },
         "format": {
           "type": "string",
@@ -3783,31 +3776,7 @@ Reads features from various file formats (CSV, TSV, JSON) with configurable pars
         }
       }
     }
-  ],
-  "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
-    }
-  }
+  ]
 }
 ```
 ### Input Ports
@@ -3986,11 +3955,24 @@ Writes features from various formats
         },
         "output": {
           "title": "Output path",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Code"
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          ]
+          }
         }
       }
     },
@@ -4009,11 +3991,24 @@ Writes features from various formats
         },
         "output": {
           "title": "Output path",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Code"
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          ]
+          }
         }
       }
     },
@@ -4027,14 +4022,27 @@ Writes features from various formats
       ],
       "properties": {
         "converter": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Code"
+          "type": [
+            "object",
+            "null"
+          ],
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
             },
-            {
-              "type": "null"
+            "value": {
+              "type": "string"
             }
-          ]
+          }
         },
         "format": {
           "type": "string",
@@ -4044,11 +4052,24 @@ Writes features from various formats
         },
         "output": {
           "title": "Output path",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Code"
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          ]
+          }
         }
       }
     },
@@ -4092,11 +4113,24 @@ Writes features from various formats
         },
         "output": {
           "title": "Output path",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Code"
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          ]
+          }
         },
         "prettyPrint": {
           "description": "Whether to format output with indentation (default: true)",
@@ -4108,31 +4142,7 @@ Writes features from various formats
         }
       }
     }
-  ],
-  "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
-    }
-  }
+  ]
 }
 ```
 ### Input Ports
@@ -4167,35 +4177,24 @@ Extracts file paths from directories or archives, creating features for each dis
     "sourceDataset": {
       "title": "Source Dataset",
       "description": "Path or expression pointing to the source directory or archive file",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
     }
   }
 }
@@ -4333,50 +4332,52 @@ Reads geographic features from GeoJSON files, supporting both single features an
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "inline": {
-      "title": "Inline Content",
-      "description": "Expression that returns the file content as text instead of reading from a file path",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
     },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
+    "inline": {
+      "title": "Inline Content",
+      "description": "Expression that returns the file content as text instead of reading from a file path",
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
     }
   }
 }
@@ -4415,38 +4416,29 @@ Writes geographic features to GeoJSON files with optional grouping
     },
     "output": {
       "description": "Output path or expression for the GeoJSON file to create",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Attribute": {
-      "type": "string"
-    },
-    "Code": {
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
+    }
+  },
+  "definitions": {
+    "Attribute": {
+      "type": "string"
     }
   }
 }
@@ -4488,14 +4480,27 @@ Reads geographic features from GeoPackage (.gpkg) files with support for vector 
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "force2D": {
       "default": false,
@@ -4508,14 +4513,27 @@ Reads geographic features from GeoPackage (.gpkg) files with support for vector 
     "inline": {
       "title": "Inline Content",
       "description": "Expression that returns the file content as text instead of reading from a file path",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "layerName": {
       "type": [
@@ -4548,28 +4566,6 @@ Reads geographic features from GeoPackage (.gpkg) files with support for vector 
     }
   },
   "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
-    },
     "GeoPackageReadMode": {
       "type": "string",
       "enum": [
@@ -4629,11 +4625,24 @@ Writes geographic features to GeoPackage (.gpkg) files with proper SQLite struct
     },
     "output": {
       "description": "Output path for the GeoPackage file to create",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "overwrite": {
       "description": "Overwrite existing file (default: false)",
@@ -4650,30 +4659,6 @@ Writes geographic features to GeoPackage (.gpkg) files with proper SQLite struct
       "description": "Table name to create (default: \"features\")",
       "default": "features",
       "type": "string"
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
     }
   }
 }
@@ -5126,14 +5111,27 @@ Reads 3D models from glTF 2.0 files, supporting meshes, nodes, scenes, and geome
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "includeNodes": {
       "title": "Include Nodes",
@@ -5144,14 +5142,27 @@ Reads 3D models from glTF 2.0 files, supporting meshes, nodes, scenes, and geome
     "inline": {
       "title": "Inline Content",
       "description": "Expression that returns the file content as text instead of reading from a file path",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "mergeMeshes": {
       "title": "Merge Meshes",
@@ -5164,30 +5175,6 @@ Reads 3D models from glTF 2.0 files, supporting meshes, nodes, scenes, and geome
       "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
       "default": true,
       "type": "boolean"
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
     }
   }
 }
@@ -5231,41 +5218,30 @@ Writes 3D features to GLTF format with optional texture attachment
     },
     "output": {
       "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    },
-    "schemaKey": {
-      "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
-      "type": [
-        "string",
-        "null"
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
     },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
+    "schemaKey": {
+      "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
+      "type": [
+        "string",
+        "null"
       ]
     }
   }
@@ -6924,50 +6900,52 @@ Reads features from JSON files, supporting both single objects and arrays of obj
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "inline": {
-      "title": "Inline Content",
-      "description": "Expression that returns the file content as text instead of reading from a file path",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
     },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
+    "inline": {
+      "title": "Inline Content",
+      "description": "Expression that returns the file content as text instead of reading from a file path",
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
     }
   }
 }
@@ -6996,46 +6974,48 @@ Writes features to JSON files.
   "properties": {
     "converter": {
       "description": "Optional converter expression to transform features before writing",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "output": {
-      "description": "Output path or expression for the JSON file to create",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
     },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
+    "output": {
+      "description": "Output path or expression for the JSON file to create",
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
     }
   }
 }
@@ -7751,14 +7731,27 @@ Reads 3D models from Wavefront OBJ files, supporting vertices, faces, normals, t
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "includeNormals": {
       "title": "Include Normals",
@@ -7775,27 +7768,53 @@ Reads 3D models from Wavefront OBJ files, supporting vertices, faces, normals, t
     "inline": {
       "title": "Inline Content",
       "description": "Expression that returns the file content as text instead of reading from a file path",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "materialFile": {
       "title": "Material File",
       "description": "Expression that returns the path to an external MTL file to use instead of mtllib directives in the OBJ file. When specified, this overrides any material library references in the OBJ file.",
       "default": null,
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "mergeGroups": {
       "title": "Merge Groups",
@@ -7814,30 +7833,6 @@ Reads 3D models from Wavefront OBJ files, supporting vertices, faces, normals, t
       "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
       "default": false,
       "type": "boolean"
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
     }
   }
 }
@@ -7868,11 +7863,24 @@ Writes 3D features to Wavefront OBJ format with optional material (MTL) files
     "output": {
       "title": "Output Path",
       "description": "Expression for the output file path where the OBJ file will be written",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "writeMaterials": {
       "title": "Write Materials",
@@ -7899,30 +7907,6 @@ Writes 3D features to Wavefront OBJ format with optional material (MTL) files
       "type": [
         "boolean",
         "null"
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
       ]
     }
   }
@@ -10151,14 +10135,27 @@ Reads geographic features from Shapefile archives (.zip containing .shp, .dbf, .
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      }
     },
     "encoding": {
       "title": "Character Encoding",
@@ -10177,38 +10174,27 @@ Reads geographic features from Shapefile archives (.zip containing .shp, .dbf, .
     "inline": {
       "title": "Inline Content",
       "description": "Expression that returns the file content as text instead of reading from a file path",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Code"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
     }
   }
 }
@@ -10247,38 +10233,29 @@ Writes geographic features to ESRI Shapefile format with optional grouping
     },
     "output": {
       "description": "Output path or expression for the Shapefile to create",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Attribute": {
-      "type": "string"
-    },
-    "Code": {
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
+    }
+  },
+  "definitions": {
+    "Attribute": {
+      "type": "string"
     }
   }
 }
@@ -10493,44 +10470,46 @@ Read Features from SQL Database
     "databaseUrl": {
       "title": "Database URL",
       "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    },
-    "sql": {
-      "title": "SQL Query",
-      "description": "SQL query expression to execute for retrieving data",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
     },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
+    "sql": {
+      "title": "SQL Query",
+      "description": "SQL query expression to execute for retrieving data",
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
     }
   }
 }
@@ -11127,35 +11106,24 @@ Writes features to XML files.
   "properties": {
     "output": {
       "description": "Output path or expression for the XML file to create",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
     }
   }
 }
@@ -11184,35 +11152,24 @@ Writes features to a zip file
   "properties": {
     "output": {
       "description": "Output path",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
       ],
       "properties": {
         "type": {
-          "$ref": "#/definitions/CodeType"
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
         },
         "value": {
           "type": "string"
         }
       }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
     }
   }
 }

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -627,18 +627,27 @@ Create, Convert, Rename, and Remove Feature Attributes
         "value": {
           "title": "Value",
           "description": "Value to use for the operation",
-          "anyOf": [
-            {
-              "codeTypes": [
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
                 "flowExpr",
                 "string"
-              ],
-              "type": "code"
+              ]
             },
-            {
-              "type": "null"
+            "value": {
+              "type": "string"
             }
-          ]
+          },
+          "x-flow-code": true
         }
       }
     }
@@ -1365,18 +1374,27 @@ Export Features as Cesium 3D Tiles for Web Visualization
     "compressOutput": {
       "title": "Compressed Output Path",
       "description": "Optional path for compressed archive output",
-      "anyOf": [
-        {
-          "codeTypes": [
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
             "flowExpr",
             "string"
-          ],
-          "type": "code"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      },
+      "x-flow-code": true
     },
     "dracoCompression": {
       "title": "Draco Compression",
@@ -1403,11 +1421,24 @@ Export Features as Cesium 3D Tiles for Web Visualization
     "output": {
       "title": "Output Path",
       "description": "Directory path where the 3D tiles will be written",
-      "codeTypes": [
-        "flowExpr",
-        "string"
+      "type": "object",
+      "required": [
+        "type",
+        "value"
       ],
-      "type": "code"
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "x-flow-code": true
     },
     "schemaKey": {
       "title": "Schema Key",
@@ -3301,10 +3332,23 @@ Filter Features Based on Custom Conditions
       "properties": {
         "expr": {
           "title": "Condition expression",
-          "codeTypes": [
-            "flowExpr"
+          "type": "object",
+          "required": [
+            "type",
+            "value"
           ],
-          "type": "code"
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "x-flow-code": true
         },
         "outputPort": {
           "title": "Output port",
@@ -4227,11 +4271,24 @@ Experimental testbed for the Flow expression engine
           "type": "string"
         },
         "value": {
-          "codeTypes": [
-            "flowExpr",
-            "string"
+          "type": "object",
+          "required": [
+            "type",
+            "value"
           ],
-          "type": "code"
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "x-flow-code": true
         }
       }
     }
@@ -7235,18 +7292,27 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
     "compressOutput": {
       "title": "Compress Output",
       "description": "Optional expression to determine whether to compress the output tiles",
-      "anyOf": [
-        {
-          "codeTypes": [
+      "type": [
+        "object",
+        "null"
+      ],
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
             "flowExpr",
             "string"
-          ],
-          "type": "code"
+          ]
         },
-        {
-          "type": "null"
+        "value": {
+          "type": "string"
         }
-      ]
+      },
+      "x-flow-code": true
     },
     "extent": {
       "title": "Extent",
@@ -7261,11 +7327,24 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
     "layerName": {
       "title": "Layer Name",
       "description": "Name of the layer within the MVT tiles",
-      "codeTypes": [
-        "flowExpr",
-        "string"
+      "type": "object",
+      "required": [
+        "type",
+        "value"
       ],
-      "type": "code"
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "x-flow-code": true
     },
     "maxZoom": {
       "title": "Maximum Zoom",
@@ -7284,11 +7363,24 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
     "output": {
       "title": "Output",
       "description": "Output directory path or expression for the generated MVT tiles",
-      "codeTypes": [
-        "flowExpr",
-        "string"
+      "type": "object",
+      "required": [
+        "type",
+        "value"
       ],
-      "type": "code"
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "x-flow-code": true
     },
     "schemaKey": {
       "title": "Schema Key",

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -631,6 +631,7 @@ Create, Convert, Rename, and Remove Feature Attributes
             "object",
             "null"
           ],
+          "format": "code",
           "required": [
             "type",
             "value"
@@ -646,8 +647,7 @@ Create, Convert, Rename, and Remove Feature Attributes
             "value": {
               "type": "string"
             }
-          },
-          "x-flow-code": true
+          }
         }
       }
     }
@@ -1378,6 +1378,7 @@ Export Features as Cesium 3D Tiles for Web Visualization
         "object",
         "null"
       ],
+      "format": "code",
       "required": [
         "type",
         "value"
@@ -1393,8 +1394,7 @@ Export Features as Cesium 3D Tiles for Web Visualization
         "value": {
           "type": "string"
         }
-      },
-      "x-flow-code": true
+      }
     },
     "dracoCompression": {
       "title": "Draco Compression",
@@ -1422,6 +1422,7 @@ Export Features as Cesium 3D Tiles for Web Visualization
       "title": "Output Path",
       "description": "Directory path where the 3D tiles will be written",
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
@@ -1437,8 +1438,7 @@ Export Features as Cesium 3D Tiles for Web Visualization
         "value": {
           "type": "string"
         }
-      },
-      "x-flow-code": true
+      }
     },
     "schemaKey": {
       "title": "Schema Key",
@@ -3333,6 +3333,7 @@ Filter Features Based on Custom Conditions
         "expr": {
           "title": "Condition expression",
           "type": "object",
+          "format": "code",
           "required": [
             "type",
             "value"
@@ -3347,8 +3348,7 @@ Filter Features Based on Custom Conditions
             "value": {
               "type": "string"
             }
-          },
-          "x-flow-code": true
+          }
         },
         "outputPort": {
           "title": "Output port",
@@ -4272,6 +4272,7 @@ Experimental testbed for the Flow expression engine
         },
         "value": {
           "type": "object",
+          "format": "code",
           "required": [
             "type",
             "value"
@@ -4287,8 +4288,7 @@ Experimental testbed for the Flow expression engine
             "value": {
               "type": "string"
             }
-          },
-          "x-flow-code": true
+          }
         }
       }
     }
@@ -7296,6 +7296,7 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
         "object",
         "null"
       ],
+      "format": "code",
       "required": [
         "type",
         "value"
@@ -7311,8 +7312,7 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
         "value": {
           "type": "string"
         }
-      },
-      "x-flow-code": true
+      }
     },
     "extent": {
       "title": "Extent",
@@ -7328,6 +7328,7 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
       "title": "Layer Name",
       "description": "Name of the layer within the MVT tiles",
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
@@ -7343,8 +7344,7 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
         "value": {
           "type": "string"
         }
-      },
-      "x-flow-code": true
+      }
     },
     "maxZoom": {
       "title": "Maximum Zoom",
@@ -7364,6 +7364,7 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
       "title": "Output",
       "description": "Output directory path or expression for the generated MVT tiles",
       "type": "object",
+      "format": "code",
       "required": [
         "type",
         "value"
@@ -7379,8 +7380,7 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
         "value": {
           "type": "string"
         }
-      },
-      "x-flow-code": true
+      }
     },
     "schemaKey": {
       "title": "Schema Key",

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -596,28 +596,6 @@ Create, Convert, Rename, and Remove Feature Attributes
     }
   },
   "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
-    },
     "Method": {
       "type": "string",
       "enum": [
@@ -651,7 +629,11 @@ Create, Convert, Rename, and Remove Feature Attributes
           "description": "Value to use for the operation",
           "anyOf": [
             {
-              "$ref": "#/definitions/Code"
+              "codeTypes": [
+                "flowExpr",
+                "string"
+              ],
+              "type": "code"
             },
             {
               "type": "null"
@@ -1385,7 +1367,11 @@ Export Features as Cesium 3D Tiles for Web Visualization
       "description": "Optional path for compressed archive output",
       "anyOf": [
         {
-          "$ref": "#/definitions/Code"
+          "codeTypes": [
+            "flowExpr",
+            "string"
+          ],
+          "type": "code"
         },
         {
           "type": "null"
@@ -1417,11 +1403,11 @@ Export Features as Cesium 3D Tiles for Web Visualization
     "output": {
       "title": "Output Path",
       "description": "Directory path where the 3D tiles will be written",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
+      "codeTypes": [
+        "flowExpr",
+        "string"
+      ],
+      "type": "code"
     },
     "schemaKey": {
       "title": "Schema Key",
@@ -1437,30 +1423,6 @@ Export Features as Cesium 3D Tiles for Web Visualization
       "type": [
         "boolean",
         "null"
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
       ]
     }
   }
@@ -3330,28 +3292,6 @@ Filter Features Based on Custom Conditions
     }
   },
   "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
-    },
     "Condition": {
       "type": "object",
       "required": [
@@ -3361,11 +3301,10 @@ Filter Features Based on Custom Conditions
       "properties": {
         "expr": {
           "title": "Condition expression",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Code"
-            }
-          ]
+          "codeTypes": [
+            "flowExpr"
+          ],
+          "type": "code"
         },
         "outputPort": {
           "title": "Output port",
@@ -4277,28 +4216,6 @@ Experimental testbed for the Flow expression engine
     }
   },
   "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
-      ]
-    },
     "Mapping": {
       "type": "object",
       "required": [
@@ -4310,7 +4227,11 @@ Experimental testbed for the Flow expression engine
           "type": "string"
         },
         "value": {
-          "$ref": "#/definitions/Code"
+          "codeTypes": [
+            "flowExpr",
+            "string"
+          ],
+          "type": "code"
         }
       }
     }
@@ -7316,7 +7237,11 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
       "description": "Optional expression to determine whether to compress the output tiles",
       "anyOf": [
         {
-          "$ref": "#/definitions/Code"
+          "codeTypes": [
+            "flowExpr",
+            "string"
+          ],
+          "type": "code"
         },
         {
           "type": "null"
@@ -7336,11 +7261,11 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
     "layerName": {
       "title": "Layer Name",
       "description": "Name of the layer within the MVT tiles",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
+      "codeTypes": [
+        "flowExpr",
+        "string"
+      ],
+      "type": "code"
     },
     "maxZoom": {
       "title": "Maximum Zoom",
@@ -7359,11 +7284,11 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
     "output": {
       "title": "Output",
       "description": "Output directory path or expression for the generated MVT tiles",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Code"
-        }
-      ]
+      "codeTypes": [
+        "flowExpr",
+        "string"
+      ],
+      "type": "code"
     },
     "schemaKey": {
       "title": "Schema Key",
@@ -7379,30 +7304,6 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
       "type": [
         "boolean",
         "null"
-      ]
-    }
-  },
-  "definitions": {
-    "Code": {
-      "type": "object",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "$ref": "#/definitions/CodeType"
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "CodeType": {
-      "type": "string",
-      "enum": [
-        "flowExpr",
-        "string"
       ]
     }
   }

--- a/engine/runtime/action-processor/src/feature/filter.rs
+++ b/engine/runtime/action-processor/src/feature/filter.rs
@@ -8,7 +8,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
 };
-use reearth_flow_types::{Code, CompiledCode};
+use reearth_flow_types::{Code, CodeType, CompiledCode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -123,7 +123,7 @@ struct FeatureFilterParam {
 #[serde(rename_all = "camelCase")]
 struct Condition {
     /// # Condition expression
-    expr: Code,
+    expr: Code<{ CodeType::FlowExpr as u32 }>,
     /// # Output port
     output_port: Port,
 }

--- a/engine/runtime/action-sink/src/file/czml.rs
+++ b/engine/runtime/action-sink/src/file/czml.rs
@@ -1361,13 +1361,12 @@ mod tests {
     }
 
     fn make_timeseries_params() -> CzmlWriterCompiledParam {
+        let output: Code = Code {
+            ty: CodeType::String,
+            value: "/tmp/test.czml".to_string(),
+        };
         CzmlWriterCompiledParam {
-            output: Code {
-                ty: CodeType::String,
-                value: "/tmp/test.czml".to_string(),
-            }
-            .compile()
-            .unwrap(),
+            output: output.compile().unwrap(),
             group_by: None,
             time_field: Some(Attribute::new("timestamp")),
             epoch: Some("2024-01-01T00:00:00Z".into()),
@@ -1487,13 +1486,12 @@ mod tests {
     }
 
     fn make_default_params() -> CzmlWriterCompiledParam {
+        let output: Code = Code {
+            ty: CodeType::String,
+            value: "/tmp/test.czml".to_string(),
+        };
         CzmlWriterCompiledParam {
-            output: Code {
-                ty: CodeType::String,
-                value: "/tmp/test.czml".to_string(),
-            }
-            .compile()
-            .unwrap(),
+            output: output.compile().unwrap(),
             group_by: None,
             time_field: None,
             epoch: None,
@@ -1578,13 +1576,12 @@ mod tests {
     #[test]
     fn test_build_entity_packet_numeric_times() {
         // Test with numeric time values and no explicit epoch
+        let output: Code = Code {
+            ty: CodeType::String,
+            value: "/tmp/test.czml".to_string(),
+        };
         let params = CzmlWriterCompiledParam {
-            output: Code {
-                ty: CodeType::String,
-                value: "/tmp/test.czml".to_string(),
-            }
-            .compile()
-            .unwrap(),
+            output: output.compile().unwrap(),
             group_by: None,
             time_field: Some(Attribute::new("timestamp")),
             epoch: None, // No explicit epoch - should auto-generate

--- a/engine/runtime/action-sink/src/file/obj.rs
+++ b/engine/runtime/action-sink/src/file/obj.rs
@@ -610,12 +610,11 @@ mod tests {
 
         features.push(feature);
 
-        let output: Code = Code {
+        let code: Code = Code {
             ty: CodeType::String,
             value: "/tmp/test.obj".to_string(),
-        }
-        .compile()
-        .unwrap();
+        };
+        let output = code.compile().unwrap();
 
         let writer = ObjWriter {
             output,

--- a/engine/runtime/action-sink/src/file/obj.rs
+++ b/engine/runtime/action-sink/src/file/obj.rs
@@ -565,7 +565,9 @@ mod tests {
     use reearth_flow_geometry::types::{
         coordinate::Coordinate, geometry::Geometry3D, polygon::Polygon3D,
     };
-    use reearth_flow_types::{Attribute, AttributeValue, Feature, Geometry, GeometryValue};
+    use reearth_flow_types::{
+        Attribute, AttributeValue, Code, CodeType, Feature, Geometry, GeometryValue,
+    };
 
     #[test]
     fn test_generate_simple_obj() {
@@ -608,8 +610,8 @@ mod tests {
 
         features.push(feature);
 
-        let output = Code {
-            ty: reearth_flow_types::CodeType::String,
+        let output: Code = Code {
+            ty: CodeType::String,
             value: "/tmp/test.obj".to_string(),
         }
         .compile()

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -33,33 +33,135 @@ use crate::feature::Feature;
 )]
 pub struct Expr(String);
 
-impl Expr {
-    pub fn compile(&self) -> reearth_flow_expr::Result<CompiledCode> {
-        compile(self.as_ref()).map(CompiledCode::Expr)
+#[repr(u32)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum CodeType {
+    FlowExpr = 1 << 0,
+    String = 1 << 1,
+}
+
+impl CodeType {
+    pub const ALL: u32 = Self::FlowExpr as u32 | Self::String as u32;
+
+    pub fn all_variants() -> &'static [CodeType] {
+        &[CodeType::FlowExpr, CodeType::String]
+    }
+
+    pub fn as_mask(self) -> u32 {
+        self as u32
+    }
+
+    pub fn serde_name(self) -> &'static str {
+        match self {
+            CodeType::FlowExpr => "flowExpr",
+            CodeType::String => "string",
+        }
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub enum CodeType {
-    FlowExpr,
-    String,
-}
+/// Bitmask constant covering all [`CodeType`] variants; used as the default for [`Code`].
+pub const ALL_CODE_TYPES: u32 = CodeType::ALL;
 
-#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct Code {
-    #[serde(rename = "type")]
+#[derive(Debug, Clone)]
+pub struct Code<const MASK: u32 = ALL_CODE_TYPES> {
     pub ty: CodeType,
     pub value: String,
 }
 
-impl Code {
+impl<const MASK: u32> Code<MASK> {
     pub fn compile(&self) -> reearth_flow_expr::Result<CompiledCode> {
         match self.ty {
             CodeType::FlowExpr => compile(&self.value).map(CompiledCode::Expr),
             CodeType::String => Ok(CompiledCode::Literal(self.value.clone())),
         }
+    }
+}
+
+impl<const MASK: u32> Serialize for Code<MASK> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("Code", 2)?;
+        state.serialize_field("type", &self.ty)?;
+        state.serialize_field("value", &self.value)?;
+        state.end()
+    }
+}
+
+impl<'de, const MASK: u32> Deserialize<'de> for Code<MASK> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct Helper {
+            #[serde(rename = "type")]
+            ty: CodeType,
+            value: String,
+        }
+        let h = Helper::deserialize(deserializer)?;
+        if h.ty.as_mask() & MASK == 0 {
+            let allowed: Vec<&str> = CodeType::all_variants()
+                .iter()
+                .copied()
+                .filter(|v| v.as_mask() & MASK != 0)
+                .map(|v| v.serde_name())
+                .collect();
+            return Err(serde::de::Error::custom(format!(
+                "code type `{}` is not allowed here; allowed: [{}]",
+                h.ty.serde_name(),
+                allowed.join(", ")
+            )));
+        }
+        Ok(Code {
+            ty: h.ty,
+            value: h.value,
+        })
+    }
+}
+
+impl<const MASK: u32> schemars::JsonSchema for Code<MASK> {
+    fn schema_name() -> String {
+        let parts: Vec<&str> = CodeType::all_variants()
+            .iter()
+            .copied()
+            .filter(|v| v.as_mask() & MASK != 0)
+            .map(|v| v.serde_name())
+            .collect();
+        format!("Code_{}", parts.join("_"))
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        use schemars::schema::*;
+
+        let allowed: Vec<serde_json::Value> = CodeType::all_variants()
+            .iter()
+            .copied()
+            .filter(|v| v.as_mask() & MASK != 0)
+            .map(|v| serde_json::Value::String(v.serde_name().to_string()))
+            .collect();
+
+        let type_schema = Schema::Object(SchemaObject {
+            enum_values: Some(allowed),
+            ..Default::default()
+        });
+
+        let value_schema = gen.subschema_for::<String>();
+
+        let mut properties = schemars::Map::new();
+        properties.insert("type".to_string(), type_schema);
+        properties.insert("value".to_string(), value_schema);
+
+        let mut required = std::collections::BTreeSet::new();
+        required.insert("type".to_string());
+        required.insert("value".to_string());
+
+        Schema::Object(SchemaObject {
+            instance_type: Some(InstanceType::Object.into()),
+            object: Some(Box::new(ObjectValidation {
+                required,
+                properties,
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
     }
 }
 

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -119,47 +119,35 @@ impl<'de, const MASK: u32> Deserialize<'de> for Code<MASK> {
 
 impl<const MASK: u32> schemars::JsonSchema for Code<MASK> {
     fn schema_name() -> String {
-        let parts: Vec<&str> = CodeType::all_variants()
-            .iter()
-            .copied()
-            .filter(|v| v.as_mask() & MASK != 0)
-            .map(|v| v.serde_name())
-            .collect();
-        format!("Code_{}", parts.join("_"))
+        "Code".to_string()
     }
 
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    fn is_referenceable() -> bool {
+        false
+    }
+
+    fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         use schemars::schema::*;
 
-        let allowed: Vec<serde_json::Value> = CodeType::all_variants()
+        let code_types: Vec<serde_json::Value> = CodeType::all_variants()
             .iter()
             .copied()
             .filter(|v| v.as_mask() & MASK != 0)
             .map(|v| serde_json::Value::String(v.serde_name().to_string()))
             .collect();
 
-        let type_schema = Schema::Object(SchemaObject {
-            enum_values: Some(allowed),
-            ..Default::default()
-        });
-
-        let value_schema = gen.subschema_for::<String>();
-
-        let mut properties = schemars::Map::new();
-        properties.insert("type".to_string(), type_schema);
-        properties.insert("value".to_string(), value_schema);
-
-        let mut required = std::collections::BTreeSet::new();
-        required.insert("type".to_string());
-        required.insert("value".to_string());
+        let mut extensions = schemars::Map::new();
+        extensions.insert(
+            "type".to_string(),
+            serde_json::Value::String("code".to_string()),
+        );
+        extensions.insert(
+            "codeTypes".to_string(),
+            serde_json::Value::Array(code_types),
+        );
 
         Schema::Object(SchemaObject {
-            instance_type: Some(InstanceType::Object.into()),
-            object: Some(Box::new(ObjectValidation {
-                required,
-                properties,
-                ..Default::default()
-            })),
+            extensions,
             ..Default::default()
         })
     }

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -151,11 +151,9 @@ impl<const MASK: u32> schemars::JsonSchema for Code<MASK> {
         properties.insert("type".to_string(), type_property);
         properties.insert("value".to_string(), value_property);
 
-        let mut extensions = schemars::Map::new();
-        extensions.insert("x-flow-code".to_string(), serde_json::Value::Bool(true));
-
         Schema::Object(SchemaObject {
             instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Object))),
+            format: Some("code".to_string()),
             object: Some(Box::new(ObjectValidation {
                 required: ["type".to_string(), "value".to_string()]
                     .into_iter()
@@ -163,7 +161,6 @@ impl<const MASK: u32> schemars::JsonSchema for Code<MASK> {
                 properties,
                 ..Default::default()
             })),
-            extensions,
             ..Default::default()
         })
     }

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -91,13 +91,12 @@ impl<const MASK: u32> Serialize for Code<MASK> {
 impl<'de, const MASK: u32> Deserialize<'de> for Code<MASK> {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Deserialize)]
-        #[serde(rename = "Code")]
-        struct Helper {
+        struct Code {
             #[serde(rename = "type")]
             ty: CodeType,
             value: String,
         }
-        let h = Helper::deserialize(deserializer)?;
+        let h = Code::deserialize(deserializer)?;
         if h.ty.as_mask() & MASK == 0 {
             let allowed: Vec<&str> = CodeType::all_variants()
                 .iter()
@@ -111,7 +110,7 @@ impl<'de, const MASK: u32> Deserialize<'de> for Code<MASK> {
                 allowed.join(", ")
             )));
         }
-        Ok(Code {
+        Ok(Self {
             ty: h.ty,
             value: h.value,
         })

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -129,24 +129,40 @@ impl<const MASK: u32> schemars::JsonSchema for Code<MASK> {
     fn json_schema(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         use schemars::schema::*;
 
-        let code_types: Vec<serde_json::Value> = CodeType::all_variants()
+        let allowed_types: Vec<serde_json::Value> = CodeType::all_variants()
             .iter()
             .copied()
             .filter(|v| v.as_mask() & MASK != 0)
             .map(|v| serde_json::Value::String(v.serde_name().to_string()))
             .collect();
 
+        let type_property = Schema::Object(SchemaObject {
+            instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
+            enum_values: Some(allowed_types),
+            ..Default::default()
+        });
+
+        let value_property = Schema::Object(SchemaObject {
+            instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::String))),
+            ..Default::default()
+        });
+
+        let mut properties = schemars::Map::new();
+        properties.insert("type".to_string(), type_property);
+        properties.insert("value".to_string(), value_property);
+
         let mut extensions = schemars::Map::new();
-        extensions.insert(
-            "type".to_string(),
-            serde_json::Value::String("code".to_string()),
-        );
-        extensions.insert(
-            "codeTypes".to_string(),
-            serde_json::Value::Array(code_types),
-        );
+        extensions.insert("x-flow-code".to_string(), serde_json::Value::Bool(true));
 
         Schema::Object(SchemaObject {
+            instance_type: Some(SingleOrVec::Single(Box::new(InstanceType::Object))),
+            object: Some(Box::new(ObjectValidation {
+                required: ["type".to_string(), "value".to_string()]
+                    .into_iter()
+                    .collect(),
+                properties,
+                ..Default::default()
+            })),
             extensions,
             ..Default::default()
         })

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -91,6 +91,7 @@ impl<const MASK: u32> Serialize for Code<MASK> {
 impl<'de, const MASK: u32> Deserialize<'de> for Code<MASK> {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Deserialize)]
+        #[serde(rename = "Code")]
         struct Helper {
             #[serde(rename = "type")]
             ty: CodeType,

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -462,7 +462,7 @@ mod tests {
     use crate::feature::Feature;
 
     fn eval_bool(expr: &str, feature: &Feature) -> bool {
-        let code = Code {
+        let code: Code = Code {
             ty: CodeType::FlowExpr,
             value: expr.to_string(),
         };
@@ -482,7 +482,7 @@ mod tests {
         );
         let env_vars = Arc::new(env_vars);
 
-        let literal = Code {
+        let literal: Code = Code {
             ty: CodeType::String,
             value: "hello".to_string(),
         };
@@ -495,7 +495,7 @@ mod tests {
             "hello"
         );
 
-        let expr = Code {
+        let expr: Code = Code {
             ty: CodeType::FlowExpr,
             value: r#"env["key"]"#.to_string(),
         };
@@ -508,7 +508,7 @@ mod tests {
         );
 
         // attributes are not in scope
-        let no_attr = Code {
+        let no_attr: Code = Code {
             ty: CodeType::FlowExpr,
             value: "attributes".to_string(),
         };

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -516,4 +516,13 @@ mod tests {
         assert!(!eval_bool(r#""foo" not in attributes"#, &feature));
         assert!(eval_bool(r#""missing" not in attributes"#, &feature));
     }
+
+    #[test]
+    fn code_mask_enforced_on_deserialize() {
+        type FlowExprOnly = Code<{ CodeType::FlowExpr as u32 }>;
+        serde_json::from_str::<FlowExprOnly>(r#"{"type":"flowExpr","value":"1+1"}"#).unwrap();
+        let err =
+            serde_json::from_str::<FlowExprOnly>(r#"{"type":"string","value":"x"}"#).unwrap_err();
+        assert!(err.to_string().contains("not allowed"));
+    }
 }

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -647,18 +647,27 @@
               "value": {
                 "title": "Value",
                 "description": "Value to use for the operation",
-                "anyOf": [
-                  {
-                    "codeTypes": [
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
                       "flowExpr",
                       "string"
-                    ],
-                    "type": "code"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -1399,18 +1408,27 @@
           "compressOutput": {
             "title": "Compressed Output Path",
             "description": "Optional path for compressed archive output",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "dracoCompression": {
             "title": "Draco Compression",
@@ -1437,11 +1455,24 @@
           "output": {
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -3394,10 +3425,23 @@
             "properties": {
               "expr": {
                 "title": "Condition expression",
-                "codeTypes": [
-                  "flowExpr"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               },
               "outputPort": {
                 "title": "Output port",
@@ -4341,11 +4385,24 @@
                 "type": "string"
               },
               "value": {
-                "codeTypes": [
-                  "flowExpr",
-                  "string"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -7418,18 +7475,27 @@
           "compressOutput": {
             "title": "Compress Output",
             "description": "Optional expression to determine whether to compress the output tiles",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "extent": {
             "title": "Extent",
@@ -7444,11 +7510,24 @@
           "layerName": {
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7467,11 +7546,24 @@
           "output": {
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "Schema Key",

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -651,6 +651,7 @@
                   "object",
                   "null"
                 ],
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -666,8 +667,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -1412,6 +1412,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1427,8 +1428,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "dracoCompression": {
             "title": "Draco Compression",
@@ -1456,6 +1456,7 @@
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1471,8 +1472,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -3426,6 +3426,7 @@
               "expr": {
                 "title": "Condition expression",
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -3440,8 +3441,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               },
               "outputPort": {
                 "title": "Output port",
@@ -4386,6 +4386,7 @@
               },
               "value": {
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -4401,8 +4402,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -7479,6 +7479,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7494,8 +7495,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "extent": {
             "title": "Extent",
@@ -7511,6 +7511,7 @@
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7526,8 +7527,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7547,6 +7547,7 @@
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7562,8 +7563,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "Schema Key",

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -707,28 +707,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapper": {
             "type": "object",
             "properties": {
@@ -748,25 +726,51 @@
               },
               "expr": {
                 "title": "Expression to evaluate",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "multipleExpr": {
                 "title": "Expression to evaluate multiple attributes",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "parentAttribute": {
                 "title": "Parent attribute name",
@@ -1519,14 +1523,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "type": [
@@ -1537,38 +1554,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -1622,11 +1628,24 @@
           },
           "output": {
             "description": "Output file path expression",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "prettyPrint": {
             "description": "Whether to format output with indentation (default: true)",
@@ -1634,30 +1653,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -1904,14 +1899,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "Character Encoding",
@@ -1955,14 +1963,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "offset": {
             "title": "Header Row Offset",
@@ -1976,28 +1997,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "CsvFormat": {
             "oneOf": [
               {
@@ -2131,36 +2130,27 @@
           },
           "output": {
             "description": "Output path or expression for the CSV/TSV file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
+          }
+        },
+        "definitions": {
           "CsvFormat": {
             "oneOf": [
               {
@@ -2259,14 +2249,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2d": {
             "title": "Force 2D",
@@ -2277,14 +2280,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "skipDocumentPacket": {
             "title": "Skip Document Packet",
@@ -2304,28 +2320,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "TimeSamplingStrategy": {
             "description": "Strategy for handling time-dynamic CZML properties.",
             "oneOf": [
@@ -2461,11 +2455,24 @@
           "output": {
             "title": "Output File Path",
             "description": "Path where the CZML file will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "timeField": {
             "title": "Time Field",
@@ -2483,28 +2490,6 @@
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           },
           "InterpolationAlgorithm": {
             "description": "Interpolation algorithm for Cesium time-dynamic properties.",
@@ -2960,41 +2945,30 @@
         "properties": {
           "output": {
             "description": "Output path or expression for the Excel file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sheetName": {
-            "description": "Sheet name (defaults to \"Sheet1\")",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "sheetName": {
+            "description": "Sheet name (defaults to \"Sheet1\")",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -3067,11 +3041,24 @@
           "dataset": {
             "title": "Dataset",
             "description": "Path expression resolving to the CityGML 3.0 file to read.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "extractTags": {
             "title": "Extract Tags",
@@ -3081,30 +3068,6 @@
             "items": {
               "type": "string"
             }
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3136,23 +3099,49 @@
           "codelistsPath": {
             "title": "Codelists Path",
             "description": "Optional path to the codelists directory for resolving codelist values",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "dataset": {
             "title": "Dataset",
             "description": "Path or expression to the CityGML dataset file to be read",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "title": "Flatten",
@@ -3160,30 +3149,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3275,35 +3240,24 @@
           "creator": {
             "title": "Script Expression",
             "description": "Write a script expression that returns a map (single feature) or array of maps (multiple features). Each map represents feature attributes as key-value pairs.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3765,11 +3719,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3818,11 +3785,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3871,11 +3851,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -3885,31 +3878,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4094,11 +4063,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4117,11 +4099,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4135,14 +4130,27 @@
             ],
             "properties": {
               "converter": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -4152,11 +4160,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4200,11 +4221,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4216,31 +4250,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4276,35 +4286,24 @@
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Path or expression pointing to the source directory or archive file",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -4454,50 +4453,52 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -4538,38 +4539,29 @@
           },
           "output": {
             "description": "Output path or expression for the GeoJSON file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -4613,14 +4605,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2D": {
             "default": false,
@@ -4633,14 +4638,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "layerName": {
             "type": [
@@ -4673,28 +4691,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "GeoPackageReadMode": {
             "type": "string",
             "enum": [
@@ -4756,11 +4752,24 @@
           },
           "output": {
             "description": "Output path for the GeoPackage file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "overwrite": {
             "description": "Overwrite existing file (default: false)",
@@ -4777,30 +4786,6 @@
             "description": "Table name to create (default: \"features\")",
             "default": "features",
             "type": "string"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5276,14 +5261,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNodes": {
             "title": "Include Nodes",
@@ -5294,14 +5292,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeMeshes": {
             "title": "Merge Meshes",
@@ -5314,30 +5325,6 @@
             "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
             "default": true,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5381,41 +5368,30 @@
           },
           "output": {
             "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "schemaKey": {
-            "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "schemaKey": {
+            "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -7097,50 +7073,52 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7171,46 +7149,48 @@
         "properties": {
           "converter": {
             "description": "Optional converter expression to transform features before writing",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "output": {
-            "description": "Output path or expression for the JSON file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "output": {
+            "description": "Output path or expression for the JSON file to create",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7945,14 +7925,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNormals": {
             "title": "Include Normals",
@@ -7969,27 +7962,53 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "materialFile": {
             "title": "Material File",
             "description": "Expression that returns the path to an external MTL file to use instead of mtllib directives in the OBJ file. When specified, this overrides any material library references in the OBJ file.",
             "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeGroups": {
             "title": "Merge Groups",
@@ -8008,30 +8027,6 @@
             "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
             "default": false,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -8062,11 +8057,24 @@
           "output": {
             "title": "Output Path",
             "description": "Expression for the output file path where the OBJ file will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "writeMaterials": {
             "title": "Write Materials",
@@ -8093,30 +8101,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -10429,14 +10413,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "Character Encoding",
@@ -10455,38 +10452,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -10527,38 +10513,29 @@
           },
           "output": {
             "description": "Output path or expression for the Shapefile to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -10777,44 +10754,46 @@
           "databaseUrl": {
             "title": "Database URL",
             "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sql": {
-            "title": "SQL Query",
-            "description": "SQL query expression to execute for retrieving data",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "sql": {
+            "title": "SQL Query",
+            "description": "SQL query expression to execute for retrieving data",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -11445,35 +11424,24 @@
         "properties": {
           "output": {
             "description": "Output path or expression for the XML file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -11504,35 +11472,24 @@
         "properties": {
           "output": {
             "description": "Output path",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -616,28 +616,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Method": {
             "type": "string",
             "enum": [
@@ -671,7 +649,11 @@
                 "description": "Value to use for the operation",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Code"
+                    "codeTypes": [
+                      "flowExpr",
+                      "string"
+                    ],
+                    "type": "code"
                   },
                   {
                     "type": "null"
@@ -1419,7 +1401,11 @@
             "description": "Optional path for compressed archive output",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -1451,11 +1437,11 @@
           "output": {
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -1471,30 +1457,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3423,28 +3385,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3454,11 +3394,10 @@
             "properties": {
               "expr": {
                 "title": "Condition expression",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
-                  }
-                ]
+                "codeTypes": [
+                  "flowExpr"
+                ],
+                "type": "code"
               },
               "outputPort": {
                 "title": "Output port",
@@ -4391,28 +4330,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapping": {
             "type": "object",
             "required": [
@@ -4424,7 +4341,11 @@
                 "type": "string"
               },
               "value": {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               }
             }
           }
@@ -7499,7 +7420,11 @@
             "description": "Optional expression to determine whether to compress the output tiles",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -7519,11 +7444,11 @@
           "layerName": {
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7542,11 +7467,11 @@
           "output": {
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -7562,30 +7487,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -647,18 +647,27 @@
               "value": {
                 "title": "Value",
                 "description": "Value to use for the operation",
-                "anyOf": [
-                  {
-                    "codeTypes": [
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
                       "flowExpr",
                       "string"
-                    ],
-                    "type": "code"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -1399,18 +1408,27 @@
           "compressOutput": {
             "title": "Compressed Output Path",
             "description": "Optional path for compressed archive output",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "dracoCompression": {
             "title": "Draco Compression",
@@ -1437,11 +1455,24 @@
           "output": {
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -3394,10 +3425,23 @@
             "properties": {
               "expr": {
                 "title": "Condition expression",
-                "codeTypes": [
-                  "flowExpr"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               },
               "outputPort": {
                 "title": "Output port",
@@ -4341,11 +4385,24 @@
                 "type": "string"
               },
               "value": {
-                "codeTypes": [
-                  "flowExpr",
-                  "string"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -7418,18 +7475,27 @@
           "compressOutput": {
             "title": "Compress Output",
             "description": "Optional expression to determine whether to compress the output tiles",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "extent": {
             "title": "Extent",
@@ -7444,11 +7510,24 @@
           "layerName": {
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7467,11 +7546,24 @@
           "output": {
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "Schema Key",

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -651,6 +651,7 @@
                   "object",
                   "null"
                 ],
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -666,8 +667,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -1412,6 +1412,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1427,8 +1428,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "dracoCompression": {
             "title": "Draco Compression",
@@ -1456,6 +1456,7 @@
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1471,8 +1472,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -3426,6 +3426,7 @@
               "expr": {
                 "title": "Condition expression",
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -3440,8 +3441,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               },
               "outputPort": {
                 "title": "Output port",
@@ -4386,6 +4386,7 @@
               },
               "value": {
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -4401,8 +4402,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -7479,6 +7479,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7494,8 +7495,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "extent": {
             "title": "Extent",
@@ -7511,6 +7511,7 @@
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7526,8 +7527,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7547,6 +7547,7 @@
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7562,8 +7563,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "Schema Key",

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -707,28 +707,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapper": {
             "type": "object",
             "properties": {
@@ -748,25 +726,51 @@
               },
               "expr": {
                 "title": "Expression to evaluate",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "multipleExpr": {
                 "title": "Expression to evaluate multiple attributes",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "parentAttribute": {
                 "title": "Parent attribute name",
@@ -1519,14 +1523,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "type": [
@@ -1537,38 +1554,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -1622,11 +1628,24 @@
           },
           "output": {
             "description": "Output file path expression",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "prettyPrint": {
             "description": "Whether to format output with indentation (default: true)",
@@ -1634,30 +1653,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -1904,14 +1899,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "Character Encoding",
@@ -1955,14 +1963,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "offset": {
             "title": "Header Row Offset",
@@ -1976,28 +1997,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "CsvFormat": {
             "oneOf": [
               {
@@ -2131,36 +2130,27 @@
           },
           "output": {
             "description": "Output path or expression for the CSV/TSV file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
+          }
+        },
+        "definitions": {
           "CsvFormat": {
             "oneOf": [
               {
@@ -2259,14 +2249,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2d": {
             "title": "Force 2D",
@@ -2277,14 +2280,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "skipDocumentPacket": {
             "title": "Skip Document Packet",
@@ -2304,28 +2320,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "TimeSamplingStrategy": {
             "description": "Strategy for handling time-dynamic CZML properties.",
             "oneOf": [
@@ -2461,11 +2455,24 @@
           "output": {
             "title": "Output File Path",
             "description": "Path where the CZML file will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "timeField": {
             "title": "Time Field",
@@ -2483,28 +2490,6 @@
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           },
           "InterpolationAlgorithm": {
             "description": "Interpolation algorithm for Cesium time-dynamic properties.",
@@ -2960,41 +2945,30 @@
         "properties": {
           "output": {
             "description": "Output path or expression for the Excel file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sheetName": {
-            "description": "Sheet name (defaults to \"Sheet1\")",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "sheetName": {
+            "description": "Sheet name (defaults to \"Sheet1\")",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -3067,11 +3041,24 @@
           "dataset": {
             "title": "Dataset",
             "description": "Path expression resolving to the CityGML 3.0 file to read.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "extractTags": {
             "title": "Extract Tags",
@@ -3081,30 +3068,6 @@
             "items": {
               "type": "string"
             }
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3136,23 +3099,49 @@
           "codelistsPath": {
             "title": "Codelists Path",
             "description": "Optional path to the codelists directory for resolving codelist values",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "dataset": {
             "title": "Dataset",
             "description": "Path or expression to the CityGML dataset file to be read",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "title": "Flatten",
@@ -3160,30 +3149,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3275,35 +3240,24 @@
           "creator": {
             "title": "Script Expression",
             "description": "Write a script expression that returns a map (single feature) or array of maps (multiple features). Each map represents feature attributes as key-value pairs.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3765,11 +3719,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3818,11 +3785,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3871,11 +3851,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -3885,31 +3878,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4094,11 +4063,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4117,11 +4099,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4135,14 +4130,27 @@
             ],
             "properties": {
               "converter": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -4152,11 +4160,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4200,11 +4221,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4216,31 +4250,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4276,35 +4286,24 @@
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Path or expression pointing to the source directory or archive file",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -4454,50 +4453,52 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -4538,38 +4539,29 @@
           },
           "output": {
             "description": "Output path or expression for the GeoJSON file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -4613,14 +4605,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2D": {
             "default": false,
@@ -4633,14 +4638,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "layerName": {
             "type": [
@@ -4673,28 +4691,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "GeoPackageReadMode": {
             "type": "string",
             "enum": [
@@ -4756,11 +4752,24 @@
           },
           "output": {
             "description": "Output path for the GeoPackage file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "overwrite": {
             "description": "Overwrite existing file (default: false)",
@@ -4777,30 +4786,6 @@
             "description": "Table name to create (default: \"features\")",
             "default": "features",
             "type": "string"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5276,14 +5261,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNodes": {
             "title": "Include Nodes",
@@ -5294,14 +5292,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeMeshes": {
             "title": "Merge Meshes",
@@ -5314,30 +5325,6 @@
             "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
             "default": true,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5381,41 +5368,30 @@
           },
           "output": {
             "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "schemaKey": {
-            "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "schemaKey": {
+            "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -7097,50 +7073,52 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7171,46 +7149,48 @@
         "properties": {
           "converter": {
             "description": "Optional converter expression to transform features before writing",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "output": {
-            "description": "Output path or expression for the JSON file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "output": {
+            "description": "Output path or expression for the JSON file to create",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7945,14 +7925,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNormals": {
             "title": "Include Normals",
@@ -7969,27 +7962,53 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "materialFile": {
             "title": "Material File",
             "description": "Expression that returns the path to an external MTL file to use instead of mtllib directives in the OBJ file. When specified, this overrides any material library references in the OBJ file.",
             "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeGroups": {
             "title": "Merge Groups",
@@ -8008,30 +8027,6 @@
             "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
             "default": false,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -8062,11 +8057,24 @@
           "output": {
             "title": "Output Path",
             "description": "Expression for the output file path where the OBJ file will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "writeMaterials": {
             "title": "Write Materials",
@@ -8093,30 +8101,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -10429,14 +10413,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "Character Encoding",
@@ -10455,38 +10452,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -10527,38 +10513,29 @@
           },
           "output": {
             "description": "Output path or expression for the Shapefile to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -10777,44 +10754,46 @@
           "databaseUrl": {
             "title": "Database URL",
             "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sql": {
-            "title": "SQL Query",
-            "description": "SQL query expression to execute for retrieving data",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "sql": {
+            "title": "SQL Query",
+            "description": "SQL query expression to execute for retrieving data",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -11445,35 +11424,24 @@
         "properties": {
           "output": {
             "description": "Output path or expression for the XML file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -11504,35 +11472,24 @@
         "properties": {
           "output": {
             "description": "Output path",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -616,28 +616,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Method": {
             "type": "string",
             "enum": [
@@ -671,7 +649,11 @@
                 "description": "Value to use for the operation",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Code"
+                    "codeTypes": [
+                      "flowExpr",
+                      "string"
+                    ],
+                    "type": "code"
                   },
                   {
                     "type": "null"
@@ -1419,7 +1401,11 @@
             "description": "Optional path for compressed archive output",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -1451,11 +1437,11 @@
           "output": {
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -1471,30 +1457,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3423,28 +3385,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3454,11 +3394,10 @@
             "properties": {
               "expr": {
                 "title": "Condition expression",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
-                  }
-                ]
+                "codeTypes": [
+                  "flowExpr"
+                ],
+                "type": "code"
               },
               "outputPort": {
                 "title": "Output port",
@@ -4391,28 +4330,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapping": {
             "type": "object",
             "required": [
@@ -4424,7 +4341,11 @@
                 "type": "string"
               },
               "value": {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               }
             }
           }
@@ -7499,7 +7420,11 @@
             "description": "Optional expression to determine whether to compress the output tiles",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -7519,11 +7444,11 @@
           "layerName": {
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7542,11 +7467,11 @@
           "output": {
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -7562,30 +7487,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -647,18 +647,27 @@
               "value": {
                 "title": "Value",
                 "description": "Value to use for the operation",
-                "anyOf": [
-                  {
-                    "codeTypes": [
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
                       "flowExpr",
                       "string"
-                    ],
-                    "type": "code"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -1399,18 +1408,27 @@
           "compressOutput": {
             "title": "Compressed Output Path",
             "description": "Optional path for compressed archive output",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "dracoCompression": {
             "title": "Draco Compression",
@@ -1437,11 +1455,24 @@
           "output": {
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -3394,10 +3425,23 @@
             "properties": {
               "expr": {
                 "title": "Condition expression",
-                "codeTypes": [
-                  "flowExpr"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               },
               "outputPort": {
                 "title": "Output port",
@@ -4341,11 +4385,24 @@
                 "type": "string"
               },
               "value": {
-                "codeTypes": [
-                  "flowExpr",
-                  "string"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -7418,18 +7475,27 @@
           "compressOutput": {
             "title": "Compress Output",
             "description": "Optional expression to determine whether to compress the output tiles",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "extent": {
             "title": "Extent",
@@ -7444,11 +7510,24 @@
           "layerName": {
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7467,11 +7546,24 @@
           "output": {
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "Schema Key",

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -651,6 +651,7 @@
                   "object",
                   "null"
                 ],
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -666,8 +667,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -1412,6 +1412,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1427,8 +1428,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "dracoCompression": {
             "title": "Draco Compression",
@@ -1456,6 +1456,7 @@
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1471,8 +1472,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -3426,6 +3426,7 @@
               "expr": {
                 "title": "Condition expression",
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -3440,8 +3441,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               },
               "outputPort": {
                 "title": "Output port",
@@ -4386,6 +4386,7 @@
               },
               "value": {
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -4401,8 +4402,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -7479,6 +7479,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7494,8 +7495,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "extent": {
             "title": "Extent",
@@ -7511,6 +7511,7 @@
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7526,8 +7527,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7547,6 +7547,7 @@
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7562,8 +7563,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "Schema Key",

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -707,28 +707,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapper": {
             "type": "object",
             "properties": {
@@ -748,25 +726,51 @@
               },
               "expr": {
                 "title": "Expression to evaluate",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "multipleExpr": {
                 "title": "Expression to evaluate multiple attributes",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "parentAttribute": {
                 "title": "Parent attribute name",
@@ -1519,14 +1523,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "type": [
@@ -1537,38 +1554,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -1622,11 +1628,24 @@
           },
           "output": {
             "description": "Output file path expression",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "prettyPrint": {
             "description": "Whether to format output with indentation (default: true)",
@@ -1634,30 +1653,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -1904,14 +1899,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "Character Encoding",
@@ -1955,14 +1963,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "offset": {
             "title": "Header Row Offset",
@@ -1976,28 +1997,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "CsvFormat": {
             "oneOf": [
               {
@@ -2131,36 +2130,27 @@
           },
           "output": {
             "description": "Output path or expression for the CSV/TSV file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
+          }
+        },
+        "definitions": {
           "CsvFormat": {
             "oneOf": [
               {
@@ -2259,14 +2249,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2d": {
             "title": "Force 2D",
@@ -2277,14 +2280,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "skipDocumentPacket": {
             "title": "Skip Document Packet",
@@ -2304,28 +2320,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "TimeSamplingStrategy": {
             "description": "Strategy for handling time-dynamic CZML properties.",
             "oneOf": [
@@ -2461,11 +2455,24 @@
           "output": {
             "title": "Output File Path",
             "description": "Path where the CZML file will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "timeField": {
             "title": "Time Field",
@@ -2483,28 +2490,6 @@
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           },
           "InterpolationAlgorithm": {
             "description": "Interpolation algorithm for Cesium time-dynamic properties.",
@@ -2960,41 +2945,30 @@
         "properties": {
           "output": {
             "description": "Output path or expression for the Excel file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sheetName": {
-            "description": "Sheet name (defaults to \"Sheet1\")",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "sheetName": {
+            "description": "Sheet name (defaults to \"Sheet1\")",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -3067,11 +3041,24 @@
           "dataset": {
             "title": "Dataset",
             "description": "Path expression resolving to the CityGML 3.0 file to read.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "extractTags": {
             "title": "Extraer Etiquetas",
@@ -3081,30 +3068,6 @@
             "items": {
               "type": "string"
             }
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3136,23 +3099,49 @@
           "codelistsPath": {
             "title": "Codelists Path",
             "description": "Optional path to the codelists directory for resolving codelist values",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "dataset": {
             "title": "Dataset",
             "description": "Path or expression to the CityGML dataset file to be read",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "title": "Flatten",
@@ -3160,30 +3149,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3275,35 +3240,24 @@
           "creator": {
             "title": "Script Expression",
             "description": "Write a script expression that returns a map (single feature) or array of maps (multiple features). Each map represents feature attributes as key-value pairs.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3765,11 +3719,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3818,11 +3785,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3871,11 +3851,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -3885,31 +3878,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4094,11 +4063,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4117,11 +4099,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4135,14 +4130,27 @@
             ],
             "properties": {
               "converter": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -4152,11 +4160,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4200,11 +4221,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4216,31 +4250,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4276,35 +4286,24 @@
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Path or expression pointing to the source directory or archive file",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -4454,50 +4453,52 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -4538,38 +4539,29 @@
           },
           "output": {
             "description": "Output path or expression for the GeoJSON file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -4613,14 +4605,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2D": {
             "default": false,
@@ -4633,14 +4638,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "layerName": {
             "type": [
@@ -4673,28 +4691,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "GeoPackageReadMode": {
             "type": "string",
             "enum": [
@@ -4756,11 +4752,24 @@
           },
           "output": {
             "description": "Output path for the GeoPackage file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "overwrite": {
             "description": "Overwrite existing file (default: false)",
@@ -4777,30 +4786,6 @@
             "description": "Table name to create (default: \"features\")",
             "default": "features",
             "type": "string"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5276,14 +5261,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNodes": {
             "title": "Include Nodes",
@@ -5294,14 +5292,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeMeshes": {
             "title": "Merge Meshes",
@@ -5314,30 +5325,6 @@
             "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
             "default": true,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5381,41 +5368,30 @@
           },
           "output": {
             "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "schemaKey": {
-            "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "schemaKey": {
+            "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -7097,50 +7073,52 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7171,46 +7149,48 @@
         "properties": {
           "converter": {
             "description": "Optional converter expression to transform features before writing",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "output": {
-            "description": "Output path or expression for the JSON file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "output": {
+            "description": "Output path or expression for the JSON file to create",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7945,14 +7925,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNormals": {
             "title": "Include Normals",
@@ -7969,27 +7962,53 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "materialFile": {
             "title": "Material File",
             "description": "Expression that returns the path to an external MTL file to use instead of mtllib directives in the OBJ file. When specified, this overrides any material library references in the OBJ file.",
             "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeGroups": {
             "title": "Merge Groups",
@@ -8008,30 +8027,6 @@
             "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
             "default": false,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -8062,11 +8057,24 @@
           "output": {
             "title": "Output Path",
             "description": "Expression for the output file path where the OBJ file will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "writeMaterials": {
             "title": "Write Materials",
@@ -8093,30 +8101,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -10429,14 +10413,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "Character Encoding",
@@ -10455,38 +10452,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -10527,38 +10513,29 @@
           },
           "output": {
             "description": "Output path or expression for the Shapefile to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -10777,44 +10754,46 @@
           "databaseUrl": {
             "title": "Database URL",
             "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sql": {
-            "title": "SQL Query",
-            "description": "SQL query expression to execute for retrieving data",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "sql": {
+            "title": "SQL Query",
+            "description": "SQL query expression to execute for retrieving data",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -11445,35 +11424,24 @@
         "properties": {
           "output": {
             "description": "Output path or expression for the XML file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -11504,35 +11472,24 @@
         "properties": {
           "output": {
             "description": "Output path",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -616,28 +616,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Method": {
             "type": "string",
             "enum": [
@@ -671,7 +649,11 @@
                 "description": "Value to use for the operation",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Code"
+                    "codeTypes": [
+                      "flowExpr",
+                      "string"
+                    ],
+                    "type": "code"
                   },
                   {
                     "type": "null"
@@ -1419,7 +1401,11 @@
             "description": "Optional path for compressed archive output",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -1451,11 +1437,11 @@
           "output": {
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -1471,30 +1457,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3423,28 +3385,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3454,11 +3394,10 @@
             "properties": {
               "expr": {
                 "title": "Condition expression",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
-                  }
-                ]
+                "codeTypes": [
+                  "flowExpr"
+                ],
+                "type": "code"
               },
               "outputPort": {
                 "title": "Output port",
@@ -4391,28 +4330,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapping": {
             "type": "object",
             "required": [
@@ -4424,7 +4341,11 @@
                 "type": "string"
               },
               "value": {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               }
             }
           }
@@ -7499,7 +7420,11 @@
             "description": "Optional expression to determine whether to compress the output tiles",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -7519,11 +7444,11 @@
           "layerName": {
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7542,11 +7467,11 @@
           "output": {
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -7562,30 +7487,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -647,18 +647,27 @@
               "value": {
                 "title": "Value",
                 "description": "Value to use for the operation",
-                "anyOf": [
-                  {
-                    "codeTypes": [
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
                       "flowExpr",
                       "string"
-                    ],
-                    "type": "code"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -1399,18 +1408,27 @@
           "compressOutput": {
             "title": "Compressed Output Path",
             "description": "Optional path for compressed archive output",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "dracoCompression": {
             "title": "Draco Compression",
@@ -1437,11 +1455,24 @@
           "output": {
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -3394,10 +3425,23 @@
             "properties": {
               "expr": {
                 "title": "Condition expression",
-                "codeTypes": [
-                  "flowExpr"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               },
               "outputPort": {
                 "title": "Output port",
@@ -4341,11 +4385,24 @@
                 "type": "string"
               },
               "value": {
-                "codeTypes": [
-                  "flowExpr",
-                  "string"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -7418,18 +7475,27 @@
           "compressOutput": {
             "title": "Compress Output",
             "description": "Optional expression to determine whether to compress the output tiles",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "extent": {
             "title": "Extent",
@@ -7444,11 +7510,24 @@
           "layerName": {
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7467,11 +7546,24 @@
           "output": {
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "Schema Key",

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -651,6 +651,7 @@
                   "object",
                   "null"
                 ],
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -666,8 +667,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -1412,6 +1412,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1427,8 +1428,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "dracoCompression": {
             "title": "Draco Compression",
@@ -1456,6 +1456,7 @@
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1471,8 +1472,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -3426,6 +3426,7 @@
               "expr": {
                 "title": "Condition expression",
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -3440,8 +3441,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               },
               "outputPort": {
                 "title": "Output port",
@@ -4386,6 +4386,7 @@
               },
               "value": {
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -4401,8 +4402,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -7479,6 +7479,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7494,8 +7495,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "extent": {
             "title": "Extent",
@@ -7511,6 +7511,7 @@
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7526,8 +7527,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7547,6 +7547,7 @@
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7562,8 +7563,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "Schema Key",

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -707,28 +707,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapper": {
             "type": "object",
             "properties": {
@@ -748,25 +726,51 @@
               },
               "expr": {
                 "title": "Expression to evaluate",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "multipleExpr": {
                 "title": "Expression to evaluate multiple attributes",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "parentAttribute": {
                 "title": "Parent attribute name",
@@ -1519,14 +1523,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "type": [
@@ -1537,38 +1554,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -1622,11 +1628,24 @@
           },
           "output": {
             "description": "Output file path expression",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "prettyPrint": {
             "description": "Whether to format output with indentation (default: true)",
@@ -1634,30 +1653,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -1904,14 +1899,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "Character Encoding",
@@ -1955,14 +1963,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "offset": {
             "title": "Header Row Offset",
@@ -1976,28 +1997,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "CsvFormat": {
             "oneOf": [
               {
@@ -2131,36 +2130,27 @@
           },
           "output": {
             "description": "Output path or expression for the CSV/TSV file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
+          }
+        },
+        "definitions": {
           "CsvFormat": {
             "oneOf": [
               {
@@ -2259,14 +2249,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2d": {
             "title": "Force 2D",
@@ -2277,14 +2280,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "skipDocumentPacket": {
             "title": "Skip Document Packet",
@@ -2304,28 +2320,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "TimeSamplingStrategy": {
             "description": "Strategy for handling time-dynamic CZML properties.",
             "oneOf": [
@@ -2461,11 +2455,24 @@
           "output": {
             "title": "Output File Path",
             "description": "Path where the CZML file will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "timeField": {
             "title": "Time Field",
@@ -2483,28 +2490,6 @@
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           },
           "InterpolationAlgorithm": {
             "description": "Interpolation algorithm for Cesium time-dynamic properties.",
@@ -2960,41 +2945,30 @@
         "properties": {
           "output": {
             "description": "Output path or expression for the Excel file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sheetName": {
-            "description": "Sheet name (defaults to \"Sheet1\")",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "sheetName": {
+            "description": "Sheet name (defaults to \"Sheet1\")",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -3067,11 +3041,24 @@
           "dataset": {
             "title": "Dataset",
             "description": "Path expression resolving to the CityGML 3.0 file to read.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "extractTags": {
             "title": "Extraire les Balises",
@@ -3081,30 +3068,6 @@
             "items": {
               "type": "string"
             }
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3136,23 +3099,49 @@
           "codelistsPath": {
             "title": "Codelists Path",
             "description": "Optional path to the codelists directory for resolving codelist values",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "dataset": {
             "title": "Dataset",
             "description": "Path or expression to the CityGML dataset file to be read",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "title": "Flatten",
@@ -3160,30 +3149,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3275,35 +3240,24 @@
           "creator": {
             "title": "Script Expression",
             "description": "Write a script expression that returns a map (single feature) or array of maps (multiple features). Each map represents feature attributes as key-value pairs.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3765,11 +3719,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3818,11 +3785,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3871,11 +3851,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -3885,31 +3878,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4094,11 +4063,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4117,11 +4099,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4135,14 +4130,27 @@
             ],
             "properties": {
               "converter": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -4152,11 +4160,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4200,11 +4221,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4216,31 +4250,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4276,35 +4286,24 @@
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Path or expression pointing to the source directory or archive file",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -4454,50 +4453,52 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -4538,38 +4539,29 @@
           },
           "output": {
             "description": "Output path or expression for the GeoJSON file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -4613,14 +4605,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2D": {
             "default": false,
@@ -4633,14 +4638,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "layerName": {
             "type": [
@@ -4673,28 +4691,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "GeoPackageReadMode": {
             "type": "string",
             "enum": [
@@ -4756,11 +4752,24 @@
           },
           "output": {
             "description": "Output path for the GeoPackage file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "overwrite": {
             "description": "Overwrite existing file (default: false)",
@@ -4777,30 +4786,6 @@
             "description": "Table name to create (default: \"features\")",
             "default": "features",
             "type": "string"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5276,14 +5261,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNodes": {
             "title": "Include Nodes",
@@ -5294,14 +5292,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeMeshes": {
             "title": "Merge Meshes",
@@ -5314,30 +5325,6 @@
             "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
             "default": true,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5381,41 +5368,30 @@
           },
           "output": {
             "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "schemaKey": {
-            "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "schemaKey": {
+            "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -7097,50 +7073,52 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7171,46 +7149,48 @@
         "properties": {
           "converter": {
             "description": "Optional converter expression to transform features before writing",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "output": {
-            "description": "Output path or expression for the JSON file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "output": {
+            "description": "Output path or expression for the JSON file to create",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7945,14 +7925,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNormals": {
             "title": "Include Normals",
@@ -7969,27 +7962,53 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "materialFile": {
             "title": "Material File",
             "description": "Expression that returns the path to an external MTL file to use instead of mtllib directives in the OBJ file. When specified, this overrides any material library references in the OBJ file.",
             "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeGroups": {
             "title": "Merge Groups",
@@ -8008,30 +8027,6 @@
             "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
             "default": false,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -8062,11 +8057,24 @@
           "output": {
             "title": "Output Path",
             "description": "Expression for the output file path where the OBJ file will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "writeMaterials": {
             "title": "Write Materials",
@@ -8093,30 +8101,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -10429,14 +10413,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "Character Encoding",
@@ -10455,38 +10452,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -10527,38 +10513,29 @@
           },
           "output": {
             "description": "Output path or expression for the Shapefile to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -10777,44 +10754,46 @@
           "databaseUrl": {
             "title": "Database URL",
             "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sql": {
-            "title": "SQL Query",
-            "description": "SQL query expression to execute for retrieving data",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "sql": {
+            "title": "SQL Query",
+            "description": "SQL query expression to execute for retrieving data",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -11445,35 +11424,24 @@
         "properties": {
           "output": {
             "description": "Output path or expression for the XML file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -11504,35 +11472,24 @@
         "properties": {
           "output": {
             "description": "Output path",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -616,28 +616,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Method": {
             "type": "string",
             "enum": [
@@ -671,7 +649,11 @@
                 "description": "Value to use for the operation",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Code"
+                    "codeTypes": [
+                      "flowExpr",
+                      "string"
+                    ],
+                    "type": "code"
                   },
                   {
                     "type": "null"
@@ -1419,7 +1401,11 @@
             "description": "Optional path for compressed archive output",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -1451,11 +1437,11 @@
           "output": {
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -1471,30 +1457,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3423,28 +3385,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3454,11 +3394,10 @@
             "properties": {
               "expr": {
                 "title": "Condition expression",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
-                  }
-                ]
+                "codeTypes": [
+                  "flowExpr"
+                ],
+                "type": "code"
               },
               "outputPort": {
                 "title": "Output port",
@@ -4391,28 +4330,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapping": {
             "type": "object",
             "required": [
@@ -4424,7 +4341,11 @@
                 "type": "string"
               },
               "value": {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               }
             }
           }
@@ -7499,7 +7420,11 @@
             "description": "Optional expression to determine whether to compress the output tiles",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -7519,11 +7444,11 @@
           "layerName": {
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7542,11 +7467,11 @@
           "output": {
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -7562,30 +7487,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -654,6 +654,7 @@
                   "object",
                   "null"
                 ],
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -669,8 +670,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -1415,6 +1415,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1430,8 +1431,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "dracoCompression": {
             "title": "Draco 圧縮",
@@ -1459,6 +1459,7 @@
             "title": "出力パス",
             "description": "3D タイルを書き出すディレクトリパス",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1474,8 +1475,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "スキーマキー",
@@ -3429,6 +3429,7 @@
               "expr": {
                 "title": "条件式",
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -3443,8 +3444,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               },
               "outputPort": {
                 "title": "出力ポート",
@@ -4389,6 +4389,7 @@
               },
               "value": {
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -4404,8 +4405,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -7482,6 +7482,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7497,8 +7498,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "extent": {
             "title": "エクステント",
@@ -7514,6 +7514,7 @@
             "title": "レイヤー名",
             "description": "MVT タイル内のレイヤー名",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7529,8 +7530,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "maxZoom": {
             "title": "最大ズームレベル",
@@ -7550,6 +7550,7 @@
             "title": "出力先",
             "description": "生成する MVT タイルの出力ディレクトリパスまたは式",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7565,8 +7566,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "スキーマキー",

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -650,18 +650,27 @@
               "value": {
                 "title": "値",
                 "description": "操作に使用する値",
-                "anyOf": [
-                  {
-                    "codeTypes": [
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
                       "flowExpr",
                       "string"
-                    ],
-                    "type": "code"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -1402,18 +1411,27 @@
           "compressOutput": {
             "title": "圧縮出力パス",
             "description": "圧縮アーカイブ出力の出力先パス（任意）",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "dracoCompression": {
             "title": "Draco 圧縮",
@@ -1440,11 +1458,24 @@
           "output": {
             "title": "出力パス",
             "description": "3D タイルを書き出すディレクトリパス",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "スキーマキー",
@@ -3397,10 +3428,23 @@
             "properties": {
               "expr": {
                 "title": "条件式",
-                "codeTypes": [
-                  "flowExpr"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               },
               "outputPort": {
                 "title": "出力ポート",
@@ -4344,11 +4388,24 @@
                 "type": "string"
               },
               "value": {
-                "codeTypes": [
-                  "flowExpr",
-                  "string"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -7421,18 +7478,27 @@
           "compressOutput": {
             "title": "出力を圧縮",
             "description": "出力タイルを圧縮するかを決定する式（任意）",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "extent": {
             "title": "エクステント",
@@ -7447,11 +7513,24 @@
           "layerName": {
             "title": "レイヤー名",
             "description": "MVT タイル内のレイヤー名",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "maxZoom": {
             "title": "最大ズームレベル",
@@ -7470,11 +7549,24 @@
           "output": {
             "title": "出力先",
             "description": "生成する MVT タイルの出力ディレクトリパスまたは式",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "スキーマキー",

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -710,28 +710,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapper": {
             "type": "object",
             "properties": {
@@ -751,25 +729,51 @@
               },
               "expr": {
                 "title": "評価する式",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "multipleExpr": {
                 "title": "複数属性を評価する式",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "parentAttribute": {
                 "title": "親属性名",
@@ -1522,14 +1526,27 @@
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"data.csv\" や変数参照）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "type": [
@@ -1540,38 +1557,27 @@
           "inline": {
             "title": "インラインコンテンツ",
             "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -1625,11 +1631,24 @@
           },
           "output": {
             "description": "出力ファイルパスの式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "prettyPrint": {
             "description": "インデント付きでフォーマット出力するか（デフォルト: true）",
@@ -1637,30 +1656,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -1907,14 +1902,27 @@
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"data.csv\" や変数参照）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "文字エンコーディング",
@@ -1958,14 +1966,27 @@
           "inline": {
             "title": "インラインコンテンツ",
             "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "offset": {
             "title": "ヘッダー行オフセット",
@@ -1979,28 +2000,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "CsvFormat": {
             "oneOf": [
               {
@@ -2134,36 +2133,27 @@
           },
           "output": {
             "description": "作成する CSV/TSV ファイルの出力パスまたは式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
+          }
+        },
+        "definitions": {
           "CsvFormat": {
             "oneOf": [
               {
@@ -2262,14 +2252,27 @@
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"data.czml\" や変数参照）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2d": {
             "title": "2D に強制",
@@ -2280,14 +2283,27 @@
           "inline": {
             "title": "インラインコンテンツ",
             "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "skipDocumentPacket": {
             "title": "ドキュメントパケットをスキップ",
@@ -2307,28 +2323,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "TimeSamplingStrategy": {
             "description": "Strategy for handling time-dynamic CZML properties.",
             "oneOf": [
@@ -2464,11 +2458,24 @@
           "output": {
             "title": "出力ファイルパス",
             "description": "CZML ファイルを書き出すパス",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "timeField": {
             "title": "時刻フィールド",
@@ -2486,28 +2493,6 @@
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           },
           "InterpolationAlgorithm": {
             "description": "Interpolation algorithm for Cesium time-dynamic properties.",
@@ -2963,41 +2948,30 @@
         "properties": {
           "output": {
             "description": "作成する Excel ファイルの出力パスまたは式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sheetName": {
-            "description": "シート名（デフォルト: \"Sheet1\"）",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "sheetName": {
+            "description": "シート名（デフォルト: \"Sheet1\"）",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -3070,11 +3044,24 @@
           "dataset": {
             "title": "データセット",
             "description": "読み込む CityGML 3.0 ファイルへのパス式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "extractTags": {
             "title": "タグの抽出",
@@ -3084,30 +3071,6 @@
             "items": {
               "type": "string"
             }
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3139,23 +3102,49 @@
           "codelistsPath": {
             "title": "コードリストパス",
             "description": "コードリスト値を解決するためのコードリストディレクトリへのパス（任意）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "dataset": {
             "title": "データセット",
             "description": "読み込む CityGML データセットファイルへのパスまたは式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "title": "フラット化",
@@ -3163,30 +3152,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3278,35 +3243,24 @@
           "creator": {
             "title": "スクリプト式",
             "description": "マップ（単一フィーチャー）またはマップの配列（複数フィーチャー）を返すスクリプト式を記述する。各マップはフィーチャー属性をキーと値のペアで表す。",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3768,11 +3722,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3821,11 +3788,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3874,11 +3854,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -3888,31 +3881,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4097,11 +4066,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4120,11 +4102,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4138,14 +4133,27 @@
             ],
             "properties": {
               "converter": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -4155,11 +4163,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4203,11 +4224,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4219,31 +4253,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4279,35 +4289,24 @@
           "sourceDataset": {
             "title": "ソースデータセット",
             "description": "ソースディレクトリまたはアーカイブファイルへのパスまたは式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -4457,50 +4456,52 @@
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"data.geojson\" や変数参照）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "インラインコンテンツ",
-            "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "インラインコンテンツ",
+            "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -4541,38 +4542,29 @@
           },
           "output": {
             "description": "作成する GeoJSON ファイルの出力パスまたは式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -4616,14 +4608,27 @@
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"data.gpkg\" や変数参照）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2D": {
             "default": false,
@@ -4636,14 +4641,27 @@
           "inline": {
             "title": "インラインコンテンツ",
             "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "layerName": {
             "type": [
@@ -4676,28 +4694,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "GeoPackageReadMode": {
             "type": "string",
             "enum": [
@@ -4759,11 +4755,24 @@
           },
           "output": {
             "description": "作成する GeoPackage ファイルの出力パス",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "overwrite": {
             "description": "既存ファイルを上書きする（デフォルト: false）",
@@ -4780,30 +4789,6 @@
             "description": "作成するテーブル名（デフォルト: \"features\"）",
             "default": "features",
             "type": "string"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5279,14 +5264,27 @@
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"model.glb\" や変数参照）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNodes": {
             "title": "ノードを含める",
@@ -5297,14 +5295,27 @@
           "inline": {
             "title": "インラインコンテンツ",
             "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeMeshes": {
             "title": "メッシュをマージ",
@@ -5317,30 +5328,6 @@
             "description": "true の場合、すべてのプリミティブを三角形に変換する（将来の使用のために予約済み。現在はすべてのプリミティブが三角形として処理される）",
             "default": true,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5384,41 +5371,30 @@
           },
           "output": {
             "description": "出力ファイルパス。`schemaKey` が設定されている場合はディレクトリとして扱われ、各フィーチャータイプは `<output>/<schemaKeyValue>.glb` に書き出される。それ以外は、すべてのフィーチャーがこの単一ファイルに書き出される。",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "schemaKey": {
-            "description": "フィーチャーはこの属性でグループ化され、別々のファイルに書き出される。このキーは出力属性から除外される。",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "schemaKey": {
+            "description": "フィーチャーはこの属性でグループ化され、別々のファイルに書き出される。このキーは出力属性から除外される。",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -7100,50 +7076,52 @@
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"data.json\" や変数参照）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "インラインコンテンツ",
-            "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "インラインコンテンツ",
+            "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7174,46 +7152,48 @@
         "properties": {
           "converter": {
             "description": "書き出し前にフィーチャーを変換するコンバーター式（任意）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "output": {
-            "description": "作成する JSON ファイルの出力パスまたは式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "output": {
+            "description": "作成する JSON ファイルの出力パスまたは式",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7948,14 +7928,27 @@
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"model.obj\" や変数参照）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNormals": {
             "title": "法線を含める",
@@ -7972,27 +7965,53 @@
           "inline": {
             "title": "インラインコンテンツ",
             "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "materialFile": {
             "title": "マテリアルファイル",
             "description": "OBJ ファイルの mtllib ディレクティブの代わりに使用する外部 MTL ファイルへのパスを返す式。指定した場合、OBJ ファイル内のマテリアルライブラリ参照を上書きする。",
             "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeGroups": {
             "title": "グループをマージ",
@@ -8011,30 +8030,6 @@
             "description": "3 頂点を超えるポリゴンをファン三角形分割で三角形に変換する",
             "default": false,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -8065,11 +8060,24 @@
           "output": {
             "title": "出力パス",
             "description": "OBJ ファイルを書き出す出力ファイルパスの式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "writeMaterials": {
             "title": "マテリアルを書き出す",
@@ -8096,30 +8104,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -10432,14 +10416,27 @@
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"data.csv\" や変数参照）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "文字エンコーディング",
@@ -10458,38 +10455,27 @@
           "inline": {
             "title": "インラインコンテンツ",
             "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -10530,38 +10516,29 @@
           },
           "output": {
             "description": "作成する Shapefile の出力パスまたは式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -10780,44 +10757,46 @@
           "databaseUrl": {
             "title": "データベース URL",
             "description": "データベース接続 URL（例: `sqlite:///tests/sqlite/sqlite.db`、`mysql://user:password@localhost:3306/db`、`postgresql://user:password@localhost:5432/db`）",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sql": {
-            "title": "SQL クエリ",
-            "description": "データ取得のために実行する SQL クエリ式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "sql": {
+            "title": "SQL クエリ",
+            "description": "データ取得のために実行する SQL クエリ式",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -11448,35 +11427,24 @@
         "properties": {
           "output": {
             "description": "作成する XML ファイルの出力パスまたは式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -11507,35 +11475,24 @@
         "properties": {
           "output": {
             "description": "出力パス",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -619,28 +619,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Method": {
             "type": "string",
             "enum": [
@@ -674,7 +652,11 @@
                 "description": "操作に使用する値",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Code"
+                    "codeTypes": [
+                      "flowExpr",
+                      "string"
+                    ],
+                    "type": "code"
                   },
                   {
                     "type": "null"
@@ -1422,7 +1404,11 @@
             "description": "圧縮アーカイブ出力の出力先パス（任意）",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -1454,11 +1440,11 @@
           "output": {
             "title": "出力パス",
             "description": "3D タイルを書き出すディレクトリパス",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "スキーマキー",
@@ -1474,30 +1460,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3426,28 +3388,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3457,11 +3397,10 @@
             "properties": {
               "expr": {
                 "title": "条件式",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
-                  }
-                ]
+                "codeTypes": [
+                  "flowExpr"
+                ],
+                "type": "code"
               },
               "outputPort": {
                 "title": "出力ポート",
@@ -4394,28 +4333,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapping": {
             "type": "object",
             "required": [
@@ -4427,7 +4344,11 @@
                 "type": "string"
               },
               "value": {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               }
             }
           }
@@ -7502,7 +7423,11 @@
             "description": "出力タイルを圧縮するかを決定する式（任意）",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -7522,11 +7447,11 @@
           "layerName": {
             "title": "レイヤー名",
             "description": "MVT タイル内のレイヤー名",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "maxZoom": {
             "title": "最大ズームレベル",
@@ -7545,11 +7470,11 @@
           "output": {
             "title": "出力先",
             "description": "生成する MVT タイルの出力ディレクトリパスまたは式",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "スキーマキー",
@@ -7565,30 +7490,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -647,18 +647,27 @@
               "value": {
                 "title": "Value",
                 "description": "Value to use for the operation",
-                "anyOf": [
-                  {
-                    "codeTypes": [
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
                       "flowExpr",
                       "string"
-                    ],
-                    "type": "code"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -1399,18 +1408,27 @@
           "compressOutput": {
             "title": "Compressed Output Path",
             "description": "Optional path for compressed archive output",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "dracoCompression": {
             "title": "Draco Compression",
@@ -1437,11 +1455,24 @@
           "output": {
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -3394,10 +3425,23 @@
             "properties": {
               "expr": {
                 "title": "Condition expression",
-                "codeTypes": [
-                  "flowExpr"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               },
               "outputPort": {
                 "title": "Output port",
@@ -4341,11 +4385,24 @@
                 "type": "string"
               },
               "value": {
-                "codeTypes": [
-                  "flowExpr",
-                  "string"
+                "type": "object",
+                "required": [
+                  "type",
+                  "value"
                 ],
-                "type": "code"
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "x-flow-code": true
               }
             }
           }
@@ -7418,18 +7475,27 @@
           "compressOutput": {
             "title": "Compress Output",
             "description": "Optional expression to determine whether to compress the output tiles",
-            "anyOf": [
-              {
-                "codeTypes": [
+            "type": [
+              "object",
+              "null"
+            ],
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
                   "flowExpr",
                   "string"
-                ],
-                "type": "code"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            },
+            "x-flow-code": true
           },
           "extent": {
             "title": "Extent",
@@ -7444,11 +7510,24 @@
           "layerName": {
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7467,11 +7546,24 @@
           "output": {
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
-            "codeTypes": [
-              "flowExpr",
-              "string"
+            "type": "object",
+            "required": [
+              "type",
+              "value"
             ],
-            "type": "code"
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "x-flow-code": true
           },
           "schemaKey": {
             "title": "Schema Key",

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -651,6 +651,7 @@
                   "object",
                   "null"
                 ],
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -666,8 +667,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -1412,6 +1412,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1427,8 +1428,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "dracoCompression": {
             "title": "Draco Compression",
@@ -1456,6 +1456,7 @@
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -1471,8 +1472,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -3426,6 +3426,7 @@
               "expr": {
                 "title": "Condition expression",
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -3440,8 +3441,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               },
               "outputPort": {
                 "title": "Output port",
@@ -4386,6 +4386,7 @@
               },
               "value": {
                 "type": "object",
+                "format": "code",
                 "required": [
                   "type",
                   "value"
@@ -4401,8 +4402,7 @@
                   "value": {
                     "type": "string"
                   }
-                },
-                "x-flow-code": true
+                }
               }
             }
           }
@@ -7479,6 +7479,7 @@
               "object",
               "null"
             ],
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7494,8 +7495,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "extent": {
             "title": "Extent",
@@ -7511,6 +7511,7 @@
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7526,8 +7527,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7547,6 +7547,7 @@
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
@@ -7562,8 +7563,7 @@
               "value": {
                 "type": "string"
               }
-            },
-            "x-flow-code": true
+            }
           },
           "schemaKey": {
             "title": "Schema Key",

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -616,28 +616,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Method": {
             "type": "string",
             "enum": [
@@ -671,7 +649,11 @@
                 "description": "Value to use for the operation",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Code"
+                    "codeTypes": [
+                      "flowExpr",
+                      "string"
+                    ],
+                    "type": "code"
                   },
                   {
                     "type": "null"
@@ -1419,7 +1401,11 @@
             "description": "Optional path for compressed archive output",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -1451,11 +1437,11 @@
           "output": {
             "title": "Output Path",
             "description": "Directory path where the 3D tiles will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -1471,30 +1457,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3423,28 +3385,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Condition": {
             "type": "object",
             "required": [
@@ -3454,11 +3394,10 @@
             "properties": {
               "expr": {
                 "title": "Condition expression",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
-                  }
-                ]
+                "codeTypes": [
+                  "flowExpr"
+                ],
+                "type": "code"
               },
               "outputPort": {
                 "title": "Output port",
@@ -4391,28 +4330,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapping": {
             "type": "object",
             "required": [
@@ -4424,7 +4341,11 @@
                 "type": "string"
               },
               "value": {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               }
             }
           }
@@ -7499,7 +7420,11 @@
             "description": "Optional expression to determine whether to compress the output tiles",
             "anyOf": [
               {
-                "$ref": "#/definitions/Code"
+                "codeTypes": [
+                  "flowExpr",
+                  "string"
+                ],
+                "type": "code"
               },
               {
                 "type": "null"
@@ -7519,11 +7444,11 @@
           "layerName": {
             "title": "Layer Name",
             "description": "Name of the layer within the MVT tiles",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "maxZoom": {
             "title": "Maximum Zoom",
@@ -7542,11 +7467,11 @@
           "output": {
             "title": "Output",
             "description": "Output directory path or expression for the generated MVT tiles",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
+            "codeTypes": [
+              "flowExpr",
+              "string"
+            ],
+            "type": "code"
           },
           "schemaKey": {
             "title": "Schema Key",
@@ -7562,30 +7487,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -707,28 +707,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "Mapper": {
             "type": "object",
             "properties": {
@@ -748,25 +726,51 @@
               },
               "expr": {
                 "title": "Expression to evaluate",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "multipleExpr": {
                 "title": "Expression to evaluate multiple attributes",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "parentAttribute": {
                 "title": "Parent attribute name",
@@ -1519,14 +1523,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "type": [
@@ -1537,38 +1554,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -1622,11 +1628,24 @@
           },
           "output": {
             "description": "Output file path expression",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "prettyPrint": {
             "description": "Whether to format output with indentation (default: true)",
@@ -1634,30 +1653,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -1904,14 +1899,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "Character Encoding",
@@ -1955,14 +1963,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "offset": {
             "title": "Header Row Offset",
@@ -1976,28 +1997,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "CsvFormat": {
             "oneOf": [
               {
@@ -2131,36 +2130,27 @@
           },
           "output": {
             "description": "Output path or expression for the CSV/TSV file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
+          }
+        },
+        "definitions": {
           "CsvFormat": {
             "oneOf": [
               {
@@ -2259,14 +2249,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2d": {
             "title": "Force 2D",
@@ -2277,14 +2280,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "skipDocumentPacket": {
             "title": "Skip Document Packet",
@@ -2304,28 +2320,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "TimeSamplingStrategy": {
             "description": "Strategy for handling time-dynamic CZML properties.",
             "oneOf": [
@@ -2461,11 +2455,24 @@
           "output": {
             "title": "Output File Path",
             "description": "Path where the CZML file will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "timeField": {
             "title": "Time Field",
@@ -2483,28 +2490,6 @@
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           },
           "InterpolationAlgorithm": {
             "description": "Interpolation algorithm for Cesium time-dynamic properties.",
@@ -2960,41 +2945,30 @@
         "properties": {
           "output": {
             "description": "Output path or expression for the Excel file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sheetName": {
-            "description": "Sheet name (defaults to \"Sheet1\")",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "sheetName": {
+            "description": "Sheet name (defaults to \"Sheet1\")",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -3067,11 +3041,24 @@
           "dataset": {
             "title": "Dataset",
             "description": "Path expression resolving to the CityGML 3.0 file to read.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "extractTags": {
             "title": "提取标签",
@@ -3081,30 +3068,6 @@
             "items": {
               "type": "string"
             }
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3136,23 +3099,49 @@
           "codelistsPath": {
             "title": "Codelists Path",
             "description": "Optional path to the codelists directory for resolving codelist values",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "dataset": {
             "title": "Dataset",
             "description": "Path or expression to the CityGML dataset file to be read",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "flatten": {
             "title": "Flatten",
@@ -3160,30 +3149,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -3275,35 +3240,24 @@
           "creator": {
             "title": "Script Expression",
             "description": "Write a script expression that returns a map (single feature) or array of maps (multiple features). Each map represents feature attributes as key-value pairs.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -3765,11 +3719,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3818,11 +3785,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3871,11 +3851,24 @@
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -3885,31 +3878,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4094,11 +4063,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4117,11 +4099,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4135,14 +4130,27 @@
             ],
             "properties": {
               "converter": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
                   },
-                  {
-                    "type": "null"
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "format": {
                 "type": "string",
@@ -4152,11 +4160,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               }
             }
           },
@@ -4200,11 +4221,24 @@
               },
               "output": {
                 "title": "Output path",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Code"
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
                   }
-                ]
+                }
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4216,31 +4250,7 @@
               }
             }
           }
-        ],
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          }
-        }
+        ]
       },
       "builtin": true,
       "inputPorts": [
@@ -4276,35 +4286,24 @@
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Path or expression pointing to the source directory or archive file",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -4454,50 +4453,52 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -4538,38 +4539,29 @@
           },
           "output": {
             "description": "Output path or expression for the GeoJSON file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -4613,14 +4605,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "force2D": {
             "default": false,
@@ -4633,14 +4638,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "layerName": {
             "type": [
@@ -4673,28 +4691,6 @@
           }
         },
         "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
-          },
           "GeoPackageReadMode": {
             "type": "string",
             "enum": [
@@ -4756,11 +4752,24 @@
           },
           "output": {
             "description": "Output path for the GeoPackage file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "overwrite": {
             "description": "Overwrite existing file (default: false)",
@@ -4777,30 +4786,6 @@
             "description": "Table name to create (default: \"features\")",
             "default": "features",
             "type": "string"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5276,14 +5261,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNodes": {
             "title": "Include Nodes",
@@ -5294,14 +5292,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeMeshes": {
             "title": "Merge Meshes",
@@ -5314,30 +5325,6 @@
             "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
             "default": true,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -5381,41 +5368,30 @@
           },
           "output": {
             "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "schemaKey": {
-            "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
+          "schemaKey": {
+            "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
+            "type": [
+              "string",
+              "null"
             ]
           }
         }
@@ -7097,50 +7073,52 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7171,46 +7149,48 @@
         "properties": {
           "converter": {
             "description": "Optional converter expression to transform features before writing",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "output": {
-            "description": "Output path or expression for the JSON file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "output": {
+            "description": "Output path or expression for the JSON file to create",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -7945,14 +7925,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "includeNormals": {
             "title": "Include Normals",
@@ -7969,27 +7962,53 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "materialFile": {
             "title": "Material File",
             "description": "Expression that returns the path to an external MTL file to use instead of mtllib directives in the OBJ file. When specified, this overrides any material library references in the OBJ file.",
             "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "mergeGroups": {
             "title": "Merge Groups",
@@ -8008,30 +8027,6 @@
             "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
             "default": false,
             "type": "boolean"
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -8062,11 +8057,24 @@
           "output": {
             "title": "Output Path",
             "description": "Expression for the output file path where the OBJ file will be written",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "writeMaterials": {
             "title": "Write Materials",
@@ -8093,30 +8101,6 @@
             "type": [
               "boolean",
               "null"
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "$ref": "#/definitions/CodeType"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
             ]
           }
         }
@@ -10429,14 +10413,27 @@
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
-              {
-                "type": "null"
+              "value": {
+                "type": "string"
               }
-            ]
+            }
           },
           "encoding": {
             "title": "Character Encoding",
@@ -10455,38 +10452,27 @@
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Code"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
-            "type": "object",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -10527,38 +10513,29 @@
           },
           "output": {
             "description": "Output path or expression for the Shapefile to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -10777,44 +10754,46 @@
           "databaseUrl": {
             "title": "Database URL",
             "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          },
-          "sql": {
-            "title": "SQL Query",
-            "description": "SQL query expression to execute for retrieving data",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
           },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
+          "sql": {
+            "title": "SQL Query",
+            "description": "SQL query expression to execute for retrieving data",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -11445,35 +11424,24 @@
         "properties": {
           "output": {
             "description": "Output path or expression for the XML file to create",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },
@@ -11504,35 +11472,24 @@
         "properties": {
           "output": {
             "description": "Output path",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Code"
-              }
-            ]
-          }
-        },
-        "definitions": {
-          "Code": {
             "type": "object",
+            "format": "code",
             "required": [
               "type",
               "value"
             ],
             "properties": {
               "type": {
-                "$ref": "#/definitions/CodeType"
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
               },
               "value": {
                 "type": "string"
               }
             }
-          },
-          "CodeType": {
-            "type": "string",
-            "enum": [
-              "flowExpr",
-              "string"
-            ]
           }
         }
       },

--- a/engine/schema/i18n/actions/en.json
+++ b/engine/schema/i18n/actions/en.json
@@ -239,10 +239,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Mapper": {
           "attribute": {
             "title": "Attribute name"
@@ -564,12 +560,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -589,12 +579,6 @@
         },
         "prettyPrint": {
           "description": "Whether to format output with indentation (default: true)"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -673,10 +657,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "GeometryConfig": {
           "epsg": {
             "title": "EPSG Code",
@@ -713,12 +693,6 @@
         },
         "output": {
           "description": "Output path or expression for the CSV/TSV file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -761,12 +735,6 @@
         "timeSampling": {
           "title": "Time Sampling Strategy",
           "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -830,12 +798,6 @@
         "timeField": {
           "title": "Time Field",
           "description": "Attribute containing the timestamp for each feature. Supports two formats: - **ISO 8601 strings**: e.g., \"2024-01-01T00:00:00Z\", \"2024-01-01T12:30:45+09:00\" - **Numeric values**: Seconds as offset from epoch (e.g., \"0\", \"60\", \"120.5\")\n\nWhen set together with `groupTimeseriesBy`, features sharing the same group key are combined into a single CZML entity with time-tagged position samples for animation in Cesium.\n\n**Example workflow configuration:** ```yaml - action: CzmlWriter with: output: \"output.czml\" timeField: \"timestamp\" groupTimeseriesBy: \"vehicleId\" epoch: \"2024-01-01T00:00:00Z\"  # Optional for numeric times (auto-defaults to Unix epoch) ```"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -1001,12 +963,6 @@
         "sheetName": {
           "description": "Sheet name (defaults to \"Sheet1\")"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1037,12 +993,6 @@
           "title": "Extract Tags",
           "description": "Feature type names to flatten as individual features. Accepts qualified (`bldg:Building`), local (`Building`), or Clark notation (`{http://…}Building`). Empty means emit all top-level city objects unchanged."
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1064,12 +1014,6 @@
         "flatten": {
           "title": "Flatten",
           "description": "Whether to flatten the hierarchical structure of the CityGML data"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1106,12 +1050,6 @@
         "creator": {
           "title": "Script Expression",
           "description": "Write a script expression that returns a map (single feature) or array of maps (multiple features). Each map represents feature attributes as key-value pairs."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1258,12 +1196,6 @@
         "": {
           "title": "FeatureReaderParam"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1323,12 +1255,6 @@
           "title": "FeatureWriter Parameters",
           "description": "Configuration for writing features to different file formats."
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1346,12 +1272,6 @@
         "sourceDataset": {
           "title": "Source Dataset",
           "description": "Path or expression pointing to the source directory or archive file"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1402,12 +1322,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1423,12 +1337,6 @@
         },
         "output": {
           "description": "Output path or expression for the GeoJSON file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1455,12 +1363,6 @@
         "readMode": {},
         "spatialFilter": {},
         "tileFormat": {}
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1491,12 +1393,6 @@
         },
         "tableName": {
           "description": "Table name to create (default: \"features\")"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1646,12 +1542,6 @@
           "title": "Triangulate",
           "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1673,12 +1563,6 @@
         },
         "schemaKey": {
           "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -2128,12 +2012,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -2148,12 +2026,6 @@
         },
         "output": {
           "description": "Output path or expression for the JSON file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -2443,12 +2315,6 @@
           "title": "Triangulate",
           "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -2473,12 +2339,6 @@
         "writeTexcoords": {
           "title": "Write Texture Coordinates",
           "description": "Include texture coordinate (UV) data in the output (currently not supported - geometry types don't include UV data)"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3121,12 +2981,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -3142,12 +2996,6 @@
         },
         "output": {
           "description": "Output path or expression for the Shapefile to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3239,12 +3087,6 @@
         "sql": {
           "title": "SQL Query",
           "description": "SQL query expression to execute for retrieving data"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3441,12 +3283,6 @@
         "output": {
           "description": "Output path or expression for the XML file to create"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -3459,12 +3295,6 @@
         },
         "output": {
           "description": "Output path"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     }

--- a/engine/schema/i18n/actions/en.json
+++ b/engine/schema/i18n/actions/en.json
@@ -212,10 +212,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Operation": {
           "attribute": {
             "title": "Attribute name"
@@ -549,12 +545,6 @@
         "skipUnexposedAttributes": {
           "title": "Skip unexposed Attributes",
           "description": "Skip attributes with double underscore prefix"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1165,10 +1155,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Condition": {
           "expr": {
             "title": "Condition expression"
@@ -1391,10 +1377,6 @@
         "mappings": {}
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Mapping": {
           "attribute": {},
           "value": {}
@@ -2288,12 +2270,6 @@
         "skipUnexposedAttributes": {
           "title": "Skip Unexposed Attributes",
           "description": "Skip attributes with double underscore prefix"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -214,10 +214,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Operation": {
           "attribute": {
             "title": "Attribute name"
@@ -554,12 +550,6 @@
         "skipUnexposedAttributes": {
           "title": "Skip unexposed Attributes",
           "description": "Skip attributes with double underscore prefix"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1177,10 +1167,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Condition": {
           "expr": {
             "title": "Condition expression"
@@ -1405,10 +1391,6 @@
         "mappings": {}
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Mapping": {
           "attribute": {},
           "value": {}
@@ -2313,12 +2295,6 @@
         "skipUnexposedAttributes": {
           "title": "Skip Unexposed Attributes",
           "description": "Skip attributes with double underscore prefix"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -241,10 +241,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Mapper": {
           "attribute": {
             "title": "Attribute name"
@@ -570,12 +566,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -596,12 +586,6 @@
         },
         "prettyPrint": {
           "description": "Whether to format output with indentation (default: true)"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -681,10 +665,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "GeometryConfig": {
           "epsg": {
             "title": "EPSG Code",
@@ -722,12 +702,6 @@
         },
         "output": {
           "description": "Output path or expression for the CSV/TSV file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -770,12 +744,6 @@
         "timeSampling": {
           "title": "Time Sampling Strategy",
           "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -839,12 +807,6 @@
         "timeField": {
           "title": "Time Field",
           "description": "Attribute containing the timestamp for each feature. Supports two formats: - **ISO 8601 strings**: e.g., \"2024-01-01T00:00:00Z\", \"2024-01-01T12:30:45+09:00\" - **Numeric values**: Seconds as offset from epoch (e.g., \"0\", \"60\", \"120.5\")\n\nWhen set together with `groupTimeseriesBy`, features sharing the same group key are combined into a single CZML entity with time-tagged position samples for animation in Cesium.\n\n**Example workflow configuration:** ```yaml - action: CzmlWriter with: output: \"output.czml\" timeField: \"timestamp\" groupTimeseriesBy: \"vehicleId\" epoch: \"2024-01-01T00:00:00Z\"  # Optional for numeric times (auto-defaults to Unix epoch) ```"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -1012,12 +974,6 @@
         "sheetName": {
           "description": "Sheet name (defaults to \"Sheet1\")"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1049,12 +1005,6 @@
           "title": "Extraer Etiquetas",
           "description": "Nombres de tipos de entidad a aplanar como entidades individuales. Acepta forma calificada (`bldg:Building`), local (`Building`) o notación Clark (`{http://…}Building`). Vacío significa emitir todos los objetos urbanos de nivel superior sin cambios."
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1076,12 +1026,6 @@
         "flatten": {
           "title": "Flatten",
           "description": "Whether to flatten the hierarchical structure of the CityGML data"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1118,12 +1062,6 @@
         "creator": {
           "title": "Script Expression",
           "description": "Write a script expression that returns a map (single feature) or array of maps (multiple features). Each map represents feature attributes as key-value pairs."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1271,12 +1209,6 @@
         "": {
           "title": "FeatureReaderParam"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1336,12 +1268,6 @@
           "title": "FeatureWriter Parameters",
           "description": "Configuration for writing features to different file formats."
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1359,12 +1285,6 @@
         "sourceDataset": {
           "title": "Source Dataset",
           "description": "Path or expression pointing to the source directory or archive file"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1417,12 +1337,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1438,12 +1352,6 @@
         },
         "output": {
           "description": "Output path or expression for the GeoJSON file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1470,12 +1378,6 @@
         "readMode": {},
         "spatialFilter": {},
         "tileFormat": {}
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1506,12 +1408,6 @@
         },
         "tableName": {
           "description": "Table name to create (default: \"features\")"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1664,12 +1560,6 @@
           "title": "Triangulate",
           "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1691,12 +1581,6 @@
         },
         "schemaKey": {
           "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -2150,12 +2034,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -2171,12 +2049,6 @@
         },
         "output": {
           "description": "Output path or expression for the JSON file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -2471,12 +2343,6 @@
           "title": "Triangulate",
           "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -2502,12 +2368,6 @@
         "writeTexcoords": {
           "title": "Write Texture Coordinates",
           "description": "Include texture coordinate (UV) data in the output (currently not supported - geometry types don't include UV data)"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3170,12 +3030,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -3191,12 +3045,6 @@
         },
         "output": {
           "description": "Output path or expression for the Shapefile to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3290,12 +3138,6 @@
         "sql": {
           "title": "SQL Query",
           "description": "SQL query expression to execute for retrieving data"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3494,12 +3336,6 @@
         "output": {
           "description": "Output path or expression for the XML file to create"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -3512,12 +3348,6 @@
         },
         "output": {
           "description": "Output path"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     }

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -214,10 +214,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Operation": {
           "attribute": {
             "title": "Attribute name"
@@ -554,12 +550,6 @@
         "skipUnexposedAttributes": {
           "title": "Skip unexposed Attributes",
           "description": "Skip attributes with double underscore prefix"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1177,10 +1167,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Condition": {
           "expr": {
             "title": "Condition expression"
@@ -1405,10 +1391,6 @@
         "mappings": {}
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Mapping": {
           "attribute": {},
           "value": {}
@@ -2313,12 +2295,6 @@
         "skipUnexposedAttributes": {
           "title": "Skip Unexposed Attributes",
           "description": "Skip attributes with double underscore prefix"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -241,10 +241,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Mapper": {
           "attribute": {
             "title": "Attribute name"
@@ -570,12 +566,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -596,12 +586,6 @@
         },
         "prettyPrint": {
           "description": "Whether to format output with indentation (default: true)"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -681,10 +665,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "GeometryConfig": {
           "epsg": {
             "title": "EPSG Code",
@@ -722,12 +702,6 @@
         },
         "output": {
           "description": "Output path or expression for the CSV/TSV file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -770,12 +744,6 @@
         "timeSampling": {
           "title": "Time Sampling Strategy",
           "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -839,12 +807,6 @@
         "timeField": {
           "title": "Time Field",
           "description": "Attribute containing the timestamp for each feature. Supports two formats: - **ISO 8601 strings**: e.g., \"2024-01-01T00:00:00Z\", \"2024-01-01T12:30:45+09:00\" - **Numeric values**: Seconds as offset from epoch (e.g., \"0\", \"60\", \"120.5\")\n\nWhen set together with `groupTimeseriesBy`, features sharing the same group key are combined into a single CZML entity with time-tagged position samples for animation in Cesium.\n\n**Example workflow configuration:** ```yaml - action: CzmlWriter with: output: \"output.czml\" timeField: \"timestamp\" groupTimeseriesBy: \"vehicleId\" epoch: \"2024-01-01T00:00:00Z\"  # Optional for numeric times (auto-defaults to Unix epoch) ```"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -1012,12 +974,6 @@
         "sheetName": {
           "description": "Sheet name (defaults to \"Sheet1\")"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1049,12 +1005,6 @@
           "title": "Extraire les Balises",
           "description": "Noms de types d'entité à aplatir en entités individuelles. Accepte la forme qualifiée (`bldg:Building`), locale (`Building`) ou la notation Clark (`{http://…}Building`). Vide signifie émettre tous les objets urbains de niveau supérieur sans modification."
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1076,12 +1026,6 @@
         "flatten": {
           "title": "Flatten",
           "description": "Whether to flatten the hierarchical structure of the CityGML data"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1118,12 +1062,6 @@
         "creator": {
           "title": "Script Expression",
           "description": "Write a script expression that returns a map (single feature) or array of maps (multiple features). Each map represents feature attributes as key-value pairs."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1271,12 +1209,6 @@
         "": {
           "title": "FeatureReaderParam"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1336,12 +1268,6 @@
           "title": "FeatureWriter Parameters",
           "description": "Configuration for writing features to different file formats."
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1359,12 +1285,6 @@
         "sourceDataset": {
           "title": "Source Dataset",
           "description": "Path or expression pointing to the source directory or archive file"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1417,12 +1337,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1438,12 +1352,6 @@
         },
         "output": {
           "description": "Output path or expression for the GeoJSON file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1470,12 +1378,6 @@
         "readMode": {},
         "spatialFilter": {},
         "tileFormat": {}
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1506,12 +1408,6 @@
         },
         "tableName": {
           "description": "Table name to create (default: \"features\")"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1664,12 +1560,6 @@
           "title": "Triangulate",
           "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1691,12 +1581,6 @@
         },
         "schemaKey": {
           "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -2150,12 +2034,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -2171,12 +2049,6 @@
         },
         "output": {
           "description": "Output path or expression for the JSON file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -2471,12 +2343,6 @@
           "title": "Triangulate",
           "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -2502,12 +2368,6 @@
         "writeTexcoords": {
           "title": "Write Texture Coordinates",
           "description": "Include texture coordinate (UV) data in the output (currently not supported - geometry types don't include UV data)"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3170,12 +3030,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -3191,12 +3045,6 @@
         },
         "output": {
           "description": "Output path or expression for the Shapefile to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3290,12 +3138,6 @@
         "sql": {
           "title": "SQL Query",
           "description": "SQL query expression to execute for retrieving data"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3494,12 +3336,6 @@
         "output": {
           "description": "Output path or expression for the XML file to create"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -3512,12 +3348,6 @@
         },
         "output": {
           "description": "Output path"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     }

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -217,10 +217,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Operation": {
           "attribute": {
             "title": "属性名"
@@ -557,12 +553,6 @@
         "skipUnexposedAttributes": {
           "title": "非公開属性をスキップ",
           "description": "ダブルアンダースコアで始まる属性をスキップする"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1180,10 +1170,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Condition": {
           "expr": {
             "title": "条件式"
@@ -1408,10 +1394,6 @@
         "mappings": {}
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Mapping": {
           "attribute": {},
           "value": {}
@@ -2316,12 +2298,6 @@
         "skipUnexposedAttributes": {
           "title": "非公開属性をスキップ",
           "description": "ダブルアンダースコアで始まる属性をスキップする"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -244,10 +244,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Mapper": {
           "attribute": {
             "title": "属性名"
@@ -573,12 +569,6 @@
           "title": "インラインコンテンツ",
           "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -599,12 +589,6 @@
         },
         "prettyPrint": {
           "description": "インデント付きでフォーマット出力するか（デフォルト: true）"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -684,10 +668,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "GeometryConfig": {
           "epsg": {
             "title": "EPSG コード",
@@ -725,12 +705,6 @@
         },
         "output": {
           "description": "作成する CSV/TSV ファイルの出力パスまたは式"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -773,12 +747,6 @@
         "timeSampling": {
           "title": "時系列サンプリング戦略",
           "description": "CZML パケット内の時間動的プロパティの処理方法。CzmlWriter との無損失ラウンドトリップのためデフォルトは \"preserveRaw\"。"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -842,12 +810,6 @@
         "timeField": {
           "title": "時刻フィールド",
           "description": "各フィーチャーのタイムスタンプを含む属性。2 種類の形式をサポート: - **ISO 8601 文字列**: 例: \"2024-01-01T00:00:00Z\" - **数値**: エポックからのオフセット秒数（例: \"0\"、\"60\"、\"120.5\"）\n\n`groupTimeseriesBy` と組み合わせると、同じグループキーを持つフィーチャーが Cesium アニメーション用の時刻タグ付き位置サンプルを持つ単一の CZML エンティティに統合される。"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -1015,12 +977,6 @@
         "sheetName": {
           "description": "シート名（デフォルト: \"Sheet1\"）"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1052,12 +1008,6 @@
           "title": "タグの抽出",
           "description": "個別フィーチャーとして展開するフィーチャータイプ名。修飾名（`bldg:Building`）、ローカル名（`Building`）、またはClark記法（`{http://…}Building`）で指定可能。空の場合はすべてのトップレベル都市オブジェクトをそのまま出力する。"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1079,12 +1029,6 @@
         "flatten": {
           "title": "フラット化",
           "description": "CityGML データの階層構造をフラット化するか"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1121,12 +1065,6 @@
         "creator": {
           "title": "スクリプト式",
           "description": "マップ（単一フィーチャー）またはマップの配列（複数フィーチャー）を返すスクリプト式を記述する。各マップはフィーチャー属性をキーと値のペアで表す。"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1274,12 +1212,6 @@
         "": {
           "title": "FeatureReader パラメータ"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1339,12 +1271,6 @@
           "title": "FeatureWriter パラメータ",
           "description": "さまざまなファイル形式にフィーチャーを書き出す設定"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1362,12 +1288,6 @@
         "sourceDataset": {
           "title": "ソースデータセット",
           "description": "ソースディレクトリまたはアーカイブファイルへのパスまたは式"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1420,12 +1340,6 @@
           "title": "インラインコンテンツ",
           "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1441,12 +1355,6 @@
         },
         "output": {
           "description": "作成する GeoJSON ファイルの出力パスまたは式"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1473,12 +1381,6 @@
         "readMode": {},
         "spatialFilter": {},
         "tileFormat": {}
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1509,12 +1411,6 @@
         },
         "tableName": {
           "description": "作成するテーブル名（デフォルト: \"features\"）"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1667,12 +1563,6 @@
           "title": "三角形分割",
           "description": "true の場合、すべてのプリミティブを三角形に変換する（将来の使用のために予約済み。現在はすべてのプリミティブが三角形として処理される）"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1694,12 +1584,6 @@
         },
         "schemaKey": {
           "description": "フィーチャーはこの属性でグループ化され、別々のファイルに書き出される。このキーは出力属性から除外される。"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -2153,12 +2037,6 @@
           "title": "インラインコンテンツ",
           "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -2174,12 +2052,6 @@
         },
         "output": {
           "description": "作成する JSON ファイルの出力パスまたは式"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -2474,12 +2346,6 @@
           "title": "三角形分割",
           "description": "3 頂点を超えるポリゴンをファン三角形分割で三角形に変換する"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -2505,12 +2371,6 @@
         "writeTexcoords": {
           "title": "テクスチャ座標を書き出す",
           "description": "出力にテクスチャ座標（UV）データを含める（現在未対応 - ジオメトリタイプに UV データが含まれていない）"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3173,12 +3033,6 @@
           "title": "インラインコンテンツ",
           "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -3194,12 +3048,6 @@
         },
         "output": {
           "description": "作成する Shapefile の出力パスまたは式"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3293,12 +3141,6 @@
         "sql": {
           "title": "SQL クエリ",
           "description": "データ取得のために実行する SQL クエリ式"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3497,12 +3339,6 @@
         "output": {
           "description": "作成する XML ファイルの出力パスまたは式"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -3515,12 +3351,6 @@
         },
         "output": {
           "description": "出力パス"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     }

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -214,10 +214,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Operation": {
           "attribute": {
             "title": "Attribute name"
@@ -554,12 +550,6 @@
         "skipUnexposedAttributes": {
           "title": "Skip unexposed Attributes",
           "description": "Skip attributes with double underscore prefix"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1177,10 +1167,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Condition": {
           "expr": {
             "title": "Condition expression"
@@ -1405,10 +1391,6 @@
         "mappings": {}
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Mapping": {
           "attribute": {},
           "value": {}
@@ -2313,12 +2295,6 @@
         "skipUnexposedAttributes": {
           "title": "Skip Unexposed Attributes",
           "description": "Skip attributes with double underscore prefix"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -241,10 +241,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "Mapper": {
           "attribute": {
             "title": "Attribute name"
@@ -570,12 +566,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -596,12 +586,6 @@
         },
         "prettyPrint": {
           "description": "Whether to format output with indentation (default: true)"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -681,10 +665,6 @@
         }
       },
       "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        },
         "GeometryConfig": {
           "epsg": {
             "title": "EPSG Code",
@@ -722,12 +702,6 @@
         },
         "output": {
           "description": "Output path or expression for the CSV/TSV file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -770,12 +744,6 @@
         "timeSampling": {
           "title": "Time Sampling Strategy",
           "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -839,12 +807,6 @@
         "timeField": {
           "title": "Time Field",
           "description": "Attribute containing the timestamp for each feature. Supports two formats: - **ISO 8601 strings**: e.g., \"2024-01-01T00:00:00Z\", \"2024-01-01T12:30:45+09:00\" - **Numeric values**: Seconds as offset from epoch (e.g., \"0\", \"60\", \"120.5\")\n\nWhen set together with `groupTimeseriesBy`, features sharing the same group key are combined into a single CZML entity with time-tagged position samples for animation in Cesium.\n\n**Example workflow configuration:** ```yaml - action: CzmlWriter with: output: \"output.czml\" timeField: \"timestamp\" groupTimeseriesBy: \"vehicleId\" epoch: \"2024-01-01T00:00:00Z\"  # Optional for numeric times (auto-defaults to Unix epoch) ```"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       },
       "enumI18n": {
@@ -1012,12 +974,6 @@
         "sheetName": {
           "description": "Sheet name (defaults to \"Sheet1\")"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1049,12 +1005,6 @@
           "title": "提取标签",
           "description": "要展开为独立要素的要素类型名称。接受限定形式（`bldg:Building`）、本地形式（`Building`）或Clark记法（`{http://…}Building`）。留空表示原样输出所有顶级城市对象。"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1076,12 +1026,6 @@
         "flatten": {
           "title": "Flatten",
           "description": "Whether to flatten the hierarchical structure of the CityGML data"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1118,12 +1062,6 @@
         "creator": {
           "title": "Script Expression",
           "description": "Write a script expression that returns a map (single feature) or array of maps (multiple features). Each map represents feature attributes as key-value pairs."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1271,12 +1209,6 @@
         "": {
           "title": "FeatureReaderParam"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1336,12 +1268,6 @@
           "title": "FeatureWriter Parameters",
           "description": "Configuration for writing features to different file formats."
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1359,12 +1285,6 @@
         "sourceDataset": {
           "title": "Source Dataset",
           "description": "Path or expression pointing to the source directory or archive file"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1417,12 +1337,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1438,12 +1352,6 @@
         },
         "output": {
           "description": "Output path or expression for the GeoJSON file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1470,12 +1378,6 @@
         "readMode": {},
         "spatialFilter": {},
         "tileFormat": {}
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1506,12 +1408,6 @@
         },
         "tableName": {
           "description": "Table name to create (default: \"features\")"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -1664,12 +1560,6 @@
           "title": "Triangulate",
           "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -1691,12 +1581,6 @@
         },
         "schemaKey": {
           "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes."
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -2150,12 +2034,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -2171,12 +2049,6 @@
         },
         "output": {
           "description": "Output path or expression for the JSON file to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -2471,12 +2343,6 @@
           "title": "Triangulate",
           "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -2502,12 +2368,6 @@
         "writeTexcoords": {
           "title": "Write Texture Coordinates",
           "description": "Include texture coordinate (UV) data in the output (currently not supported - geometry types don't include UV data)"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3170,12 +3030,6 @@
           "title": "Inline Content",
           "description": "Expression that returns the file content as text instead of reading from a file path"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -3191,12 +3045,6 @@
         },
         "output": {
           "description": "Output path or expression for the Shapefile to create"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3290,12 +3138,6 @@
         "sql": {
           "title": "SQL Query",
           "description": "SQL query expression to execute for retrieving data"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     },
@@ -3494,12 +3336,6 @@
         "output": {
           "description": "Output path or expression for the XML file to create"
         }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
-        }
       }
     },
     {
@@ -3512,12 +3348,6 @@
         },
         "output": {
           "description": "Output path"
-        }
-      },
-      "definitionI18n": {
-        "Code": {
-          "type": {},
-          "value": {}
         }
       }
     }


### PR DESCRIPTION
# Overview

Currently Code in schema is a fixed type, so all code fields must have identical allowed language list.

This PR adds const generics to define accepted code types optionally for some fields. For example, conditions in FeatureFilter should not take plain string literal types. This PR also updates schema to pass the accepted types to the frontend.

## Changes

- added repr(u32) bitmask operations to CodeType.
- made Code generic over const MASK: u32 (defaulting to ALL_CODE_TYPES) to restrict accepted code types per field.
- manually implemented Serialize, Deserialize, and JsonSchema for Code<MASK> to enforce and expose the allowlist.
- inlined Code schema per usage site (instead of a shared $ref) since the schema varies by MASK.
- narrowed FeatureFilter's expr field to Code<{ CodeType::FlowExpr as u32 }>, excluding plain string literals.
- removed the impl Expr { compile() } method that was dead code.