### PR TITLE
chore: add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,23 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: reearth-flow
+  namespace: reearth
+  description: DAG workflow execution engine for geospatial data (Rust engine + Go
+    GraphQL server + React UI)
+  annotations:
+    github.com/project-slug: reearth/reearth-flow
+  links:
+  - url: https://github.com/reearth/reearth-flow
+    title: GitHub
+    icon: github
+  tags:
+  - rust
+  - go
+  - react
+  - workflow
+  - dag
+spec:
+  type: service
+  lifecycle: production
+  owner: reearth/flow


### PR DESCRIPTION
Registers this repo in Eukarya's internal developer portal (Backstage). Backstage auto-discovers this file from the default branch once merged.

- **Component:** `reearth-flow` (namespace `reearth`)
- **Owner:** `reearth/flow`
- **Type / lifecycle:** `service` / `production`

Owner and type were inferred from GitHub team ownership and repo metadata — please edit `spec.owner` / `spec.type` in the file if they're off.

Part of the org-wide Backstage catalog rollout.