### PR TITLE
test(web): add e2e tests for deployment workflow

### DIFF
--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -14,4 +14,8 @@ src/routeTree.gen.ts
 
 public/mockServiceWorker.js
 
+e2e/playwright-report/
+e2e/test-results/
+e2e/.auth/
+
 CLAUDE.md

--- a/ui/e2e/pages/deploymentsPage.ts
+++ b/ui/e2e/pages/deploymentsPage.ts
@@ -1,0 +1,211 @@
+import { expect, Locator, Page } from "@playwright/test";
+
+import { HomePage } from "./homePage";
+
+const E2E_DEPLOYMENT_PREFIX = "e2e-deployment-";
+
+export function uniqueDeploymentDescription(label = "deploy"): string {
+  return `${E2E_DEPLOYMENT_PREFIX}${label}-${Date.now()}-${Math.floor(
+    Math.random() * 1000,
+  )}`;
+}
+
+export class DeploymentsPage {
+  readonly heading: Locator;
+  readonly newDeploymentButton: Locator;
+  readonly searchInput: Locator;
+  readonly emptyState: Locator;
+  readonly detailsTitle: Locator;
+  readonly detailsRunButton: Locator;
+  readonly detailsEditButton: Locator;
+  readonly detailsDeleteButton: Locator;
+  readonly editDialog: Locator;
+  readonly editDescriptionInput: Locator;
+  readonly editSubmitButton: Locator;
+  readonly runDialog: Locator;
+  readonly runConfirmButton: Locator;
+  readonly addDialog: Locator;
+  readonly addDialogFileInput: Locator;
+  readonly addDialogDescriptionInput: Locator;
+  readonly addDialogSubmitButton: Locator;
+  readonly deploymentCreatedToast: Locator;
+  readonly deploymentUpdatedToast: Locator;
+  readonly deploymentDeletedToast: Locator;
+  readonly deploymentExecutedToast: Locator;
+
+  constructor(private page: Page) {
+    this.heading = page.locator("p.text-lg", { hasText: "Deployments" });
+    this.newDeploymentButton = page.getByRole("button", {
+      name: "New Deployment",
+    });
+    this.searchInput = page.getByPlaceholder("Search...");
+    this.emptyState = page.getByText("No Deployments");
+
+    this.detailsTitle = page.getByText("Deployment Details", { exact: true });
+    this.detailsRunButton = page.getByRole("button", {
+      name: "Run",
+      exact: true,
+    });
+    this.detailsEditButton = page.getByRole("button", {
+      name: "Edit Deployment",
+    });
+    this.detailsDeleteButton = page.getByRole("button", {
+      name: "Delete",
+      exact: true,
+    });
+
+    this.editDialog = page
+      .getByRole("dialog")
+      .filter({ hasText: "Edit Deployment" });
+    this.editDescriptionInput = this.editDialog.getByPlaceholder(
+      "Give your deployment a meaningful description...",
+    );
+    this.editSubmitButton = this.editDialog.getByRole("button", {
+      name: "Update Deployment",
+    });
+
+    this.runDialog = page
+      .getByRole("dialog")
+      .filter({ hasText: "Run Deployment" });
+    this.runConfirmButton = this.runDialog.getByRole("button", {
+      name: "Run",
+      exact: true,
+    });
+
+    this.addDialog = page
+      .getByRole("dialog")
+      .filter({ hasText: "Create a deployment from file" });
+    this.addDialogFileInput = this.addDialog.locator('input[type="file"]');
+    this.addDialogDescriptionInput = this.addDialog.getByPlaceholder(
+      "Give your deployment a meaningful description...",
+    );
+    this.addDialogSubmitButton = this.addDialog.getByRole("button", {
+      name: "Deploy",
+      exact: true,
+    });
+
+    this.deploymentCreatedToast = page.getByText("Deployment Created", {
+      exact: true,
+    });
+    this.deploymentUpdatedToast = page.getByText("Deployment Updated", {
+      exact: true,
+    });
+    this.deploymentDeletedToast = page.getByText("Successful Deletion", {
+      exact: true,
+    });
+    this.deploymentExecutedToast = page.getByText("Deployment Executed", {
+      exact: true,
+    });
+  }
+
+  async goto() {
+    const home = new HomePage(this.page);
+    await this.page.goto("/");
+    await home.waitForLoaded();
+    await home.navigateTo("Deployments");
+    await this.waitForLoaded();
+  }
+
+  async waitForLoaded() {
+    await this.heading.waitFor({ state: "visible", timeout: 30_000 });
+    await this.newDeploymentButton.waitFor({ state: "visible" });
+  }
+
+  deploymentRow(description: string): Locator {
+    return this.page
+      .locator("tbody tr")
+      .filter({ has: this.page.getByText(description, { exact: true }) });
+  }
+
+  // Table column order: Description, Project Name, Version, Updated At,
+  // Quick Actions.
+  versionCell(description: string): Locator {
+    return this.deploymentRow(description).first().locator("td").nth(2);
+  }
+
+  updatedAtCell(description: string): Locator {
+    return this.deploymentRow(description).first().locator("td").nth(3);
+  }
+
+  async search(term: string) {
+    await this.searchInput.fill(term);
+  }
+
+  async clearSearch() {
+    await this.searchInput.fill("");
+  }
+
+  async openDetails(description: string) {
+    const row = this.deploymentRow(description).first();
+    // Click the description cell so the row's navigation handler fires
+    // instead of one of the Quick Actions buttons.
+    await row.getByText(description, { exact: true }).click();
+    await expect(this.detailsTitle).toBeVisible();
+  }
+
+  async editFromDetails(newDescription: string) {
+    await this.detailsEditButton.click();
+    await expect(this.editDialog).toBeVisible();
+    await this.editDescriptionInput.fill(newDescription);
+    await this.editSubmitButton.click();
+    await expect(this.deploymentUpdatedToast).toBeVisible({ timeout: 30_000 });
+    await expect(this.editDialog).toBeHidden();
+  }
+
+  async deleteFromDetails() {
+    await this.detailsDeleteButton.click();
+    const alert = this.page.getByRole("alertdialog");
+    await alert.getByRole("button", { name: "Continue" }).click();
+    await expect(this.deploymentDeletedToast).toBeVisible({ timeout: 30_000 });
+    await alert.waitFor({ state: "hidden" });
+  }
+
+  async runFromDetails() {
+    await this.detailsRunButton.click();
+    await expect(this.runDialog).toBeVisible();
+    await this.runConfirmButton.click();
+    await expect(this.deploymentExecutedToast).toBeVisible({
+      timeout: 30_000,
+    });
+  }
+
+  async createFromFile(workflowFile: string, description: string) {
+    await this.newDeploymentButton.click();
+    await expect(this.addDialog).toBeVisible();
+    // Submit needs both a valid workflow file and a description.
+    await expect(this.addDialogSubmitButton).toBeDisabled();
+    await this.addDialogFileInput.setInputFiles(workflowFile);
+    await this.addDialogDescriptionInput.fill(description);
+    await expect(this.addDialogSubmitButton).toBeEnabled();
+    await this.addDialogSubmitButton.click();
+    await expect(this.deploymentCreatedToast).toBeVisible({ timeout: 30_000 });
+    await expect(this.addDialog).toBeHidden();
+  }
+
+  private async waitForListSettled(description: string) {
+    await expect(
+      this.deploymentRow(description).first().or(this.emptyState),
+    ).toBeVisible({ timeout: 15_000 });
+  }
+
+  async deleteDeployment(description: string) {
+    const row = this.deploymentRow(description).first();
+    await row.waitFor({ state: "visible" });
+    // Quick Actions cell: Run, Edit, Delete — Delete is the last button.
+    await row.getByRole("button").last().click();
+    const alert = this.page.getByRole("alertdialog");
+    await alert.getByRole("button", { name: "Continue" }).click();
+    await alert.waitFor({ state: "hidden" });
+  }
+
+  async deleteDeploymentIfExists(description: string) {
+    for (let guard = 0; guard < 25; guard++) {
+      await this.clearSearch();
+      await this.search(description);
+      await this.waitForListSettled(description);
+      if ((await this.deploymentRow(description).count()) === 0) break;
+      await this.deleteDeployment(description);
+    }
+    await this.clearSearch();
+  }
+}

--- a/ui/e2e/pages/deploymentsPage.ts
+++ b/ui/e2e/pages/deploymentsPage.ts
@@ -137,8 +137,6 @@ export class DeploymentsPage {
 
   async openDetails(description: string) {
     const row = this.deploymentRow(description).first();
-    // Click the description cell so the row's navigation handler fires
-    // instead of one of the Quick Actions buttons.
     await row.getByText(description, { exact: true }).click();
     await expect(this.detailsTitle).toBeVisible();
   }
@@ -172,7 +170,6 @@ export class DeploymentsPage {
   async createFromFile(workflowFile: string, description: string) {
     await this.newDeploymentButton.click();
     await expect(this.addDialog).toBeVisible();
-    // Submit needs both a valid workflow file and a description.
     await expect(this.addDialogSubmitButton).toBeDisabled();
     await this.addDialogFileInput.setInputFiles(workflowFile);
     await this.addDialogDescriptionInput.fill(description);
@@ -191,7 +188,6 @@ export class DeploymentsPage {
   async deleteDeployment(description: string) {
     const row = this.deploymentRow(description).first();
     await row.waitFor({ state: "visible" });
-    // Quick Actions cell: Run, Edit, Delete — Delete is the last button.
     await row.getByRole("button").last().click();
     const alert = this.page.getByRole("alertdialog");
     await alert.getByRole("button", { name: "Continue" }).click();

--- a/ui/e2e/pages/deploymentsPage.ts
+++ b/ui/e2e/pages/deploymentsPage.ts
@@ -192,6 +192,7 @@ export class DeploymentsPage {
     const alert = this.page.getByRole("alertdialog");
     await alert.getByRole("button", { name: "Continue" }).click();
     await alert.waitFor({ state: "hidden" });
+    await expect(this.deploymentRow(description)).toHaveCount(0);
   }
 
   async deleteDeploymentIfExists(description: string) {

--- a/ui/e2e/pages/editorPage.ts
+++ b/ui/e2e/pages/editorPage.ts
@@ -20,6 +20,11 @@ export class EditorPage {
   readonly actionPicker: Locator;
   readonly paramsDialog: Locator;
   readonly confirmDialog: Locator;
+  readonly deployButton: Locator;
+  readonly deployDescriptionInput: Locator;
+  readonly deploySubmitButton: Locator;
+  readonly deploymentCreatedToast: Locator;
+  readonly deploymentUpdatedToast: Locator;
 
   constructor(private page: Page) {
     this.canvas = page.locator(".react-flow");
@@ -33,6 +38,23 @@ export class EditorPage {
       .getByRole("dialog")
       .filter({ hasText: "Action Editor" });
     this.confirmDialog = page.getByRole("alertdialog");
+    this.deployButton = page
+      .locator("#right-top > div > div")
+      .last()
+      .locator("button")
+      .first();
+    this.deployDescriptionInput = page.getByPlaceholder(
+      "Give your deployment a meaningful description...",
+    );
+    this.deploySubmitButton = page.getByRole("button", {
+      name: /^(Deploy|Update)$/,
+    });
+    this.deploymentCreatedToast = page.getByText("Deployment Created", {
+      exact: true,
+    });
+    this.deploymentUpdatedToast = page.getByText("Deployment Updated", {
+      exact: true,
+    });
   }
 
   toolButton(tool: ToolId): Locator {
@@ -232,5 +254,29 @@ export class EditorPage {
   async openSubworkflow(node: Locator) {
     await this.openNodeContextMenu(node);
     await this.contextMenuItem("Open Subworkflow").click();
+  }
+
+  async openDeployPopover() {
+    await this.deployButton.click();
+    await expect(this.deployDescriptionInput).toBeVisible();
+  }
+
+  async deploy(description: string) {
+    await this.openDeployPopover();
+    await this.deployDescriptionInput.fill(description);
+    await this.deploySubmitButton.click();
+    await expect(this.deploymentCreatedToast).toBeVisible({ timeout: 30_000 });
+    await expect(this.deployDescriptionInput).toBeHidden();
+  }
+
+  async updateDeployment(newDescription: string) {
+    await this.openDeployPopover();
+    await expect(this.deploySubmitButton).toHaveText("Update", {
+      timeout: 15_000,
+    });
+    await this.deployDescriptionInput.fill(newDescription);
+    await this.deploySubmitButton.click();
+    await expect(this.deploymentUpdatedToast).toBeVisible({ timeout: 30_000 });
+    await expect(this.deployDescriptionInput).toBeHidden();
   }
 }

--- a/ui/e2e/pages/editorPage.ts
+++ b/ui/e2e/pages/editorPage.ts
@@ -21,6 +21,7 @@ export class EditorPage {
   readonly paramsDialog: Locator;
   readonly confirmDialog: Locator;
   readonly deployButton: Locator;
+  readonly deployPopover: Locator;
   readonly deployDescriptionInput: Locator;
   readonly deploySubmitButton: Locator;
   readonly deploymentCreatedToast: Locator;
@@ -43,10 +44,13 @@ export class EditorPage {
       .last()
       .locator("button")
       .first();
-    this.deployDescriptionInput = page.getByPlaceholder(
+    this.deployPopover = page
+      .getByRole("dialog")
+      .filter({ hasText: "Deploy Project" });
+    this.deployDescriptionInput = this.deployPopover.getByPlaceholder(
       "Give your deployment a meaningful description...",
     );
-    this.deploySubmitButton = page.getByRole("button", {
+    this.deploySubmitButton = this.deployPopover.getByRole("button", {
       name: /^(Deploy|Update)$/,
     });
     this.deploymentCreatedToast = page.getByText("Deployment Created", {

--- a/ui/e2e/playwright.config.ts
+++ b/ui/e2e/playwright.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     screenshot: "only-on-failure",
     video: "retain-on-failure",
     viewport: { width: 1920, height: 1080 },
+    locale: "en-US",
   },
   projects: [
     {

--- a/ui/e2e/tests/area-calculator.spec.ts
+++ b/ui/e2e/tests/area-calculator.spec.ts
@@ -24,7 +24,7 @@ test.describe("Area calculator pipeline", { tag: "@pipeline" }, () => {
 
   test.afterEach(async () => {
     await deployments.goto();
-    await deployments.deleteDeploymentIfExists(description).catch(() => { });
+    await deployments.deleteDeploymentIfExists(description).catch(() => {});
   });
 
   test("deploys, runs to completion, and produces the park-areas artifact", async ({
@@ -41,7 +41,7 @@ test.describe("Area calculator pipeline", { tag: "@pipeline" }, () => {
     await expect(page).toHaveURL(/\/workspaces\/[^/]+\/jobs\/[^/]+$/, {
       timeout: 15_000,
     });
-    console.log("JOB_URL:", page.url());
+    test.info().annotations.push({ type: "job-url", description: page.url() });
 
     // Wait for a terminal status; engine cold start can take minutes.
     const terminalStatus = page
@@ -53,6 +53,9 @@ test.describe("Area calculator pipeline", { tag: "@pipeline" }, () => {
     // The output artifact is listed asynchronously after completion.
     const outputUrl = page.getByText(/park-areas\.geojson/).first();
     await expect(outputUrl).toBeVisible({ timeout: 90_000 });
-    console.log("OUTPUT_URL:", (await outputUrl.textContent())?.trim());
+    test.info().annotations.push({
+      type: "output-url",
+      description: (await outputUrl.textContent())?.trim() ?? "",
+    });
   });
 });

--- a/ui/e2e/tests/area-calculator.spec.ts
+++ b/ui/e2e/tests/area-calculator.spec.ts
@@ -1,0 +1,58 @@
+import * as path from "path";
+
+import { expect, test } from "@playwright/test";
+
+import {
+  DeploymentsPage,
+  uniqueDeploymentDescription,
+} from "../pages/deploymentsPage";
+
+const WORKFLOW = path.resolve(
+  __dirname,
+  "fixtures/workflows/area-calculator.yml",
+);
+
+test.describe("Area calculator pipeline", { tag: "@pipeline" }, () => {
+  let deployments: DeploymentsPage;
+  let description: string;
+
+  test.beforeEach(async ({ page }) => {
+    deployments = new DeploymentsPage(page);
+    description = uniqueDeploymentDescription("area-calc");
+    await deployments.goto();
+  });
+
+  test.afterEach(async () => {
+    await deployments.goto();
+    await deployments.deleteDeploymentIfExists(description).catch(() => { });
+  });
+
+  test("deploys, runs to completion, and produces the park-areas artifact", async ({
+    page,
+  }) => {
+    test.setTimeout(360_000);
+
+    await deployments.createFromFile(WORKFLOW, description);
+
+    await deployments.search(description);
+    await deployments.openDetails(description);
+    await deployments.runFromDetails();
+
+    await expect(page).toHaveURL(/\/workspaces\/[^/]+\/jobs\/[^/]+$/, {
+      timeout: 15_000,
+    });
+    console.log("JOB_URL:", page.url());
+
+    // Wait for a terminal status; engine cold start can take minutes.
+    const terminalStatus = page
+      .getByText(/^(completed|failed|cancelled)$/)
+      .first();
+    await expect(terminalStatus).toBeVisible({ timeout: 300_000 });
+    await expect(terminalStatus).toHaveText("completed");
+
+    // The output artifact is listed asynchronously after completion.
+    const outputUrl = page.getByText(/park-areas\.geojson/).first();
+    await expect(outputUrl).toBeVisible({ timeout: 90_000 });
+    console.log("OUTPUT_URL:", (await outputUrl.textContent())?.trim());
+  });
+});

--- a/ui/e2e/tests/deployments.spec.ts
+++ b/ui/e2e/tests/deployments.spec.ts
@@ -48,10 +48,10 @@ test.describe("Deployment lifecycle", { tag: "@regression" }, () => {
   test.afterEach(async () => {
     await deployments.goto();
     for (const description of deploymentDescriptions) {
-      await deployments.deleteDeploymentIfExists(description).catch(() => { });
+      await deployments.deleteDeploymentIfExists(description).catch(() => {});
     }
     await projects.goto();
-    await projects.deleteProjectIfExists(projectName).catch(() => { });
+    await projects.deleteProjectIfExists(projectName).catch(() => {});
   });
 
   test("deploys a workflow and it appears in the Deployments table with correct metadata", async () => {
@@ -214,15 +214,19 @@ test.describe("Deployment lifecycle", { tag: "@regression" }, () => {
       page.getByText(/^(queued|running|completed|failed|cancelled)$/).first(),
     ).toBeVisible({ timeout: 15_000 });
 
+    // Cancel the job so it does not keep consuming the shared dev engine.
+    // The button only renders while the job is queued/running.
     const cancelJob = page.getByRole("button", { name: "Cancel Job" });
-    await cancelJob
-      .click({ timeout: 10_000 })
-      .then(() =>
-        expect(page.getByText("Job Cancelled", { exact: true })).toBeVisible({
-          timeout: 15_000,
-        }),
-      )
-      .catch(() => { });
+    const canCancel = await cancelJob
+      .waitFor({ state: "visible", timeout: 10_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (canCancel) {
+      await cancelJob.click();
+      await expect(
+        page.getByText("Job Cancelled", { exact: true }),
+      ).toBeVisible({ timeout: 15_000 });
+    }
   });
 });
 
@@ -240,7 +244,7 @@ test.describe("Deployment from file upload", { tag: "@regression" }, () => {
     await deployments.goto();
     await deployments
       .deleteDeploymentIfExists(deploymentDescription)
-      .catch(() => { });
+      .catch(() => {});
   });
 
   test("creates a deployment from an uploaded workflow file", async () => {

--- a/ui/e2e/tests/deployments.spec.ts
+++ b/ui/e2e/tests/deployments.spec.ts
@@ -1,0 +1,258 @@
+import * as path from "path";
+
+import { expect, test } from "@playwright/test";
+
+import {
+  DeploymentsPage,
+  uniqueDeploymentDescription,
+} from "../pages/deploymentsPage";
+import { EditorPage } from "../pages/editorPage";
+import { ProjectsPage, uniqueProjectName } from "../pages/projectsPage";
+
+const WORKFLOW_FIXTURE = path.resolve(
+  __dirname,
+  "fixtures/sample-workflow.json",
+);
+
+test.describe("Deployment lifecycle", { tag: "@regression" }, () => {
+  test.describe.configure({ timeout: 150_000 });
+
+  let projects: ProjectsPage;
+  let editor: EditorPage;
+  let deployments: DeploymentsPage;
+  let projectName: string;
+  let deploymentDescription: string;
+  let deploymentDescriptions: string[];
+
+  const newDeploymentDescription = (label?: string) => {
+    const description = uniqueDeploymentDescription(label);
+    deploymentDescriptions.push(description);
+    return description;
+  };
+
+  test.beforeEach(async ({ page }) => {
+    projects = new ProjectsPage(page);
+    editor = new EditorPage(page);
+    deployments = new DeploymentsPage(page);
+    projectName = uniqueProjectName("deployment");
+    deploymentDescriptions = [];
+    deploymentDescription = newDeploymentDescription();
+
+    await projects.goto();
+    await projects.createProject(projectName, "created by e2e deployment test");
+    await projects.search(projectName);
+    await projects.openProject(projectName);
+    await editor.waitForLoaded();
+  });
+
+  test.afterEach(async () => {
+    await deployments.goto();
+    for (const description of deploymentDescriptions) {
+      await deployments.deleteDeploymentIfExists(description).catch(() => { });
+    }
+    await projects.goto();
+    await projects.deleteProjectIfExists(projectName).catch(() => { });
+  });
+
+  test("deploys a workflow and it appears in the Deployments table with correct metadata", async () => {
+    await editor.addActionNode(
+      "transformer",
+      await editor.canvasPoint(0.5, 0.5),
+    );
+
+    await editor.deploy(deploymentDescription);
+
+    await deployments.goto();
+    await deployments.search(deploymentDescription);
+
+    const row = deployments.deploymentRow(deploymentDescription);
+    await expect(row).toHaveCount(1);
+    await expect(row).toContainText(projectName);
+    await expect(deployments.versionCell(deploymentDescription)).toHaveText(
+      "v1",
+    );
+    await expect(deployments.updatedAtCell(deploymentDescription)).toHaveText(
+      /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+    );
+  });
+
+  test("re-deploying the same project updates the deployment and bumps the version", async () => {
+    await editor.addActionNode(
+      "transformer",
+      await editor.canvasPoint(0.5, 0.5),
+    );
+    await editor.deploy(deploymentDescription);
+
+    const updatedDescription = newDeploymentDescription("update");
+    await editor.updateDeployment(updatedDescription);
+
+    await deployments.goto();
+    await deployments.search(updatedDescription);
+
+    const row = deployments.deploymentRow(updatedDescription);
+    await expect(row).toHaveCount(1);
+    await expect(row).toContainText(projectName);
+    await expect(deployments.versionCell(updatedDescription)).toHaveText("v2");
+    await deployments.search(deploymentDescription);
+    await expect(deployments.emptyState).toBeVisible();
+  });
+
+  test("shows deployment details and navigates back to the list", async ({
+    page,
+  }) => {
+    await editor.addActionNode(
+      "transformer",
+      await editor.canvasPoint(0.5, 0.5),
+    );
+    await editor.deploy(deploymentDescription);
+
+    await deployments.goto();
+    await deployments.search(deploymentDescription);
+    await deployments.openDetails(deploymentDescription);
+
+    await expect(page).toHaveURL(/\/workspaces\/[^/]+\/deployments\/[^/]+$/);
+    await expect(
+      page.getByText(deploymentDescription, { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText(projectName, { exact: true })).toBeVisible();
+    await expect(page.getByText("v1", { exact: true })).toBeVisible();
+    await expect(deployments.detailsRunButton).toBeVisible();
+    await expect(deployments.detailsEditButton).toBeVisible();
+    await expect(deployments.detailsDeleteButton).toBeVisible();
+
+    await page.goBack();
+    await deployments.waitForLoaded();
+  });
+
+  test("edits the deployment description from the details view", async ({
+    page,
+  }) => {
+    await editor.addActionNode(
+      "transformer",
+      await editor.canvasPoint(0.5, 0.5),
+    );
+    await editor.deploy(deploymentDescription);
+
+    await deployments.goto();
+    await deployments.search(deploymentDescription);
+    await deployments.openDetails(deploymentDescription);
+
+    await deployments.detailsEditButton.click();
+    await expect(deployments.editDialog).toBeVisible();
+    await expect(deployments.editDescriptionInput).toHaveValue(
+      deploymentDescription,
+    );
+    await expect(deployments.editSubmitButton).toBeDisabled();
+
+    const updatedDescription = newDeploymentDescription("edit");
+    await deployments.editDescriptionInput.fill(updatedDescription);
+    await expect(deployments.editSubmitButton).toBeEnabled();
+    await deployments.editSubmitButton.click();
+    await expect(deployments.deploymentUpdatedToast).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // Verify the rename through the table.
+    await page.goBack();
+    await deployments.waitForLoaded();
+    await deployments.search(updatedDescription);
+    await expect(deployments.deploymentRow(updatedDescription)).toHaveCount(1);
+    await deployments.search(deploymentDescription);
+    await expect(deployments.emptyState).toBeVisible();
+  });
+
+  test("deletes a deployment from the details view", async () => {
+    await editor.addActionNode(
+      "transformer",
+      await editor.canvasPoint(0.5, 0.5),
+    );
+    await editor.deploy(deploymentDescription);
+
+    await deployments.goto();
+    await deployments.search(deploymentDescription);
+    await deployments.openDetails(deploymentDescription);
+
+    await deployments.deleteFromDetails();
+
+    await deployments.waitForLoaded();
+    await deployments.search(deploymentDescription);
+    await expect(deployments.emptyState).toBeVisible();
+  });
+
+  test("disables the deploy submit button until a description is entered", async () => {
+    await editor.openDeployPopover();
+    await expect(editor.deploySubmitButton).toBeDisabled();
+
+    await editor.deployDescriptionInput.fill(deploymentDescription);
+    await expect(editor.deploySubmitButton).toBeEnabled();
+
+    await editor.deployDescriptionInput.fill("   ");
+    await expect(editor.deploySubmitButton).toBeDisabled();
+  });
+
+  test("runs a deployment and a job is created for it", async ({ page }) => {
+    await editor.addActionNode(
+      "transformer",
+      await editor.canvasPoint(0.5, 0.5),
+    );
+    await editor.deploy(deploymentDescription);
+
+    await deployments.goto();
+    await deployments.search(deploymentDescription);
+    await deployments.openDetails(deploymentDescription);
+
+    await deployments.runFromDetails();
+
+    await expect(page).toHaveURL(/\/workspaces\/[^/]+\/jobs\/[^/]+$/, {
+      timeout: 15_000,
+    });
+    await expect(page.getByText("Job Details", { exact: true })).toBeVisible();
+    await expect(
+      page.getByText(deploymentDescription, { exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByText(/^(queued|running|completed|failed|cancelled)$/).first(),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const cancelJob = page.getByRole("button", { name: "Cancel Job" });
+    await cancelJob
+      .click({ timeout: 10_000 })
+      .then(() =>
+        expect(page.getByText("Job Cancelled", { exact: true })).toBeVisible({
+          timeout: 15_000,
+        }),
+      )
+      .catch(() => { });
+  });
+});
+
+test.describe("Deployment from file upload", { tag: "@regression" }, () => {
+  let deployments: DeploymentsPage;
+  let deploymentDescription: string;
+
+  test.beforeEach(async ({ page }) => {
+    deployments = new DeploymentsPage(page);
+    deploymentDescription = uniqueDeploymentDescription("file");
+    await deployments.goto();
+  });
+
+  test.afterEach(async () => {
+    await deployments.goto();
+    await deployments
+      .deleteDeploymentIfExists(deploymentDescription)
+      .catch(() => { });
+  });
+
+  test("creates a deployment from an uploaded workflow file", async () => {
+    await deployments.createFromFile(WORKFLOW_FIXTURE, deploymentDescription);
+
+    await deployments.search(deploymentDescription);
+
+    const row = deployments.deploymentRow(deploymentDescription);
+    await expect(row).toHaveCount(1);
+
+    await expect(deployments.versionCell(deploymentDescription)).toHaveText(
+      "v0",
+    );
+  });
+});

--- a/ui/e2e/tests/fixtures/sample-workflow.json
+++ b/ui/e2e/tests/fixtures/sample-workflow.json
@@ -10,23 +10,38 @@
         {
           "id": "11111111-1111-4111-8111-111111111111",
           "name": "Create Features",
-          "type": "source",
+          "type": "action",
           "action": "FeatureCreator",
           "with": {
-            "creator": "[{ value: 1 }]"
+            "creator": "[#{ name: \"alpha\", value: 10 }, #{ name: \"beta\", value: 25 }, #{ name: \"gamma\", value: 40 }]"
           }
         },
         {
           "id": "22222222-2222-4222-8222-222222222222",
           "name": "Manage Attributes",
-          "type": "processor",
-          "action": "AttributeManager"
+          "type": "action",
+          "action": "AttributeManager",
+          "with": {
+            "operations": [
+              {
+                "attribute": "doubledValue",
+                "method": "create",
+                "value": {
+                  "type": "flowExpr",
+                  "value": "attributes[\"value\"] * 2"
+                }
+              }
+            ]
+          }
         },
         {
           "id": "33333333-3333-4333-8333-333333333333",
-          "name": "Discard Output",
-          "type": "sink",
-          "action": "NoopSink"
+          "name": "Write Output",
+          "type": "action",
+          "action": "JsonWriter",
+          "with": {
+            "output": "file::join_path(env.get(\"workerArtifactPath\"), \"result.json\")"
+          }
         }
       ],
       "edges": [

--- a/ui/e2e/tests/fixtures/workflows/area-calculator.yml
+++ b/ui/e2e/tests/fixtures/workflows/area-calculator.yml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/workflow.json
+#   GeoJsonReader ──> AreaCalculator ──> GeoJsonWriter
+#
+id: 7efa24a6-19fa-4be1-8f5b-7e5e14b6e551
+name: "Area Calculator"
+entryGraphId: dfb479fd-caf1-48c6-beff-257262ebb59d
+with:
+  # Injected by the worker at runtime; points at the job's artifact sandbox.
+  workerArtifactPath: null
+  parks: |
+    {"type":"FeatureCollection","features":[
+      {"type":"Feature","properties":{"name":"Imperial Palace East Gardens"},"geometry":{"type":"Polygon","coordinates":[[[139.7528,35.6838],[139.7628,35.6838],[139.7628,35.6919],[139.7528,35.6919],[139.7528,35.6838]]]}},
+      {"type":"Feature","properties":{"name":"Yoyogi Park"},"geometry":{"type":"Polygon","coordinates":[[[139.6929,35.6664],[139.7010,35.6664],[139.7010,35.6751],[139.6929,35.6751],[139.6929,35.6664]]]}},
+      {"type":"Feature","properties":{"name":"Ueno Park"},"geometry":{"type":"Polygon","coordinates":[[[139.7702,35.7110],[139.7774,35.7110],[139.7774,35.7196],[139.7702,35.7196],[139.7702,35.7110]]]}}
+    ]}
+graphs:
+  - id: dfb479fd-caf1-48c6-beff-257262ebb59d
+    name: main
+    nodes:
+      - id: 975a786f-5738-48a1-8666-8e7ecf38cb93
+        name: Read Park Boundaries
+        type: action
+        action: GeoJsonReader
+        with:
+          inline: |
+            env.get("parks")
+
+      - id: 854740f8-8159-480c-80c1-b0b7596a03f2
+        name: Calculate Area
+        type: action
+        action: AreaCalculator
+        with:
+          areaType: planeArea
+          # Coordinates are EPSG:4326 degrees, so the raw planar area is in
+          # square degrees. Near Tokyo (35.7°N) one square degree is roughly
+          # 1.0029e10 m², so this multiplier converts to approximate m².
+          multiplier: 10029000000.0
+          outputAttribute: areaSqm
+
+      - id: a287e65d-e503-40cb-9188-5edf1d0e263b
+        name: Write Park Areas
+        type: action
+        action: GeoJsonWriter
+        with:
+          output: |
+            file::join_path(env.get("workerArtifactPath"), "park-areas.geojson")
+
+    edges:
+      - id: f5fe8722-2c01-4227-a61a-5d5a91071fd2
+        from: 975a786f-5738-48a1-8666-8e7ecf38cb93
+        to: 854740f8-8159-480c-80c1-b0b7596a03f2
+        fromPort: default
+        toPort: default
+      - id: c81306e8-a0c5-4c6f-bf25-a5e4821dc2f4
+        from: 854740f8-8159-480c-80c1-b0b7596a03f2
+        to: a287e65d-e503-40cb-9188-5edf1d0e263b
+        fromPort: default
+        toPort: default


### PR DESCRIPTION
# Overview

## What I've done

- Cover the deployment lifecycle: deploy, re-deploy/version bump, details view, edit, delete, run-to-job, and create-from-file upload
- Add area-calculator workflow (GeoJsonReader -> AreaCalculator -> GeoJsonWriter) with a @pipeline test that runs it on the engine and waits for a terminal status and output artifact.
- Fix sample-workflow.json to the engine format (type: action, Rhai map syntax, JsonWriter sink) so it actually executes instead of failing at runtime 
- Pin Playwright locale to en-US

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
