### PR TITLE
refactor(engine): migrate `AttributeMapper` to FlowExpr

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.378"
+version = "0.0.379"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.378"
+version = "0.0.379"
 
 [profile.dev]
 opt-level = 0

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -695,8 +695,27 @@ Transform Feature Attributes Using Expressions and Mappings
     }
   },
   "definitions": {
-    "Expr": {
-      "type": "string"
+    "Code": {
+      "type": "object",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/CodeType"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "CodeType": {
+      "type": "string",
+      "enum": [
+        "flowExpr",
+        "string"
+      ]
     },
     "Mapper": {
       "type": "object",
@@ -719,7 +738,7 @@ Transform Feature Attributes Using Expressions and Mappings
           "title": "Expression to evaluate",
           "anyOf": [
             {
-              "$ref": "#/definitions/Expr"
+              "$ref": "#/definitions/Code"
             },
             {
               "type": "null"
@@ -730,7 +749,7 @@ Transform Feature Attributes Using Expressions and Mappings
           "title": "Expression to evaluate multiple attributes",
           "anyOf": [
             {
-              "$ref": "#/definitions/Expr"
+              "$ref": "#/definitions/Code"
             },
             {
               "type": "null"

--- a/engine/runtime/action-processor/src/attribute/mapper.rs
+++ b/engine/runtime/action-processor/src/attribute/mapper.rs
@@ -166,15 +166,22 @@ impl Processor for AttributeMapper {
             match &mapper.attribute {
                 Some(attribute) => {
                     if let Some(expr) = &mapper.expr {
-                        let new_value = expr
-                            .eval(feature, Arc::clone(&env_vars))
-                            .unwrap_or(AttributeValue::Null);
+                        let new_value = match expr.eval(feature, Arc::clone(&env_vars)) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to evaluate expr for attribute `{attribute}`: {e:?}"
+                                );
+                                AttributeValue::Null
+                            }
+                        };
                         attributes.insert(Attribute::new(attribute.clone()), new_value);
                         continue;
                     } else if let Some(value_attribute) = &mapper.value_attribute {
                         if let Some(value) = feature.get(value_attribute) {
                             attributes.insert(Attribute::new(attribute.clone()), value.clone());
                         } else {
+                            tracing::error!("value_attribute `{value_attribute}` not found in feature for attribute `{attribute}`");
                             attributes
                                 .insert(Attribute::new(attribute.clone()), AttributeValue::Null);
                         }
@@ -191,14 +198,22 @@ impl Processor for AttributeMapper {
                 }
                 None => {
                     if let Some(multiple_expr) = &mapper.multiple_expr {
-                        if let Ok(AttributeValue::Map(new_value)) =
-                            multiple_expr.eval(feature, Arc::clone(&env_vars))
-                        {
-                            attributes.extend(
-                                new_value
-                                    .iter()
-                                    .map(|(k, v)| (Attribute::new(k.clone()), v.clone())),
-                            );
+                        match multiple_expr.eval(feature, Arc::clone(&env_vars)) {
+                            Err(e) => {
+                                tracing::error!("Failed to evaluate multiple_expr: {e:?}");
+                            }
+                            Ok(AttributeValue::Map(new_value)) => {
+                                attributes.extend(
+                                    new_value
+                                        .iter()
+                                        .map(|(k, v)| (Attribute::new(k.clone()), v.clone())),
+                                );
+                            }
+                            Ok(other) => {
+                                tracing::error!(
+                                    "multiple_expr did not produce a Map, got: {other:?}"
+                                );
+                            }
                         }
                     }
                 }

--- a/engine/runtime/action-processor/src/attribute/mapper.rs
+++ b/engine/runtime/action-processor/src/attribute/mapper.rs
@@ -8,8 +8,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
 };
-use reearth_flow_types::{Attribute, AttributeValue, Expr};
-use rhai::Dynamic;
+use reearth_flow_types::{Attribute, AttributeValue, Code, CompiledCode};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -50,12 +49,12 @@ impl ProcessorFactory for AttributeMapperFactory {
 
     fn build(
         &self,
-        ctx: NodeContext,
+        _ctx: NodeContext,
         _event_hub: EventHub,
         _action: String,
         with: Option<HashMap<String, Value>>,
     ) -> Result<Box<dyn Processor>, BoxedError> {
-        let params: AttributeMapperParam = if let Some(with) = with.clone() {
+        let params: AttributeMapperParam = if let Some(with) = with {
             let value: Value = serde_json::to_value(with).map_err(|e| {
                 AttributeProcessorError::MapperFactory(format!(
                     "Failed to serialize `with` parameter: {e}"
@@ -72,13 +71,11 @@ impl ProcessorFactory for AttributeMapperFactory {
             )
             .into());
         };
-        let expr_engine = Arc::clone(&ctx.expr_engine);
         let mut mappers = Vec::<CompiledMapper>::new();
         for mapper in &params.mappers {
             let expr = if let Some(expr) = &mapper.expr {
                 Some(
-                    expr_engine
-                        .compile(expr.as_ref())
+                    expr.compile()
                         .map_err(|e| AttributeProcessorError::MapperFactory(format!("{e:?}")))?,
                 )
             } else {
@@ -86,8 +83,8 @@ impl ProcessorFactory for AttributeMapperFactory {
             };
             let multiple_expr = if let Some(multiple_expr) = &mapper.multiple_expr {
                 Some(
-                    expr_engine
-                        .compile(multiple_expr.as_ref())
+                    multiple_expr
+                        .compile()
                         .map_err(|e| AttributeProcessorError::MapperFactory(format!("{e:?}")))?,
                 )
             } else {
@@ -104,7 +101,6 @@ impl ProcessorFactory for AttributeMapperFactory {
         }
 
         let processor = AttributeMapper {
-            global_params: with,
             mapper: CompiledAttributeMapperParam { mappers },
         };
         Ok(Box::new(processor))
@@ -126,7 +122,7 @@ struct Mapper {
     /// # Attribute name
     attribute: Option<String>,
     /// # Expression to evaluate
-    expr: Option<Expr>,
+    expr: Option<Code>,
     /// # Attribute name to get value from
     value_attribute: Option<String>,
     /// # Parent attribute name
@@ -134,7 +130,7 @@ struct Mapper {
     /// # Child attribute name
     child_attribute: Option<String>,
     /// # Expression to evaluate multiple attributes
-    multiple_expr: Option<Expr>,
+    multiple_expr: Option<Code>,
 }
 
 #[derive(Debug, Clone)]
@@ -145,16 +141,15 @@ struct CompiledAttributeMapperParam {
 #[derive(Debug, Clone)]
 struct CompiledMapper {
     attribute: Option<String>,
-    expr: Option<rhai::AST>,
+    expr: Option<CompiledCode>,
     value_attribute: Option<String>,
     parent_attribute: Option<String>,
     child_attribute: Option<String>,
-    multiple_expr: Option<rhai::AST>,
+    multiple_expr: Option<CompiledCode>,
 }
 
 #[derive(Debug, Clone)]
 pub struct AttributeMapper {
-    global_params: Option<HashMap<String, serde_json::Value>>,
     mapper: CompiledAttributeMapperParam,
 }
 
@@ -165,27 +160,16 @@ impl Processor for AttributeMapper {
         fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
         let feature = &ctx.feature;
-        let expr_engine = Arc::clone(&ctx.expr_engine);
+        let env_vars = ctx.expr_engine.vars();
         let mut attributes = IndexMap::<Attribute, AttributeValue>::new();
-        let scope = feature.new_scope(expr_engine.clone(), &self.global_params);
         for mapper in &self.mapper.mappers {
             match &mapper.attribute {
                 Some(attribute) => {
                     if let Some(expr) = &mapper.expr {
-                        let new_value = scope.eval_ast::<Dynamic>(expr);
-                        if let Ok(new_value) = new_value {
-                            if let Ok(new_value) = new_value.try_into() {
-                                attributes.insert(Attribute::new(attribute.clone()), new_value);
-                            } else {
-                                attributes.insert(
-                                    Attribute::new(attribute.clone()),
-                                    AttributeValue::Null,
-                                );
-                            }
-                        } else {
-                            attributes
-                                .insert(Attribute::new(attribute.clone()), AttributeValue::Null);
-                        }
+                        let new_value = expr
+                            .eval(feature, Arc::clone(&env_vars))
+                            .unwrap_or(AttributeValue::Null);
+                        attributes.insert(Attribute::new(attribute.clone()), new_value);
                         continue;
                     } else if let Some(value_attribute) = &mapper.value_attribute {
                         if let Some(value) = feature.get(value_attribute) {
@@ -207,17 +191,14 @@ impl Processor for AttributeMapper {
                 }
                 None => {
                     if let Some(multiple_expr) = &mapper.multiple_expr {
-                        let new_value = scope.eval_ast::<Dynamic>(multiple_expr);
-                        if let Ok(new_value) = new_value {
-                            if new_value.is::<rhai::Map>() {
-                                if let Ok(AttributeValue::Map(new_value)) = new_value.try_into() {
-                                    attributes.extend(
-                                        new_value
-                                            .iter()
-                                            .map(|(k, v)| (Attribute::new(k.clone()), v.clone())),
-                                    );
-                                }
-                            }
+                        if let Ok(AttributeValue::Map(new_value)) =
+                            multiple_expr.eval(feature, Arc::clone(&env_vars))
+                        {
+                            attributes.extend(
+                                new_value
+                                    .iter()
+                                    .map(|(k, v)| (Attribute::new(k.clone()), v.clone())),
+                            );
                         }
                     }
                 }

--- a/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
@@ -102,17 +102,11 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["index"]
+          valueAttribute: index
         - attribute: Folder
-          expr:
-            type: flowExpr
-            value: attributes["udxDirs"]
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["name"]
+          valueAttribute: name
         # - attribute: line
         #   expr: attributes["xmlError"][0]["line"]
         # - attribute: col
@@ -142,17 +136,11 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["index"]
+          valueAttribute: index
         - attribute: Folder
-          expr:
-            type: flowExpr
-            value: attributes["udxDirs"]
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["name"]
+          valueAttribute: name
         - attribute: line
           expr:
             type: flowExpr
@@ -209,13 +197,9 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["index"]
+          valueAttribute: index
         - attribute: Folder
-          expr:
-            type: flowExpr
-            value: attributes["udxDirs"]
+          valueAttribute: udxDirs
         - attribute: Filename
           expr:
             type: flowExpr
@@ -234,33 +218,29 @@ nodes:
                 "Over"
               }
         - attribute: "XML検証結果"
-          expr:
-            type: flowExpr
-            value: attributes["status"]
+          valueAttribute: status
         - attribute: "L01エラー"
           expr:
             type: flowExpr
-            value: attributes["L01Errors"]
+            value: attributes.get("L01Errors", 0)
         - attribute: "L02エラー"
           expr:
             type: flowExpr
-            value: attributes["L02Errors"]
+            value: attributes.get("L02Errors", 0)
         - attribute: "L03エラー"
           expr:
             type: flowExpr
-            value: attributes["invalidFeatureTypesNum"]
+            value: attributes.get("invalidFeatureTypesNum", 0)
         - attribute: "L03エラー詳細"
-          expr:
-            type: flowExpr
-            value: attributes["invalidFeatureTypesDetail"]
+          valueAttribute: invalidFeatureTypesDetail
         - attribute: "L04エラー"
           expr:
             type: flowExpr
-            value: attributes["inCorrectCodeValue"]
+            value: attributes.get("inCorrectCodeValue", 0)
         - attribute: "不正なcodeSpace数"
           expr:
             type: flowExpr
-            value: attributes["inCorrectCodeSpace"]
+            value: attributes.get("inCorrectCodeSpace", 0)
         - attribute: "L05CRS識別子"
           expr:
             type: flowExpr
@@ -282,27 +262,25 @@ nodes:
         - attribute: "L06エラー"
           expr:
             type: flowExpr
-            value: attributes["inCorrectExtents"]
+            value: attributes.get("inCorrectExtents", 0)
         - attribute: "T03エラー"
           expr:
             type: flowExpr
-            value: attributes["xlinkInvalidObjectType"]
+            value: attributes.get("xlinkInvalidObjectType", 0)
         - attribute: "xlink参照先なし"
           expr:
             type: flowExpr
-            value: attributes["xlinkHasNoReference"]
+            value: attributes.get("xlinkHasNoReference", 0)
         - attribute: "gml:id重複"
-          expr:
-            type: flowExpr
-            value: attributes["duplicateGmlIdCount"]
+          valueAttribute: duplicateGmlIdCount
         - attribute: "gml:id書式不正"
           expr:
             type: flowExpr
-            value: attributes["gmlIdNotWellformed"]
+            value: attributes.get("gmlIdNotWellformed", 0)
         - attribute: "L-frn-01エラー"
           expr:
             type: flowExpr
-            value: attributes["invalidLodXGeometry"]
+            value: attributes.get("invalidLodXGeometry", 0)
         - attribute: "補足"
           expr:
             type: flowExpr
@@ -401,25 +379,15 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["index"]
+          valueAttribute: index
         - attribute: Folder
-          expr:
-            type: flowExpr
-            value: attributes["udxDirs"]
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["name"]
+          valueAttribute: name
         - attribute: XML Tag
-          expr:
-            type: flowExpr
-            value: attributes["tag"]
+          valueAttribute: tag
         - attribute: gml:id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
 
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
@@ -437,25 +405,15 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["index"]
+          valueAttribute: index
         - attribute: Folder
-          expr:
-            type: flowExpr
-            value: attributes["udxDirs"]
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["name"]
+          valueAttribute: name
         - attribute: XML Tag
-          expr:
-            type: flowExpr
-            value: attributes["tag"]
+          valueAttribute: tag
         - attribute: gml:id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
 
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
@@ -473,73 +431,41 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["index"]
+          valueAttribute: index
         - attribute: Folder
-          expr:
-            type: flowExpr
-            value: attributes["udxDirs"]
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["name"]
+          valueAttribute: name
         - attribute: gml:id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         # min
         - attribute: Min Latitude
-          expr:
-            type: flowExpr
-            value: attributes["minLatitude"]
+          valueAttribute: minLatitude
         - attribute: Min Longitude
-          expr:
-            type: flowExpr
-            value: attributes["minLongitude"]
+          valueAttribute: minLongitude
         - attribute: Min Elevation
-          expr:
-            type: flowExpr
-            value: attributes["minElevation"]
+          valueAttribute: minElevation
         # max
         - attribute: Max Latitude
-          expr:
-            type: flowExpr
-            value: attributes["maxLatitude"]
+          valueAttribute: maxLatitude
         - attribute: Max Longitude
-          expr:
-            type: flowExpr
-            value: attributes["maxLongitude"]
+          valueAttribute: maxLongitude
         - attribute: Max Elevation
-          expr:
-            type: flowExpr
-            value: attributes["maxElevation"]
+          valueAttribute: maxElevation
         # lower
         - attribute: Lower Latitude
-          expr:
-            type: flowExpr
-            value: attributes["lowerLatitude"]
+          valueAttribute: lowerLatitude
         - attribute: Lower Longitude
-          expr:
-            type: flowExpr
-            value: attributes["lowerLongitude"]
+          valueAttribute: lowerLongitude
         - attribute: Lower Elevation
-          expr:
-            type: flowExpr
-            value: attributes["lowerElevation"]
+          valueAttribute: lowerElevation
         # upper
         - attribute: Upper Latitude
-          expr:
-            type: flowExpr
-            value: attributes["upperLatitude"]
+          valueAttribute: upperLatitude
         - attribute: Upper Longitude
-          expr:
-            type: flowExpr
-            value: attributes["upperLongitude"]
+          valueAttribute: upperLongitude
         - attribute: Upper Elevation
-          expr:
-            type: flowExpr
-            value: attributes["upperElevation"]
+          valueAttribute: upperElevation
 
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
@@ -557,37 +483,21 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["index"]
+          valueAttribute: index
         - attribute: Folder
-          expr:
-            type: flowExpr
-            value: attributes["udxDirs"]
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["name"]
+          valueAttribute: name
         - attribute: gml:id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: XML Tag
-          expr:
-            type: flowExpr
-            value: attributes["tag"]
+          valueAttribute: tag
         - attribute: XPath
-          expr:
-            type: flowExpr
-            value: attributes["xpath"]
+          valueAttribute: xpath
         - attribute: CodeSpace
-          expr:
-            type: flowExpr
-            value: attributes["codeSpace"]
+          valueAttribute: codeSpace
         - attribute: Code
-          expr:
-            type: flowExpr
-            value: attributes["codeSpaceValue"]
+          valueAttribute: codeSpaceValue
 
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
@@ -605,37 +515,21 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["index"]
+          valueAttribute: index
         - attribute: Folder
-          expr:
-            type: flowExpr
-            value: attributes["udxDirs"]
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["name"]
+          valueAttribute: name
         - attribute: FeatureType
-          expr:
-            type: flowExpr
-            value: attributes["featureType"]
+          valueAttribute: featureType
         - attribute: XPath
-          expr:
-            type: flowExpr
-            value: attributes["xpath"]
+          valueAttribute: xpath
         - attribute: XML Tag
-          expr:
-            type: flowExpr
-            value: attributes["tag"]
+          valueAttribute: tag
         - attribute: gml:id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: CodeSpace
-          expr:
-            type: flowExpr
-            value: attributes["codeSpace"]
+          valueAttribute: codeSpace
 
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
@@ -676,29 +570,17 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["index"]
+          valueAttribute: index
         - attribute: Folder
-          expr:
-            type: flowExpr
-            value: attributes["udxDirs"]
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["name"]
+          valueAttribute: name
         - attribute: XPath
-          expr:
-            type: flowExpr
-            value: attributes["xpath"]
+          valueAttribute: xpath
         - attribute: XML Tag
-          expr:
-            type: flowExpr
-            value: attributes["tag"]
+          valueAttribute: tag
         - attribute: xlink:href
-          expr:
-            type: flowExpr
-            value: attributes["xlinkHref"]
+          valueAttribute: xlinkHref
 
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
@@ -716,41 +598,23 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["index"]
+          valueAttribute: index
         - attribute: Folder
-          expr:
-            type: flowExpr
-            value: attributes["udxDirs"]
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["name"]
+          valueAttribute: name
         - attribute: XPath
-          expr:
-            type: flowExpr
-            value: attributes["xpath"]
+          valueAttribute: xpath
         - attribute: XML Tag
-          expr:
-            type: flowExpr
-            value: attributes["tag"]
+          valueAttribute: tag
         - attribute: xlink:href
-          expr:
-            type: flowExpr
-            value: attributes["xlinkHref"]
+          valueAttribute: xlinkHref
         - attribute: ref XPath
-          expr:
-            type: flowExpr
-            value: attributes["refGmlXpath"]
+          valueAttribute: refGmlXpath
         - attribute: ref Tag
-          expr:
-            type: flowExpr
-            value: attributes["refGmlTag"]
+          valueAttribute: refGmlTag
         - attribute: ref gml:id
-          expr:
-            type: flowExpr
-            value: attributes["refGmlId"]
+          valueAttribute: refGmlId
 
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
@@ -768,29 +632,19 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["index"]
+          valueAttribute: index
         - attribute: Folder
-          expr:
-            type: flowExpr
-            value: attributes["udxDirs"]
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["name"]
+          valueAttribute: name
         - attribute: FeatureType
           expr:
             type: flowExpr
-            value: attributes["parentTag"]
+            value: attributes.get("parentTag", attributes["featureType"])
         - attribute: gml:id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: InvalidGeometry
-          expr:
-            type: flowExpr
-            value: attributes["invalidGeometry"]
+          valueAttribute: invalidGeometry
 
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry

--- a/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
@@ -223,12 +223,12 @@ nodes:
         - attribute: "サイズ[KB]"
           expr:
             type: flowExpr
-            value: attributes["fileSize"] / 1024
+            value: attributes["fileSize"] // 1024
         - attribute: "1GB以下"
           expr:
             type: flowExpr
             value: |
-              if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
                 "OK"
               } else {
                 "Over"

--- a/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
@@ -102,19 +102,29 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          expr:
+            type: flowExpr
+            value: attributes["index"]
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Filename
-          expr: env.get("__value").name
+          expr:
+            type: flowExpr
+            value: attributes["name"]
         # - attribute: line
-        #   expr: env.get("__value").xmlError[0].line
+        #   expr: attributes["xmlError"][0]["line"]
         # - attribute: col
-        #   expr: env.get("__value").xmlError[0].col
+        #   expr: attributes["xmlError"][0]["col"]
         - attribute: type
-          expr: env.get("__value").xmlError[0].errorType
+          expr:
+            type: flowExpr
+            value: attributes["xmlError"][0]["errorType"]
         - attribute: desc
-          expr: env.get("__value").xmlError[0].message
+          expr:
+            type: flowExpr
+            value: attributes["xmlError"][0]["message"]
 
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
@@ -132,19 +142,31 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          expr:
+            type: flowExpr
+            value: attributes["index"]
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Filename
-          expr: env.get("__value").name
+          expr:
+            type: flowExpr
+            value: attributes["name"]
         - attribute: line
-          expr: env.get("__value").xmlError[0].line
+          expr:
+            type: flowExpr
+            value: attributes["xmlError"][0]["line"]
         # - attribute: col
-        #   expr: env.get("__value").xmlError[0].col
+        #   expr: attributes["xmlError"][0]["col"]
         - attribute: type
-          expr: env.get("__value").xmlError[0].errorType
+          expr:
+            type: flowExpr
+            value: attributes["xmlError"][0]["errorType"]
         - attribute: desc
-          expr: env.get("__value").xmlError[0].message
+          expr:
+            type: flowExpr
+            value: attributes["xmlError"][0]["message"]
 
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
@@ -187,80 +209,104 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: |
-            env.get("__value").index
+          expr:
+            type: flowExpr
+            value: attributes["index"]
         - attribute: Folder
-          expr: |
-            env.get("__value").udxDirs
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Filename
-          expr: |
-            file::extract_filename(env.get("__value").path)
+          expr:
+            type: flowExpr
+            value: attributes["path"].split("/")[-1]
         - attribute: "サイズ[KB]"
-          expr: |
-            env.get("__value").fileSize / 1024
+          expr:
+            type: flowExpr
+            value: attributes["fileSize"] / 1024
         - attribute: "1GB以下"
-          expr: |
-            if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-              "OK"
-            } else {
-              "Over"
-            }
+          expr:
+            type: flowExpr
+            value: |
+              if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+                "OK"
+              } else {
+                "Over"
+              }
         - attribute: "XML検証結果"
-          expr: |
-            env.get("__value").status
+          expr:
+            type: flowExpr
+            value: attributes["status"]
         - attribute: "L01エラー"
-          expr: |
-            env.get("__value").L01Errors ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["L01Errors"]
         - attribute: "L02エラー"
-          expr: |
-            env.get("__value").L02Errors ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["L02Errors"]
         - attribute: "L03エラー"
-          expr: |
-            env.get("__value").invalidFeatureTypesNum ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["invalidFeatureTypesNum"]
         - attribute: "L03エラー詳細"
-          expr: |
-            env.get("__value").invalidFeatureTypesDetail
+          expr:
+            type: flowExpr
+            value: attributes["invalidFeatureTypesDetail"]
         - attribute: "L04エラー"
-          expr: |
-            env.get("__value").inCorrectCodeValue ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["inCorrectCodeValue"]
         - attribute: "不正なcodeSpace数"
-          expr: |
-            env.get("__value").inCorrectCodeSpace ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["inCorrectCodeSpace"]
         - attribute: "L05CRS識別子"
-          expr: |
-            if env.get("__value").isCorrectSrsName {
-              "OK"
-            } else {
-              "Wrong"
-            }
+          expr:
+            type: flowExpr
+            value: |
+              if attributes["isCorrectSrsName"] {
+                "OK"
+              } else {
+                "Wrong"
+              }
         - attribute: "不正なCRS識別子"
-          expr: |
-            if env.get("__value").isCorrectSrsName {
-              ""
-            } else {
-              env.get("__value").srsName
-            }
+          expr:
+            type: flowExpr
+            value: |
+              if attributes["isCorrectSrsName"] {
+                ""
+              } else {
+                attributes["srsName"]
+              }
         - attribute: "L06エラー"
-          expr: |
-            env.get("__value").inCorrectExtents ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["inCorrectExtents"]
         - attribute: "T03エラー"
-          expr: |
-            env.get("__value").xlinkInvalidObjectType ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["xlinkInvalidObjectType"]
         - attribute: "xlink参照先なし"
-          expr: |
-            env.get("__value").xlinkHasNoReference ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["xlinkHasNoReference"]
         - attribute: "gml:id重複"
-          expr: |
-            env.get("__value").duplicateGmlIdCount
+          expr:
+            type: flowExpr
+            value: attributes["duplicateGmlIdCount"]
         - attribute: "gml:id書式不正"
-          expr: |
-            env.get("__value").gmlIdNotWellformed ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["gmlIdNotWellformed"]
         - attribute: "L-frn-01エラー"
-          expr: |
-            env.get("__value").invalidLodXGeometry ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["invalidLodXGeometry"]
         - attribute: "補足"
-          expr: |
-            env.get("__value").miscellaneous ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("miscellaneous", "")
 
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
@@ -355,15 +401,25 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          expr:
+            type: flowExpr
+            value: attributes["index"]
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Filename
-          expr: env.get("__value").name
+          expr:
+            type: flowExpr
+            value: attributes["name"]
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          expr:
+            type: flowExpr
+            value: attributes["tag"]
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
 
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
@@ -381,15 +437,25 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          expr:
+            type: flowExpr
+            value: attributes["index"]
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Filename
-          expr: env.get("__value").name
+          expr:
+            type: flowExpr
+            value: attributes["name"]
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          expr:
+            type: flowExpr
+            value: attributes["tag"]
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
 
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
@@ -407,41 +473,73 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          expr:
+            type: flowExpr
+            value: attributes["index"]
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Filename
-          expr: env.get("__value").name
+          expr:
+            type: flowExpr
+            value: attributes["name"]
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         # min
         - attribute: Min Latitude
-          expr: env.get("__value").minLatitude
+          expr:
+            type: flowExpr
+            value: attributes["minLatitude"]
         - attribute: Min Longitude
-          expr: env.get("__value").minLongitude
+          expr:
+            type: flowExpr
+            value: attributes["minLongitude"]
         - attribute: Min Elevation
-          expr: env.get("__value").minElevation
+          expr:
+            type: flowExpr
+            value: attributes["minElevation"]
         # max
         - attribute: Max Latitude
-          expr: env.get("__value").maxLatitude
+          expr:
+            type: flowExpr
+            value: attributes["maxLatitude"]
         - attribute: Max Longitude
-          expr: env.get("__value").maxLongitude
+          expr:
+            type: flowExpr
+            value: attributes["maxLongitude"]
         - attribute: Max Elevation
-          expr: env.get("__value").maxElevation
+          expr:
+            type: flowExpr
+            value: attributes["maxElevation"]
         # lower
         - attribute: Lower Latitude
-          expr: env.get("__value").lowerLatitude
+          expr:
+            type: flowExpr
+            value: attributes["lowerLatitude"]
         - attribute: Lower Longitude
-          expr: env.get("__value").lowerLongitude
+          expr:
+            type: flowExpr
+            value: attributes["lowerLongitude"]
         - attribute: Lower Elevation
-          expr: env.get("__value").lowerElevation
+          expr:
+            type: flowExpr
+            value: attributes["lowerElevation"]
         # upper
         - attribute: Upper Latitude
-          expr: env.get("__value").upperLatitude
+          expr:
+            type: flowExpr
+            value: attributes["upperLatitude"]
         - attribute: Upper Longitude
-          expr: env.get("__value").upperLongitude
+          expr:
+            type: flowExpr
+            value: attributes["upperLongitude"]
         - attribute: Upper Elevation
-          expr: env.get("__value").upperElevation
+          expr:
+            type: flowExpr
+            value: attributes["upperElevation"]
 
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
@@ -459,21 +557,37 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          expr:
+            type: flowExpr
+            value: attributes["index"]
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Filename
-          expr: env.get("__value").name
+          expr:
+            type: flowExpr
+            value: attributes["name"]
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          expr:
+            type: flowExpr
+            value: attributes["tag"]
         - attribute: XPath
-          expr: env.get("__value").xpath
+          expr:
+            type: flowExpr
+            value: attributes["xpath"]
         - attribute: CodeSpace
-          expr: env.get("__value").codeSpace
+          expr:
+            type: flowExpr
+            value: attributes["codeSpace"]
         - attribute: Code
-          expr: env.get("__value").codeSpaceValue
+          expr:
+            type: flowExpr
+            value: attributes["codeSpaceValue"]
 
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
@@ -491,21 +605,37 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          expr:
+            type: flowExpr
+            value: attributes["index"]
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Filename
-          expr: env.get("__value").name
+          expr:
+            type: flowExpr
+            value: attributes["name"]
         - attribute: FeatureType
-          expr: env.get("__value").featureType
+          expr:
+            type: flowExpr
+            value: attributes["featureType"]
         - attribute: XPath
-          expr: env.get("__value").xpath
+          expr:
+            type: flowExpr
+            value: attributes["xpath"]
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          expr:
+            type: flowExpr
+            value: attributes["tag"]
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: CodeSpace
-          expr: env.get("__value").codeSpace
+          expr:
+            type: flowExpr
+            value: attributes["codeSpace"]
 
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
@@ -523,13 +653,21 @@ nodes:
     with:
       mappers:
         - attribute: flag
-          expr: env.get("__value").flag
+          expr:
+            type: flowExpr
+            value: attributes.get("flag")
         - attribute: filename
-          expr: env.get("__value").filename ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("filename", "")
         - attribute: fileCount
-          expr: env.get("__value").fileCount ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("fileCount", 0)
         - attribute: duplicateGmlIdCount
-          expr: env.get("__value").duplicateGmlIdCount ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("duplicateGmlIdCount", 0)
 
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
@@ -538,17 +676,29 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          expr:
+            type: flowExpr
+            value: attributes["index"]
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Filename
-          expr: env.get("__value").name
+          expr:
+            type: flowExpr
+            value: attributes["name"]
         - attribute: XPath
-          expr: env.get("__value").xpath
+          expr:
+            type: flowExpr
+            value: attributes["xpath"]
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          expr:
+            type: flowExpr
+            value: attributes["tag"]
         - attribute: xlink:href
-          expr: env.get("__value").xlinkHref
+          expr:
+            type: flowExpr
+            value: attributes["xlinkHref"]
 
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
@@ -566,23 +716,41 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          expr:
+            type: flowExpr
+            value: attributes["index"]
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Filename
-          expr: env.get("__value").name
+          expr:
+            type: flowExpr
+            value: attributes["name"]
         - attribute: XPath
-          expr: env.get("__value").xpath
+          expr:
+            type: flowExpr
+            value: attributes["xpath"]
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          expr:
+            type: flowExpr
+            value: attributes["tag"]
         - attribute: xlink:href
-          expr: env.get("__value").xlinkHref
+          expr:
+            type: flowExpr
+            value: attributes["xlinkHref"]
         - attribute: ref XPath
-          expr: env.get("__value").refGmlXpath
+          expr:
+            type: flowExpr
+            value: attributes["refGmlXpath"]
         - attribute: ref Tag
-          expr: env.get("__value").refGmlTag
+          expr:
+            type: flowExpr
+            value: attributes["refGmlTag"]
         - attribute: ref gml:id
-          expr: env.get("__value").refGmlId
+          expr:
+            type: flowExpr
+            value: attributes["refGmlId"]
 
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
@@ -600,18 +768,29 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          expr:
+            type: flowExpr
+            value: attributes["index"]
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Filename
-          expr: env.get("__value").name
+          expr:
+            type: flowExpr
+            value: attributes["name"]
         - attribute: FeatureType
-          expr: |
-            env.get("__value").parentTag ?? env.get("__value").featureType
+          expr:
+            type: flowExpr
+            value: attributes["parentTag"]
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: InvalidGeometry
-          expr: env.get("__value").invalidGeometry
+          expr:
+            type: flowExpr
+            value: attributes["invalidGeometry"]
 
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry

--- a/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
@@ -640,7 +640,7 @@ nodes:
         - attribute: FeatureType
           expr:
             type: flowExpr
-            value: attributes.get("parentTag", attributes["featureType"])
+            value: attributes.get("parentTag") or attributes.get("featureType")
         - attribute: gml:id
           valueAttribute: gmlId
         - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-02-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-02-common.yml
@@ -100,8 +100,9 @@ nodes:
         - attribute: dirs
           valueAttribute: udxDirs
         - attribute: filename
-          expr: |
-            file::extract_filename(env.get("__value")["path"])
+          expr:
+            type: flowExpr
+            value: attributes["path"].split("/")[-1]
         - attribute: gml_id
           valueAttribute: gmlId
         - attribute: severity
@@ -153,8 +154,9 @@ nodes:
         - attribute: dirs
           valueAttribute: udxDirs
         - attribute: filename
-          expr: |
-            file::extract_filename(env.get("__value")["path"])
+          expr:
+            type: flowExpr
+            value: attributes["path"].split("/")[-1]
         - attribute: gml_id
           valueAttribute: gmlId
         - attribute: feature_type
@@ -184,8 +186,9 @@ nodes:
         - attribute: dirs
           valueAttribute: udxDirs
         - attribute: filename
-          expr: |
-            file::extract_filename(env.get("__value")["path"])
+          expr:
+            type: flowExpr
+            value: attributes["path"].split("/")[-1]
         - attribute: gml_id
           valueAttribute: gmlId
         - attribute: feature_type

--- a/engine/runtime/examples/fixture/graphs/plateau6/quality-check/01-01-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau6/quality-check/01-01-common.yml
@@ -102,19 +102,23 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          valueAttribute: index
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr: env.get("__value").name
+          valueAttribute: name
         # - attribute: line
-        #   expr: env.get("__value").xmlError[0].line
+        #   expr: attributes["xmlError"][0]["line"]
         # - attribute: col
-        #   expr: env.get("__value").xmlError[0].col
+        #   expr: attributes["xmlError"][0]["col"]
         - attribute: type
-          expr: env.get("__value").xmlError[0].errorType
+          expr:
+            type: flowExpr
+            value: attributes["xmlError"][0]["errorType"]
         - attribute: desc
-          expr: env.get("__value").xmlError[0].message
+          expr:
+            type: flowExpr
+            value: attributes["xmlError"][0]["message"]
 
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
@@ -132,19 +136,25 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          valueAttribute: index
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr: env.get("__value").name
+          valueAttribute: name
         - attribute: line
-          expr: env.get("__value").xmlError[0].line
+          expr:
+            type: flowExpr
+            value: attributes["xmlError"][0]["line"]
         # - attribute: col
-        #   expr: env.get("__value").xmlError[0].col
+        #   expr: attributes["xmlError"][0]["col"]
         - attribute: type
-          expr: env.get("__value").xmlError[0].errorType
+          expr:
+            type: flowExpr
+            value: attributes["xmlError"][0]["errorType"]
         - attribute: desc
-          expr: env.get("__value").xmlError[0].message
+          expr:
+            type: flowExpr
+            value: attributes["xmlError"][0]["message"]
 
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
@@ -187,80 +197,94 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: |
-            env.get("__value").index
+          valueAttribute: index
         - attribute: Folder
-          expr: |
-            env.get("__value").udxDirs
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr: |
-            file::extract_filename(env.get("__value").path)
+          expr:
+            type: flowExpr
+            value: attributes["path"].split("/")[-1]
         - attribute: "サイズ[KB]"
-          expr: |
-            env.get("__value").fileSize / 1024
+          expr:
+            type: flowExpr
+            value: attributes["fileSize"] // 1024
         - attribute: "1GB以下"
-          expr: |
-            if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-              "OK"
-            } else {
-              "Over"
-            }
+          expr:
+            type: flowExpr
+            value: |
+              if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
+                "OK"
+              } else {
+                "Over"
+              }
         - attribute: "XML検証結果"
-          expr: |
-            env.get("__value").status
+          valueAttribute: status
         - attribute: "L01エラー"
-          expr: |
-            env.get("__value").L01Errors ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("L01Errors", 0)
         - attribute: "L02エラー"
-          expr: |
-            env.get("__value").L02Errors ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("L02Errors", 0)
         - attribute: "L03エラー"
-          expr: |
-            env.get("__value").invalidFeatureTypesNum ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("invalidFeatureTypesNum", 0)
         - attribute: "L03エラー詳細"
-          expr: |
-            env.get("__value").invalidFeatureTypesDetail
+          valueAttribute: invalidFeatureTypesDetail
         - attribute: "L04エラー"
-          expr: |
-            env.get("__value").inCorrectCodeValue ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("inCorrectCodeValue", 0)
         - attribute: "不正なcodeSpace数"
-          expr: |
-            env.get("__value").inCorrectCodeSpace ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("inCorrectCodeSpace", 0)
         - attribute: "L05CRS識別子"
-          expr: |
-            if env.get("__value").isCorrectSrsName {
-              "OK"
-            } else {
-              "Wrong"
-            }
+          expr:
+            type: flowExpr
+            value: |
+              if attributes["isCorrectSrsName"] {
+                "OK"
+              } else {
+                "Wrong"
+              }
         - attribute: "不正なCRS識別子"
-          expr: |
-            if env.get("__value").isCorrectSrsName {
-              ""
-            } else {
-              env.get("__value").srsName
-            }
+          expr:
+            type: flowExpr
+            value: |
+              if attributes["isCorrectSrsName"] {
+                ""
+              } else {
+                attributes["srsName"]
+              }
         - attribute: "L06エラー"
-          expr: |
-            env.get("__value").inCorrectExtents ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("inCorrectExtents", 0)
         - attribute: "T03エラー"
-          expr: |
-            env.get("__value").xlinkInvalidObjectType ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("xlinkInvalidObjectType", 0)
         - attribute: "xlink参照先なし"
-          expr: |
-            env.get("__value").xlinkHasNoReference ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("xlinkHasNoReference", 0)
         - attribute: "gml:id重複"
-          expr: |
-            env.get("__value").duplicateGmlIdCount
+          valueAttribute: duplicateGmlIdCount
         - attribute: "gml:id書式不正"
-          expr: |
-            env.get("__value").gmlIdNotWellformed ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("gmlIdNotWellformed", 0)
         - attribute: "L-frn-01エラー"
-          expr: |
-            env.get("__value").invalidLodXGeometry ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("invalidLodXGeometry", 0)
         - attribute: "補足"
-          expr: |
-            env.get("__value").miscellaneous ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("miscellaneous", "")
 
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
@@ -355,15 +379,15 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          valueAttribute: index
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr: env.get("__value").name
+          valueAttribute: name
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          valueAttribute: tag
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          valueAttribute: gmlId
 
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
@@ -381,15 +405,15 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          valueAttribute: index
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr: env.get("__value").name
+          valueAttribute: name
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          valueAttribute: tag
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          valueAttribute: gmlId
 
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
@@ -407,41 +431,41 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          valueAttribute: index
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr: env.get("__value").name
+          valueAttribute: name
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          valueAttribute: gmlId
         # min
         - attribute: Min Latitude
-          expr: env.get("__value").minLatitude
+          valueAttribute: minLatitude
         - attribute: Min Longitude
-          expr: env.get("__value").minLongitude
+          valueAttribute: minLongitude
         - attribute: Min Elevation
-          expr: env.get("__value").minElevation
+          valueAttribute: minElevation
         # max
         - attribute: Max Latitude
-          expr: env.get("__value").maxLatitude
+          valueAttribute: maxLatitude
         - attribute: Max Longitude
-          expr: env.get("__value").maxLongitude
+          valueAttribute: maxLongitude
         - attribute: Max Elevation
-          expr: env.get("__value").maxElevation
+          valueAttribute: maxElevation
         # lower
         - attribute: Lower Latitude
-          expr: env.get("__value").lowerLatitude
+          valueAttribute: lowerLatitude
         - attribute: Lower Longitude
-          expr: env.get("__value").lowerLongitude
+          valueAttribute: lowerLongitude
         - attribute: Lower Elevation
-          expr: env.get("__value").lowerElevation
+          valueAttribute: lowerElevation
         # upper
         - attribute: Upper Latitude
-          expr: env.get("__value").upperLatitude
+          valueAttribute: upperLatitude
         - attribute: Upper Longitude
-          expr: env.get("__value").upperLongitude
+          valueAttribute: upperLongitude
         - attribute: Upper Elevation
-          expr: env.get("__value").upperElevation
+          valueAttribute: upperElevation
 
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
@@ -459,21 +483,21 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          valueAttribute: index
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr: env.get("__value").name
+          valueAttribute: name
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          valueAttribute: gmlId
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          valueAttribute: tag
         - attribute: XPath
-          expr: env.get("__value").xpath
+          valueAttribute: xpath
         - attribute: CodeSpace
-          expr: env.get("__value").codeSpace
+          valueAttribute: codeSpace
         - attribute: Code
-          expr: env.get("__value").codeSpaceValue
+          valueAttribute: codeSpaceValue
 
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
@@ -491,21 +515,21 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          valueAttribute: index
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr: env.get("__value").name
+          valueAttribute: name
         - attribute: FeatureType
-          expr: env.get("__value").featureType
+          valueAttribute: featureType
         - attribute: XPath
-          expr: env.get("__value").xpath
+          valueAttribute: xpath
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          valueAttribute: tag
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          valueAttribute: gmlId
         - attribute: CodeSpace
-          expr: env.get("__value").codeSpace
+          valueAttribute: codeSpace
 
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
@@ -523,13 +547,21 @@ nodes:
     with:
       mappers:
         - attribute: flag
-          expr: env.get("__value").flag
+          expr:
+            type: flowExpr
+            value: attributes.get("flag")
         - attribute: filename
-          expr: env.get("__value").filename ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("filename", "")
         - attribute: fileCount
-          expr: env.get("__value").fileCount ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("fileCount", 0)
         - attribute: duplicateGmlIdCount
-          expr: env.get("__value").duplicateGmlIdCount ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("duplicateGmlIdCount", 0)
 
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
@@ -538,17 +570,17 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          valueAttribute: index
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr: env.get("__value").name
+          valueAttribute: name
         - attribute: XPath
-          expr: env.get("__value").xpath
+          valueAttribute: xpath
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          valueAttribute: tag
         - attribute: xlink:href
-          expr: env.get("__value").xlinkHref
+          valueAttribute: xlinkHref
 
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
@@ -566,23 +598,23 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          valueAttribute: index
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr: env.get("__value").name
+          valueAttribute: name
         - attribute: XPath
-          expr: env.get("__value").xpath
+          valueAttribute: xpath
         - attribute: XML Tag
-          expr: env.get("__value").tag
+          valueAttribute: tag
         - attribute: xlink:href
-          expr: env.get("__value").xlinkHref
+          valueAttribute: xlinkHref
         - attribute: ref XPath
-          expr: env.get("__value").refGmlXpath
+          valueAttribute: refGmlXpath
         - attribute: ref Tag
-          expr: env.get("__value").refGmlTag
+          valueAttribute: refGmlTag
         - attribute: ref gml:id
-          expr: env.get("__value").refGmlId
+          valueAttribute: refGmlId
 
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
@@ -600,18 +632,19 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").index
+          valueAttribute: index
         - attribute: Folder
-          expr: env.get("__value").udxDirs
+          valueAttribute: udxDirs
         - attribute: Filename
-          expr: env.get("__value").name
+          valueAttribute: name
         - attribute: FeatureType
-          expr: |
-            env.get("__value").parentTag ?? env.get("__value").featureType
+          expr:
+            type: flowExpr
+            value: attributes.get("parentTag") or attributes.get("featureType")
         - attribute: gml:id
-          expr: env.get("__value").gmlId
+          valueAttribute: gmlId
         - attribute: InvalidGeometry
-          expr: env.get("__value").invalidGeometry
+          valueAttribute: invalidGeometry
 
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
@@ -439,7 +439,7 @@ graphs:
         method: create
         value:
           type: flowExpr
-          value: Url(attributes["path"]).name.split("_")[0]
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: feature_type
         method: create
         value:
@@ -785,7 +785,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
           if attributes["baseCityCode"] == attributes["city_code"] {
             city_gml + "_bldg_3dtiles_lod1.zip"
           } else {
@@ -811,7 +811,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
           if attributes["baseCityCode"] == attributes["city_code"] {
             city_gml + "_bldg_3dtiles_lod2.zip"
           } else {
@@ -837,7 +837,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
           if attributes["baseCityCode"] == attributes["city_code"] {
             city_gml + "_bldg_3dtiles_lod2_no_texture.zip"
           } else {
@@ -863,7 +863,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
           if attributes["baseCityCode"] == attributes["city_code"] {
             city_gml + "_bldg_3dtiles_lod3.zip"
           } else {
@@ -889,7 +889,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
           if attributes["baseCityCode"] == attributes["city_code"] {
             city_gml + "_bldg_3dtiles_lod3_no_texture.zip"
           } else {
@@ -915,7 +915,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
           if attributes["baseCityCode"] == attributes["city_code"] {
             city_gml + "_bldg_3dtiles_lod4.zip"
           } else {
@@ -941,7 +941,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
           if attributes["baseCityCode"] == attributes["city_code"] {
             city_gml + "_bldg_3dtiles_lod4_no_texture.zip"
           } else {

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
@@ -143,7 +143,7 @@ graphs:
               method: create
               value:
                 type: flowExpr
-                value: 'Url(attributes["path"]).name.split("_")[0]'
+                value: 'attributes["path"].split("/")[-1].split("_")[0]'
             - attribute: feature_type
               method: create
               value:
@@ -516,7 +516,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
               if attributes["baseCityCode"] == attributes["city_code"] {
                 city_gml + "_bldg_3dtiles_lod1.zip"
               } else {
@@ -543,7 +543,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
               if attributes["baseCityCode"] == attributes["city_code"] {
                 city_gml + "_bldg_3dtiles_lod2.zip"
               } else {
@@ -570,7 +570,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
               if attributes["baseCityCode"] == attributes["city_code"] {
                 city_gml + "_bldg_3dtiles_lod2_no_texture.zip"
               } else {
@@ -597,7 +597,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
               if attributes["baseCityCode"] == attributes["city_code"] {
                 city_gml + "_bldg_3dtiles_lod3.zip"
               } else {
@@ -624,7 +624,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
               if attributes["baseCityCode"] == attributes["city_code"] {
                 city_gml + "_bldg_3dtiles_lod3_no_texture.zip"
               } else {
@@ -651,7 +651,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
               if attributes["baseCityCode"] == attributes["city_code"] {
                 city_gml + "_bldg_3dtiles_lod4.zip"
               } else {
@@ -678,7 +678,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_bldg");
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_bldg");
               if attributes["baseCityCode"] == attributes["city_code"] {
                 city_gml + "_bldg_3dtiles_lod4_no_texture.zip"
               } else {

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy.yml
@@ -330,7 +330,7 @@ graphs:
         method: create
         value:
           type: flowExpr
-          value: Url(attributes["path"]).name.split("_")[0]
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: gml_id
         method: create
         value:
@@ -455,7 +455,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
           city_gml + "_" + attributes["__package"] + "_3dtiles_lod3.zip"
   - id: 2ccf7b99-4123-446e-8ff7-049be1c604c7
     name: AttributeManagerByLod0-2
@@ -540,7 +540,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
           city_gml + "_" + attributes["__package"] + "_mvt_lod" + attributes["__lod"] + ".zip"
       skipUnexposedAttributes: true
       colonToUnderscore: true
@@ -651,7 +651,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
           city_gml + "_" + attributes["__package"] + "_dm_geometric_attributes.zip"
       skipUnexposedAttributes: true
       colonToUnderscore: true

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/02-tran-rwy-trk-squr-wwy/workflow.yml
@@ -73,7 +73,7 @@ graphs:
               method: create
               value:
                 type: flowExpr
-                value: 'Url(attributes["path"]).name.split("_")[0]'
+                value: 'attributes["path"].split("/")[-1].split("_")[0]'
             - attribute: gml_id
               method: create
               value:
@@ -205,7 +205,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
               city_gml + "_" + attributes["__package"] + "_3dtiles_lod3.zip"
 
       - id: 2ccf7b99-4123-446e-8ff7-049be1c604c7
@@ -301,7 +301,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
               city_gml + "_" + attributes["__package"] + "_mvt_lod" + attributes["__lod"] + ".zip"
           skipUnexposedAttributes: true
           colonToUnderscore: true
@@ -417,7 +417,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
               city_gml + "_" + attributes["__package"] + "_dm_geometric_attributes.zip"
           skipUnexposedAttributes: true
           colonToUnderscore: true

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/03-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/03-frn-veg.yml
@@ -386,7 +386,7 @@ graphs:
         method: create
         value:
           type: flowExpr
-          value: Url(attributes["path"]).name.split("_")[0]
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: gml_id
         method: create
         value:
@@ -513,7 +513,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_frn");
+          stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_frn");
           lod = attributes["lod"];
           stem + "_frn_3dtiles_lod" + lod + ".zip"
   - id: 1137c768-ea24-4cf2-bd16-b8f82d9a67d0
@@ -643,7 +643,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_frn");
+          stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_frn");
           stem + "_frn_dm_geometric_attributes.zip"
       colonToUnderscore: true
   - id: bd4ff879-8448-434d-9c47-ef85722b40cb
@@ -757,7 +757,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_veg");
+          stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_veg");
           lod = attributes["lod"];
           stem + "_veg_SolitaryVegetationObject_3dtiles_lod" + lod + ".zip"
   - id: 591050d4-8284-4708-a3e3-0bcb99bbd83c
@@ -905,7 +905,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_veg");
+          stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_veg");
           stem + "_veg_SolitaryVegetationObject_dm_geometric_attributes.zip"
       colonToUnderscore: true
   - id: 2233fddd-fdc3-44a1-93e2-86805de13a3a
@@ -990,7 +990,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_veg");
+          stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_veg");
           lod = attributes["lod"];
           stem + "_veg_PlantCover_3dtiles_lod" + lod + ".zip"
   - id: aa9b681b-0cc1-4445-bff6-be41bb9c764f
@@ -1130,7 +1130,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_veg");
+          stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_veg");
           stem + "_veg_PlantCover_dm_geometric_attributes.zip"
       colonToUnderscore: true
   edges:

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/03-frn-veg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/03-frn-veg/workflow.yml
@@ -135,7 +135,7 @@ graphs:
               method: create
               value:
                 type: flowExpr
-                value: 'Url(attributes["path"]).name.split("_")[0]'
+                value: 'attributes["path"].split("/")[-1].split("_")[0]'
             - attribute: gml_id
               method: create
               value:
@@ -273,7 +273,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_frn");
+              stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_frn");
               lod = attributes["lod"];
               stem + "_frn_3dtiles_lod" + lod + ".zip"
 
@@ -408,7 +408,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_frn");
+              stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_frn");
               stem + "_frn_dm_geometric_attributes.zip"
           colonToUnderscore: true
 
@@ -531,7 +531,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_veg");
+              stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_veg");
               lod = attributes["lod"];
               stem + "_veg_SolitaryVegetationObject_3dtiles_lod" + lod + ".zip"
 
@@ -684,7 +684,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_veg");
+              stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_veg");
               stem + "_veg_SolitaryVegetationObject_dm_geometric_attributes.zip"
           colonToUnderscore: true
 
@@ -777,7 +777,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_veg");
+              stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_veg");
               lod = attributes["lod"];
               stem + "_veg_PlantCover_3dtiles_lod" + lod + ".zip"
 
@@ -922,7 +922,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_veg");
+              stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_veg");
               stem + "_veg_PlantCover_dm_geometric_attributes.zip"
           colonToUnderscore: true
 

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld.yml
@@ -183,8 +183,9 @@ graphs:
     with:
       mappers:
       - attribute: meshcode
-        expr: |
-          file::extract_filename_without_ext(env.get("__value")["path"]).split("_")[0]
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: city_code
         valueAttribute: cityCode
       - attribute: city_name
@@ -194,35 +195,45 @@ graphs:
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: luse_class
-        expr: |
-          env.get("__value")["luse:class"]
+        expr:
+          type: flowExpr
+          value: attributes.get("luse:class")
       - attribute: luse_usage
-        expr: |
-          env.get("__value")["luse:usage"]
+        expr:
+          type: flowExpr
+          value: attributes.get("luse:usage")
       - attribute: core_creationDate
-        expr: |
-          env.get("__value")["core:creationDate"]
+        expr:
+          type: flowExpr
+          value: attributes.get("core:creationDate")
       - attribute: uro_urbanPlanType
-        expr: |
-          env.get("__value")["uro:LandUseDetailAttribute_uro:urbanPlanType"]
+        expr:
+          type: flowExpr
+          value: attributes.get("uro:LandUseDetailAttribute_uro:urbanPlanType")
       - attribute: uro_prefecture
-        expr: |
-          env.get("__value")["uro:LandUseDetailAttribute_uro:prefecture"]
+        expr:
+          type: flowExpr
+          value: attributes.get("uro:LandUseDetailAttribute_uro:prefecture")
       - attribute: uro_city
-        expr: |
-          env.get("__value")["uro:LandUseDetailAttribute_uro:city"]
+        expr:
+          type: flowExpr
+          value: attributes.get("uro:LandUseDetailAttribute_uro:city")
       - attribute: uro_surveyYear
-        expr: |
-          env.get("__value")["uro:LandUseDetailAttribute_uro:surveyYear"]
+        expr:
+          type: flowExpr
+          value: attributes.get("uro:LandUseDetailAttribute_uro:surveyYear")
       - attribute: uro_areaInSquareMeter
-        expr: |
-          env.get("__value")["uro:LandUseDetailAttribute_uro:areaInSquareMeter"]
+        expr:
+          type: flowExpr
+          value: attributes.get("uro:LandUseDetailAttribute_uro:areaInSquareMeter")
       - attribute: uro_orgLandUse
-        expr: |
-          env.get("__value")["uro:LandUseDetailAttribute_uro:orgLandUse"]
+        expr:
+          type: flowExpr
+          value: attributes.get("uro:LandUseDetailAttribute_uro:orgLandUse")
       - attribute: uro_geometrySrcDescLod1
-        expr: |
-          env.get("__value")["uro:DataQualityAttribute_uro:geometrySrcDescLod1"]
+        expr:
+          type: flowExpr
+          value: attributes.get("uro:DataQualityAttribute_uro:geometrySrcDescLod1")
       - attribute: attributes
         valueAttribute: attributes
   - id: b4862d31-4bb2-49b1-8f0d-6d58dd4cb385
@@ -252,8 +263,9 @@ graphs:
     with:
       mappers:
       - attribute: meshcode
-        expr: |
-          file::extract_filename_without_ext(env.get("__value")["path"]).split("_")[0]
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: city_code
         valueAttribute: cityCode
       - attribute: city_name
@@ -263,46 +275,58 @@ graphs:
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: core_creationDate
-        expr: |
-          env.get("__value")["core:creationDate"]
+        expr:
+          type: flowExpr
+          value: attributes.get("core:creationDate")
       - attribute: urf_validFrom
-        expr: |
-          env.get("__value")["urf:validFrom"]
+        expr:
+          type: flowExpr
+          value: attributes.get("urf:validFrom")
       - attribute: urf_prefecture
-        expr: |
-          env.get("__value")["urf:prefecture"]
+        expr:
+          type: flowExpr
+          value: attributes.get("urf:prefecture")
       - attribute: urf_location
-        expr: |
-          env.get("__value")["urf:location"]
+        expr:
+          type: flowExpr
+          value: attributes.get("urf:location")
       - attribute: urf_disasterType
-        expr: |
-          env.get("__value")["urf:disasterType"]
+        expr:
+          type: flowExpr
+          value: attributes.get("urf:disasterType")
       - attribute: urf_areaType
-        expr: |
-          env.get("__value")["urf:areaType"]
+        expr:
+          type: flowExpr
+          value: attributes.get("urf:areaType")
       - attribute: urf_zoneNumber
-        expr: |
-          env.get("__value")["urf:zoneNumber"]
+        expr:
+          type: flowExpr
+          value: attributes.get("urf:zoneNumber")
       - attribute: urf_zoneName
-        expr: |
-          env.get("__value")["urf:zoneName"]
+        expr:
+          type: flowExpr
+          value: attributes.get("urf:zoneName")
       - attribute: urf_status
-        expr: |
-          env.get("__value")["urf:status"]
+        expr:
+          type: flowExpr
+          value: attributes.get("urf:status")
       - attribute: uro_geometrySrcDescLod1
-        expr: |
-          env.get("__value")["uro:DataQualityAttribute_uro:geometrySrcDescLod1"]
+        expr:
+          type: flowExpr
+          value: attributes.get("uro:DataQualityAttribute_uro:geometrySrcDescLod1")
       - attribute: attributes
         valueAttribute: attributes
       - attribute: sort_order
-        expr: |
-          let area_type = env.get("__value")["urf:areaType_code"];
-          if area_type == () { area_type = env.get("__value")["urf:areaType"]; }
-          if area_type == "1" || area_type == 1 { 1 }
-          else if area_type == "2" || area_type == 2 { 2 }
-          else if area_type == "3" || area_type == 3 { 3 }
-          else if area_type == "4" || area_type == 4 { 4 }
-          else { 999 }
+        expr:
+          type: flowExpr
+          value: |
+            area_type = attributes.get("urf:areaType_code");
+            if area_type == null { area_type = attributes.get("urf:areaType") };
+            if area_type == "1" or area_type == 1 { 1 }
+            else if area_type == "2" or area_type == 2 { 2 }
+            else if area_type == "3" or area_type == 3 { 3 }
+            else if area_type == "4" or area_type == 4 { 4 }
+            else { 999 }
   - id: 9c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f
     name: FeatureSorterLsld
     type: action

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld.yml
@@ -254,7 +254,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip");
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip");
           city_gml.remove_suffix("_luse") + "_luse_mvt.zip"
   - id: 7a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
     name: AttributeMapperLsld
@@ -361,7 +361,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip");
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip");
           city_gml.remove_suffix("_lsld") + "_lsld_mvt.zip"
   edges:
   - id: 5ebf24ab-1d98-49d5-8f58-eb7c18d27244

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld.yml
@@ -321,7 +321,7 @@ graphs:
           type: flowExpr
           value: |
             area_type = attributes.get("urf:areaType_code");
-            if area_type == null { area_type = attributes.get("urf:areaType") };
+            if area_type == null { area_type = attributes.get("urf:areaType") }
             if area_type == "1" or area_type == 1 { 1 }
             else if area_type == "2" or area_type == 2 { 2 }
             else if area_type == "3" or area_type == 3 { 3 }

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld/workflow.yml
@@ -162,7 +162,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip");
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip");
               city_gml.remove_suffix("_luse") + "_luse_mvt.zip"
 
       # LSLD processing branch
@@ -274,7 +274,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip");
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip");
               city_gml.remove_suffix("_lsld") + "_lsld_mvt.zip"
 
     edges:

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld/workflow.yml
@@ -231,7 +231,7 @@ graphs:
                 type: flowExpr
                 value: |
                   area_type = attributes.get("urf:areaType_code");
-                  if area_type == null { area_type = attributes.get("urf:areaType") };
+                  if area_type == null { area_type = attributes.get("urf:areaType") }
                   if area_type == "1" or area_type == 1 { 1 }
                   else if area_type == "2" or area_type == 2 { 2 }
                   else if area_type == "3" or area_type == 3 { 3 }

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/04-luse-lsld/workflow.yml
@@ -90,8 +90,9 @@ graphs:
         with:
           mappers:
             - attribute: meshcode
-              expr: |
-                file::extract_filename_without_ext(env.get("__value")["path"]).split("_")[0]
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-1].split("_")[0]
             - attribute: city_code
               valueAttribute: cityCode
             - attribute: city_name
@@ -101,35 +102,45 @@ graphs:
             - attribute: gml_id
               valueAttribute: gmlId
             - attribute: luse_class
-              expr: |
-                env.get("__value")["luse:class"]
+              expr:
+                type: flowExpr
+                value: attributes.get("luse:class")
             - attribute: luse_usage
-              expr: |
-                env.get("__value")["luse:usage"]
+              expr:
+                type: flowExpr
+                value: attributes.get("luse:usage")
             - attribute: core_creationDate
-              expr: |
-                env.get("__value")["core:creationDate"]
+              expr:
+                type: flowExpr
+                value: attributes.get("core:creationDate")
             - attribute: uro_urbanPlanType
-              expr: |
-                env.get("__value")["uro:LandUseDetailAttribute_uro:urbanPlanType"]
+              expr:
+                type: flowExpr
+                value: attributes.get("uro:LandUseDetailAttribute_uro:urbanPlanType")
             - attribute: uro_prefecture
-              expr: |
-                env.get("__value")["uro:LandUseDetailAttribute_uro:prefecture"]
+              expr:
+                type: flowExpr
+                value: attributes.get("uro:LandUseDetailAttribute_uro:prefecture")
             - attribute: uro_city
-              expr: |
-                env.get("__value")["uro:LandUseDetailAttribute_uro:city"]
+              expr:
+                type: flowExpr
+                value: attributes.get("uro:LandUseDetailAttribute_uro:city")
             - attribute: uro_surveyYear
-              expr: |
-                env.get("__value")["uro:LandUseDetailAttribute_uro:surveyYear"]
+              expr:
+                type: flowExpr
+                value: attributes.get("uro:LandUseDetailAttribute_uro:surveyYear")
             - attribute: uro_areaInSquareMeter
-              expr: |
-                env.get("__value")["uro:LandUseDetailAttribute_uro:areaInSquareMeter"]
+              expr:
+                type: flowExpr
+                value: attributes.get("uro:LandUseDetailAttribute_uro:areaInSquareMeter")
             - attribute: uro_orgLandUse
-              expr: |
-                env.get("__value")["uro:LandUseDetailAttribute_uro:orgLandUse"]
+              expr:
+                type: flowExpr
+                value: attributes.get("uro:LandUseDetailAttribute_uro:orgLandUse")
             - attribute: uro_geometrySrcDescLod1
-              expr: |
-                env.get("__value")["uro:DataQualityAttribute_uro:geometrySrcDescLod1"]
+              expr:
+                type: flowExpr
+                value: attributes.get("uro:DataQualityAttribute_uro:geometrySrcDescLod1")
             - attribute: attributes
               valueAttribute: attributes
 
@@ -162,8 +173,9 @@ graphs:
         with:
           mappers:
             - attribute: meshcode
-              expr: |
-                file::extract_filename_without_ext(env.get("__value")["path"]).split("_")[0]
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-1].split("_")[0]
             - attribute: city_code
               valueAttribute: cityCode
             - attribute: city_name
@@ -173,46 +185,58 @@ graphs:
             - attribute: gml_id
               valueAttribute: gmlId
             - attribute: core_creationDate
-              expr: |
-                env.get("__value")["core:creationDate"]
+              expr:
+                type: flowExpr
+                value: attributes.get("core:creationDate")
             - attribute: urf_validFrom
-              expr: |
-                env.get("__value")["urf:validFrom"]
+              expr:
+                type: flowExpr
+                value: attributes.get("urf:validFrom")
             - attribute: urf_prefecture
-              expr: |
-                env.get("__value")["urf:prefecture"]
+              expr:
+                type: flowExpr
+                value: attributes.get("urf:prefecture")
             - attribute: urf_location
-              expr: |
-                env.get("__value")["urf:location"]
+              expr:
+                type: flowExpr
+                value: attributes.get("urf:location")
             - attribute: urf_disasterType
-              expr: |
-                env.get("__value")["urf:disasterType"]
+              expr:
+                type: flowExpr
+                value: attributes.get("urf:disasterType")
             - attribute: urf_areaType
-              expr: |
-                env.get("__value")["urf:areaType"]
+              expr:
+                type: flowExpr
+                value: attributes.get("urf:areaType")
             - attribute: urf_zoneNumber
-              expr: |
-                env.get("__value")["urf:zoneNumber"]
+              expr:
+                type: flowExpr
+                value: attributes.get("urf:zoneNumber")
             - attribute: urf_zoneName
-              expr: |
-                env.get("__value")["urf:zoneName"]
+              expr:
+                type: flowExpr
+                value: attributes.get("urf:zoneName")
             - attribute: urf_status
-              expr: |
-                env.get("__value")["urf:status"]
+              expr:
+                type: flowExpr
+                value: attributes.get("urf:status")
             - attribute: uro_geometrySrcDescLod1
-              expr: |
-                env.get("__value")["uro:DataQualityAttribute_uro:geometrySrcDescLod1"]
+              expr:
+                type: flowExpr
+                value: attributes.get("uro:DataQualityAttribute_uro:geometrySrcDescLod1")
             - attribute: attributes
               valueAttribute: attributes
             - attribute: sort_order
-              expr: |
-                let area_type = env.get("__value")["urf:areaType_code"];
-                if area_type == () { area_type = env.get("__value")["urf:areaType"]; }
-                if area_type == "1" || area_type == 1 { 1 }
-                else if area_type == "2" || area_type == 2 { 2 }
-                else if area_type == "3" || area_type == 3 { 3 }
-                else if area_type == "4" || area_type == 4 { 4 }
-                else { 999 }
+              expr:
+                type: flowExpr
+                value: |
+                  area_type = attributes.get("urf:areaType_code");
+                  if area_type == null { area_type = attributes.get("urf:areaType") };
+                  if area_type == "1" or area_type == 1 { 1 }
+                  else if area_type == "2" or area_type == 2 { 2 }
+                  else if area_type == "3" or area_type == 3 { 3 }
+                  else if area_type == "4" or area_type == 4 { 4 }
+                  else { 999 }
 
       - id: 9c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f
         name: FeatureSorterLsld

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld.yml
@@ -279,7 +279,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          citygml = Url(env["cityGmlPath"]).name.split("_op_")[0];
+          citygml = env["cityGmlPath"].split("/")[-1].split("_op_")[0];
           udx_dirs = attributes["udxDirs"].replace("/", "_");
           scale = "";
           if attributes.get("__scale") { scale = "_" + attributes["__scale"] }

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld.yml
@@ -236,13 +236,13 @@ graphs:
         valueAttribute: uro:rank
       - attribute: uro:rank_code
         expr:
-          type: string
+          type: flowExpr
           value: '0'
       - attribute: uro:rankOrg
         valueAttribute: uro:rankOrg
       - attribute: uro:rankOrg_code
         expr:
-          type: string
+          type: flowExpr
           value: '0'
       - attribute: uro:adminType
         valueAttribute: uro:adminType

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld.yml
@@ -235,11 +235,15 @@ graphs:
       - attribute: uro:rank
         valueAttribute: uro:rank
       - attribute: uro:rank_code
-        expr: '0'
+        expr:
+          type: string
+          value: '0'
       - attribute: uro:rankOrg
         valueAttribute: uro:rankOrg
       - attribute: uro:rankOrg_code
-        expr: '0'
+        expr:
+          type: string
+          value: '0'
       - attribute: uro:adminType
         valueAttribute: uro:adminType
       - attribute: uro:scale

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld/workflow.yml
@@ -142,11 +142,15 @@ graphs:
             - attribute: uro:rank
               valueAttribute: uro:rank
             - attribute: uro:rank_code
-              expr: "0"
+              expr:
+                type: string
+                value: "0"
             - attribute: uro:rankOrg
               valueAttribute: uro:rankOrg
             - attribute: uro:rankOrg_code
-              expr: "0"
+              expr:
+                type: string
+                value: "0"
             - attribute: uro:adminType
               valueAttribute: uro:adminType
             - attribute: uro:scale

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld/workflow.yml
@@ -191,7 +191,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              citygml = Url(env["cityGmlPath"]).name.split("_op_")[0];
+              citygml = env["cityGmlPath"].split("/")[-1].split("_op_")[0];
               udx_dirs = attributes["udxDirs"].replace("/", "_");
               scale = "";
               if attributes.get("__scale") { scale = "_" + attributes["__scale"] }

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/05-fld/workflow.yml
@@ -143,13 +143,13 @@ graphs:
               valueAttribute: uro:rank
             - attribute: uro:rank_code
               expr:
-                type: string
+                type: flowExpr
                 value: "0"
             - attribute: uro:rankOrg
               valueAttribute: uro:rankOrg
             - attribute: uro:rankOrg_code
               expr:
-                type: string
+                type: flowExpr
                 value: "0"
             - attribute: uro:adminType
               valueAttribute: uro:adminType

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/06-area-urf.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/06-area-urf.yml
@@ -165,7 +165,7 @@ graphs:
         method: create
         value:
           type: flowExpr
-          value: Url(attributes["path"]).name.split("_")[0]
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: gml_id
         method: create
         value:
@@ -400,7 +400,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip");
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip");
           ft = attributes["feature_type"].split(":")[1];
           stem = city_gml.remove_suffix("_" + ft);
           filename = stem + "_" + ft + "_mvt_lod" + attributes["__lod"] + ".zip";

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/06-area-urf/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/06-area-urf/workflow.yml
@@ -68,7 +68,7 @@ graphs:
               method: create
               value:
                 type: flowExpr
-                value: 'Url(attributes["path"]).name.split("_")[0]'
+                value: 'attributes["path"].split("/")[-1].split("_")[0]'
             - attribute: gml_id
               method: create
               value:
@@ -210,7 +210,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip");
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip");
               ft = attributes["feature_type"].split(":")[1];
               stem = city_gml.remove_suffix("_" + ft);
               filename = stem + "_" + ft + "_mvt_lod" + attributes["__lod"] + ".zip";

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons.yml
@@ -458,28 +458,31 @@ graphs:
     action: AttributeMapper
     with:
       mappers:
-      - multipleExpr: |
-          let result = #{};
-          let val = env.get("__value");
-          let exclude = [
-            "package", "fileIndex", "extension", "root", "gmlRootId", "udxDirs", "cityGmlPath",
-            "schemas", "dirCodelists", "dirSchemas", "gmlName", "codelists", "maxLod", "dirRoot",
-            "path", "cityCode", "cityName", "gmlId"
-          ];
-          for key in val.keys() {
-            if !exclude.contains(key) {
-              result[key] = val[key];
-            }
-          }
-          result
+      - multipleExpr:
+          type: flowExpr
+          value: |
+            result = {};
+            exclude = [
+              "package", "fileIndex", "extension", "root", "gmlRootId", "udxDirs", "cityGmlPath",
+              "schemas", "dirCodelists", "dirSchemas", "gmlName", "codelists", "maxLod", "dirRoot",
+              "path", "cityCode", "cityName", "gmlId"
+            ];
+            for key in attributes {
+              if key not in exclude {
+                result[key] = attributes[key]
+              }
+            };
+            result
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: meshcode
-        expr: |
-          file::extract_filename_without_ext(env.get("__value")["path"]).split("_")[0]
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: feature_type
-        expr: |
-          env.get("__value")["__citygml_feature_type"]
+        expr:
+          type: flowExpr
+          value: attributes["__citygml_feature_type"]
       - attribute: city_code
         valueAttribute: cityCode
       - attribute: city_name

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons.yml
@@ -417,7 +417,7 @@ graphs:
         method: create
         value:
           type: flowExpr
-          value: Url(attributes["path"]).name.split("_")[0]
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: gml_id
         method: create
         value:
@@ -609,7 +609,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
           filename = city_gml + "_" + attributes["__package"] + "_dm_geometric_attributes.zip";
           filename
       skipUnexposedAttributes: true
@@ -664,7 +664,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
           city_gml + "_" + attributes["__package"] + "_3dtiles_lod1.zip"
   - id: a61799d5-176e-4fb9-aa64-5d350adf0bb8
     name: cesium3DTilesWriterByLod2
@@ -682,7 +682,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
           city_gml + "_" + attributes["__package"] + "_3dtiles_lod2.zip"
   - id: 953f5c48-9875-4c78-a1d6-4619f8fdedd2
     name: cesium3DTilesWriterByLod3
@@ -700,7 +700,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
           city_gml + "_" + attributes["__package"] + "_3dtiles_lod3.zip"
   - id: b0f8f2c5-bb9b-4f4f-8c27-254367031ded
     name: cesium3DTilesWriterByLod4
@@ -718,7 +718,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
           city_gml + "_" + attributes["package"] + "_3dtiles_lod4.zip"
   edges:
   - id: 5ebf24ab-1d98-49d5-8f58-eb7c18d27244

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons.yml
@@ -480,9 +480,7 @@ graphs:
           type: flowExpr
           value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: feature_type
-        expr:
-          type: flowExpr
-          value: attributes["__citygml_feature_type"]
+        valueAttribute: __citygml_feature_type
       - attribute: city_code
         valueAttribute: cityCode
       - attribute: city_name

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons/workflow.yml
@@ -165,7 +165,7 @@ graphs:
               method: create
               value:
                 type: flowExpr
-                value: 'Url(attributes["path"]).name.split("_")[0]'
+                value: 'attributes["path"].split("/")[-1].split("_")[0]'
             - attribute: gml_id
               method: create
               value:
@@ -368,7 +368,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
               filename = city_gml + "_" + attributes["__package"] + "_dm_geometric_attributes.zip";
               filename
           skipUnexposedAttributes: true
@@ -434,7 +434,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
               city_gml + "_" + attributes["__package"] + "_3dtiles_lod1.zip"
 
       - id: a61799d5-176e-4fb9-aa64-5d350adf0bb8
@@ -453,7 +453,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
               city_gml + "_" + attributes["__package"] + "_3dtiles_lod2.zip"
 
       - id: 953f5c48-9875-4c78-a1d6-4619f8fdedd2
@@ -472,7 +472,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
               city_gml + "_" + attributes["__package"] + "_3dtiles_lod3.zip"
 
       - id: b0f8f2c5-bb9b-4f4f-8c27-254367031ded
@@ -491,7 +491,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
               city_gml + "_" + attributes["package"] + "_3dtiles_lod4.zip"
 
     edges:

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons/workflow.yml
@@ -210,28 +210,31 @@ graphs:
         action: AttributeMapper
         with:
           mappers:
-            - multipleExpr: |
-                let result = #{};
-                let val = env.get("__value");
-                let exclude = [
-                  "package", "fileIndex", "extension", "root", "gmlRootId", "udxDirs", "cityGmlPath",
-                  "schemas", "dirCodelists", "dirSchemas", "gmlName", "codelists", "maxLod", "dirRoot",
-                  "path", "cityCode", "cityName", "gmlId"
-                ];
-                for key in val.keys() {
-                  if !exclude.contains(key) {
-                    result[key] = val[key];
-                  }
-                }
-                result
+            - multipleExpr:
+                type: flowExpr
+                value: |
+                  result = {};
+                  exclude = [
+                    "package", "fileIndex", "extension", "root", "gmlRootId", "udxDirs", "cityGmlPath",
+                    "schemas", "dirCodelists", "dirSchemas", "gmlName", "codelists", "maxLod", "dirRoot",
+                    "path", "cityCode", "cityName", "gmlId"
+                  ];
+                  for key in attributes {
+                    if key not in exclude {
+                      result[key] = attributes[key]
+                    }
+                  };
+                  result
             - attribute: gml_id
               valueAttribute: gmlId
             - attribute: meshcode
-              expr: |
-                file::extract_filename_without_ext(env.get("__value")["path"]).split("_")[0]
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-1].split("_")[0]
             - attribute: feature_type
-              expr: |
-                env.get("__value")["__citygml_feature_type"]
+              expr:
+                type: flowExpr
+                value: attributes["__citygml_feature_type"]
             - attribute: city_code
               valueAttribute: cityCode
             - attribute: city_name

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/07-brid-tun-cons/workflow.yml
@@ -232,9 +232,7 @@ graphs:
                 type: flowExpr
                 value: attributes["path"].split("/")[-1].split("_")[0]
             - attribute: feature_type
-              expr:
-                type: flowExpr
-                value: attributes["__citygml_feature_type"]
+              valueAttribute: __citygml_feature_type
             - attribute: city_code
               valueAttribute: cityCode
             - attribute: city_name

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/08-ubld.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/08-ubld.yml
@@ -326,7 +326,7 @@ graphs:
         method: create
         value:
           type: flowExpr
-          value: Url(attributes["path"]).name.split("_")[0]
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: gml_id
         method: create
         value:
@@ -406,7 +406,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
           city_gml + "_" + attributes["package"] + "_3dtiles_lod" + attributes["lod"] + ".zip"
   edges:
   - id: 25accc00-50d0-4fe9-a289-0e84ecaca659

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/08-ubld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/08-ubld/workflow.yml
@@ -69,7 +69,7 @@ graphs:
               method: create
               value:
                 type: flowExpr
-                value: 'Url(attributes["path"]).name.split("_")[0]'
+                value: 'attributes["path"].split("/")[-1].split("_")[0]'
             - attribute: gml_id
               method: create
               value:
@@ -156,7 +156,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
               city_gml + "_" + attributes["package"] + "_3dtiles_lod" + attributes["lod"] + ".zip"
 
     edges:

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/09-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/09-unf.yml
@@ -384,7 +384,7 @@ graphs:
         method: create
         value:
           type: flowExpr
-          value: Url(attributes["path"]).name.split("_")[0]
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: gml_id
         method: create
         value:
@@ -479,7 +479,7 @@ graphs:
         type: flowExpr
         value: |
           ft = attributes["feature_type"].split(":")[-1];
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
           city_gml + "_" + attributes["package"] + "_" + ft + "_3dtiles_lod" + attributes["lod"] + ".zip"
   - id: 5ea849f7-c314-4460-ad98-50be3e2fe24d
     name: FeatureSorterDmGeometricAttribute
@@ -563,7 +563,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+          stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
           ft = attributes["feature_type"].split(":")[1];
           stem + "_" + attributes["__package"] + "_" + ft + "_dm_geometric_attributes.zip"
       skipUnexposedAttributes: true

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/09-unf/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/09-unf/workflow.yml
@@ -133,7 +133,7 @@ graphs:
               method: create
               value:
                 type: flowExpr
-                value: 'Url(attributes["path"]).name.split("_")[0]'
+                value: 'attributes["path"].split("/")[-1].split("_")[0]'
             - attribute: gml_id
               method: create
               value:
@@ -237,7 +237,7 @@ graphs:
             type: flowExpr
             value: |
               ft = attributes["feature_type"].split(":")[-1];
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
               city_gml + "_" + attributes["package"] + "_" + ft + "_3dtiles_lod" + attributes["lod"] + ".zip"
 
       # DmGeometricAttribute processing
@@ -327,7 +327,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              stem = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
+              stem = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["__package"]);
               ft = attributes["feature_type"].split(":")[1];
               stem + "_" + attributes["__package"] + "_" + ft + "_dm_geometric_attributes.zip"
           skipUnexposedAttributes: true

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/10-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/10-wtr.yml
@@ -326,7 +326,7 @@ graphs:
         method: create
         value:
           type: flowExpr
-          value: Url(attributes["path"]).name.split("_")[0]
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: gml_id
         method: create
         value:
@@ -417,7 +417,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
           city_gml + "_" + attributes["package"] + "_mvt_lod0.zip"
       skipUnexposedAttributes: true
       colonToUnderscore: true
@@ -438,7 +438,7 @@ graphs:
       compressOutput:
         type: flowExpr
         value: |
-          city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
+          city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
           city_gml + "_" + attributes["package"] + "_3dtiles_lod1.zip"
   edges:
   - id: a869fc02-dfdb-4c39-ac49-7329be13c1b9

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/10-wtr/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/10-wtr/workflow.yml
@@ -69,7 +69,7 @@ graphs:
               method: create
               value:
                 type: flowExpr
-                value: 'Url(attributes["path"]).name.split("_")[0]'
+                value: 'attributes["path"].split("/")[-1].split("_")[0]'
             - attribute: gml_id
               method: create
               value:
@@ -168,7 +168,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
               city_gml + "_" + attributes["package"] + "_mvt_lod0.zip"
           skipUnexposedAttributes: true
           colonToUnderscore: true
@@ -190,7 +190,7 @@ graphs:
           compressOutput:
             type: flowExpr
             value: |
-              city_gml = Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
+              city_gml = env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_" + attributes["package"]);
               city_gml + "_" + attributes["package"] + "_3dtiles_lod1.zip"
 
     edges:

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/11-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/11-gen.yml
@@ -326,7 +326,7 @@ graphs:
         method: create
         value:
           type: flowExpr
-          value: Url(attributes["path"]).name.split("_")[0]
+          value: attributes["path"].split("/")[-1].split("_")[0]
       - attribute: gml_id
         method: create
         value:
@@ -438,7 +438,7 @@ graphs:
         value: '"gen_" + attributes["__gml_name_code"] + "_lod" + attributes["__lod"]'
       compressOutput:
         type: flowExpr
-        value: Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_gen") + "_gen_" + attributes["__gml_name_code"] + "_mvt_lod" + attributes["__lod"] + ".zip"
+        value: env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_gen") + "_gen_" + attributes["__gml_name_code"] + "_mvt_lod" + attributes["__lod"] + ".zip"
       skipUnexposedAttributes: true
       colonToUnderscore: true
   edges:

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/11-gen/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/11-gen/workflow.yml
@@ -69,7 +69,7 @@ graphs:
               method: create
               value:
                 type: flowExpr
-                value: 'Url(attributes["path"]).name.split("_")[0]'
+                value: 'attributes["path"].split("/")[-1].split("_")[0]'
             - attribute: gml_id
               method: create
               value:
@@ -190,7 +190,7 @@ graphs:
             value: '"gen_" + attributes["__gml_name_code"] + "_lod" + attributes["__lod"]'
           compressOutput:
             type: flowExpr
-            value: 'Url(env["cityGmlPath"]).name.remove_suffix(".zip").remove_suffix("_gen") + "_gen_" + attributes["__gml_name_code"] + "_mvt_lod" + attributes["__lod"] + ".zip"'
+            value: env["cityGmlPath"].split("/")[-1].remove_suffix(".zip").remove_suffix("_gen") + "_gen_" + attributes["__gml_name_code"] + "_mvt_lod" + attributes["__lod"] + ".zip"
           skipUnexposedAttributes: true
           colonToUnderscore: true
 

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
@@ -519,12 +519,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
@@ -903,7 +903,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
@@ -411,17 +411,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -445,17 +439,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -505,13 +493,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -530,33 +514,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -578,27 +558,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -683,25 +661,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -717,25 +685,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -751,69 +709,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -829,37 +755,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -875,37 +785,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -943,29 +837,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -981,41 +863,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1031,29 +895,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
@@ -411,15 +411,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -435,17 +445,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -483,80 +505,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -637,15 +683,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -661,15 +717,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -685,37 +751,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -731,21 +829,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -761,21 +875,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -791,13 +921,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -805,17 +943,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -831,23 +981,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -863,18 +1031,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1298,8 +1477,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -1347,8 +1527,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -1376,8 +1557,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -414,15 +414,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -438,17 +448,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -486,80 +508,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -640,15 +686,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -664,15 +720,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -688,37 +754,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -734,21 +832,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -764,21 +878,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -794,13 +924,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -808,17 +946,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -834,23 +984,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -866,18 +1034,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1301,8 +1480,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -1350,8 +1530,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -1379,8 +1560,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -2304,15 +2486,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: Building.gml_id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: BuildingPart.gml_id
-        expr: env.get("__value").featureId
+        expr:
+          type: flowExpr
+          value: attributes["featureId"]
       - attribute: lod
-        expr: env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
   - id: 9e8f7a6b-5c4d-3e2f-1a0b-9c8d7e6f5a4b
     name: CsvWriterBuildingPartLod0Or1
     type: action
@@ -2377,21 +2569,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: Building.gml_id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: BuildingPart.gml_id
-        expr: env.get("__value").featureId
+        expr:
+          type: flowExpr
+          value: attributes["featureId"]
       - attribute: lod
-        expr: env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: status
-        expr: env.get("__value")._status
+        expr:
+          type: flowExpr
+          value: attributes["_status"]
       - attribute: connected_id
-        expr: env.get("__value")._connected_id
+        expr:
+          type: flowExpr
+          value: attributes["_connected_id"]
       - attribute: connected_parts
-        expr: env.get("__value")._connected_parts
+        expr:
+          type: flowExpr
+          value: attributes["_connected_parts"]
   - id: d9c0e1f2-3a4b-5c6d-7e8f-9a0b1c2d3e4f
     name: CsvWriterLbldg02Errors
     type: action
@@ -2706,20 +2914,25 @@ graphs:
     with:
       mappers:
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Building Usage Attribute Error
-        expr: |
-          env.get("__value").errors
+        expr:
+          type: flowExpr
+          value: attributes["errors"]
       - attribute: Feature Type
-        expr: |
-          env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
   - id: 72b70428-0bb9-401b-a295-881556adc526
     name: FileTSVWriterLBDLG04-05
     type: action
@@ -2735,20 +2948,25 @@ graphs:
     with:
       mappers:
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: City Code Error
-        expr: |
-          env.get("__value").cityCodeError
+        expr:
+          type: flowExpr
+          value: attributes["cityCodeError"]
       - attribute: Feature Type
-        expr: |
-          env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
   - id: ab3505ad-4e89-4442-ab36-c52ac29c332e
     name: FileTSVWriterCityCodeError
     type: action
@@ -2822,29 +3040,38 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").gmlName
+        expr:
+          type: flowExpr
+          value: attributes["gmlName"]
       - attribute: uro:buildingID
-        expr: |
-          let attributes = env.get("__value").cityGmlAttributes ?? #{};
-          let building_id_attribute = (attributes["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-          building_id_attribute["uro:buildingID"] ?? ""
+        expr:
+          type: flowExpr
+          value: |
+            city_gml = attributes.get("cityGmlAttributes", {});
+            bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+            bldg_id_attr.get("uro:buildingID", "")
       - attribute: uro:branchID
-        expr: |
-          let attributes = env.get("__value").cityGmlAttributes ?? #{};
-          let building_id_attribute = (attributes["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-          building_id_attribute["uro:branchID"] ?? "（なし）"
+        expr:
+          type: flowExpr
+          value: |
+            city_gml = attributes.get("cityGmlAttributes", {});
+            bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+            bldg_id_attr.get("uro:branchID", "（なし）")
       - attribute: uro:partID
-        expr: |
-          let attributes = env.get("__value").cityGmlAttributes ?? #{};
-          let building_id_attribute = (attributes["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-          building_id_attribute["uro:partID"] ?? "（なし）"
+        expr:
+          type: flowExpr
+          value: |
+            city_gml = attributes.get("cityGmlAttributes", {});
+            bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+            bldg_id_attr.get("uro:partID", "（なし）")
   - id: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
     name: FeatureWriter-invalid-building-id-format
     type: action
@@ -2907,39 +3134,40 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: GmlId
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: UroBuildingId
-        expr: |
-          let city_gml_attrs = env.get("__value").cityGmlAttributes ?? #{};
-          let bldg_id_attr = (city_gml_attrs["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-          bldg_id_attr["uro:buildingID"] ?? ""
+        expr:
+          type: flowExpr
+          value: |
+            city_gml = attributes.get("cityGmlAttributes", {});
+            bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+            bldg_id_attr.get("uro:buildingID", "")
       - attribute: UroBranchId
-        expr: |
-          let city_gml_attrs = env.get("__value").cityGmlAttributes ?? #{};
-          let bldg_id_attr = (city_gml_attrs["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-          let branch_id = bldg_id_attr["uro:branchID"] ?? "";
-          if (branch_id == "") {
-            "（なし）"
-          } else {
-            branch_id
-          }
+        expr:
+          type: flowExpr
+          value: |
+            city_gml = attributes.get("cityGmlAttributes", {});
+            bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+            branch_id = bldg_id_attr.get("uro:branchID", "");
+            if branch_id == "" { "（なし）" } else { branch_id }
       - attribute: UroPartId
-        expr: |
-          let city_gml_attrs = env.get("__value").cityGmlAttributes ?? #{};
-          let bldg_id_attr = (city_gml_attrs["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-          let part_id = bldg_id_attr["uro:partID"] ?? "";
-          if (part_id == "") {
-            "（なし）"
-          } else {
-            part_id
-          }
+        expr:
+          type: flowExpr
+          value: |
+            city_gml = attributes.get("cityGmlAttributes", {});
+            bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+            part_id = bldg_id_attr.get("uro:partID", "");
+            if part_id == "" { "（なし）" } else { part_id }
   - id: bba483d0-9813-499e-a0f6-22874646450d
     name: FeatureWriterCsv-c-bldg-01
     type: action
@@ -3246,26 +3474,35 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").gmlPath)
+        expr:
+          type: flowExpr
+          value: attributes["gmlPath"].split("/")[-1]
       - attribute: gmlFilename
-        expr: |
-          file::extract_filename(env.get("__value").gmlPath)
+        expr:
+          type: flowExpr
+          value: attributes["gmlPath"].split("/")[-1]
       - attribute: Building gml:id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Unmatched Xlink Tag
-        expr: |
-          collection::join_array((env.get("__value").unmatchedXlinkTag ?? []), ",")
+        expr:
+          type: flowExpr
+          value: |
+            ",".join(attributes.get("unmatchedXlinkTag", []))
       - attribute: Attribute
-        expr: |
-          env.get("__value").Attribute
+        expr:
+          type: flowExpr
+          value: attributes["Attribute"]
       - attribute: Unmatched Xlink ID
-        expr: |
-          collection::join_array((env.get("__value").unmatchedXlinkId ?? []), ",")
+        expr:
+          type: flowExpr
+          value: |
+            ",".join(attributes.get("unmatchedXlinkId", []))
   - id: 99d8e9f0-1a2b-3c4d-5e6f-7a8b9c0d1e2f
     name: AttributeManagerLbldg06
     type: action
@@ -3319,20 +3556,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").gmlPath)
+        expr:
+          type: flowExpr
+          value: attributes["gmlPath"].split("/")[-1]
       - attribute: Building gml:id
-        expr: |
-          env.get("__value").bldgGmlId
+        expr:
+          type: flowExpr
+          value: attributes["bldgGmlId"]
       - attribute: BuildingInstallation gml:id
-        expr: |
-          env.get("__value").instGmlId
+        expr:
+          type: flowExpr
+          value: attributes["instGmlId"]
       - attribute: GeometryType
-        expr: |
-          env.get("__value").geomTag
+        expr:
+          type: flowExpr
+          value: attributes["geomTag"]
   - id: 2bae2659-e981-4eb1-8cbe-ce0352584a10
     name: FileWriterTsvT-bldg-02
     type: action
@@ -3519,27 +3761,33 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: issue
-        expr: |
-          let value = env.get("__value");
-          if value.validationResult?.details != () {
-            return value.validationResult.details[0][0];
-          }
-          if "issue" in value {
-            return value.issue;
-          }
-          "UnknownError"
+        expr:
+          type: flowExpr
+          value: |
+            vr = attributes.get("validationResult");
+            if vr != null and "details" in vr {
+              vr["details"][0][0]
+            } else if "issue" in attributes {
+              attributes["issue"]
+            } else {
+              "UnknownError"
+            }
   - id: a7b3c9e5-4f8d-4c2e-9a1b-6e3f5d8c2a7b
     name: FeatureWriterLod0IncorrectOrientation
     type: action
@@ -3599,27 +3847,33 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: issue
-        expr: |
-          let value = env.get("__value");
-          if value.validationResult?.details != () {
-            return value.validationResult.details[0][0];
-          }
-          if "issue" in value {
-            return value.issue;
-          }
-          "UnknownError"
+        expr:
+          type: flowExpr
+          value: |
+            vr = attributes.get("validationResult");
+            if vr != null and "details" in vr {
+              vr["details"][0][0]
+            } else if "issue" in attributes {
+              attributes["issue"]
+            } else {
+              "UnknownError"
+            }
   - id: d5a7b9f3-6e4c-4d8a-9f2b-3c7e8d5a6b9f
     name: FeatureWriterLod1InvalidSurface
     type: action
@@ -3678,27 +3932,33 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: issue
-        expr: |
-          let value = env.get("__value");
-          if value.validationResult?.details != () {
-            return value.validationResult.details[0][0];
-          }
-          if "issue" in value {
-            return value.issue;
-          }
-          "UnknownError"
+        expr:
+          type: flowExpr
+          value: |
+            vr = attributes.get("validationResult");
+            if vr != null and "details" in vr {
+              vr["details"][0][0]
+            } else if "issue" in attributes {
+              attributes["issue"]
+            } else {
+              "UnknownError"
+            }
   - id: 9e3c6b8f-5a2d-4f7e-8c1a-4d9b6e3c8f5a
     name: FeatureWriterLod2-4InvalidSurface
     type: action
@@ -3777,24 +4037,41 @@ graphs:
     with:
       mappers:
       - attribute: filename_a
-        expr: env.get("__value").gmlFilename_1
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename_1"]
       - attribute: filename_b
-        expr: env.get("__value").gmlFilename_2
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename_2"]
       - attribute: feature_type_a
-        expr: env.get("__value").featureType_1
+        expr:
+          type: flowExpr
+          value: attributes["featureType_1"]
       - attribute: feature_type_b
-        expr: env.get("__value").featureType_2
+        expr:
+          type: flowExpr
+          value: attributes["featureType_2"]
       - attribute: lod_a
-        expr: env.get("__value").lod_1
+        expr:
+          type: flowExpr
+          value: attributes["lod_1"]
       - attribute: lod_b
-        expr: env.get("__value").lod_2
+        expr:
+          type: flowExpr
+          value: attributes["lod_2"]
       - attribute: gml_id_a
-        expr: env.get("__value").gmlId_1
+        expr:
+          type: flowExpr
+          value: attributes["gmlId_1"]
       - attribute: gml_id_b
-        expr: env.get("__value").gmlId_2
+        expr:
+          type: flowExpr
+          value: attributes["gmlId_2"]
       - attribute: issue
-        expr: |
-          "Surface Intersection"
+        expr:
+          type: string
+          value: Surface Intersection
   - id: aa7bb8cc-9dd0-4ee1-9ff2-5aa3bb4cc5dd
     name: FeatureWriterLod0SurfaceIntersection
     type: action
@@ -3846,29 +4123,37 @@ graphs:
     with:
       mappers:
       - attribute: gmlFilename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: meshcode
-        expr: |
-          env.get("__value").meshcode
+        expr:
+          type: flowExpr
+          value: attributes["meshcode"]
       - attribute: meshcount
-        expr: |
-          env.get("__value")._mesh_count
+        expr:
+          type: flowExpr
+          value: attributes["_mesh_count"]
       - attribute: mesh2area
-        expr: |
-          env.get("__value")._meshcode_to_area
+        expr:
+          type: flowExpr
+          value: attributes["_meshcode_to_area"]
   - id: 77e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a
     name: AttributeManagerIncorrectMeshCode
     type: action
@@ -3931,20 +4216,25 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: issue
-        expr: |
-          "Surface Not Closed"
+        expr:
+          type: string
+          value: Surface Not Closed
   - id: 89712e8f-e0ac-4bb3-a92f-c5ff06fe4c96
     name: FeatureWriterL14-BoundaryNotClosed
     type: action
@@ -3986,20 +4276,25 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: issue
-        expr: |
-          "InvalidSolidBoundaries"
+        expr:
+          type: string
+          value: InvalidSolidBoundaries
   - id: 527087b4-0411-49bd-ae5f-c1c7f9a5ccb8
     name: FeatureWriterL14-BoundaryOtherIssues
     type: action
@@ -4196,35 +4491,47 @@ graphs:
     with:
       mappers:
       - attribute: intersection_id
-        expr: |
-          "lod" + env.get("__value").attrList[0].lod + "_" + env.get("__value").attrList[0].pair_id
+        expr:
+          type: flowExpr
+          value: |
+            item = attributes["attrList"][0];
+            "lod" + item["lod"] + "_" + item["pair_id"]
       - attribute: gmlFilenameA
-        expr: |
-          env.get("__value").attrList[0].gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["attrList"][0]["gmlFilename"]
       - attribute: gmlFilenameB
-        expr: |
-          env.get("__value").attrList[1].gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["attrList"][1]["gmlFilename"]
       - attribute: featureTypeA
-        expr: |
-          env.get("__value").attrList[0].featureType
+        expr:
+          type: flowExpr
+          value: attributes["attrList"][0]["featureType"]
       - attribute: featureTypeB
-        expr: |
-          env.get("__value").attrList[1].featureType
+        expr:
+          type: flowExpr
+          value: attributes["attrList"][1]["featureType"]
       - attribute: lodA
-        expr: |
-          env.get("__value").attrList[0].lod
+        expr:
+          type: flowExpr
+          value: attributes["attrList"][0]["lod"]
       - attribute: lodB
-        expr: |
-          env.get("__value").attrList[1].lod
+        expr:
+          type: flowExpr
+          value: attributes["attrList"][1]["lod"]
       - attribute: gmlIdA
-        expr: |
-          env.get("__value").attrList[0].gmlId
+        expr:
+          type: flowExpr
+          value: attributes["attrList"][0]["gmlId"]
       - attribute: gmlIdB
-        expr: |
-          env.get("__value").attrList[1].gmlId
+        expr:
+          type: flowExpr
+          value: attributes["attrList"][1]["gmlId"]
       - attribute: issue
-        expr: |
-          "Solid Intersection"
+        expr:
+          type: string
+          value: Solid Intersection
   - id: 99cbea75-f9dc-429c-9d42-0213a893090d
     name: FeatureWriterLod1SolidIntersection
     type: action
@@ -4904,20 +5211,25 @@ graphs:
     with:
       mappers:
       - attribute: gmlPath
-        expr: |
-          env.get("__value").path
+        expr:
+          type: flowExpr
+          value: attributes["path"]
       - attribute: gmlFilename
-        expr: |
-          env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: fileIndex
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: codelists
-        expr: |
-          env.get("__value").dirCodelists
+        expr:
+          type: flowExpr
+          value: attributes["dirCodelists"]
       - attribute: schemas
-        expr: |
-          env.get("__value").dirSchemas
+        expr:
+          type: flowExpr
+          value: attributes["dirSchemas"]
   - id: a8a7e7f8-8d73-4078-9cff-4476924f2ad7
     name: FeatureSorter
     type: action
@@ -4988,11 +5300,13 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
   - id: 4712539b-5103-41ee-9359-0333eefb82ef
     name: GeometryRemoverForErrorSummary
     type: action
@@ -5013,95 +5327,125 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Filename
-        expr: |
-          env.get("__value").filename
+        expr:
+          type: flowExpr
+          value: attributes["filename"]
       - attribute: 市区町村コードエラー
-        expr: |
-          env.get("__value")._num_incorrect_city_code ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_incorrect_city_code", 0)
       - attribute: C-bldg-01 エラー
-        expr: |
-          env.get("__value")._num_duplicate_building_id ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_duplicate_building_id", 0)
       - attribute: 不正な建物ID
-        expr: |
-          env.get("__value")._num_missing_building_id ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_missing_building_id", 0)
       - attribute: L-bldg-02 エラー
-        expr: |
-          env.get("__value")._num_lbldg02_error ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lbldg02_error", 0)
       - attribute: L-bldg-04,05 エラー
-        expr: |
-          env.get("__value")._num_incorrect_usage_attribute ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_incorrect_usage_attribute", 0)
       - attribute: L-bldg-06 エラー
-        expr: |
-          env.get("__value")._num_lbldg06_error ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lbldg06_error", 0)
       - attribute: T-bldg-02エラー
-        expr: |
-          env.get("__value")._num_invalid_bldginst_geom_type ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_invalid_bldginst_geom_type", 0)
       - attribute: LOD0 面のエラー
-        expr: |
-          env.get("__value")._num_lod0_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod0_invalid_surface", 0)
       - attribute: LOD0 面の向きエラー
-        expr: |
-          env.get("__value")._num_lod0_incorrect_orientation ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod0_incorrect_orientation", 0)
       - attribute: LOD0 面の交差
-        expr: |
-          env.get("__value")._num_lod0_surface_intersection ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod0_surface_intersection", 0)
       - attribute: LOD1 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod1_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod1_invalid_surface", 0)
       - attribute: LOD1 非水密立体
-        expr: |
-          env.get("__value")._num_lod1_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod1_not_closed_solid", 0)
       - attribute: LOD1 立体のエラー
-        expr: |
-          env.get("__value")._num_lod1_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod1_solid_issues", 0)
       - attribute: LOD2 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod2_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod2_invalid_surface", 0)
       - attribute: LOD3 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod3_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod3_invalid_surface", 0)
       - attribute: LOD4 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod4_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod4_invalid_surface", 0)
       - attribute: LOD2 非水密立体
-        expr: |
-          env.get("__value")._num_lod2_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod2_not_closed_solid", 0)
       - attribute: LOD3 非水密立体
-        expr: |
-          env.get("__value")._num_lod3_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod3_not_closed_solid", 0)
       - attribute: LOD4 非水密立体
-        expr: |
-          env.get("__value")._num_lod4_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod4_not_closed_solid", 0)
       - attribute: LOD2 立体のエラー
-        expr: |
-          env.get("__value")._num_lod2_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod2_solid_issues", 0)
       - attribute: LOD3 立体のエラー
-        expr: |
-          env.get("__value")._num_lod3_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod3_solid_issues", 0)
       - attribute: LOD4 立体のエラー
-        expr: |
-          env.get("__value")._num_lod4_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod4_solid_issues", 0)
       - attribute: 図郭不正
-        expr: |
-          env.get("__value")._num_incorrect_meshcode ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_incorrect_meshcode", 0)
       - attribute: LOD0-1のBuildingPart
-        expr: |
-          env.get("__value")._num_lod0_1_buildingpart ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod0_1_buildingpart", 0)
       - attribute: LOD1 立体の交差
-        expr: |
-          env.get("__value")._num_lod1_solid_intersection ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod1_solid_intersection", 0)
       - attribute: LOD2 立体の交差
-        expr: |
-          env.get("__value")._num_lod2_solid_intersection ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod2_solid_intersection", 0)
       - attribute: LOD3 立体の交差
-        expr: |
-          env.get("__value")._num_lod3_solid_intersection ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod3_solid_intersection", 0)
       - attribute: LOD4 立体の交差
-        expr: |
-          env.get("__value")._num_lod4_solid_intersection ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod4_solid_intersection", 0)
   - id: e4f5a6b7-8c9d-0e1f-2a3b-4c5d6e7f8a9b
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -414,17 +414,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -448,17 +442,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -508,13 +496,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -533,33 +517,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -581,27 +561,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -686,25 +664,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -720,25 +688,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -754,69 +712,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -832,37 +758,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -878,37 +788,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -946,29 +840,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -984,41 +866,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1034,29 +898,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -2486,25 +2340,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: Building.gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: BuildingPart.gml_id
-        expr:
-          type: flowExpr
-          value: attributes["featureId"]
+        valueAttribute: featureId
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
   - id: 9e8f7a6b-5c4d-3e2f-1a0b-9c8d7e6f5a4b
     name: CsvWriterBuildingPartLod0Or1
     type: action
@@ -2569,37 +2413,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: Building.gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: BuildingPart.gml_id
-        expr:
-          type: flowExpr
-          value: attributes["featureId"]
+        valueAttribute: featureId
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: status
-        expr:
-          type: flowExpr
-          value: attributes["_status"]
+        valueAttribute: _status
       - attribute: connected_id
-        expr:
-          type: flowExpr
-          value: attributes["_connected_id"]
+        valueAttribute: _connected_id
       - attribute: connected_parts
-        expr:
-          type: flowExpr
-          value: attributes["_connected_parts"]
+        valueAttribute: _connected_parts
   - id: d9c0e1f2-3a4b-5c6d-7e8f-9a0b1c2d3e4f
     name: CsvWriterLbldg02Errors
     type: action
@@ -2914,25 +2742,15 @@ graphs:
     with:
       mappers:
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Building Usage Attribute Error
-        expr:
-          type: flowExpr
-          value: attributes["errors"]
+        valueAttribute: errors
       - attribute: Feature Type
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
   - id: 72b70428-0bb9-401b-a295-881556adc526
     name: FileTSVWriterLBDLG04-05
     type: action
@@ -2948,25 +2766,15 @@ graphs:
     with:
       mappers:
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: City Code Error
-        expr:
-          type: flowExpr
-          value: attributes["cityCodeError"]
+        valueAttribute: cityCodeError
       - attribute: Feature Type
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
   - id: ab3505ad-4e89-4442-ab36-c52ac29c332e
     name: FileTSVWriterCityCodeError
     type: action
@@ -3040,17 +2848,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["gmlName"]
+        valueAttribute: gmlName
       - attribute: uro:buildingID
         expr:
           type: flowExpr
@@ -3134,17 +2936,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: GmlId
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: UroBuildingId
         expr:
           type: flowExpr
@@ -3474,9 +3270,7 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: Filename
         expr:
           type: flowExpr
@@ -3486,18 +3280,14 @@ graphs:
           type: flowExpr
           value: attributes["gmlPath"].split("/")[-1]
       - attribute: Building gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Unmatched Xlink Tag
         expr:
           type: flowExpr
           value: |
             ",".join(attributes.get("unmatchedXlinkTag", []))
       - attribute: Attribute
-        expr:
-          type: flowExpr
-          value: attributes["Attribute"]
+        valueAttribute: Attribute
       - attribute: Unmatched Xlink ID
         expr:
           type: flowExpr
@@ -3556,25 +3346,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: Filename
         expr:
           type: flowExpr
           value: attributes["gmlPath"].split("/")[-1]
       - attribute: Building gml:id
-        expr:
-          type: flowExpr
-          value: attributes["bldgGmlId"]
+        valueAttribute: bldgGmlId
       - attribute: BuildingInstallation gml:id
-        expr:
-          type: flowExpr
-          value: attributes["instGmlId"]
+        valueAttribute: instGmlId
       - attribute: GeometryType
-        expr:
-          type: flowExpr
-          value: attributes["geomTag"]
+        valueAttribute: geomTag
   - id: 2bae2659-e981-4eb1-8cbe-ce0352584a10
     name: FileWriterTsvT-bldg-02
     type: action
@@ -3761,21 +3543,13 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: issue
         expr:
           type: flowExpr
@@ -3847,21 +3621,13 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: issue
         expr:
           type: flowExpr
@@ -3932,21 +3698,13 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: issue
         expr:
           type: flowExpr
@@ -4037,37 +3795,21 @@ graphs:
     with:
       mappers:
       - attribute: filename_a
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename_1"]
+        valueAttribute: gmlFilename_1
       - attribute: filename_b
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename_2"]
+        valueAttribute: gmlFilename_2
       - attribute: feature_type_a
-        expr:
-          type: flowExpr
-          value: attributes["featureType_1"]
+        valueAttribute: featureType_1
       - attribute: feature_type_b
-        expr:
-          type: flowExpr
-          value: attributes["featureType_2"]
+        valueAttribute: featureType_2
       - attribute: lod_a
-        expr:
-          type: flowExpr
-          value: attributes["lod_1"]
+        valueAttribute: lod_1
       - attribute: lod_b
-        expr:
-          type: flowExpr
-          value: attributes["lod_2"]
+        valueAttribute: lod_2
       - attribute: gml_id_a
-        expr:
-          type: flowExpr
-          value: attributes["gmlId_1"]
+        valueAttribute: gmlId_1
       - attribute: gml_id_b
-        expr:
-          type: flowExpr
-          value: attributes["gmlId_2"]
+        valueAttribute: gmlId_2
       - attribute: issue
         expr:
           type: string
@@ -4123,37 +3865,21 @@ graphs:
     with:
       mappers:
       - attribute: gmlFilename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: meshcode
-        expr:
-          type: flowExpr
-          value: attributes["meshcode"]
+        valueAttribute: meshcode
       - attribute: meshcount
-        expr:
-          type: flowExpr
-          value: attributes["_mesh_count"]
+        valueAttribute: _mesh_count
       - attribute: mesh2area
-        expr:
-          type: flowExpr
-          value: attributes["_meshcode_to_area"]
+        valueAttribute: _meshcode_to_area
   - id: 77e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a
     name: AttributeManagerIncorrectMeshCode
     type: action
@@ -4216,21 +3942,13 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: issue
         expr:
           type: string
@@ -4276,21 +3994,13 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: issue
         expr:
           type: string

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -4495,7 +4495,7 @@ graphs:
           type: flowExpr
           value: |
             item = attributes["attrList"][0];
-            "lod" + item["lod"] + "_" + item["pair_id"]
+            "lod" + str(item["lod"]) + "_" + str(item["pair_id"])
       - attribute: gmlFilenameA
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -522,12 +522,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -906,7 +906,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -5211,25 +5211,15 @@ graphs:
     with:
       mappers:
       - attribute: gmlPath
-        expr:
-          type: flowExpr
-          value: attributes["path"]
+        valueAttribute: path
       - attribute: gmlFilename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: fileIndex
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: codelists
-        expr:
-          type: flowExpr
-          value: attributes["dirCodelists"]
+        valueAttribute: dirCodelists
       - attribute: schemas
-        expr:
-          type: flowExpr
-          value: attributes["dirSchemas"]
+        valueAttribute: dirSchemas
   - id: a8a7e7f8-8d73-4078-9cff-4476924f2ad7
     name: FeatureSorter
     type: action
@@ -5300,13 +5290,9 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
   - id: 4712539b-5103-41ee-9359-0333eefb82ef
     name: GeometryRemoverForErrorSummary
     type: action
@@ -5327,13 +5313,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["filename"]
+        valueAttribute: filename
       - attribute: 市区町村コードエラー
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/building_part_validation.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/building_part_validation.yml
@@ -20,15 +20,25 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").fileIndex
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: Building.gml_id
-          expr: env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: BuildingPart.gml_id
-          expr: env.get("__value").featureId
+          expr:
+            type: flowExpr
+            value: attributes["featureId"]
         - attribute: lod
-          expr: env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
 
   - id: 9e8f7a6b-5c4d-3e2f-1a0b-9c8d7e6f5a4b
     name: CsvWriterBuildingPartLod0Or1
@@ -110,21 +120,37 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: env.get("__value").fileIndex
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: Building.gml_id
-          expr: env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: BuildingPart.gml_id
-          expr: env.get("__value").featureId
+          expr:
+            type: flowExpr
+            value: attributes["featureId"]
         - attribute: lod
-          expr: env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: status
-          expr: env.get("__value")._status
+          expr:
+            type: flowExpr
+            value: attributes["_status"]
         - attribute: connected_id
-          expr: env.get("__value")._connected_id
+          expr:
+            type: flowExpr
+            value: attributes["_connected_id"]
         - attribute: connected_parts
-          expr: env.get("__value")._connected_parts
+          expr:
+            type: flowExpr
+            value: attributes["_connected_parts"]
 
   - id: d9c0e1f2-3a4b-5c6d-7e8f-9a0b1c2d3e4f
     name: CsvWriterLbldg02Errors

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/building_part_validation.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/building_part_validation.yml
@@ -20,25 +20,15 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["fileIndex"]
+          valueAttribute: fileIndex
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: Building.gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: BuildingPart.gml_id
-          expr:
-            type: flowExpr
-            value: attributes["featureId"]
+          valueAttribute: featureId
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
 
   - id: 9e8f7a6b-5c4d-3e2f-1a0b-9c8d7e6f5a4b
     name: CsvWriterBuildingPartLod0Or1
@@ -120,37 +110,21 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["fileIndex"]
+          valueAttribute: fileIndex
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: Building.gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: BuildingPart.gml_id
-          expr:
-            type: flowExpr
-            value: attributes["featureId"]
+          valueAttribute: featureId
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: status
-          expr:
-            type: flowExpr
-            value: attributes["_status"]
+          valueAttribute: _status
         - attribute: connected_id
-          expr:
-            type: flowExpr
-            value: attributes["_connected_id"]
+          valueAttribute: _connected_id
         - attribute: connected_parts
-          expr:
-            type: flowExpr
-            value: attributes["_connected_parts"]
+          valueAttribute: _connected_parts
 
   - id: d9c0e1f2-3a4b-5c6d-7e8f-9a0b1c2d3e4f
     name: CsvWriterLbldg02Errors

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/format_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/format_checks.yml
@@ -222,20 +222,25 @@ nodes:
     with:
       mappers:
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: Building Usage Attribute Error
-          expr: |
-            env.get("__value").errors
+          expr:
+            type: flowExpr
+            value: attributes["errors"]
         - attribute: Feature Type
-          expr: |
-            env.get("__value").featureType
+          expr:
+            type: flowExpr
+            value: attributes["featureType"]
 
   - id: 72b70428-0bb9-401b-a295-881556adc526
     name: FileTSVWriterLBDLG04-05
@@ -253,20 +258,25 @@ nodes:
     with:
       mappers:
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: City Code Error
-          expr: |
-            env.get("__value").cityCodeError
+          expr:
+            type: flowExpr
+            value: attributes["cityCodeError"]
         - attribute: Feature Type
-          expr: |
-            env.get("__value").featureType
+          expr:
+            type: flowExpr
+            value: attributes["featureType"]
 
   - id: ab3505ad-4e89-4442-ab36-c52ac29c332e
     name: FileTSVWriterCityCodeError
@@ -349,29 +359,38 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: FeatureType
-          expr: |
-            env.get("__value").gmlName
+          expr:
+            type: flowExpr
+            value: attributes["gmlName"]
         - attribute: "uro:buildingID"
-          expr: |
-            let attributes = env.get("__value").cityGmlAttributes ?? #{};
-            let building_id_attribute = (attributes["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-            building_id_attribute["uro:buildingID"] ?? ""
+          expr:
+            type: flowExpr
+            value: |
+              city_gml = attributes.get("cityGmlAttributes", {});
+              bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+              bldg_id_attr.get("uro:buildingID", "")
         - attribute: "uro:branchID"
-          expr: |
-            let attributes = env.get("__value").cityGmlAttributes ?? #{};
-            let building_id_attribute = (attributes["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-            building_id_attribute["uro:branchID"] ?? "（なし）"
+          expr:
+            type: flowExpr
+            value: |
+              city_gml = attributes.get("cityGmlAttributes", {});
+              bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+              bldg_id_attr.get("uro:branchID", "（なし）")
         - attribute: "uro:partID"
-          expr: |
-            let attributes = env.get("__value").cityGmlAttributes ?? #{};
-            let building_id_attribute = (attributes["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-            building_id_attribute["uro:partID"] ?? "（なし）"
+          expr:
+            type: flowExpr
+            value: |
+              city_gml = attributes.get("cityGmlAttributes", {});
+              bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+              bldg_id_attr.get("uro:partID", "（なし）")
 
   - id: 4c5d6e7f-8a9b-0c1d-2e3f-4a5b6c7d8e9f
     name: FeatureWriter-invalid-building-id-format
@@ -439,40 +458,40 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: GmlId
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: UroBuildingId
-          expr: |
-            let city_gml_attrs = env.get("__value").cityGmlAttributes ?? #{};
-            let bldg_id_attr = (city_gml_attrs["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-            bldg_id_attr["uro:buildingID"] ?? ""
+          expr:
+            type: flowExpr
+            value: |
+              city_gml = attributes.get("cityGmlAttributes", {});
+              bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+              bldg_id_attr.get("uro:buildingID", "")
         - attribute: UroBranchId
-          expr: |
-            let city_gml_attrs = env.get("__value").cityGmlAttributes ?? #{};
-            let bldg_id_attr = (city_gml_attrs["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-            let branch_id = bldg_id_attr["uro:branchID"] ?? "";
-            if (branch_id == "") {
-              "（なし）"
-            } else {
-              branch_id
-            }
-
+          expr:
+            type: flowExpr
+            value: |
+              city_gml = attributes.get("cityGmlAttributes", {});
+              bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+              branch_id = bldg_id_attr.get("uro:branchID", "");
+              if branch_id == "" { "（なし）" } else { branch_id }
         - attribute: UroPartId
-          expr: |
-            let city_gml_attrs = env.get("__value").cityGmlAttributes ?? #{};
-            let bldg_id_attr = (city_gml_attrs["uro:BuildingIDAttribute"] ?? []).get(0) ?? #{};
-            let part_id = bldg_id_attr["uro:partID"] ?? "";
-            if (part_id == "") {
-              "（なし）"
-            } else {
-              part_id
-            }
+          expr:
+            type: flowExpr
+            value: |
+              city_gml = attributes.get("cityGmlAttributes", {});
+              bldg_id_attr = city_gml.get("uro:BuildingIDAttribute", []).get(0, {});
+              part_id = bldg_id_attr.get("uro:partID", "");
+              if part_id == "" { "（なし）" } else { part_id }
 
   - id: bba483d0-9813-499e-a0f6-22874646450d
     name: FeatureWriterCsv-c-bldg-01

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/format_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/format_checks.yml
@@ -222,25 +222,15 @@ nodes:
     with:
       mappers:
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["fileIndex"]
+          valueAttribute: fileIndex
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: Building Usage Attribute Error
-          expr:
-            type: flowExpr
-            value: attributes["errors"]
+          valueAttribute: errors
         - attribute: Feature Type
-          expr:
-            type: flowExpr
-            value: attributes["featureType"]
+          valueAttribute: featureType
 
   - id: 72b70428-0bb9-401b-a295-881556adc526
     name: FileTSVWriterLBDLG04-05
@@ -258,25 +248,15 @@ nodes:
     with:
       mappers:
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["fileIndex"]
+          valueAttribute: fileIndex
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: City Code Error
-          expr:
-            type: flowExpr
-            value: attributes["cityCodeError"]
+          valueAttribute: cityCodeError
         - attribute: Feature Type
-          expr:
-            type: flowExpr
-            value: attributes["featureType"]
+          valueAttribute: featureType
 
   - id: ab3505ad-4e89-4442-ab36-c52ac29c332e
     name: FileTSVWriterCityCodeError
@@ -359,17 +339,11 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["fileIndex"]
+          valueAttribute: fileIndex
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: FeatureType
-          expr:
-            type: flowExpr
-            value: attributes["gmlName"]
+          valueAttribute: gmlName
         - attribute: "uro:buildingID"
           expr:
             type: flowExpr
@@ -458,17 +432,11 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["fileIndex"]
+          valueAttribute: fileIndex
         - attribute: Filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: GmlId
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: UroBuildingId
           expr:
             type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/ref_and_type_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/ref_and_type_checks.yml
@@ -71,9 +71,7 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["fileIndex"]
+          valueAttribute: fileIndex
         - attribute: Filename
           expr:
             type: flowExpr
@@ -83,18 +81,14 @@ nodes:
             type: flowExpr
             value: attributes["gmlPath"].split("/")[-1]
         - attribute: "Building gml:id"
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: "Unmatched Xlink Tag"
           expr:
             type: flowExpr
             value: |
               ",".join(attributes.get("unmatchedXlinkTag", []))
         - attribute: Attribute
-          expr:
-            type: flowExpr
-            value: attributes["Attribute"]
+          valueAttribute: Attribute
         - attribute: "Unmatched Xlink ID"
           expr:
             type: flowExpr
@@ -161,25 +155,17 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr:
-            type: flowExpr
-            value: attributes["fileIndex"]
+          valueAttribute: fileIndex
         - attribute: Filename
           expr:
             type: flowExpr
             value: attributes["gmlPath"].split("/")[-1]
         - attribute: "Building gml:id"
-          expr:
-            type: flowExpr
-            value: attributes["bldgGmlId"]
+          valueAttribute: bldgGmlId
         - attribute: "BuildingInstallation gml:id"
-          expr:
-            type: flowExpr
-            value: attributes["instGmlId"]
+          valueAttribute: instGmlId
         - attribute: "GeometryType"
-          expr:
-            type: flowExpr
-            value: attributes["geomTag"]
+          valueAttribute: geomTag
 
   - id: 2bae2659-e981-4eb1-8cbe-ce0352584a10
     name: FileWriterTsvT-bldg-02

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/ref_and_type_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/ref_and_type_checks.yml
@@ -71,26 +71,35 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            file::extract_filename(env.get("__value").gmlPath)
+          expr:
+            type: flowExpr
+            value: attributes["gmlPath"].split("/")[-1]
         - attribute: gmlFilename
-          expr: |
-            file::extract_filename(env.get("__value").gmlPath)
+          expr:
+            type: flowExpr
+            value: attributes["gmlPath"].split("/")[-1]
         - attribute: "Building gml:id"
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: "Unmatched Xlink Tag"
-          expr: |
-            collection::join_array((env.get("__value").unmatchedXlinkTag ?? []), ",")
+          expr:
+            type: flowExpr
+            value: |
+              ",".join(attributes.get("unmatchedXlinkTag", []))
         - attribute: Attribute
-          expr: |
-            env.get("__value").Attribute
+          expr:
+            type: flowExpr
+            value: attributes["Attribute"]
         - attribute: "Unmatched Xlink ID"
-          expr: |
-            collection::join_array((env.get("__value").unmatchedXlinkId ?? []), ",")
+          expr:
+            type: flowExpr
+            value: |
+              ",".join(attributes.get("unmatchedXlinkId", []))
 
   - id: 99d8e9f0-1a2b-3c4d-5e6f-7a8b9c0d1e2f
     name: AttributeManagerLbldg06
@@ -152,20 +161,25 @@ nodes:
     with:
       mappers:
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            file::extract_filename(env.get("__value").gmlPath)
+          expr:
+            type: flowExpr
+            value: attributes["gmlPath"].split("/")[-1]
         - attribute: "Building gml:id"
-          expr: |
-            env.get("__value").bldgGmlId
+          expr:
+            type: flowExpr
+            value: attributes["bldgGmlId"]
         - attribute: "BuildingInstallation gml:id"
-          expr: |
-            env.get("__value").instGmlId
+          expr:
+            type: flowExpr
+            value: attributes["instGmlId"]
         - attribute: "GeometryType"
-          expr: |
-            env.get("__value").geomTag
+          expr:
+            type: flowExpr
+            value: attributes["geomTag"]
 
   - id: 2bae2659-e981-4eb1-8cbe-ce0352584a10
     name: FileWriterTsvT-bldg-02

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/surface_validation.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/surface_validation.yml
@@ -846,7 +846,7 @@ nodes:
             type: flowExpr
             value: |
               item = attributes["attrList"][0];
-              "lod" + item["lod"] + "_" + item["pair_id"]
+              "lod" + str(item["lod"]) + "_" + str(item["pair_id"])
         - attribute: gmlFilenameA
           expr:
             type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/surface_validation.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/surface_validation.yml
@@ -26,21 +26,13 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
-          expr:
-            type: flowExpr
-            value: attributes["featureType"]
+          valueAttribute: featureType
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: issue
           expr:
             type: flowExpr
@@ -121,21 +113,13 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
-          expr:
-            type: flowExpr
-            value: attributes["featureType"]
+          valueAttribute: featureType
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: issue
           expr:
             type: flowExpr
@@ -214,21 +198,13 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
-          expr:
-            type: flowExpr
-            value: attributes["featureType"]
+          valueAttribute: featureType
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: issue
           expr:
             type: flowExpr
@@ -332,37 +308,21 @@ nodes:
     with:
       mappers:
         - attribute: filename_a
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename_1"]
+          valueAttribute: gmlFilename_1
         - attribute: filename_b
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename_2"]
+          valueAttribute: gmlFilename_2
         - attribute: feature_type_a
-          expr:
-            type: flowExpr
-            value: attributes["featureType_1"]
+          valueAttribute: featureType_1
         - attribute: feature_type_b
-          expr:
-            type: flowExpr
-            value: attributes["featureType_2"]
+          valueAttribute: featureType_2
         - attribute: lod_a
-          expr:
-            type: flowExpr
-            value: attributes["lod_1"]
+          valueAttribute: lod_1
         - attribute: lod_b
-          expr:
-            type: flowExpr
-            value: attributes["lod_2"]
+          valueAttribute: lod_2
         - attribute: gml_id_a
-          expr:
-            type: flowExpr
-            value: attributes["gmlId_1"]
+          valueAttribute: gmlId_1
         - attribute: gml_id_b
-          expr:
-            type: flowExpr
-            value: attributes["gmlId_2"]
+          valueAttribute: gmlId_2
         - attribute: issue
           expr:
             type: string
@@ -425,37 +385,21 @@ nodes:
     with:
       mappers:
         - attribute: gmlFilename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
-          expr:
-            type: flowExpr
-            value: attributes["featureType"]
+          valueAttribute: featureType
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: meshcode
-          expr:
-            type: flowExpr
-            value: attributes["meshcode"]
+          valueAttribute: meshcode
         - attribute: meshcount
-          expr:
-            type: flowExpr
-            value: attributes["_mesh_count"]
+          valueAttribute: _mesh_count
         - attribute: mesh2area
-          expr:
-            type: flowExpr
-            value: attributes["_meshcode_to_area"]
+          valueAttribute: _meshcode_to_area
 
   - id: 77e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a
     name: AttributeManagerIncorrectMeshCode
@@ -529,21 +473,13 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
-          expr:
-            type: flowExpr
-            value: attributes["featureType"]
+          valueAttribute: featureType
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: issue
           expr:
             type: string
@@ -593,21 +529,13 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
-          expr:
-            type: flowExpr
-            value: attributes["featureType"]
+          valueAttribute: featureType
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: issue
           expr:
             type: string

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/surface_validation.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/surface_validation.yml
@@ -26,27 +26,33 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            env.get("__value").featureType
+          expr:
+            type: flowExpr
+            value: attributes["featureType"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: issue
-          expr: |
-            let value = env.get("__value");
-            if value.validationResult?.details != () {
-              return value.validationResult.details[0][0];
-            }
-            if "issue" in value {
-              return value.issue;
-            }
-            "UnknownError"
+          expr:
+            type: flowExpr
+            value: |
+              vr = attributes.get("validationResult");
+              if vr != null and "details" in vr {
+                vr["details"][0][0]
+              } else if "issue" in attributes {
+                attributes["issue"]
+              } else {
+                "UnknownError"
+              }
 
   - id: a7b3c9e5-4f8d-4c2e-9a1b-6e3f5d8c2a7b
     name: FeatureWriterLod0IncorrectOrientation
@@ -115,27 +121,33 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            env.get("__value").featureType
+          expr:
+            type: flowExpr
+            value: attributes["featureType"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: issue
-          expr: |
-            let value = env.get("__value");
-            if value.validationResult?.details != () {
-              return value.validationResult.details[0][0];
-            }
-            if "issue" in value {
-              return value.issue;
-            }
-            "UnknownError"
+          expr:
+            type: flowExpr
+            value: |
+              vr = attributes.get("validationResult");
+              if vr != null and "details" in vr {
+                vr["details"][0][0]
+              } else if "issue" in attributes {
+                attributes["issue"]
+              } else {
+                "UnknownError"
+              }
 
   - id: d5a7b9f3-6e4c-4d8a-9f2b-3c7e8d5a6b9f
     name: FeatureWriterLod1InvalidSurface
@@ -202,27 +214,33 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            env.get("__value").featureType
+          expr:
+            type: flowExpr
+            value: attributes["featureType"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: issue
-          expr: |
-            let value = env.get("__value");
-            if value.validationResult?.details != () {
-              return value.validationResult.details[0][0];
-            }
-            if "issue" in value {
-              return value.issue;
-            }
-            "UnknownError"
+          expr:
+            type: flowExpr
+            value: |
+              vr = attributes.get("validationResult");
+              if vr != null and "details" in vr {
+                vr["details"][0][0]
+              } else if "issue" in attributes {
+                attributes["issue"]
+              } else {
+                "UnknownError"
+              }
 
   - id: 9e3c6b8f-5a2d-4f7e-8c1a-4d9b6e3c8f5a
     name: FeatureWriterLod2-4InvalidSurface
@@ -314,24 +332,41 @@ nodes:
     with:
       mappers:
         - attribute: filename_a
-          expr: env.get("__value").gmlFilename_1
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename_1"]
         - attribute: filename_b
-          expr: env.get("__value").gmlFilename_2
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename_2"]
         - attribute: feature_type_a
-          expr: env.get("__value").featureType_1
+          expr:
+            type: flowExpr
+            value: attributes["featureType_1"]
         - attribute: feature_type_b
-          expr: env.get("__value").featureType_2
+          expr:
+            type: flowExpr
+            value: attributes["featureType_2"]
         - attribute: lod_a
-          expr: env.get("__value").lod_1
+          expr:
+            type: flowExpr
+            value: attributes["lod_1"]
         - attribute: lod_b
-          expr: env.get("__value").lod_2
+          expr:
+            type: flowExpr
+            value: attributes["lod_2"]
         - attribute: gml_id_a
-          expr: env.get("__value").gmlId_1
+          expr:
+            type: flowExpr
+            value: attributes["gmlId_1"]
         - attribute: gml_id_b
-          expr: env.get("__value").gmlId_2
+          expr:
+            type: flowExpr
+            value: attributes["gmlId_2"]
         - attribute: issue
-          expr: |
-            "Surface Intersection"
+          expr:
+            type: string
+            value: Surface Intersection
 
   - id: aa7bb8cc-9dd0-4ee1-9ff2-5aa3bb4cc5dd
     name: FeatureWriterLod0SurfaceIntersection
@@ -390,29 +425,37 @@ nodes:
     with:
       mappers:
         - attribute: gmlFilename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            env.get("__value").featureType
+          expr:
+            type: flowExpr
+            value: attributes["featureType"]
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: meshcode
-          expr: |
-            env.get("__value").meshcode
+          expr:
+            type: flowExpr
+            value: attributes["meshcode"]
         - attribute: meshcount
-          expr: |
-            env.get("__value")._mesh_count
+          expr:
+            type: flowExpr
+            value: attributes["_mesh_count"]
         - attribute: mesh2area
-          expr: |
-            env.get("__value")._meshcode_to_area
+          expr:
+            type: flowExpr
+            value: attributes["_meshcode_to_area"]
 
   - id: 77e7f8a9-0b1c-2d3e-4f5a-6b7c8d9e0f1a
     name: AttributeManagerIncorrectMeshCode
@@ -486,20 +529,25 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            env.get("__value").featureType
+          expr:
+            type: flowExpr
+            value: attributes["featureType"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: issue
-          expr: |
-            "Surface Not Closed"
+          expr:
+            type: string
+            value: Surface Not Closed
 
   - id: 89712e8f-e0ac-4bb3-a92f-c5ff06fe4c96
     name: FeatureWriterL14-BoundaryNotClosed
@@ -545,20 +593,25 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            env.get("__value").featureType
+          expr:
+            type: flowExpr
+            value: attributes["featureType"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: issue
-          expr: |
-            "InvalidSolidBoundaries"
+          expr:
+            type: string
+            value: InvalidSolidBoundaries
 
   - id: 527087b4-0411-49bd-ae5f-c1c7f9a5ccb8
     name: FeatureWriterL14-BoundaryOtherIssues
@@ -789,35 +842,47 @@ nodes:
     with:
       mappers:
         - attribute: intersection_id
-          expr: |
-            "lod" + env.get("__value").attrList[0].lod + "_" + env.get("__value").attrList[0].pair_id
+          expr:
+            type: flowExpr
+            value: |
+              item = attributes["attrList"][0];
+              "lod" + item["lod"] + "_" + item["pair_id"]
         - attribute: gmlFilenameA
-          expr: |
-            env.get("__value").attrList[0].gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["attrList"][0]["gmlFilename"]
         - attribute: gmlFilenameB
-          expr: |
-            env.get("__value").attrList[1].gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["attrList"][1]["gmlFilename"]
         - attribute: featureTypeA
-          expr: |
-            env.get("__value").attrList[0].featureType
+          expr:
+            type: flowExpr
+            value: attributes["attrList"][0]["featureType"]
         - attribute: featureTypeB
-          expr: |
-            env.get("__value").attrList[1].featureType
+          expr:
+            type: flowExpr
+            value: attributes["attrList"][1]["featureType"]
         - attribute: lodA
-          expr: |
-            env.get("__value").attrList[0].lod
+          expr:
+            type: flowExpr
+            value: attributes["attrList"][0]["lod"]
         - attribute: lodB
-          expr: |
-            env.get("__value").attrList[1].lod
+          expr:
+            type: flowExpr
+            value: attributes["attrList"][1]["lod"]
         - attribute: gmlIdA
-          expr: |
-            env.get("__value").attrList[0].gmlId
+          expr:
+            type: flowExpr
+            value: attributes["attrList"][0]["gmlId"]
         - attribute: gmlIdB
-          expr: |
-            env.get("__value").attrList[1].gmlId
+          expr:
+            type: flowExpr
+            value: attributes["attrList"][1]["gmlId"]
         - attribute: issue
-          expr: |
-            "Solid Intersection"
+          expr:
+            type: string
+            value: Solid Intersection
 
   - id: 99cbea75-f9dc-429c-9d42-0213a893090d
     name: FeatureWriterLod1SolidIntersection

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
@@ -137,25 +137,15 @@ graphs:
         with:
           mappers:
             - attribute: gmlPath
-              expr:
-                type: flowExpr
-                value: attributes["path"]
+              valueAttribute: path
             - attribute: gmlFilename
-              expr:
-                type: flowExpr
-                value: attributes["name"]
+              valueAttribute: name
             - attribute: fileIndex
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: codelists
-              expr:
-                type: flowExpr
-                value: attributes["dirCodelists"]
+              valueAttribute: dirCodelists
             - attribute: schemas
-              expr:
-                type: flowExpr
-                value: attributes["dirSchemas"]
+              valueAttribute: dirSchemas
 
       - id: a8a7e7f8-8d73-4078-9cff-4476924f2ad7
         name: FeatureSorter
@@ -237,13 +227,9 @@ graphs:
         with:
           mappers:
             - attribute: index
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: filename
-              expr:
-                type: flowExpr
-                value: attributes["gmlFilename"]
+              valueAttribute: gmlFilename
 
       # Phase 2: FeatureMerger for aggregating error counts
       - id: 4712539b-5103-41ee-9359-0333eefb82ef
@@ -269,13 +255,9 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr:
-                type: flowExpr
-                value: attributes["index"]
+              valueAttribute: index
             - attribute: Filename
-              expr:
-                type: flowExpr
-                value: attributes["filename"]
+              valueAttribute: filename
             - attribute: "市区町村コードエラー"
               expr:
                 type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/workflow.yml
@@ -137,20 +137,25 @@ graphs:
         with:
           mappers:
             - attribute: gmlPath
-              expr: |
-                env.get("__value").path
+              expr:
+                type: flowExpr
+                value: attributes["path"]
             - attribute: gmlFilename
-              expr: |
-                env.get("__value").name
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: fileIndex
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: codelists
-              expr: |
-                env.get("__value").dirCodelists
+              expr:
+                type: flowExpr
+                value: attributes["dirCodelists"]
             - attribute: schemas
-              expr: |
-                env.get("__value").dirSchemas
+              expr:
+                type: flowExpr
+                value: attributes["dirSchemas"]
 
       - id: a8a7e7f8-8d73-4078-9cff-4476924f2ad7
         name: FeatureSorter
@@ -232,11 +237,13 @@ graphs:
         with:
           mappers:
             - attribute: index
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: filename
-              expr: |
-                env.get("__value").gmlFilename
+              expr:
+                type: flowExpr
+                value: attributes["gmlFilename"]
 
       # Phase 2: FeatureMerger for aggregating error counts
       - id: 4712539b-5103-41ee-9359-0333eefb82ef
@@ -262,95 +269,125 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").index
+              expr:
+                type: flowExpr
+                value: attributes["index"]
             - attribute: Filename
-              expr: |
-                env.get("__value").filename
+              expr:
+                type: flowExpr
+                value: attributes["filename"]
             - attribute: "市区町村コードエラー"
-              expr: |
-                env.get("__value")._num_incorrect_city_code ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_incorrect_city_code", 0)
             - attribute: "C-bldg-01 エラー"
-              expr: |
-                env.get("__value")._num_duplicate_building_id ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_duplicate_building_id", 0)
             - attribute: "不正な建物ID"
-              expr: |
-                env.get("__value")._num_missing_building_id ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_missing_building_id", 0)
             - attribute: "L-bldg-02 エラー"
-              expr: |
-                env.get("__value")._num_lbldg02_error ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lbldg02_error", 0)
             - attribute: "L-bldg-04,05 エラー"
-              expr: |
-                env.get("__value")._num_incorrect_usage_attribute ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_incorrect_usage_attribute", 0)
             - attribute: "L-bldg-06 エラー"
-              expr: |
-                env.get("__value")._num_lbldg06_error ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lbldg06_error", 0)
             - attribute: "T-bldg-02エラー"
-              expr: |
-                env.get("__value")._num_invalid_bldginst_geom_type ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_invalid_bldginst_geom_type", 0)
             - attribute: "LOD0 面のエラー"
-              expr: |
-                env.get("__value")._num_lod0_invalid_surface ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod0_invalid_surface", 0)
             - attribute: "LOD0 面の向きエラー"
-              expr: |
-                env.get("__value")._num_lod0_incorrect_orientation ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod0_incorrect_orientation", 0)
             - attribute: "LOD0 面の交差"
-              expr: |
-                env.get("__value")._num_lod0_surface_intersection ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod0_surface_intersection", 0)
             - attribute: "LOD1 境界面のエラー"
-              expr: |
-                env.get("__value")._num_lod1_invalid_surface ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod1_invalid_surface", 0)
             - attribute: "LOD1 非水密立体"
-              expr: |
-                env.get("__value")._num_lod1_not_closed_solid ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod1_not_closed_solid", 0)
             - attribute: "LOD1 立体のエラー"
-              expr: |
-                env.get("__value")._num_lod1_solid_issues ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod1_solid_issues", 0)
             - attribute: "LOD2 境界面のエラー"
-              expr: |
-                env.get("__value")._num_lod2_invalid_surface ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod2_invalid_surface", 0)
             - attribute: "LOD3 境界面のエラー"
-              expr: |
-                env.get("__value")._num_lod3_invalid_surface ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod3_invalid_surface", 0)
             - attribute: "LOD4 境界面のエラー"
-              expr: |
-                env.get("__value")._num_lod4_invalid_surface ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod4_invalid_surface", 0)
             - attribute: "LOD2 非水密立体"
-              expr: |
-                env.get("__value")._num_lod2_not_closed_solid ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod2_not_closed_solid", 0)
             - attribute: "LOD3 非水密立体"
-              expr: |
-                env.get("__value")._num_lod3_not_closed_solid ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod3_not_closed_solid", 0)
             - attribute: "LOD4 非水密立体"
-              expr: |
-                env.get("__value")._num_lod4_not_closed_solid ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod4_not_closed_solid", 0)
             - attribute: "LOD2 立体のエラー"
-              expr: |
-                env.get("__value")._num_lod2_solid_issues ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod2_solid_issues", 0)
             - attribute: "LOD3 立体のエラー"
-              expr: |
-                env.get("__value")._num_lod3_solid_issues ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod3_solid_issues", 0)
             - attribute: "LOD4 立体のエラー"
-              expr: |
-                env.get("__value")._num_lod4_solid_issues ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod4_solid_issues", 0)
             - attribute: "図郭不正"
-              expr: |
-                env.get("__value")._num_incorrect_meshcode ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_incorrect_meshcode", 0)
             - attribute: "LOD0-1のBuildingPart"
-              expr: |
-                env.get("__value")._num_lod0_1_buildingpart ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod0_1_buildingpart", 0)
             - attribute: "LOD1 立体の交差"
-              expr: |
-                env.get("__value")._num_lod1_solid_intersection ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod1_solid_intersection", 0)
             - attribute: "LOD2 立体の交差"
-              expr: |
-                env.get("__value")._num_lod2_solid_intersection ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod2_solid_intersection", 0)
             - attribute: "LOD3 立体の交差"
-              expr: |
-                env.get("__value")._num_lod3_solid_intersection ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod3_solid_intersection", 0)
             - attribute: "LOD4 立体の交差"
-              expr: |
-                env.get("__value")._num_lod4_solid_intersection ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod4_solid_intersection", 0)
 
       # Phase 4: CSV output
       - id: e4f5a6b7-8c9d-0e1f-2a3b-4c5d6e7f8a9b

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -2717,7 +2717,7 @@ graphs:
       - attribute: エラー数
         expr:
           type: flowExpr
-          value: 1
+          value: '1'
       - attribute: エラー内容
         expr:
           type: string

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -2661,9 +2661,9 @@ graphs:
           type: flowExpr
           value: |
             vr = attributes.get("validationResult");
-            if vr != null && vr["details"] != null {
+            if vr != null and "details" in vr {
               vr["details"][0][0]
-            } else if attributes.get("issue") != null {
+            } else if "issue" in attributes {
               attributes["issue"]
             } else {
               "UnknownError"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -1087,15 +1087,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -1111,17 +1121,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -1159,80 +1181,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -1313,15 +1359,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -1337,15 +1393,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -1361,37 +1427,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -1407,21 +1505,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -1437,21 +1551,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -1467,13 +1597,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -1481,17 +1619,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -1507,23 +1657,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1539,18 +1707,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1974,8 +2153,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -2023,8 +2203,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -2052,8 +2233,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -2397,26 +2579,33 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["package"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("package", "")
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("name", "")
       - attribute: FeatureType
-        expr: |
-          env.get("__value")["featureType"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("featureType", "")
       - attribute: LOD
-        expr: |
-          env.get("__value")["lod"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "")
       - attribute: gml:id
-        expr: |
-          env.get("__value")["gmlId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlId", "")
       - attribute: 未参照
-        expr: |
-          env.get("__value")["unreferenced"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("unreferenced", "")
   - id: 737996be-8410-4447-9986-bba01fe9ce0c
     name: XlinkCsvWriter
     type: action
@@ -2444,33 +2633,41 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["package"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("package", "")
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("name", "")
       - attribute: FeatureType
-        expr: |
-          env.get("__value")["featureType"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("featureType", "")
       - attribute: LOD
-        expr: |
-          env.get("__value")["lod"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "")
       - attribute: gml:id
-        expr: |
-          env.get("__value")["featureId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("featureId", "")
       - attribute: issue
-        expr: |
-          let value = env.get("__value");
-          if value.validationResult?.details != () {
-            return value.validationResult.details[0][0];
-          }
-          if "issue" in value {
-            return value.issue;
-          }
-          "UnknownError"
+        expr:
+          type: flowExpr
+          value: |
+            vr = attributes.get("validationResult");
+            if vr != null && vr["details"] != null {
+              vr["details"][0][0]
+            } else if attributes.get("issue") != null {
+              attributes["issue"]
+            } else {
+              "UnknownError"
+            }
   - id: d60f93c1-c55e-49ee-9332-657f4408ba05
     name: OrientationExtractor
     type: action
@@ -2494,32 +2691,41 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["package"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("package", "")
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("name", "")
       - attribute: FeatureType
-        expr: |
-          env.get("__value")["featureType"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("featureType", "")
       - attribute: LOD
-        expr: |
-          env.get("__value")["lod"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "")
       - attribute: gml:id
-        expr: |
-          env.get("__value")["featureId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("featureId", "")
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: flowExpr
+          value: 1
       - attribute: エラー内容
-        expr: |
-          "Incorrect Orientation"
+        expr:
+          type: string
+          value: Incorrect Orientation
       - attribute: 面の向き
-        expr: |
-          "right_hand_rule"
+        expr:
+          type: string
+          value: right_hand_rule
   - id: 2b0d83b3-2c7a-4314-b609-e4f7db379902
     name: CsvWriter
     type: action
@@ -2698,26 +2904,33 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["package"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("package", "")
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("name", "")
       - attribute: FeatureType
-        expr: |
-          env.get("__value")["featureType"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("featureType", "")
       - attribute: LOD
-        expr: |
-          env.get("__value")["lod"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "")
       - attribute: gml:id
-        expr: |
-          env.get("__value")["gmlId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlId", "")
       - attribute: 隣接ID
-        expr: |
-          env.get("__value")["areaOverlapIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("areaOverlapIndex", "")
   - id: e1eb4eb2-b045-4cdb-aa43-922dd5e03a79
     name: OverlapCsvWriter
     type: action
@@ -2741,11 +2954,13 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
   - id: f34d9a25-1b29-4ead-93ea-873cc5589bf1
     name: XlinkErrorCounter
     type: action
@@ -2802,23 +3017,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").Index
+        expr:
+          type: flowExpr
+          value: attributes["Index"]
       - attribute: Filename
-        expr: |
-          env.get("__value").Filename
+        expr:
+          type: flowExpr
+          value: attributes["Filename"]
       - attribute: L-TRAN-03 xlink参照エラー
-        expr: |
-          env.get("__value")._num_unreferenced_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_unreferenced_surface", 0)
       - attribute: 面の向き不正
-        expr: |
-          env.get("__value")._num_incorrect_orientation ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_incorrect_orientation", 0)
       - attribute: L-TRAN-02 隣接面重複
-        expr: |
-          env.get("__value")._num_overlaps ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_overlaps", 0)
       - attribute: 面のエラー
-        expr: |
-          env.get("__value")._surface_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_surface_issues", 0)
   - id: be20e492-76d2-4afc-a985-e040f43d55fb
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -1087,17 +1087,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -1121,17 +1115,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -1181,13 +1169,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -1206,33 +1190,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -1254,27 +1234,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -1359,25 +1337,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -1393,25 +1361,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -1427,69 +1385,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -1505,37 +1431,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -1551,37 +1461,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -1619,29 +1513,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -1657,41 +1539,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1707,29 +1571,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -2954,13 +2954,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
   - id: f34d9a25-1b29-4ead-93ea-873cc5589bf1
     name: XlinkErrorCounter
     type: action
@@ -3017,13 +3013,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["Index"]
+        valueAttribute: Index
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["Filename"]
+        valueAttribute: Filename
       - attribute: L-TRAN-03 xlink参照エラー
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -1195,12 +1195,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -1579,7 +1579,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -304,7 +304,7 @@ graphs:
             - attribute: "エラー数"
               expr:
                 type: flowExpr
-                value: 1
+                value: "1"
 
             # We hardcode the following two attributes since coming here means the orientation is incorrect
             - attribute: "エラー内容"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -276,36 +276,45 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["package"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("package", "")
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("fileIndex", "")
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("name", "")
             - attribute: FeatureType
-              expr: |
-                env.get("__value")["featureType"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("featureType", "")
             - attribute: LOD
-              expr: |
-                env.get("__value")["lod"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "")
             - attribute: "gml:id"
-              expr: |
-                env.get("__value")["featureId"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("featureId", "")
 
             # The error count is always 1
             - attribute: "エラー数"
-              expr: |
-                1
+              expr:
+                type: flowExpr
+                value: 1
 
             # We hardcode the following two attributes since coming here means the orientation is incorrect
             - attribute: "エラー内容"
-              expr: |
-                "Incorrect Orientation"
+              expr:
+                type: string
+                value: Incorrect Orientation
             - attribute: "面の向き"
-              expr: |
-                "right_hand_rule"
+              expr:
+                type: string
+                value: right_hand_rule
 
       # Write CSV output
       - id: 2b0d83b3-2c7a-4314-b609-e4f7db379902
@@ -526,26 +535,33 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["package"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("package", "")
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("fileIndex", "")
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("name", "")
             - attribute: FeatureType
-              expr: |
-                env.get("__value")["featureType"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("featureType", "")
             - attribute: LOD
-              expr: |
-                env.get("__value")["lod"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "")
             - attribute: "gml:id"
-              expr: |
-                env.get("__value")["gmlId"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("gmlId", "")
             - attribute: 隣接ID
-              expr: |
-                env.get("__value")["areaOverlapIndex"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("areaOverlapIndex", "")
 
       # Feature Writer
       - id: e1eb4eb2-b045-4cdb-aa43-922dd5e03a79
@@ -576,11 +592,13 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: Filename
-              expr: |
-                env.get("__value").name
+              expr:
+                type: flowExpr
+                value: attributes["name"]
 
       # Phase 2: Error counters - Count errors by filename for each error type
       # XLink error counter

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -668,24 +668,30 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").Index
+              expr:
+                type: flowExpr
+                value: attributes["Index"]
             - attribute: Filename
-              expr: |
-                env.get("__value").Filename
+              expr:
+                type: flowExpr
+                value: attributes["Filename"]
             # Domain-specific error columns
             - attribute: "L-TRAN-03 xlink参照エラー"
-              expr: |
-                env.get("__value")._num_unreferenced_surface ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_unreferenced_surface", 0)
             - attribute: "面の向き不正"
-              expr: |
-                env.get("__value")._num_incorrect_orientation ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_incorrect_orientation", 0)
             - attribute: "L-TRAN-02 隣接面重複"
-              expr: |
-                env.get("__value")._num_overlaps ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_overlaps", 0)
             - attribute: "面のエラー"
-              expr: |
-                env.get("__value")._surface_issues ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_surface_issues", 0)
 
       # Phase 5: CSV output
       - id: be20e492-76d2-4afc-a985-e040f43d55fb

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -149,26 +149,33 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["package"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("package", "")
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("fileIndex", "")
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("name", "")
             - attribute: FeatureType
-              expr: |
-                env.get("__value")["featureType"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("featureType", "")
             - attribute: LOD
-              expr: |
-                env.get("__value")["lod"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "")
             - attribute: "gml:id"
-              expr: |
-                env.get("__value")["gmlId"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("gmlId", "")
             - attribute: "未参照"
-              expr: |
-                env.get("__value")["unreferenced"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("unreferenced", "")
 
       # Write XLink CSV output
       - id: 737996be-8410-4447-9986-bba01fe9ce0c
@@ -205,33 +212,41 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["package"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("package", "")
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("fileIndex", "")
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("name", "")
             - attribute: FeatureType
-              expr: |
-                env.get("__value")["featureType"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("featureType", "")
             - attribute: LOD
-              expr: |
-                env.get("__value")["lod"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "")
             - attribute: "gml:id"
-              expr: |
-                env.get("__value")["featureId"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("featureId", "")
             - attribute: issue
-              expr: |
-                let value = env.get("__value");
-                if value.validationResult?.details != () {
-                  return value.validationResult.details[0][0];
-                }
-                if "issue" in value {
-                  return value.issue;
-                }
-                "UnknownError"
+              expr:
+                type: flowExpr
+                value: |
+                  vr = attributes.get("validationResult");
+                  if vr != null && vr["details"] != null {
+                    vr["details"][0][0]
+                  } else if attributes.get("issue") != null {
+                    attributes["issue"]
+                  } else {
+                    "UnknownError"
+                  }
 
       # Extract surface orientation
       - id: d60f93c1-c55e-49ee-9332-657f4408ba05

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -240,9 +240,9 @@ graphs:
                 type: flowExpr
                 value: |
                   vr = attributes.get("validationResult");
-                  if vr != null && vr["details"] != null {
+                  if vr != null and "details" in vr {
                     vr["details"][0][0]
-                  } else if attributes.get("issue") != null {
+                  } else if "issue" in attributes {
                     attributes["issue"]
                   } else {
                     "UnknownError"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -592,13 +592,9 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr:
-                type: flowExpr
-                value: attributes["name"]
+              valueAttribute: name
 
       # Phase 2: Error counters - Count errors by filename for each error type
       # XLink error counter
@@ -668,13 +664,9 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr:
-                type: flowExpr
-                value: attributes["Index"]
+              valueAttribute: Index
             - attribute: Filename
-              expr:
-                type: flowExpr
-                value: attributes["Filename"]
+              valueAttribute: Filename
             # Domain-specific error columns
             - attribute: "L-TRAN-03 xlink参照エラー"
               expr:

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
@@ -2629,23 +2629,23 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "")
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["name"]
+          value: attributes.get("name", "")
       - attribute: フィーチャータイプ
         expr:
           type: flowExpr
-          value: attributes["featureType"]
+          value: attributes.get("featureType", "")
       - attribute: インスタンス数
         expr:
           type: flowExpr
-          value: attributes["_num_instances"]
+          value: attributes.get("_num_instances", 0)
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", "")
   - id: a453192e-603c-417e-9f65-f57b8e15f7d3
     name: CsvWriterInstanceCount
     type: action
@@ -2669,23 +2669,23 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["package"]
+          value: attributes.get("package", "")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", -1)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["name"]
+          value: attributes.get("name", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["featureType"]
+          value: attributes.get("featureType", "")
       - attribute: gml_id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: issue
         expr:
           type: flowExpr
@@ -2745,23 +2745,23 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["package"]
+          value: attributes.get("package", "")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", -1)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["name"]
+          value: attributes.get("name", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["featureType"]
+          value: attributes.get("featureType", "")
       - attribute: gml_id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: エラー内容
         expr:
           type: string
@@ -2806,23 +2806,23 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["package"]
+          value: attributes.get("package", "")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", -1)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["name"]
+          value: attributes.get("name", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["featureType"]
+          value: attributes.get("featureType", "")
       - attribute: gml_id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: エラー内容
         expr:
           type: string
@@ -2861,19 +2861,19 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["package"]
+          value: attributes.get("package", "")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", -1)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["name"]
+          value: attributes.get("name", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["featureType"]
+          value: attributes.get("featureType", "")
       - attribute: lod
         expr:
           type: flowExpr
@@ -2881,11 +2881,11 @@ graphs:
       - attribute: gml_id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: ジオメトリ型
         expr:
           type: flowExpr
-          value: attributes["geometryName"]
+          value: attributes.get("geometryName", "")
   - id: 1087cae8-2937-4e33-a9ac-d20c9052f80e
     name: CsvWriterGeometryTypeError
     type: action
@@ -2914,17 +2914,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["package"]
+        valueAttribute: package
   - id: 92119eb6-9343-49b7-b6c2-e2142374c52c
     name: ErrorSummaryMerger
     type: action
@@ -2941,17 +2935,11 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["Folder"]
+        valueAttribute: Folder
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["Index"]
+        valueAttribute: Index
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["Filename"]
+        valueAttribute: Filename
       - attribute: 面のエラー
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
@@ -1084,17 +1084,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -1118,17 +1112,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -1178,13 +1166,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -1203,33 +1187,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -1251,27 +1231,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -1356,25 +1334,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -1390,25 +1358,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -1424,69 +1382,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -1502,37 +1428,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -1548,37 +1458,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -1616,29 +1510,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -1654,41 +1536,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1704,29 +1568,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
@@ -1192,12 +1192,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
@@ -1084,15 +1084,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -1108,17 +1118,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -1156,80 +1178,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -1310,15 +1356,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -1334,15 +1390,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -1358,37 +1424,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -1404,21 +1502,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -1434,21 +1548,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -1464,13 +1594,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -1478,17 +1616,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -1504,23 +1654,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1536,18 +1704,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1971,8 +2150,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -2020,8 +2200,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -2049,8 +2230,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
@@ -2627,20 +2627,25 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: フィーチャータイプ
-        expr: |
-          env.get("__value")["featureType"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: インスタンス数
-        expr: |
-          env.get("__value")["_num_instances"] ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["_num_instances"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
   - id: a453192e-603c-417e-9f65-f57b8e15f7d3
     name: CsvWriterInstanceCount
     type: action
@@ -2662,30 +2667,37 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["package"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["package"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? -1
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").featureType ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: issue
-        expr: |
-          let value = env.get("__value");
-          if value.validationResult?.details != () {
-            return value.validationResult.details[0][0];
-          }
-          if "issue" in value {
-            return value.issue;
-          }
-          "UnknownError"
+        expr:
+          type: flowExpr
+          value: |
+            vr = attributes.get("validationResult");
+            if vr != null and "details" in vr {
+              vr["details"][0][0]
+            } else if "issue" in attributes {
+              attributes["issue"]
+            } else {
+              "UnknownError"
+            }
   - id: 51bdd4e8-1f3d-4745-9e96-9cb53ee92a53
     name: CsvWriterSurfaceValidationErrors
     type: action
@@ -2731,26 +2743,33 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["package"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["package"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? -1
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").featureType ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: エラー内容
-        expr: |
-          "Surface Not Closed"
+        expr:
+          type: string
+          value: Surface Not Closed
       - attribute: エラー数
-        expr: |
-          env.get("__value").solid_boundary_issues.issue_count
+        expr:
+          type: flowExpr
+          value: attributes["solid_boundary_issues"]["issue_count"]
   - id: 89712e8f-e0ac-4bb3-a92f-c5ff06fe4c96
     name: FeatureWriterL14-BoundaryNotClosed
     type: action
@@ -2785,26 +2804,33 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["package"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["package"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? -1
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").featureType ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: エラー内容
-        expr: |
-          "InvalidSolidBoundaries"
+        expr:
+          type: string
+          value: InvalidSolidBoundaries
       - attribute: エラー数
-        expr: |
-          env.get("__value").solid_boundary_issues.issue_count
+        expr:
+          type: flowExpr
+          value: attributes["solid_boundary_issues"]["issue_count"]
   - id: 527087b4-0411-49bd-ae5f-c1c7f9a5ccb8
     name: FeatureWriterL14-BoundaryOtherIssues
     type: action
@@ -2833,26 +2859,33 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["package"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["package"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? -1
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").featureType ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: lod
-        expr: |
-          env.get("__value").lod ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "")
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: ジオメトリ型
-        expr: |
-          env.get("__value").geometryName ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["geometryName"]
   - id: 1087cae8-2937-4e33-a9ac-d20c9052f80e
     name: CsvWriterGeometryTypeError
     type: action
@@ -2881,14 +2914,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: Folder
-        expr: |
-          env.get("__value")["package"]
+        expr:
+          type: flowExpr
+          value: attributes["package"]
   - id: 92119eb6-9343-49b7-b6c2-e2142374c52c
     name: ErrorSummaryMerger
     type: action
@@ -2905,26 +2941,33 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").Folder
+        expr:
+          type: flowExpr
+          value: attributes["Folder"]
       - attribute: Index
-        expr: |
-          env.get("__value").Index
+        expr:
+          type: flowExpr
+          value: attributes["Index"]
       - attribute: Filename
-        expr: |
-          env.get("__value").Filename
+        expr:
+          type: flowExpr
+          value: attributes["Filename"]
       - attribute: 面のエラー
-        expr: |
-          env.get("__value")._num_surface_validation_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_surface_validation_errors", 0)
       - attribute: 非水密体
-        expr: |
-          env.get("__value")._num_not_closed_boundary ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_not_closed_boundary", 0)
       - attribute: 立体のエラー
-        expr: |
-          env.get("__value")._num_other_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_other_solid_issues", 0)
       - attribute: 不正なジオメトリ型
-        expr: |
-          env.get("__value")._num_geometry_type_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_geometry_type_errors", 0)
   - id: f38c754b-98cd-48e1-bfa7-adbf7c390899
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
@@ -1576,7 +1576,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg/workflow.yml
@@ -197,20 +197,25 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["udxDirs"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: フィーチャータイプ
-              expr: |
-                env.get("__value")["featureType"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["featureType"]
             - attribute: インスタンス数
-              expr: |
-                env.get("__value")["_num_instances"] ?? 0
+              expr:
+                type: flowExpr
+                value: attributes["_num_instances"]
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
       
       - id: a453192e-603c-417e-9f65-f57b8e15f7d3
         name: CsvWriterInstanceCount
@@ -236,30 +241,37 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["package"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["package"]
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? -1
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: FeatureType
-              expr: |
-                env.get("__value").featureType ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["featureType"]
             - attribute: gml_id
-              expr: |
-                env.get("__value").gmlId ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["gmlId"]
             - attribute: issue
-              expr: |
-                let value = env.get("__value");
-                if value.validationResult?.details != () {
-                  return value.validationResult.details[0][0];
-                }
-                if "issue" in value {
-                  return value.issue;
-                }
-                "UnknownError"
+              expr:
+                type: flowExpr
+                value: |
+                  vr = attributes.get("validationResult");
+                  if vr != null and "details" in vr {
+                    vr["details"][0][0]
+                  } else if "issue" in attributes {
+                    attributes["issue"]
+                  } else {
+                    "UnknownError"
+                  }
       - id: 51bdd4e8-1f3d-4745-9e96-9cb53ee92a53
         name: CsvWriterSurfaceValidationErrors
         type: action
@@ -310,26 +322,33 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["package"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["package"]
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? -1
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: FeatureType
-              expr: |
-                env.get("__value").featureType ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["featureType"]
             - attribute: gml_id
-              expr: |
-                env.get("__value").gmlId ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["gmlId"]
             - attribute: エラー内容
-              expr: |
-                "Surface Not Closed"
+              expr:
+                type: string
+                value: Surface Not Closed
             - attribute: エラー数
-              expr: |
-                env.get("__value").solid_boundary_issues.issue_count
+              expr:
+                type: flowExpr
+                value: attributes["solid_boundary_issues"]["issue_count"]
 
       - id: 89712e8f-e0ac-4bb3-a92f-c5ff06fe4c96
         name: FeatureWriterL14-BoundaryNotClosed
@@ -368,26 +387,33 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["package"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["package"]
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? -1
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: FeatureType
-              expr: |
-                env.get("__value").featureType ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["featureType"]
             - attribute: gml_id
-              expr: |
-                env.get("__value").gmlId ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["gmlId"]
             - attribute: エラー内容
-              expr: |
-                "InvalidSolidBoundaries"
+              expr:
+                type: string
+                value: InvalidSolidBoundaries
             - attribute: エラー数
-              expr: |
-                env.get("__value").solid_boundary_issues.issue_count
+              expr:
+                type: flowExpr
+                value: attributes["solid_boundary_issues"]["issue_count"]
 
       - id: 527087b4-0411-49bd-ae5f-c1c7f9a5ccb8
         name: FeatureWriterL14-BoundaryOtherIssues
@@ -420,26 +446,33 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["package"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["package"]
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? -1
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: FeatureType
-              expr: |
-                env.get("__value").featureType ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["featureType"]
             - attribute: lod
-              expr: |
-                env.get("__value").lod ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "")
             - attribute: gml_id
-              expr: |
-                env.get("__value").gmlId ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["gmlId"]
             - attribute: "ジオメトリ型"
-              expr: |
-                env.get("__value").geometryName ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["geometryName"]
 
       - id: 1087cae8-2937-4e33-a9ac-d20c9052f80e
         name: CsvWriterGeometryTypeError
@@ -475,14 +508,17 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: Filename
-              expr: |
-                env.get("__value").name
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: Folder
-              expr: |
-                env.get("__value")["package"]
+              expr:
+                type: flowExpr
+                value: attributes["package"]
 
       # FeatureMerger for aggregating error counts
       - id: 92119eb6-9343-49b7-b6c2-e2142374c52c
@@ -503,27 +539,34 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value").Folder
+              expr:
+                type: flowExpr
+                value: attributes["Folder"]
             - attribute: Index
-              expr: |
-                env.get("__value").Index
+              expr:
+                type: flowExpr
+                value: attributes["Index"]
             - attribute: Filename
-              expr: |
-                env.get("__value").Filename
+              expr:
+                type: flowExpr
+                value: attributes["Filename"]
             # Domain-specific error columns
             - attribute: "面のエラー"
-              expr: |
-                env.get("__value")._num_surface_validation_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_surface_validation_errors", 0)
             - attribute: "非水密体"
-              expr: |
-                env.get("__value")._num_not_closed_boundary ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_not_closed_boundary", 0)
             - attribute: "立体のエラー"
-              expr: |
-                env.get("__value")._num_other_solid_issues ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_other_solid_issues", 0)
             - attribute: "不正なジオメトリ型"
-              expr: |
-                env.get("__value")._num_geometry_type_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_geometry_type_errors", 0)
 
       # CSV output
       - id: f38c754b-98cd-48e1-bfa7-adbf7c390899

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg/workflow.yml
@@ -199,23 +199,23 @@ graphs:
             - attribute: Folder
               expr:
                 type: flowExpr
-                value: attributes["udxDirs"]
+                value: attributes.get("udxDirs", "")
             - attribute: Filename
               expr:
                 type: flowExpr
-                value: attributes["name"]
+                value: attributes.get("name", "")
             - attribute: フィーチャータイプ
               expr:
                 type: flowExpr
-                value: attributes["featureType"]
+                value: attributes.get("featureType", "")
             - attribute: インスタンス数
               expr:
                 type: flowExpr
-                value: attributes["_num_instances"]
+                value: attributes.get("_num_instances", 0)
             - attribute: Index
               expr:
                 type: flowExpr
-                value: attributes["fileIndex"]
+                value: attributes.get("fileIndex", "")
       
       - id: a453192e-603c-417e-9f65-f57b8e15f7d3
         name: CsvWriterInstanceCount
@@ -243,23 +243,23 @@ graphs:
             - attribute: Folder
               expr:
                 type: flowExpr
-                value: attributes["package"]
+                value: attributes.get("package", "")
             - attribute: Index
               expr:
                 type: flowExpr
-                value: attributes["fileIndex"]
+                value: attributes.get("fileIndex", -1)
             - attribute: Filename
               expr:
                 type: flowExpr
-                value: attributes["name"]
+                value: attributes.get("name", "")
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes["featureType"]
+                value: attributes.get("featureType", "")
             - attribute: gml_id
               expr:
                 type: flowExpr
-                value: attributes["gmlId"]
+                value: attributes.get("gmlId", "")
             - attribute: issue
               expr:
                 type: flowExpr
@@ -324,23 +324,23 @@ graphs:
             - attribute: Folder
               expr:
                 type: flowExpr
-                value: attributes["package"]
+                value: attributes.get("package", "")
             - attribute: Index
               expr:
                 type: flowExpr
-                value: attributes["fileIndex"]
+                value: attributes.get("fileIndex", -1)
             - attribute: Filename
               expr:
                 type: flowExpr
-                value: attributes["name"]
+                value: attributes.get("name", "")
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes["featureType"]
+                value: attributes.get("featureType", "")
             - attribute: gml_id
               expr:
                 type: flowExpr
-                value: attributes["gmlId"]
+                value: attributes.get("gmlId", "")
             - attribute: エラー内容
               expr:
                 type: string
@@ -389,23 +389,23 @@ graphs:
             - attribute: Folder
               expr:
                 type: flowExpr
-                value: attributes["package"]
+                value: attributes.get("package", "")
             - attribute: Index
               expr:
                 type: flowExpr
-                value: attributes["fileIndex"]
+                value: attributes.get("fileIndex", -1)
             - attribute: Filename
               expr:
                 type: flowExpr
-                value: attributes["name"]
+                value: attributes.get("name", "")
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes["featureType"]
+                value: attributes.get("featureType", "")
             - attribute: gml_id
               expr:
                 type: flowExpr
-                value: attributes["gmlId"]
+                value: attributes.get("gmlId", "")
             - attribute: エラー内容
               expr:
                 type: string
@@ -448,19 +448,19 @@ graphs:
             - attribute: Folder
               expr:
                 type: flowExpr
-                value: attributes["package"]
+                value: attributes.get("package", "")
             - attribute: Index
               expr:
                 type: flowExpr
-                value: attributes["fileIndex"]
+                value: attributes.get("fileIndex", -1)
             - attribute: Filename
               expr:
                 type: flowExpr
-                value: attributes["name"]
+                value: attributes.get("name", "")
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes["featureType"]
+                value: attributes.get("featureType", "")
             - attribute: lod
               expr:
                 type: flowExpr
@@ -468,11 +468,11 @@ graphs:
             - attribute: gml_id
               expr:
                 type: flowExpr
-                value: attributes["gmlId"]
+                value: attributes.get("gmlId", "")
             - attribute: "ジオメトリ型"
               expr:
                 type: flowExpr
-                value: attributes["geometryName"]
+                value: attributes.get("geometryName", "")
 
       - id: 1087cae8-2937-4e33-a9ac-d20c9052f80e
         name: CsvWriterGeometryTypeError
@@ -508,17 +508,11 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr:
-                type: flowExpr
-                value: attributes["name"]
+              valueAttribute: name
             - attribute: Folder
-              expr:
-                type: flowExpr
-                value: attributes["package"]
+              valueAttribute: package
 
       # FeatureMerger for aggregating error counts
       - id: 92119eb6-9343-49b7-b6c2-e2142374c52c
@@ -539,17 +533,11 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr:
-                type: flowExpr
-                value: attributes["Folder"]
+              valueAttribute: Folder
             - attribute: Index
-              expr:
-                type: flowExpr
-                value: attributes["Index"]
+              valueAttribute: Index
             - attribute: Filename
-              expr:
-                type: flowExpr
-                value: attributes["Filename"]
+              valueAttribute: Filename
             # Domain-specific error columns
             - attribute: "面のエラー"
               expr:

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
@@ -2608,23 +2608,23 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "")
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["name"]
+          value: attributes.get("name", "")
       - attribute: フィーチャータイプ
         expr:
           type: flowExpr
-          value: attributes["featureType"]
+          value: attributes.get("featureType", "")
       - attribute: インスタンス数
         expr:
           type: flowExpr
-          value: attributes["_num_instances"]
+          value: attributes.get("_num_instances", 0)
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", "")
   - id: a453192e-603c-417e-9f65-f57b8e15f7d3
     name: CsvWriterInstanceCount
     type: action
@@ -2642,17 +2642,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["package"]
+        valueAttribute: package
   - id: 2b79c18c-2d61-4d6f-83fb-d766451dbf44
     name: PLATEAU3.SurfaceValidator2D
     type: subGraph
@@ -2666,19 +2660,19 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["name"]
+          value: attributes.get("name", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["featureType"]
+          value: attributes.get("featureType", "")
       - attribute: エラー数
         expr:
           type: string
@@ -2686,7 +2680,7 @@ graphs:
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes["featureId"]
+          value: attributes.get("featureId", "")
       - attribute: 面の向き
         expr:
           type: string
@@ -2720,19 +2714,19 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["name"]
+          value: attributes.get("name", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["featureType"]
+          value: attributes.get("featureType", "")
       - attribute: エラー数
         expr:
           type: string
@@ -2740,7 +2734,7 @@ graphs:
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes["featureId"]
+          value: attributes.get("featureId", "")
       - attribute: エラー内容
         expr:
           type: flowExpr
@@ -2781,17 +2775,11 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["Folder"]
+        valueAttribute: Folder
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["Index"]
+        valueAttribute: Index
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["Filename"]
+        valueAttribute: Filename
       - attribute: 面の向き不正
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
@@ -1193,12 +1193,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
@@ -1577,7 +1577,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
@@ -1085,17 +1085,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -1119,17 +1113,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -1179,13 +1167,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -1204,33 +1188,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -1252,27 +1232,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -1357,25 +1335,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -1391,25 +1359,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -1425,69 +1383,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -1503,37 +1429,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -1549,37 +1459,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -1617,29 +1511,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -1655,41 +1537,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1705,29 +1569,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
@@ -2606,20 +2606,25 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: フィーチャータイプ
-        expr: |
-          env.get("__value")["featureType"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: インスタンス数
-        expr: |
-          env.get("__value")["_num_instances"] ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["_num_instances"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
   - id: a453192e-603c-417e-9f65-f57b8e15f7d3
     name: CsvWriterInstanceCount
     type: action
@@ -2637,14 +2642,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: Folder
-        expr: |
-          env.get("__value")["package"]
+        expr:
+          type: flowExpr
+          value: attributes["package"]
   - id: 2b79c18c-2d61-4d6f-83fb-d766451dbf44
     name: PLATEAU3.SurfaceValidator2D
     type: subGraph
@@ -2656,25 +2664,33 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value")["featureType"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: gml:id
-        expr: |
-          env.get("__value")["featureId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["featureId"]
       - attribute: 面の向き
-        expr: "\"right_hand_rule\" \n"
+        expr:
+          type: string
+          value: right_hand_rule
   - id: f0fc0309-6d76-4a6b-9fdf-84c433b615f2
     name: CsvWriterSurfaceOrientationErrors
     type: action
@@ -2702,26 +2718,33 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value")["featureType"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: gml:id
-        expr: |
-          env.get("__value")["featureId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["featureId"]
       - attribute: エラー内容
-        expr: |
-          env.get("__value")["issue"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("issue", "")
   - id: eb34119b-592f-4140-b9b9-f3712a805c47
     name: CsvWriterSurfaceErrors
     type: action
@@ -2758,20 +2781,25 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").Folder
+        expr:
+          type: flowExpr
+          value: attributes["Folder"]
       - attribute: Index
-        expr: |
-          env.get("__value").Index
+        expr:
+          type: flowExpr
+          value: attributes["Index"]
       - attribute: Filename
-        expr: |
-          env.get("__value").Filename
+        expr:
+          type: flowExpr
+          value: attributes["Filename"]
       - attribute: 面の向き不正
-        expr: |
-          env.get("__value")._num_incorrect_orientation ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_incorrect_orientation", 0)
       - attribute: 面のエラー
-        expr: |
-          env.get("__value")._num_surface_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_surface_issues", 0)
   - id: f38c754b-98cd-48e1-bfa7-adbf7c390899
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
@@ -1085,15 +1085,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -1109,17 +1119,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -1157,80 +1179,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -1311,15 +1357,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -1335,15 +1391,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -1359,37 +1425,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -1405,21 +1503,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -1435,21 +1549,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -1465,13 +1595,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -1479,17 +1617,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -1505,23 +1655,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1537,18 +1705,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1972,8 +2151,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -2021,8 +2201,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -2050,8 +2231,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area/workflow.yml
@@ -171,20 +171,25 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["udxDirs"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: フィーチャータイプ
-              expr: |
-                env.get("__value")["featureType"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["featureType"]
             - attribute: インスタンス数
-              expr: |
-                env.get("__value")["_num_instances"] ?? 0
+              expr:
+                type: flowExpr
+                value: attributes["_num_instances"]
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
       
       - id: a453192e-603c-417e-9f65-f57b8e15f7d3
         name: CsvWriterInstanceCount
@@ -205,14 +210,17 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: Filename
-              expr: |
-                env.get("__value").name
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: Folder
-              expr: |
-                env.get("__value")["package"]
+              expr:
+                type: flowExpr
+                value: attributes["package"]
 
       - id: 2b79c18c-2d61-4d6f-83fb-d766451dbf44
         name: PLATEAU3.SurfaceValidator2D
@@ -226,27 +234,34 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["udxDirs"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: FeatureType
-              expr: |
-                env.get("__value")["featureType"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["featureType"]
             - attribute: エラー数
-              expr: |
-                1
+              expr:
+                type: string
+                value: "1"
             - attribute: "gml:id"
-              expr: |
-                env.get("__value")["featureId"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["featureId"]
             - attribute: 面の向き
               # It is okay to hardcode here since this mapper is connected to the surface orientation error port of surface validator.
-              expr: |
-                "right_hand_rule" 
+              expr:
+                type: string
+                value: right_hand_rule
 
       - id: f0fc0309-6d76-4a6b-9fdf-84c433b615f2
         name: CsvWriterSurfaceOrientationErrors
@@ -277,26 +292,33 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["udxDirs"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: FeatureType
-              expr: |
-                env.get("__value")["featureType"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["featureType"]
             - attribute: エラー数
-              expr: |
-                1
+              expr:
+                type: string
+                value: "1"
             - attribute: "gml:id"
-              expr: |
-                env.get("__value")["featureId"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes["featureId"]
             - attribute: エラー内容
-              expr: |
-                env.get("__value")["issue"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("issue", "")
 
       - id: eb34119b-592f-4140-b9b9-f3712a805c47
         name: CsvWriterSurfaceErrors
@@ -340,20 +362,25 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value").Folder
+              expr:
+                type: flowExpr
+                value: attributes["Folder"]
             - attribute: Index
-              expr: |
-                env.get("__value").Index
+              expr:
+                type: flowExpr
+                value: attributes["Index"]
             - attribute: Filename
-              expr: |
-                env.get("__value").Filename
+              expr:
+                type: flowExpr
+                value: attributes["Filename"]
             - attribute: "面の向き不正"
-              expr: |
-                env.get("__value")._num_incorrect_orientation ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_incorrect_orientation", 0)
             - attribute: "面のエラー"
-              expr: |
-                env.get("__value")._num_surface_issues ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_surface_issues", 0)
 
       # CSV output
       - id: f38c754b-98cd-48e1-bfa7-adbf7c390899

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area/workflow.yml
@@ -173,23 +173,23 @@ graphs:
             - attribute: Folder
               expr:
                 type: flowExpr
-                value: attributes["udxDirs"]
+                value: attributes.get("udxDirs", "")
             - attribute: Filename
               expr:
                 type: flowExpr
-                value: attributes["name"]
+                value: attributes.get("name", "")
             - attribute: フィーチャータイプ
               expr:
                 type: flowExpr
-                value: attributes["featureType"]
+                value: attributes.get("featureType", "")
             - attribute: インスタンス数
               expr:
                 type: flowExpr
-                value: attributes["_num_instances"]
+                value: attributes.get("_num_instances", 0)
             - attribute: Index
               expr:
                 type: flowExpr
-                value: attributes["fileIndex"]
+                value: attributes.get("fileIndex", "")
       
       - id: a453192e-603c-417e-9f65-f57b8e15f7d3
         name: CsvWriterInstanceCount
@@ -210,17 +210,11 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr:
-                type: flowExpr
-                value: attributes["name"]
+              valueAttribute: name
             - attribute: Folder
-              expr:
-                type: flowExpr
-                value: attributes["package"]
+              valueAttribute: package
 
       - id: 2b79c18c-2d61-4d6f-83fb-d766451dbf44
         name: PLATEAU3.SurfaceValidator2D
@@ -236,19 +230,19 @@ graphs:
             - attribute: Folder
               expr:
                 type: flowExpr
-                value: attributes["udxDirs"]
+                value: attributes.get("udxDirs", "")
             - attribute: Index
               expr:
                 type: flowExpr
-                value: attributes["fileIndex"]
+                value: attributes.get("fileIndex", "")
             - attribute: Filename
               expr:
                 type: flowExpr
-                value: attributes["name"]
+                value: attributes.get("name", "")
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes["featureType"]
+                value: attributes.get("featureType", "")
             - attribute: エラー数
               expr:
                 type: string
@@ -256,7 +250,7 @@ graphs:
             - attribute: "gml:id"
               expr:
                 type: flowExpr
-                value: attributes["featureId"]
+                value: attributes.get("featureId", "")
             - attribute: 面の向き
               # It is okay to hardcode here since this mapper is connected to the surface orientation error port of surface validator.
               expr:
@@ -294,19 +288,19 @@ graphs:
             - attribute: Folder
               expr:
                 type: flowExpr
-                value: attributes["udxDirs"]
+                value: attributes.get("udxDirs", "")
             - attribute: Index
               expr:
                 type: flowExpr
-                value: attributes["fileIndex"]
+                value: attributes.get("fileIndex", "")
             - attribute: Filename
               expr:
                 type: flowExpr
-                value: attributes["name"]
+                value: attributes.get("name", "")
             - attribute: FeatureType
               expr:
                 type: flowExpr
-                value: attributes["featureType"]
+                value: attributes.get("featureType", "")
             - attribute: エラー数
               expr:
                 type: string
@@ -314,7 +308,7 @@ graphs:
             - attribute: "gml:id"
               expr:
                 type: flowExpr
-                value: attributes["featureId"]
+                value: attributes.get("featureId", "")
             - attribute: エラー内容
               expr:
                 type: flowExpr
@@ -362,17 +356,11 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr:
-                type: flowExpr
-                value: attributes["Folder"]
+              valueAttribute: Folder
             - attribute: Index
-              expr:
-                type: flowExpr
-                value: attributes["Index"]
+              valueAttribute: Index
             - attribute: Filename
-              expr:
-                type: flowExpr
-                value: attributes["Filename"]
+              valueAttribute: Filename
             - attribute: "面の向き不正"
               expr:
                 type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
@@ -526,12 +526,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
@@ -2021,29 +2021,25 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        valueAttribute: udxDirs
       - attribute: Index
-        expr: |
-          env.get("__value")._file_index
+        valueAttribute: _file_index
       - attribute: Filename
-        expr: |
-          env.get("__value").name
+        valueAttribute: name
       - attribute: 頂点数が不正な三角形
-        expr: |
-          env.get("__value")._num_incorrect_num_vertices
+        valueAttribute: _num_incorrect_num_vertices
       - attribute: 向きが不正な三角形
-        expr: |
-          env.get("__value")._num_wrong_orientation
+        valueAttribute: _num_wrong_orientation
       - attribute: 閉じていない三角形
-        expr: |
-          env.get("__value")._num_not_closed
+        valueAttribute: _num_not_closed
       - attribute: 線状・点状の三角形
-        expr: |
-          env.get("__value")._num_degenerate_triangles ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_degenerate_triangles", 0)
       - attribute: 共有先のない辺
-        expr: |
-          env.get("__value")._num_unshared_edges ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_unshared_edges", 0)
   - id: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
     name: PrepareSummaryForJSON
     type: action
@@ -2051,20 +2047,19 @@ graphs:
     with:
       mappers:
       - attribute: 頂点数が不正な三角形
-        expr: |
-          env.get("__value")._num_incorrect_num_vertices
+        valueAttribute: _num_incorrect_num_vertices
       - attribute: 閉じていない三角形
-        expr: |
-          env.get("__value")._num_not_closed
+        valueAttribute: _num_not_closed
       - attribute: 向きが不正な三角形
-        expr: |
-          env.get("__value")._num_wrong_orientation
+        valueAttribute: _num_wrong_orientation
       - attribute: 線状・点状の三角形
-        expr: |
-          env.get("__value")._num_degenerate_triangles ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_degenerate_triangles", 0)
       - attribute: _json_filename
-        expr: |
-          env.get("__value")._json_filename
+        expr:
+          type: flowExpr
+          value: attributes.get("_json_filename")
   - id: 1f2a3b4c-5d6e-7f8a-9b0c-1d2e3f4a5b6c
     name: CSVWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
@@ -418,17 +418,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -452,17 +446,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -512,13 +500,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -537,33 +521,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -585,27 +565,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -690,25 +668,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -724,25 +692,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -758,69 +716,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -836,37 +762,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -882,37 +792,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -950,29 +844,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -988,41 +870,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1038,29 +902,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
@@ -418,15 +418,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -442,17 +452,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -490,80 +512,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -644,15 +690,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -668,15 +724,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -692,37 +758,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -738,21 +836,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -768,21 +882,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -798,13 +928,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -812,17 +950,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -838,23 +988,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -870,18 +1038,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1305,8 +1484,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -1354,8 +1534,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -1383,8 +1564,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
@@ -910,7 +910,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld/workflow.yml
@@ -287,29 +287,25 @@ graphs:
         with:
           mappers:
             - attribute: "Folder"
-              expr: |
-                env.get("__value").udxDirs
+              valueAttribute: udxDirs
             - attribute: "Index"
-              expr: |
-                env.get("__value")._file_index
+              valueAttribute: _file_index
             - attribute: "Filename"
-              expr: |
-                env.get("__value").name
+              valueAttribute: name
             - attribute: "頂点数が不正な三角形"
-              expr: |
-                env.get("__value")._num_incorrect_num_vertices
+              valueAttribute: _num_incorrect_num_vertices
             - attribute: "向きが不正な三角形"
-              expr: |
-                env.get("__value")._num_wrong_orientation
+              valueAttribute: _num_wrong_orientation
             - attribute: "閉じていない三角形"
-              expr: |
-                env.get("__value")._num_not_closed
+              valueAttribute: _num_not_closed
             - attribute: "線状・点状の三角形"
-              expr: |
-                env.get("__value")._num_degenerate_triangles ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_degenerate_triangles", 0)
             - attribute: "共有先のない辺"
-              expr: |
-                env.get("__value")._num_unshared_edges ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_unshared_edges", 0)
 
       # JSON Output Preparation
       # Maps attributes needed for JSON output, including _json_filename
@@ -320,20 +316,19 @@ graphs:
         with:
           mappers:
             - attribute: "頂点数が不正な三角形"
-              expr: |
-                env.get("__value")._num_incorrect_num_vertices
+              valueAttribute: _num_incorrect_num_vertices
             - attribute: "閉じていない三角形"
-              expr: |
-                env.get("__value")._num_not_closed
+              valueAttribute: _num_not_closed
             - attribute: "向きが不正な三角形"
-              expr: |
-                env.get("__value")._num_wrong_orientation
+              valueAttribute: _num_wrong_orientation
             - attribute: "線状・点状の三角形"
-              expr: |
-                env.get("__value")._num_degenerate_triangles ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_degenerate_triangles", 0)
             - attribute: "_json_filename"
-              expr: |
-                env.get("__value")._json_filename
+              expr:
+                type: flowExpr
+                value: attributes.get("_json_filename")
 
       # File Output Writers
       # CSV Writer for detailed error summary (one row per file)

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
@@ -1083,17 +1083,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -1117,17 +1111,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -1177,13 +1165,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -1202,33 +1186,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -1250,27 +1230,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -1355,25 +1333,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -1389,25 +1357,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -1423,69 +1381,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -1501,37 +1427,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -1547,37 +1457,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -1615,29 +1509,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -1653,41 +1535,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1703,29 +1567,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
@@ -2604,20 +2604,15 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? ""
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        valueAttribute: name
       - attribute: フィーチャータイプ
-        expr: |
-          env.get("__value")["featureType"] ?? ""
+        valueAttribute: featureType
       - attribute: インスタンス数
-        expr: |
-          env.get("__value")["_num_instances"] ?? 0
+        valueAttribute: _num_instances
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        valueAttribute: fileIndex
   - id: a453192e-603c-417e-9f65-f57b8e15f7d3
     name: CsvWriterInstanceCount
     type: action
@@ -2633,11 +2628,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr: |
-          env.get("__value").name
+        valueAttribute: name
   - id: 2b79c18c-2d61-4d6f-83fb-d766451dbf44
     name: PLATEAU3.SurfaceValidator2D
     type: subGraph
@@ -2649,25 +2642,23 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? ""
+        valueAttribute: udxDirs
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        valueAttribute: name
       - attribute: FeatureType
-        expr: |
-          env.get("__value")["featureType"] ?? ""
+        valueAttribute: featureType
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: gml:id
-        expr: |
-          env.get("__value")["featureId"] ?? ""
+        valueAttribute: featureId
       - attribute: 面の向き
-        expr: "\"right_hand_rule\" \n"
+        expr:
+          type: string
+          value: right_hand_rule
   - id: f0fc0309-6d76-4a6b-9fdf-84c433b615f2
     name: CsvWriterSurfaceOrientationErrors
     type: action
@@ -2693,26 +2684,23 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? ""
+        valueAttribute: udxDirs
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr: |
-          env.get("__value")["name"] ?? ""
+        valueAttribute: name
       - attribute: FeatureType
-        expr: |
-          env.get("__value")["featureType"] ?? ""
+        valueAttribute: featureType
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: gml:id
-        expr: |
-          env.get("__value")["featureId"] ?? ""
+        valueAttribute: featureId
       - attribute: エラー内容
-        expr: |
-          env.get("__value")["issue"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("issue", "")
   - id: eb34119b-592f-4140-b9b9-f3712a805c47
     name: CsvWriterSurfaceErrors
     type: action
@@ -2747,17 +2735,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").Index
+        valueAttribute: Index
       - attribute: Filename
-        expr: |
-          env.get("__value").Filename
+        valueAttribute: Filename
       - attribute: 面の向き不正
-        expr: |
-          env.get("__value")._num_incorrect_orientation ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_incorrect_orientation", 0)
       - attribute: 面のエラー
-        expr: |
-          env.get("__value")._num_surface_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_surface_issues", 0)
   - id: f38c754b-98cd-48e1-bfa7-adbf7c390899
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
@@ -1191,12 +1191,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
@@ -1575,7 +1575,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
@@ -1083,15 +1083,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -1107,17 +1117,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -1155,80 +1177,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -1309,15 +1355,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -1333,15 +1389,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -1357,37 +1423,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -1403,21 +1501,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -1433,21 +1547,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -1463,13 +1593,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -1477,17 +1615,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -1503,23 +1653,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1535,18 +1703,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1970,8 +2149,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -2019,8 +2199,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -2048,8 +2229,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld/workflow.yml
@@ -171,20 +171,15 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["udxDirs"] ?? ""
+              valueAttribute: udxDirs
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              valueAttribute: name
             - attribute: フィーチャータイプ
-              expr: |
-                env.get("__value")["featureType"] ?? ""
+              valueAttribute: featureType
             - attribute: インスタンス数
-              expr: |
-                env.get("__value")["_num_instances"] ?? 0
+              valueAttribute: _num_instances
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? ""
+              valueAttribute: fileIndex
       
       - id: a453192e-603c-417e-9f65-f57b8e15f7d3
         name: CsvWriterInstanceCount
@@ -203,11 +198,9 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr: |
-                env.get("__value").name
+              valueAttribute: name
 
       - id: 2b79c18c-2d61-4d6f-83fb-d766451dbf44
         name: PLATEAU3.SurfaceValidator2D
@@ -221,27 +214,24 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["udxDirs"] ?? ""
+              valueAttribute: udxDirs
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? ""
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              valueAttribute: name
             - attribute: FeatureType
-              expr: |
-                env.get("__value")["featureType"] ?? ""
+              valueAttribute: featureType
             - attribute: エラー数
-              expr: |
-                1
+              expr:
+                type: string
+                value: "1"
             - attribute: "gml:id"
-              expr: |
-                env.get("__value")["featureId"] ?? ""
+              valueAttribute: featureId
             - attribute: 面の向き
               # It is okay to hardcode here since this mapper is connected to the surface orientation error port of surface validator.
-              expr: |
-                "right_hand_rule" 
+              expr:
+                type: string
+                value: right_hand_rule
 
       - id: f0fc0309-6d76-4a6b-9fdf-84c433b615f2
         name: CsvWriterSurfaceOrientationErrors
@@ -270,26 +260,23 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value")["udxDirs"] ?? ""
+              valueAttribute: udxDirs
             - attribute: Index
-              expr: |
-                env.get("__value")["fileIndex"] ?? ""
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr: |
-                env.get("__value")["name"] ?? ""
+              valueAttribute: name
             - attribute: FeatureType
-              expr: |
-                env.get("__value")["featureType"] ?? ""
+              valueAttribute: featureType
             - attribute: エラー数
-              expr: |
-                1
+              expr:
+                type: string
+                value: "1"
             - attribute: "gml:id"
-              expr: |
-                env.get("__value")["featureId"] ?? ""
+              valueAttribute: featureId
             - attribute: エラー内容
-              expr: |
-                env.get("__value")["issue"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("issue", "")
 
       - id: eb34119b-592f-4140-b9b9-f3712a805c47
         name: CsvWriterSurfaceErrors
@@ -331,17 +318,17 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").Index
+              valueAttribute: Index
             - attribute: Filename
-              expr: |
-                env.get("__value").Filename
+              valueAttribute: Filename
             - attribute: "面の向き不正"
-              expr: |
-                env.get("__value")._num_incorrect_orientation ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_incorrect_orientation", 0)
             - attribute: "面のエラー"
-              expr: |
-                env.get("__value")._num_surface_issues ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_surface_issues", 0)
 
       # CSV output
       - id: f38c754b-98cd-48e1-bfa7-adbf7c390899

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
@@ -414,15 +414,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -438,17 +448,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -486,80 +508,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -640,15 +686,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -664,15 +720,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -688,37 +754,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -734,21 +832,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -764,21 +878,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -794,13 +924,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -808,17 +946,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -834,23 +984,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -866,18 +1034,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1301,8 +1480,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -1350,8 +1530,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -1379,8 +1560,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
@@ -414,17 +414,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -448,17 +442,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -508,13 +496,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -533,33 +517,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -581,27 +561,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -686,25 +664,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -720,25 +688,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -754,69 +712,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -832,37 +758,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -878,37 +788,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -946,29 +840,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -984,41 +866,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1034,29 +898,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
@@ -522,12 +522,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
@@ -906,7 +906,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
@@ -1892,14 +1892,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr: |
-          env.get("__value").name
+        valueAttribute: name
       - attribute: Relief Index
-        expr: |
-          env.get("__value")._relief_index ?? ""
+        valueAttribute: _relief_index
   - id: 27619dc0-ace9-490a-a63d-57b2ecb4f326
     name: ShapefileWriterIncorrectNumVertices
     type: action
@@ -1926,14 +1923,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr: |
-          env.get("__value").name
+        valueAttribute: name
       - attribute: Relief Index
-        expr: |
-          env.get("__value")._relief_index ?? ""
+        valueAttribute: _relief_index
   - id: 090638b2-4923-4bd8-8b9c-4e1869612694
     name: ShapefileWriterNotClosed
     type: action
@@ -1960,14 +1954,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr: |
-          env.get("__value").name
+        valueAttribute: name
       - attribute: Relief Index
-        expr: |
-          env.get("__value")._relief_index ?? ""
+        valueAttribute: _relief_index
   - id: f364a079-e834-47f8-a53f-530a0fee07d4
     name: ShapefileWriterWrongOrientation
     type: action
@@ -2001,14 +1992,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr: |
-          env.get("__value").name
+        valueAttribute: name
       - attribute: Relief Index
-        expr: |
-          env.get("__value")._relief_index ?? ""
+        valueAttribute: _relief_index
   - id: 961aadd4-8178-4c26-8c15-b326b0d39573
     name: ShapefileWriterCorruptGeometry
     type: action
@@ -2074,14 +2062,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr: |
-          env.get("__value").name
+        valueAttribute: name
       - attribute: Relief Index
-        expr: |
-          env.get("__value")._relief_index ?? ""
+        valueAttribute: _relief_index
   - id: b4f15900-e2e3-4df0-a3a4-6cbf2d3eefaf
     name: ShapefileWriterInvalidBoundaries
     type: action
@@ -2117,29 +2102,31 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex
+        valueAttribute: fileIndex
       - attribute: Filename
-        expr: |
-          env.get("__value").name
+        valueAttribute: name
       - attribute: Relief Index
-        expr: |
-          env.get("__value")._relief_index ?? ""
+        valueAttribute: _relief_index
       - attribute: 不正な頂点の数
-        expr: |
-          env.get("__value")._num_incorrect_num_vertices ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_incorrect_num_vertices", 0)
       - attribute: 閉じていない三角形
-        expr: |
-          env.get("__value")._num_not_closed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_not_closed", 0)
       - attribute: 三角形の向き不正
-        expr: |
-          env.get("__value")._num_wrong_orientation ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_wrong_orientation", 0)
       - attribute: 潰れた三角形
-        expr: |
-          env.get("__value")._num_corrupt_geometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_corrupt_geometry", 0)
       - attribute: 不正な穴
-        expr: |
-          env.get("__value")._num_invalid_boundaries ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_invalid_boundaries", 0)
   - id: 12bbb254-4ff2-4b51-92bb-60d0a9d2d48d
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem/workflow.yml
@@ -125,14 +125,11 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr: |
-                env.get("__value").name
+              valueAttribute: name
             - attribute: "Relief Index"
-              expr: |
-                env.get("__value")._relief_index ?? ""
+              valueAttribute: _relief_index
 
       - id: 27619dc0-ace9-490a-a63d-57b2ecb4f326
         name: ShapefileWriterIncorrectNumVertices
@@ -163,14 +160,11 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr: |
-                env.get("__value").name
+              valueAttribute: name
             - attribute: "Relief Index"
-              expr: |
-                env.get("__value")._relief_index ?? ""
+              valueAttribute: _relief_index
 
       - id: 090638b2-4923-4bd8-8b9c-4e1869612694
         name: ShapefileWriterNotClosed
@@ -201,14 +195,11 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr: |
-                env.get("__value").name
+              valueAttribute: name
             - attribute: "Relief Index"
-              expr: |
-                env.get("__value")._relief_index ?? ""
+              valueAttribute: _relief_index
 
       - id: f364a079-e834-47f8-a53f-530a0fee07d4
         name: ShapefileWriterWrongOrientation
@@ -248,14 +239,11 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr: |
-                env.get("__value").name
+              valueAttribute: name
             - attribute: "Relief Index"
-              expr: |
-                env.get("__value")._relief_index ?? ""
+              valueAttribute: _relief_index
 
       - id: 961aadd4-8178-4c26-8c15-b326b0d39573
         name: ShapefileWriterCorruptGeometry
@@ -331,14 +319,11 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr: |
-                env.get("__value").name
+              valueAttribute: name
             - attribute: "Relief Index"
-              expr: |
-                env.get("__value")._relief_index ?? ""
+              valueAttribute: _relief_index
 
       - id: b4f15900-e2e3-4df0-a3a4-6cbf2d3eefaf
         name: ShapefileWriterInvalidBoundaries
@@ -380,29 +365,31 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex
+              valueAttribute: fileIndex
             - attribute: Filename
-              expr: |
-                env.get("__value").name
+              valueAttribute: name
             - attribute: "Relief Index"
-              expr: |
-                env.get("__value")._relief_index ?? ""
+              valueAttribute: _relief_index
             - attribute: "不正な頂点の数"
-              expr: |
-                env.get("__value")._num_incorrect_num_vertices ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_incorrect_num_vertices", 0)
             - attribute: "閉じていない三角形"
-              expr: |
-                env.get("__value")._num_not_closed ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_not_closed", 0)
             - attribute: "三角形の向き不正"
-              expr: |
-                env.get("__value")._num_wrong_orientation ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_wrong_orientation", 0)
             - attribute: "潰れた三角形"
-              expr: |
-                env.get("__value")._num_corrupt_geometry ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_corrupt_geometry", 0)
             - attribute: "不正な穴"
-              expr: |
-                env.get("__value")._num_invalid_boundaries ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_invalid_boundaries", 0)
 
       # CSV output
       - id: 12bbb254-4ff2-4b51-92bb-60d0a9d2d48d

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
@@ -2673,7 +2673,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
@@ -2181,17 +2181,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -2215,17 +2209,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -2275,13 +2263,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -2300,33 +2284,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -2348,27 +2328,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -2453,25 +2431,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -2487,25 +2455,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -2521,69 +2479,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -2599,37 +2525,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -2645,37 +2555,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -2713,29 +2607,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -2751,41 +2633,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -2801,29 +2665,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
@@ -2289,12 +2289,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
@@ -2181,15 +2181,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -2205,17 +2215,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -2253,80 +2275,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -2407,15 +2453,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -2431,15 +2487,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -2455,37 +2521,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -2501,21 +2599,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -2531,21 +2645,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -2561,13 +2691,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -2575,17 +2713,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -2601,23 +2751,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -2633,18 +2801,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -3068,8 +3247,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -3117,8 +3297,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -3146,8 +3327,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -3699,14 +3881,17 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: folder
-        expr: |
-          env.get("__value")["package"]
+        expr:
+          type: flowExpr
+          value: attributes["package"]
   - id: c2d3e4f5-6a7b-8c9d-0e1f-2a3b4c5d6e7f
     name: ErrorSummaryMerger
     type: action
@@ -3723,59 +3908,77 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").folder
+        expr:
+          type: flowExpr
+          value: attributes["folder"]
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Filename
-        expr: |
-          env.get("__value").filename
+        expr:
+          type: flowExpr
+          value: attributes["filename"]
       - attribute: LOD0 面のエラー
-        expr: |
-          env.get("__value")._num_lod0_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod0_invalid_surface", 0)
       - attribute: LOD0 面の向きエラー
-        expr: |
-          env.get("__value")._num_lod0_incorrect_orientation ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod0_incorrect_orientation", 0)
       - attribute: LOD0 面の交差
-        expr: |
-          env.get("__value")._num_lod0_surface_intersection ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod0_surface_intersection", 0)
       - attribute: LOD1 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod1_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod1_invalid_surface", 0)
       - attribute: LOD1 非水密立体
-        expr: |
-          env.get("__value")._num_lod1_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod1_not_closed_solid", 0)
       - attribute: LOD1 立体のエラー
-        expr: |
-          env.get("__value")._num_lod1_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod1_solid_issues", 0)
       - attribute: LOD2 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod2_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod2_invalid_surface", 0)
       - attribute: LOD3 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod3_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod3_invalid_surface", 0)
       - attribute: LOD4 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod4_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod4_invalid_surface", 0)
       - attribute: LOD2 非水密立体
-        expr: |
-          env.get("__value")._num_lod2_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod2_not_closed_solid", 0)
       - attribute: LOD3 非水密立体
-        expr: |
-          env.get("__value")._num_lod3_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod3_not_closed_solid", 0)
       - attribute: LOD4 非水密立体
-        expr: |
-          env.get("__value")._num_lod4_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod4_not_closed_solid", 0)
       - attribute: LOD2 立体のエラー
-        expr: |
-          env.get("__value")._num_lod2_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod2_solid_issues", 0)
       - attribute: LOD3 立体のエラー
-        expr: |
-          env.get("__value")._num_lod3_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod3_solid_issues", 0)
       - attribute: LOD4 立体のエラー
-        expr: |
-          env.get("__value")._num_lod4_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod4_solid_issues", 0)
   - id: e4f5a6b7-8c9d-0e1f-2a3b-4c5d6e7f8a9b
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
@@ -3881,17 +3881,11 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: folder
-        expr:
-          type: flowExpr
-          value: attributes["package"]
+        valueAttribute: package
   - id: c2d3e4f5-6a7b-8c9d-0e1f-2a3b4c5d6e7f
     name: ErrorSummaryMerger
     type: action
@@ -3908,17 +3902,11 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["folder"]
+        valueAttribute: folder
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["filename"]
+        valueAttribute: filename
       - attribute: LOD0 面のエラー
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld/workflow.yml
@@ -337,14 +337,17 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: folder
-        expr: |
-          env.get("__value")["package"]
+        expr:
+          type: flowExpr
+          value: attributes["package"]
   - id: c2d3e4f5-6a7b-8c9d-0e1f-2a3b4c5d6e7f
     name: ErrorSummaryMerger
     type: action
@@ -361,59 +364,77 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").folder
+        expr:
+          type: flowExpr
+          value: attributes["folder"]
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Filename
-        expr: |
-          env.get("__value").filename
+        expr:
+          type: flowExpr
+          value: attributes["filename"]
       - attribute: LOD0 面のエラー
-        expr: |
-          env.get("__value")._num_lod0_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod0_invalid_surface", 0)
       - attribute: LOD0 面の向きエラー
-        expr: |
-          env.get("__value")._num_lod0_incorrect_orientation ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod0_incorrect_orientation", 0)
       - attribute: LOD0 面の交差
-        expr: |
-          env.get("__value")._num_lod0_surface_intersection ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod0_surface_intersection", 0)
       - attribute: LOD1 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod1_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod1_invalid_surface", 0)
       - attribute: LOD1 非水密立体
-        expr: |
-          env.get("__value")._num_lod1_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod1_not_closed_solid", 0)
       - attribute: LOD1 立体のエラー
-        expr: |
-          env.get("__value")._num_lod1_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod1_solid_issues", 0)
       - attribute: LOD2 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod2_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod2_invalid_surface", 0)
       - attribute: LOD3 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod3_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod3_invalid_surface", 0)
       - attribute: LOD4 境界面のエラー
-        expr: |
-          env.get("__value")._num_lod4_invalid_surface ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod4_invalid_surface", 0)
       - attribute: LOD2 非水密立体
-        expr: |
-          env.get("__value")._num_lod2_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod2_not_closed_solid", 0)
       - attribute: LOD3 非水密立体
-        expr: |
-          env.get("__value")._num_lod3_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod3_not_closed_solid", 0)
       - attribute: LOD4 非水密立体
-        expr: |
-          env.get("__value")._num_lod4_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod4_not_closed_solid", 0)
       - attribute: LOD2 立体のエラー
-        expr: |
-          env.get("__value")._num_lod2_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod2_solid_issues", 0)
       - attribute: LOD3 立体のエラー
-        expr: |
-          env.get("__value")._num_lod3_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod3_solid_issues", 0)
       - attribute: LOD4 立体のエラー
-        expr: |
-          env.get("__value")._num_lod4_solid_issues ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod4_solid_issues", 0)
   - id: e4f5a6b7-8c9d-0e1f-2a3b-4c5d6e7f8a9b
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld/workflow.yml
@@ -337,17 +337,11 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: folder
-        expr:
-          type: flowExpr
-          value: attributes["package"]
+        valueAttribute: package
   - id: c2d3e4f5-6a7b-8c9d-0e1f-2a3b4c5d6e7f
     name: ErrorSummaryMerger
     type: action
@@ -364,17 +358,11 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["folder"]
+        valueAttribute: folder
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["filename"]
+        valueAttribute: filename
       - attribute: LOD0 面のエラー
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
@@ -3076,7 +3076,9 @@ graphs:
       - attribute: schemas
         valueAttribute: schemas
       - attribute: udxDirs
-        valueAttribute: path.split("/")[-2]
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f60
     name: FeatureCityGmlReader
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
@@ -3066,29 +3066,17 @@ graphs:
     with:
       mappers:
       - attribute: gmlPath
-        expr:
-          type: flowExpr
-          value: attributes["path"]
+        valueAttribute: path
       - attribute: gmlFilename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: fileIndex
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: codelists
-        expr:
-          type: flowExpr
-          value: attributes["codelists"]
+        valueAttribute: codelists
       - attribute: schemas
-        expr:
-          type: flowExpr
-          value: attributes["schemas"]
+        valueAttribute: schemas
       - attribute: udxDirs
-        expr:
-          type: flowExpr
-          value: attributes["path"].split("/")[-2]
+        valueAttribute: path.split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f60
     name: FeatureCityGmlReader
     type: action
@@ -3171,29 +3159,17 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: udxDirs
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: gmlFilename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: featureTypeName
-        expr:
-          type: flowExpr
-          value: attributes["featureTypeName"]
+        valueAttribute: featureTypeName
       - attribute: instanceCount
-        expr:
-          type: flowExpr
-          value: attributes["instanceCount"]
+        valueAttribute: instanceCount
       - attribute: lod
         expr:
           type: flowExpr
@@ -3223,9 +3199,7 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Index
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
@@ -414,17 +414,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -448,17 +442,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -508,13 +496,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -533,33 +517,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -581,27 +561,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -686,25 +664,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -720,25 +688,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -754,69 +712,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -832,37 +758,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -878,37 +788,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -946,29 +840,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -984,41 +866,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1034,29 +898,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -2522,15 +2376,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "cons")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["gmlFilename"]
+          value: attributes.get("gmlFilename", attributes.get("name", ""))
       - attribute: FeatureType
         expr:
           type: flowExpr
@@ -2538,11 +2392,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes.get("featureId", attributes.get("gmlId"))
+          value: attributes.get("featureId", attributes.get("gmlId", ""))
       - attribute: エラー数
         expr:
           type: string
@@ -2609,21 +2463,15 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
         expr:
           type: flowExpr
           value: attributes.get("featureTypeName", "OtherConstruction")
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: issue
         expr:
           type: string
@@ -2661,21 +2509,15 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
         expr:
           type: flowExpr
           value: attributes.get("featureTypeName", "OtherConstruction")
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: issue
         expr:
           type: string
@@ -2709,15 +2551,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "cons")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["gmlFilename"]
+          value: attributes.get("gmlFilename", attributes.get("name", ""))
       - attribute: FeatureType
         expr:
           type: flowExpr
@@ -2725,11 +2567,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "0")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", attributes.get("featureId", ""))
       - attribute: エラー数
         expr:
           type: string

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
@@ -2920,7 +2920,9 @@ graphs:
       - attribute: udxDirs
         expr:
           type: flowExpr
-          value: attributes["path"].split("/")[-2]
+          value: |
+            parts = attributes["path"].split("/");
+            if len(parts) >= 2 { parts[-2] } else { attributes.get("udxDirs", "") }
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f60
     name: FeatureCityGmlReader
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
@@ -522,12 +522,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
@@ -414,15 +414,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -438,17 +448,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -486,80 +508,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -640,15 +686,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -664,15 +720,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -688,37 +754,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -734,21 +832,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -764,21 +878,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -794,13 +924,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -808,17 +946,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -834,23 +984,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -866,18 +1034,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1301,8 +1480,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -1350,8 +1530,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -1379,8 +1560,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -2338,36 +2520,45 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? "cons"
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").featureTypeName ?? "OtherConstruction"
+        expr:
+          type: flowExpr
+          value: attributes.get("featureTypeName", "OtherConstruction")
       - attribute: LOD
-        expr: |
-          env.get("__value")["lod"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value")["featureId"] ?? env.get("__value")["gmlId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("featureId", attributes.get("gmlId"))
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: エラー内容
-        expr: |
-          let value = env.get("__value");
-          if value.validationResult?.details != () {
-            return value.validationResult.details[0][0];
-          }
-          if "issue" in value {
-            return value.issue;
-          }
-          "UnknownError"
+        expr:
+          type: flowExpr
+          value: |
+            vr = attributes.get("validationResult");
+            if vr != null and "details" in vr {
+              vr["details"][0][0]
+            } else if "issue" in attributes {
+              attributes["issue"]
+            } else {
+              "UnknownError"
+            }
   - id: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6a
     name: CsvWriterSurfaceErrors
     type: action
@@ -2418,20 +2609,25 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          env.get("__value").featureTypeName ?? "OtherConstruction"
+        expr:
+          type: flowExpr
+          value: attributes.get("featureTypeName", "OtherConstruction")
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: issue
-        expr: |
-          "Surface Not Closed"
+        expr:
+          type: string
+          value: Surface Not Closed
   - id: a104d5e6-f7a8-b9c0-d1e2-f3a4b5c6d7e8
     name: FeatureWriterNotClosed
     type: action
@@ -2465,20 +2661,25 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          env.get("__value").featureTypeName ?? "OtherConstruction"
+        expr:
+          type: flowExpr
+          value: attributes.get("featureTypeName", "OtherConstruction")
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: issue
-        expr: |
-          "InvalidSolidBoundaries"
+        expr:
+          type: string
+          value: InvalidSolidBoundaries
   - id: a120e2f3-a4b5-c6d7-e8f9-f0a1b2c3d4e5
     name: FeatureWriterSolidIssues
     type: action
@@ -2506,32 +2707,41 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? "cons"
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").featureTypeName ?? "OtherConstruction"
+        expr:
+          type: flowExpr
+          value: attributes.get("featureTypeName", "OtherConstruction")
       - attribute: LOD
-        expr: |
-          env.get("__value")["lod"] ?? "0"
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value")["gmlId"] ?? env.get("__value")["featureId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: エラー内容
-        expr: |
-          "Incorrect Orientation"
+        expr:
+          type: string
+          value: Incorrect Orientation
       - attribute: 面の向き
-        expr: |
-          "right_hand_rule"
+        expr:
+          type: string
+          value: right_hand_rule
   - id: e3f4a5b6-c7d8-9e0f-1a2b-3c4d5e6f7a8e
     name: CsvWriterOrientationErrors
     type: action
@@ -2856,30 +3066,29 @@ graphs:
     with:
       mappers:
       - attribute: gmlPath
-        expr: |
-          env.get("__value").path
+        expr:
+          type: flowExpr
+          value: attributes["path"]
       - attribute: gmlFilename
-        expr: |
-          env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: fileIndex
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: codelists
-        expr: |
-          env.get("__value").codelists
+        expr:
+          type: flowExpr
+          value: attributes["codelists"]
       - attribute: schemas
-        expr: |
-          env.get("__value").schemas
+        expr:
+          type: flowExpr
+          value: attributes["schemas"]
       - attribute: udxDirs
-        expr: |
-          let path = env.get("__value").path;
-          let parts = path.split("/");
-          let len = parts.len();
-          if len >= 2 {
-            parts[len - 2]
-          } else {
-            env.get("__value").udxDirs ?? ""
-          }
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f60
     name: FeatureCityGmlReader
     type: action
@@ -2962,26 +3171,33 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: udxDirs
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: gmlFilename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: featureTypeName
-        expr: |
-          env.get("__value").featureTypeName
+        expr:
+          type: flowExpr
+          value: attributes["featureTypeName"]
       - attribute: instanceCount
-        expr: |
-          env.get("__value").instanceCount
+        expr:
+          type: flowExpr
+          value: attributes["instanceCount"]
       - attribute: lod
-        expr: |
-          env.get("__value").lod ?? "0"
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "0")
   - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f20
     name: GeometryRemoverForErrorSummary
     type: action
@@ -3007,35 +3223,45 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes.get("fileIndex", attributes.get("index"))
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? env.get("__value").filename
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlFilename", attributes.get("filename"))
       - attribute: フィーチャータイプ
-        expr: |
-          env.get("__value").featureTypeName ?? "OtherConstruction"
+        expr:
+          type: flowExpr
+          value: attributes.get("featureTypeName", "OtherConstruction")
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "0"
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "0")
       - attribute: インスタンス数
-        expr: |
-          env.get("__value").instanceCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("instanceCount", 0)
       - attribute: 面のエラー
-        expr: |
-          env.get("__value")._num_surface_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_surface_errors", 0)
       - attribute: 面の向き不正
-        expr: |
-          env.get("__value")._num_orientation_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_orientation_errors", 0)
       - attribute: 非水密立体
-        expr: |
-          env.get("__value")._num_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_not_closed_solid", 0)
       - attribute: 立体のその他のエラー
-        expr: |
-          env.get("__value")._num_other_solid_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_other_solid_errors", 0)
   - id: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e80
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
@@ -906,7 +906,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/cons.yml
@@ -76,15 +76,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "cons")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", "")
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes["gmlFilename"]
+            value: attributes.get("gmlFilename", attributes.get("name", ""))
         - attribute: FeatureType
           expr:
             type: flowExpr
@@ -92,11 +92,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes.get("featureId", attributes.get("gmlId"))
+            value: attributes.get("featureId", attributes.get("gmlId", ""))
         - attribute: エラー数
           expr:
             type: string
@@ -175,21 +175,15 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
           expr:
             type: flowExpr
             value: attributes.get("featureTypeName", "OtherConstruction")
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: issue
           expr:
             type: string
@@ -235,21 +229,15 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
           expr:
             type: flowExpr
             value: attributes.get("featureTypeName", "OtherConstruction")
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: issue
           expr:
             type: string
@@ -289,15 +277,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "cons")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", "")
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes["gmlFilename"]
+            value: attributes.get("gmlFilename", attributes.get("name", ""))
         - attribute: FeatureType
           expr:
             type: flowExpr
@@ -305,11 +293,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "0")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes["gmlId"]
+            value: attributes.get("gmlId", attributes.get("featureId", ""))
         - attribute: エラー数
           expr:
             type: string

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/cons.yml
@@ -74,36 +74,45 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value")["udxDirs"] ?? "cons"
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value")["fileIndex"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: FeatureType
-          expr: |
-            env.get("__value").featureTypeName ?? "OtherConstruction"
+          expr:
+            type: flowExpr
+            value: attributes.get("featureTypeName", "OtherConstruction")
         - attribute: LOD
-          expr: |
-            env.get("__value")["lod"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value")["featureId"] ?? env.get("__value")["gmlId"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("featureId", attributes.get("gmlId"))
         - attribute: エラー数
-          expr: |
-            1
+          expr:
+            type: string
+            value: "1"
         - attribute: エラー内容
-          expr: |
-            let value = env.get("__value");
-            if value.validationResult?.details != () {
-              return value.validationResult.details[0][0];
-            }
-            if "issue" in value {
-              return value.issue;
-            }
-            "UnknownError"
+          expr:
+            type: flowExpr
+            value: |
+              vr = attributes.get("validationResult");
+              if vr != null and "details" in vr {
+                vr["details"][0][0]
+              } else if "issue" in attributes {
+                attributes["issue"]
+              } else {
+                "UnknownError"
+              }
 
   # ===== CSV Writer for surface errors =====
   - id: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6a
@@ -166,20 +175,25 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            env.get("__value").featureTypeName ?? "OtherConstruction"
+          expr:
+            type: flowExpr
+            value: attributes.get("featureTypeName", "OtherConstruction")
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: issue
-          expr: |
-            "Surface Not Closed"
+          expr:
+            type: string
+            value: Surface Not Closed
 
   # CSV Writer for NotClosed errors
   - id: a104d5e6-f7a8-b9c0-d1e2-f3a4b5c6d7e8
@@ -221,20 +235,25 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            env.get("__value").featureTypeName ?? "OtherConstruction"
+          expr:
+            type: flowExpr
+            value: attributes.get("featureTypeName", "OtherConstruction")
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: issue
-          expr: |
-            "InvalidSolidBoundaries"
+          expr:
+            type: string
+            value: InvalidSolidBoundaries
 
   # CSV Writer for Solid Issues (立体のその他のエラー)
   - id: a120e2f3-a4b5-c6d7-e8f9-f0a1b2c3d4e5
@@ -268,32 +287,41 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value")["udxDirs"] ?? "cons"
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value")["fileIndex"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: FeatureType
-          expr: |
-            env.get("__value").featureTypeName ?? "OtherConstruction"
+          expr:
+            type: flowExpr
+            value: attributes.get("featureTypeName", "OtherConstruction")
         - attribute: LOD
-          expr: |
-            env.get("__value")["lod"] ?? "0"
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value")["gmlId"] ?? env.get("__value")["featureId"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: エラー数
-          expr: |
-            1
+          expr:
+            type: string
+            value: "1"
         - attribute: エラー内容
-          expr: |
-            "Incorrect Orientation"
+          expr:
+            type: string
+            value: Incorrect Orientation
         - attribute: 面の向き
-          expr: |
-            "right_hand_rule"
+          expr:
+            type: string
+            value: right_hand_rule
 
   - id: e3f4a5b6-c7d8-9e0f-1a2b-3c4d5e6f7a8e
     name: CsvWriterOrientationErrors

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/workflow.yml
@@ -130,7 +130,9 @@ graphs:
             - attribute: schemas
               valueAttribute: schemas
             - attribute: udxDirs
-              valueAttribute: path.split("/")[-2]
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f60
         name: FeatureCityGmlReader

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/workflow.yml
@@ -120,30 +120,29 @@ graphs:
         with:
           mappers:
             - attribute: gmlPath
-              expr: |
-                env.get("__value").path
+              expr:
+                type: flowExpr
+                value: attributes["path"]
             - attribute: gmlFilename
-              expr: |
-                env.get("__value").name
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: fileIndex
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: codelists
-              expr: |
-                env.get("__value").codelists
+              expr:
+                type: flowExpr
+                value: attributes["codelists"]
             - attribute: schemas
-              expr: |
-                env.get("__value").schemas
+              expr:
+                type: flowExpr
+                value: attributes["schemas"]
             - attribute: udxDirs
-              expr: |
-                let path = env.get("__value").path;
-                let parts = path.split("/");
-                let len = parts.len();
-                if len >= 2 {
-                  parts[len - 2]
-                } else {
-                  env.get("__value").udxDirs ?? ""
-                }
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f60
         name: FeatureCityGmlReader
@@ -240,26 +239,33 @@ graphs:
         with:
           mappers:
             - attribute: index
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: filename
-              expr: |
-                env.get("__value").gmlFilename
+              expr:
+                type: flowExpr
+                value: attributes["gmlFilename"]
             - attribute: udxDirs
-              expr: |
-                env.get("__value").udxDirs
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: gmlFilename
-              expr: |
-                env.get("__value").gmlFilename
+              expr:
+                type: flowExpr
+                value: attributes["gmlFilename"]
             - attribute: featureTypeName
-              expr: |
-                env.get("__value").featureTypeName
+              expr:
+                type: flowExpr
+                value: attributes["featureTypeName"]
             - attribute: instanceCount
-              expr: |
-                env.get("__value").instanceCount
+              expr:
+                type: flowExpr
+                value: attributes["instanceCount"]
             - attribute: lod
-              expr: |
-                env.get("__value").lod ?? "0"
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "0")
 
       - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f20
         name: GeometryRemoverForErrorSummary
@@ -289,35 +295,45 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr: |
-                env.get("__value").udxDirs
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex ?? env.get("__value").index
+              expr:
+                type: flowExpr
+                value: attributes.get("fileIndex", attributes.get("index"))
             - attribute: Filename
-              expr: |
-                env.get("__value").gmlFilename ?? env.get("__value").filename
+              expr:
+                type: flowExpr
+                value: attributes.get("gmlFilename", attributes.get("filename"))
             - attribute: フィーチャータイプ
-              expr: |
-                env.get("__value").featureTypeName ?? "OtherConstruction"
+              expr:
+                type: flowExpr
+                value: attributes.get("featureTypeName", "OtherConstruction")
             - attribute: LOD
-              expr: |
-                env.get("__value").lod ?? "0"
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "0")
             - attribute: インスタンス数
-              expr: |
-                env.get("__value").instanceCount ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("instanceCount", 0)
             - attribute: 面のエラー
-              expr: |
-                env.get("__value")._num_surface_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_surface_errors", 0)
             - attribute: 面の向き不正
-              expr: |
-                env.get("__value")._num_orientation_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_orientation_errors", 0)
             - attribute: 非水密立体
-              expr: |
-                env.get("__value")._num_not_closed_solid ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_not_closed_solid", 0)
             - attribute: 立体のその他のエラー
-              expr: |
-                env.get("__value")._num_other_solid_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_other_solid_errors", 0)
 
       - id: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e80
         name: CSVSummaryWriter

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/workflow.yml
@@ -132,7 +132,9 @@ graphs:
             - attribute: udxDirs
               expr:
                 type: flowExpr
-                value: attributes["path"].split("/")[-2]
+                value: |
+                  parts = attributes["path"].split("/");
+                  if len(parts) >= 2 { parts[-2] } else { attributes.get("udxDirs", "") }
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f60
         name: FeatureCityGmlReader

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons/workflow.yml
@@ -120,29 +120,17 @@ graphs:
         with:
           mappers:
             - attribute: gmlPath
-              expr:
-                type: flowExpr
-                value: attributes["path"]
+              valueAttribute: path
             - attribute: gmlFilename
-              expr:
-                type: flowExpr
-                value: attributes["name"]
+              valueAttribute: name
             - attribute: fileIndex
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: codelists
-              expr:
-                type: flowExpr
-                value: attributes["codelists"]
+              valueAttribute: codelists
             - attribute: schemas
-              expr:
-                type: flowExpr
-                value: attributes["schemas"]
+              valueAttribute: schemas
             - attribute: udxDirs
-              expr:
-                type: flowExpr
-                value: attributes["path"].split("/")[-2]
+              valueAttribute: path.split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f60
         name: FeatureCityGmlReader
@@ -239,29 +227,17 @@ graphs:
         with:
           mappers:
             - attribute: index
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: filename
-              expr:
-                type: flowExpr
-                value: attributes["gmlFilename"]
+              valueAttribute: gmlFilename
             - attribute: udxDirs
-              expr:
-                type: flowExpr
-                value: attributes["udxDirs"]
+              valueAttribute: udxDirs
             - attribute: gmlFilename
-              expr:
-                type: flowExpr
-                value: attributes["gmlFilename"]
+              valueAttribute: gmlFilename
             - attribute: featureTypeName
-              expr:
-                type: flowExpr
-                value: attributes["featureTypeName"]
+              valueAttribute: featureTypeName
             - attribute: instanceCount
-              expr:
-                type: flowExpr
-                value: attributes["instanceCount"]
+              valueAttribute: instanceCount
             - attribute: lod
               expr:
                 type: flowExpr
@@ -295,9 +271,7 @@ graphs:
         with:
           mappers:
             - attribute: Folder
-              expr:
-                type: flowExpr
-                value: attributes["udxDirs"]
+              valueAttribute: udxDirs
             - attribute: Index
               expr:
                 type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
@@ -414,17 +414,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -448,17 +442,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -508,13 +496,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -533,33 +517,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -581,27 +561,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -686,25 +664,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -720,25 +688,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -754,69 +712,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -832,37 +758,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -878,37 +788,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -946,29 +840,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -984,41 +866,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1034,29 +898,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -2494,15 +2348,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", 0)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["gmlFilename"]
+          value: attributes.get("gmlFilename", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
@@ -2518,11 +2372,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "1")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: 無効な空間属性の型
         expr:
           type: flowExpr
@@ -2564,15 +2418,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "wtr")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", 1)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["gmlFilename"]
+          value: attributes.get("gmlFilename", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
@@ -2588,11 +2442,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "1")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: エラー数
         expr:
           type: string
@@ -2658,9 +2512,7 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
         expr:
           type: flowExpr
@@ -2674,13 +2526,9 @@ graphs:
               ft
             }
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: issue
         expr:
           type: string
@@ -2717,9 +2565,7 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
         expr:
           type: flowExpr
@@ -2733,13 +2579,9 @@ graphs:
               ft
             }
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: issue
         expr:
           type: string
@@ -2782,15 +2624,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "wtr")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", 1)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["gmlFilename"]
+          value: attributes.get("gmlFilename", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
@@ -2806,11 +2648,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "2")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: エラー数
         expr:
           type: string

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
@@ -3161,7 +3161,9 @@ graphs:
       - attribute: schemas
         valueAttribute: schemas
       - attribute: udxDirs
-        valueAttribute: path.split("/")[-2]
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
     name: FeatureCityGmlReader
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
@@ -3005,7 +3005,9 @@ graphs:
       - attribute: udxDirs
         expr:
           type: flowExpr
-          value: attributes["path"].split("/")[-2]
+          value: |
+            parts = attributes["path"].split("/");
+            if len(parts) >= 2 { parts[-2] } else { attributes.get("udxDirs", "") }
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
     name: FeatureCityGmlReader
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
@@ -414,15 +414,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -438,17 +448,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -486,80 +508,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -640,15 +686,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -664,15 +720,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -688,37 +754,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -734,21 +832,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -764,21 +878,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -794,13 +924,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -808,17 +946,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -834,23 +984,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -866,18 +1034,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1301,8 +1480,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -1350,8 +1530,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -1379,8 +1560,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -2310,31 +2492,41 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: FeatureType
-        expr: |
-          let ft = env.get("__value").featureType ?? "WaterBody";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "WaterBody"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "1"
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: 無効な空間属性の型
-        expr: |
-          env.get("__value").geometryName ?? "Unknown"
+        expr:
+          type: flowExpr
+          value: attributes.get("geometryName", "Unknown")
   - id: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
     name: FeatureWriterInvalidSpatialAttr
     type: action
@@ -2370,41 +2562,53 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs ?? "wtr"
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? 1
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: FeatureType
-        expr: |
-          let ft = env.get("__value").featureType ?? "WaterBody";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "WaterBody"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "1"
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: エラー内容
-        expr: |
-          let value = env.get("__value");
-          if value.validationResult?.details != () {
-            return value.validationResult.details[0][0];
-          }
-          if "issue" in value {
-            return value.issue;
-          }
-          "UnknownError"
+        expr:
+          type: flowExpr
+          value: |
+            vr = attributes.get("validationResult");
+            if vr != null and "details" in vr {
+              vr["details"][0][0]
+            } else if "issue" in attributes {
+              attributes["issue"]
+            } else {
+              "UnknownError"
+            }
   - id: 12a3b3c3-d3e3-f3a3-b3c3-d3e3f3a3b3c3
     name: FeatureWriterLod1SurfaceErrors
     type: action
@@ -2454,25 +2658,33 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          let ft = env.get("__value").featureType ?? "WaterBody";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "WaterBody"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: issue
-        expr: |
-          "Surface Not Closed"
+        expr:
+          type: string
+          value: Surface Not Closed
   - id: f2a3b4c5-d6e7-8f9a-0b1c-2d3e4f5a6b7c
     name: FeatureWriterNotClosed
     type: action
@@ -2505,25 +2717,33 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          let ft = env.get("__value").featureType ?? "WaterBody";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "WaterBody"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: issue
-        expr: |
-          "Invalid Solid Boundaries"
+        expr:
+          type: string
+          value: Invalid Solid Boundaries
   - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f1a
     name: FeatureWriterOtherSolidErrors
     type: action
@@ -2560,41 +2780,53 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs ?? "wtr"
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? 1
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: FeatureType
-        expr: |
-          let ft = env.get("__value").featureType ?? "WaterBody";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "WaterBody"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "2"
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: エラー内容
-        expr: |
-          let value = env.get("__value");
-          if value.validationResult?.details != () {
-            return value.validationResult.details[0][0];
-          }
-          if "issue" in value {
-            return value.issue;
-          }
-          "UnknownError"
+        expr:
+          type: flowExpr
+          value: |
+            vr = attributes.get("validationResult");
+            if vr != null and "details" in vr {
+              vr["details"][0][0]
+            } else if "issue" in attributes {
+              attributes["issue"]
+            } else {
+              "UnknownError"
+            }
   - id: 03a3b3c3-d3e3-f3a3-b3c3-d3e3f3a3b3c3
     name: FeatureWriterBoundarySurfaceErrors
     type: action
@@ -2919,32 +3151,29 @@ graphs:
     with:
       mappers:
       - attribute: gmlPath
-        expr: |
-          env.get("__value").path
+        expr:
+          type: flowExpr
+          value: attributes["path"]
       - attribute: gmlFilename
-        expr: |
-          env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: fileIndex
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: codelists
-        expr: |
-          env.get("__value").codelists
+        expr:
+          type: flowExpr
+          value: attributes["codelists"]
       - attribute: schemas
-        expr: |
-          env.get("__value").schemas
+        expr:
+          type: flowExpr
+          value: attributes["schemas"]
       - attribute: udxDirs
-        expr: |
-          // Extract folder from path (e.g., "file://path/wtr/file.gml" -> "wtr")
-          // The folder is the second-to-last segment of the path
-          let path = env.get("__value").path;
-          let parts = path.split("/");
-          let len = parts.len();
-          if len >= 2 {
-            parts[len - 2]
-          } else {
-            env.get("__value").udxDirs ?? ""
-          }
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
     name: FeatureCityGmlReader
     type: action
@@ -2986,23 +3215,29 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: udxDirs
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: gmlFilename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: WaterBody
-        expr: |
-          env.get("__value").WaterBody
+        expr:
+          type: flowExpr
+          value: attributes["WaterBody"]
       - attribute: lod
-        expr: |
-          env.get("__value").lod ?? "1"
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "1")
   - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f1a
     name: GeometryRemoverForErrorSummary
     type: action
@@ -3041,38 +3276,49 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes.get("fileIndex", attributes.get("index"))
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? env.get("__value").filename
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlFilename", attributes.get("filename"))
       - attribute: フィーチャータイプ
-        expr: |
-          "WaterBody"
+        expr:
+          type: string
+          value: WaterBody
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "1"
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "1")
       - attribute: インスタンス数
-        expr: |
-          env.get("__value").WaterBody ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("WaterBody", 0)
       - attribute: 無効な空間属性の型
-        expr: |
-          env.get("__value")._num_invalid_spatial_attr ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_invalid_spatial_attr", 0)
       - attribute: 非水密立体
-        expr: |
-          env.get("__value")._num_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_not_closed_solid", 0)
       - attribute: 立体のその他のエラー
-        expr: |
-          env.get("__value")._num_other_solid_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_other_solid_errors", 0)
       - attribute: 立体の境界面のエラー
-        expr: |
-          env.get("__value")._num_boundary_surface_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_boundary_surface_errors", 0)
       - attribute: 面のエラー
-        expr: |
-          env.get("__value")._num_lod1_surface_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod1_surface_errors", 0)
   - id: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e6f
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
@@ -3151,29 +3151,17 @@ graphs:
     with:
       mappers:
       - attribute: gmlPath
-        expr:
-          type: flowExpr
-          value: attributes["path"]
+        valueAttribute: path
       - attribute: gmlFilename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: fileIndex
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: codelists
-        expr:
-          type: flowExpr
-          value: attributes["codelists"]
+        valueAttribute: codelists
       - attribute: schemas
-        expr:
-          type: flowExpr
-          value: attributes["schemas"]
+        valueAttribute: schemas
       - attribute: udxDirs
-        expr:
-          type: flowExpr
-          value: attributes["path"].split("/")[-2]
+        valueAttribute: path.split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
     name: FeatureCityGmlReader
     type: action
@@ -3215,25 +3203,15 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: udxDirs
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: gmlFilename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: WaterBody
-        expr:
-          type: flowExpr
-          value: attributes["WaterBody"]
+        valueAttribute: WaterBody
       - attribute: lod
         expr:
           type: flowExpr
@@ -3280,9 +3258,7 @@ graphs:
           type: flowExpr
           value: attributes.get("fileIndex", attributes.get("index"))
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
@@ -522,12 +522,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
@@ -906,7 +906,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/workflow.yml
@@ -130,7 +130,9 @@ graphs:
             - attribute: schemas
               valueAttribute: schemas
             - attribute: udxDirs
-              valueAttribute: path.split("/")[-2]
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
         name: FeatureCityGmlReader

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/workflow.yml
@@ -120,29 +120,17 @@ graphs:
         with:
           mappers:
             - attribute: gmlPath
-              expr:
-                type: flowExpr
-                value: attributes["path"]
+              valueAttribute: path
             - attribute: gmlFilename
-              expr:
-                type: flowExpr
-                value: attributes["name"]
+              valueAttribute: name
             - attribute: fileIndex
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: codelists
-              expr:
-                type: flowExpr
-                value: attributes["codelists"]
+              valueAttribute: codelists
             - attribute: schemas
-              expr:
-                type: flowExpr
-                value: attributes["schemas"]
+              valueAttribute: schemas
             - attribute: udxDirs
-              expr:
-                type: flowExpr
-                value: attributes["path"].split("/")[-2]
+              valueAttribute: path.split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
         name: FeatureCityGmlReader
@@ -192,25 +180,15 @@ graphs:
         with:
           mappers:
             - attribute: index
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: filename
-              expr:
-                type: flowExpr
-                value: attributes["gmlFilename"]
+              valueAttribute: gmlFilename
             - attribute: udxDirs
-              expr:
-                type: flowExpr
-                value: attributes["udxDirs"]
+              valueAttribute: udxDirs
             - attribute: gmlFilename
-              expr:
-                type: flowExpr
-                value: attributes["gmlFilename"]
+              valueAttribute: gmlFilename
             - attribute: WaterBody
-              expr:
-                type: flowExpr
-                value: attributes["WaterBody"]
+              valueAttribute: WaterBody
             - attribute: lod
               expr:
                 type: flowExpr
@@ -263,9 +241,7 @@ graphs:
                 type: flowExpr
                 value: attributes.get("fileIndex", attributes.get("index"))
             - attribute: Folder
-              expr:
-                type: flowExpr
-                value: attributes["udxDirs"]
+              valueAttribute: udxDirs
             - attribute: Filename
               expr:
                 type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/workflow.yml
@@ -120,32 +120,29 @@ graphs:
         with:
           mappers:
             - attribute: gmlPath
-              expr: |
-                env.get("__value").path
+              expr:
+                type: flowExpr
+                value: attributes["path"]
             - attribute: gmlFilename
-              expr: |
-                env.get("__value").name
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: fileIndex
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: codelists
-              expr: |
-                env.get("__value").codelists
+              expr:
+                type: flowExpr
+                value: attributes["codelists"]
             - attribute: schemas
-              expr: |
-                env.get("__value").schemas
+              expr:
+                type: flowExpr
+                value: attributes["schemas"]
             - attribute: udxDirs
-              expr: |
-                // Extract folder from path (e.g., "file://path/wtr/file.gml" -> "wtr")
-                // The folder is the second-to-last segment of the path
-                let path = env.get("__value").path;
-                let parts = path.split("/");
-                let len = parts.len();
-                if len >= 2 {
-                  parts[len - 2]
-                } else {
-                  env.get("__value").udxDirs ?? ""
-                }
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
         name: FeatureCityGmlReader
@@ -195,23 +192,29 @@ graphs:
         with:
           mappers:
             - attribute: index
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: filename
-              expr: |
-                env.get("__value").gmlFilename
+              expr:
+                type: flowExpr
+                value: attributes["gmlFilename"]
             - attribute: udxDirs
-              expr: |
-                env.get("__value").udxDirs
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: gmlFilename
-              expr: |
-                env.get("__value").gmlFilename
+              expr:
+                type: flowExpr
+                value: attributes["gmlFilename"]
             - attribute: WaterBody
-              expr: |
-                env.get("__value").WaterBody
+              expr:
+                type: flowExpr
+                value: attributes["WaterBody"]
             - attribute: lod
-              expr: |
-                env.get("__value").lod ?? "1"
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "1")
 
       - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f1a
         name: GeometryRemoverForErrorSummary
@@ -256,38 +259,49 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex ?? env.get("__value").index
+              expr:
+                type: flowExpr
+                value: attributes.get("fileIndex", attributes.get("index"))
             - attribute: Folder
-              expr: |
-                env.get("__value").udxDirs
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: Filename
-              expr: |
-                env.get("__value").gmlFilename ?? env.get("__value").filename
+              expr:
+                type: flowExpr
+                value: attributes.get("gmlFilename", attributes.get("filename"))
             - attribute: フィーチャータイプ
-              expr: |
-                "WaterBody"
+              expr:
+                type: string
+                value: WaterBody
             - attribute: LOD
-              expr: |
-                env.get("__value").lod ?? "1"
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "1")
             - attribute: インスタンス数
-              expr: |
-                env.get("__value").WaterBody ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("WaterBody", 0)
             - attribute: 無効な空間属性の型
-              expr: |
-                env.get("__value")._num_invalid_spatial_attr ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_invalid_spatial_attr", 0)
             - attribute: 非水密立体
-              expr: |
-                env.get("__value")._num_not_closed_solid ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_not_closed_solid", 0)
             - attribute: 立体のその他のエラー
-              expr: |
-                env.get("__value")._num_other_solid_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_other_solid_errors", 0)
             - attribute: 立体の境界面のエラー
-              expr: |
-                env.get("__value")._num_boundary_surface_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_boundary_surface_errors", 0)
             - attribute: 面のエラー
-              expr: |
-                env.get("__value")._num_lod1_surface_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod1_surface_errors", 0)
 
       - id: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e6f
         name: CSVSummaryWriter

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/workflow.yml
@@ -132,7 +132,9 @@ graphs:
             - attribute: udxDirs
               expr:
                 type: flowExpr
-                value: attributes["path"].split("/")[-2]
+                value: |
+                  parts = attributes["path"].split("/");
+                  if len(parts) >= 2 { parts[-2] } else { attributes.get("udxDirs", "") }
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5a
         name: FeatureCityGmlReader

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/wtr.yml
@@ -38,15 +38,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", 0)
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes["gmlFilename"]
+            value: attributes.get("gmlFilename", "")
         - attribute: FeatureType
           expr:
             type: flowExpr
@@ -62,11 +62,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "1")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes["gmlId"]
+            value: attributes.get("gmlId", "")
         - attribute: "無効な空間属性の型"
           expr:
             type: flowExpr
@@ -115,15 +115,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "wtr")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", 1)
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes["gmlFilename"]
+            value: attributes.get("gmlFilename", "")
         - attribute: FeatureType
           expr:
             type: flowExpr
@@ -139,11 +139,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "1")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes["gmlId"]
+            value: attributes.get("gmlId", "")
         - attribute: エラー数
           expr:
             type: string
@@ -217,9 +217,7 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
           expr:
             type: flowExpr
@@ -233,13 +231,9 @@ nodes:
                 ft
               }
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: issue
           expr:
             type: string
@@ -281,9 +275,7 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
           expr:
             type: flowExpr
@@ -297,13 +289,9 @@ nodes:
                 ft
               }
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: issue
           expr:
             type: string
@@ -352,15 +340,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "wtr")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", 1)
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes["gmlFilename"]
+            value: attributes.get("gmlFilename", "")
         - attribute: FeatureType
           expr:
             type: flowExpr
@@ -376,11 +364,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "2")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes["gmlId"]
+            value: attributes.get("gmlId", "")
         - attribute: エラー数
           expr:
             type: string

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr/wtr.yml
@@ -36,31 +36,41 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value").udxDirs ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: FeatureType
-          expr: |
-            let ft = env.get("__value").featureType ?? "WaterBody";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "WaterBody"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: LOD
-          expr: |
-            env.get("__value").lod ?? "1"
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value").gmlId ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: "無効な空間属性の型"
-          expr: |
-            env.get("__value").geometryName ?? "Unknown"
+          expr:
+            type: flowExpr
+            value: attributes.get("geometryName", "Unknown")
 
   - id: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0b
     name: FeatureWriterInvalidSpatialAttr
@@ -103,41 +113,53 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value").udxDirs ?? "wtr"
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex ?? 1
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: FeatureType
-          expr: |
-            let ft = env.get("__value").featureType ?? "WaterBody";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "WaterBody"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: LOD
-          expr: |
-            env.get("__value").lod ?? "1"
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value").gmlId ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: エラー数
-          expr: |
-            1
+          expr:
+            type: string
+            value: "1"
         - attribute: エラー内容
-          expr: |
-            let value = env.get("__value");
-            if value.validationResult?.details != () {
-              return value.validationResult.details[0][0];
-            }
-            if "issue" in value {
-              return value.issue;
-            }
-            "UnknownError"
+          expr:
+            type: flowExpr
+            value: |
+              vr = attributes.get("validationResult");
+              if vr != null and "details" in vr {
+                vr["details"][0][0]
+              } else if "issue" in attributes {
+                attributes["issue"]
+              } else {
+                "UnknownError"
+              }
 
   - id: 12a3b3c3-d3e3-f3a3-b3c3-d3e3f3a3b3c3
     name: FeatureWriterLod1SurfaceErrors
@@ -195,25 +217,33 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            let ft = env.get("__value").featureType ?? "WaterBody";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "WaterBody"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: issue
-          expr: |
-            "Surface Not Closed"
+          expr:
+            type: string
+            value: Surface Not Closed
 
   - id: f2a3b4c5-d6e7-8f9a-0b1c-2d3e4f5a6b7c
     name: FeatureWriterNotClosed
@@ -251,25 +281,33 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            let ft = env.get("__value").featureType ?? "WaterBody";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "WaterBody"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: issue
-          expr: |
-            "Invalid Solid Boundaries"
+          expr:
+            type: string
+            value: Invalid Solid Boundaries
 
   - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f1a
     name: FeatureWriterOtherSolidErrors
@@ -312,41 +350,53 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value").udxDirs ?? "wtr"
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex ?? 1
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: FeatureType
-          expr: |
-            let ft = env.get("__value").featureType ?? "WaterBody";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "WaterBody"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: LOD
-          expr: |
-            env.get("__value").lod ?? "2"
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value").gmlId ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: エラー数
-          expr: |
-            1
+          expr:
+            type: string
+            value: "1"
         - attribute: エラー内容
-          expr: |
-            let value = env.get("__value");
-            if value.validationResult?.details != () {
-              return value.validationResult.details[0][0];
-            }
-            if "issue" in value {
-              return value.issue;
-            }
-            "UnknownError"
+          expr:
+            type: flowExpr
+            value: |
+              vr = attributes.get("validationResult");
+              if vr != null and "details" in vr {
+                vr["details"][0][0]
+              } else if "issue" in attributes {
+                attributes["issue"]
+              } else {
+                "UnknownError"
+              }
 
   - id: 03a3b3c3-d3e3-f3a3-b3c3-d3e3f3a3b3c3
     name: FeatureWriterBoundarySurfaceErrors

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
@@ -904,7 +904,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
@@ -412,15 +412,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -436,17 +446,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -484,80 +506,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -638,15 +684,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -662,15 +718,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -686,37 +752,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -732,21 +830,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -762,21 +876,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -792,13 +922,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -806,17 +944,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -832,23 +982,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -864,18 +1032,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1299,8 +1478,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -1348,8 +1528,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -1377,8 +1558,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -2308,31 +2490,41 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: FeatureType
-        expr: |
-          let ft = env.get("__value").featureType ?? "UndergroundFacility";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "UndergroundFacility"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "2"
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: 無効な空間属性の型
-        expr: |
-          env.get("__value").geometryName ?? "Unknown"
+        expr:
+          type: flowExpr
+          value: attributes.get("geometryName", "Unknown")
   - id: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e91
     name: GeometryFilterLod34
     type: action
@@ -2346,31 +2538,41 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: FeatureType
-        expr: |
-          let ft = env.get("__value").featureType ?? "UndergroundFacility";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "UndergroundFacility"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "3"
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: 無効な空間属性の型
-        expr: |
-          env.get("__value").geometryName ?? "Unknown"
+        expr:
+          type: flowExpr
+          value: attributes.get("geometryName", "Unknown")
   - id: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0c
     name: FeatureWriterInvalidSpatialAttr
     type: action
@@ -2421,25 +2623,33 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          let ft = env.get("__value").featureType ?? "UndergroundFacility";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "UndergroundFacility"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: issue
-        expr: |
-          "SurfaceNotClosed"
+        expr:
+          type: string
+          value: SurfaceNotClosed
   - id: f2a3b4c5-d6e7-8f9a-0b1c-2d3e4f5a6b7d
     name: FeatureWriterNotClosed
     type: action
@@ -2473,25 +2683,33 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: feature_type
-        expr: |
-          let ft = env.get("__value").featureType ?? "UndergroundFacility";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "UndergroundFacility"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: lod
-        expr: |
-          env.get("__value").lod
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml_id
-        expr: |
-          env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: issue
-        expr: |
-          "Invalid Solid Boundaries"
+        expr:
+          type: string
+          value: Invalid Solid Boundaries
   - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f1b
     name: FeatureWriterOtherSolidErrors
     type: action
@@ -2529,41 +2747,53 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs ?? "unf"
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? 1
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: FeatureType
-        expr: |
-          let ft = env.get("__value").featureType ?? "UndergroundFacility";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "UndergroundFacility"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "2"
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: エラー内容
-        expr: |
-          let value = env.get("__value");
-          if value.validationResult?.details != () {
-            return value.validationResult.details[0][0];
-          }
-          if "issue" in value {
-            return value.issue;
-          }
-          "UnknownError"
+        expr:
+          type: flowExpr
+          value: |
+            vr = attributes.get("validationResult");
+            if vr != null and "details" in vr {
+              vr["details"][0][0]
+            } else if "issue" in attributes {
+              attributes["issue"]
+            } else {
+              "UnknownError"
+            }
   - id: 03a3b3c3-d3e3-f3a3-b3c3-d3e3f3a3b3c4
     name: FeatureWriterBoundarySurfaceErrors
     type: action
@@ -2601,41 +2831,53 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs ?? "unf"
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? 1
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: FeatureType
-        expr: |
-          let ft = env.get("__value").featureType ?? "UndergroundFacility";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "UndergroundFacility"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "3"
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: エラー内容
-        expr: |
-          let value = env.get("__value");
-          if value.validationResult?.details != () {
-            return value.validationResult.details[0][0];
-          }
-          if "issue" in value {
-            return value.issue;
-          }
-          "UnknownError"
+        expr:
+          type: flowExpr
+          value: |
+            vr = attributes.get("validationResult");
+            if vr != null and "details" in vr {
+              vr["details"][0][0]
+            } else if "issue" in attributes {
+              attributes["issue"]
+            } else {
+              "UnknownError"
+            }
   - id: 12a3b3c3-d3e3-f3a3-b3c3-d3e3f3a3b3c4
     name: FeatureWriterLod34SurfaceErrors
     type: action
@@ -2673,31 +2915,41 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs ?? "unf"
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? 1
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: FeatureType
-        expr: |
-          let ft = env.get("__value").featureType ?? "UndergroundFacility";
-          if ft.contains(":") {
-            ft.split(":")[1]
-          } else {
-            ft
-          }
+        expr:
+          type: flowExpr
+          value: |
+            ft = attributes.get("featureType");
+            if ft == null {
+              "UndergroundFacility"
+            } else if ":" in ft {
+              ft.split(":")[1]
+            } else {
+              ft
+            }
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "3"
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value").gmlId ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: 不連続パート数
-        expr: |
-          env.get("__value").discontinuous_parts_count ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("discontinuous_parts_count", 0)
   - id: 22a3b3c3-d3e3-f3a3-b3c3-d3e3f3a3b3c4
     name: FeatureWriterDiscontinuousCS
     type: action
@@ -3086,32 +3338,29 @@ graphs:
     with:
       mappers:
       - attribute: gmlPath
-        expr: |
-          env.get("__value").path
+        expr:
+          type: flowExpr
+          value: attributes["path"]
       - attribute: gmlFilename
-        expr: |
-          env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: fileIndex
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: codelists
-        expr: |
-          env.get("__value").codelists
+        expr:
+          type: flowExpr
+          value: attributes["codelists"]
       - attribute: schemas
-        expr: |
-          env.get("__value").schemas
+        expr:
+          type: flowExpr
+          value: attributes["schemas"]
       - attribute: udxDirs
-        expr: |
-          // Extract folder from path (e.g., "file://path/unf/file.gml" -> "unf")
-          // The folder is the second-to-last segment of the path
-          let path = env.get("__value").path;
-          let parts = path.split("/");
-          let len = parts.len();
-          if len >= 2 {
-            parts[len - 2]
-          } else {
-            env.get("__value").udxDirs ?? ""
-          }
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5c
     name: FeatureCityGmlReader
     type: action
@@ -3188,26 +3437,33 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: udxDirs
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: gmlFilename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: featureTypeName
-        expr: |
-          env.get("__value").featureTypeName
+        expr:
+          type: flowExpr
+          value: attributes["featureTypeName"]
       - attribute: instanceCount
-        expr: |
-          env.get("__value").instanceCount
+        expr:
+          type: flowExpr
+          value: attributes["instanceCount"]
       - attribute: lod
-        expr: |
-          env.get("__value").lod ?? "0"
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "0")
   - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f1c
     name: GeometryRemoverForErrorSummary
     type: action
@@ -3233,41 +3489,53 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes.get("fileIndex", attributes.get("index"))
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? env.get("__value").filename
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlFilename", attributes.get("filename"))
       - attribute: フィーチャータイプ
-        expr: |
-          env.get("__value").featureTypeName ?? "UndergroundFacility"
+        expr:
+          type: flowExpr
+          value: attributes.get("featureTypeName", "UndergroundFacility")
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "0"
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "0")
       - attribute: インスタンス数
-        expr: |
-          env.get("__value").instanceCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("instanceCount", 0)
       - attribute: 無効な空間属性の型
-        expr: |
-          env.get("__value")._num_invalid_spatial_attr ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_invalid_spatial_attr", 0)
       - attribute: 非水密立体
-        expr: |
-          env.get("__value")._num_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_not_closed_solid", 0)
       - attribute: 立体のその他のエラー
-        expr: |
-          env.get("__value")._num_other_solid_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_other_solid_errors", 0)
       - attribute: 立体の境界面のエラー
-        expr: |
-          env.get("__value")._num_boundary_surface_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_boundary_surface_errors", 0)
       - attribute: 面のエラー
-        expr: |
-          env.get("__value")._num_lod34_surface_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_lod34_surface_errors", 0)
       - attribute: 不連続なCompositeSurface
-        expr: |
-          env.get("__value")._num_discontinuous_cs ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_discontinuous_cs", 0)
   - id: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e61
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
@@ -412,17 +412,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -446,17 +440,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -506,13 +494,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -531,33 +515,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -579,27 +559,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -684,25 +662,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -718,25 +686,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -752,69 +710,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -830,37 +756,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -876,37 +786,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -944,29 +838,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -982,41 +864,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1032,29 +896,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -2492,15 +2346,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", 0)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["gmlFilename"]
+          value: attributes.get("gmlFilename", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
@@ -2516,11 +2370,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "2")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: 無効な空間属性の型
         expr:
           type: flowExpr
@@ -2540,15 +2394,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", 0)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["gmlFilename"]
+          value: attributes.get("gmlFilename", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
@@ -2564,11 +2418,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "3")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: 無効な空間属性の型
         expr:
           type: flowExpr
@@ -2623,9 +2477,7 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
         expr:
           type: flowExpr
@@ -2639,13 +2491,9 @@ graphs:
               ft
             }
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: issue
         expr:
           type: string
@@ -2683,9 +2531,7 @@ graphs:
     with:
       mappers:
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: feature_type
         expr:
           type: flowExpr
@@ -2699,13 +2545,9 @@ graphs:
               ft
             }
       - attribute: lod
-        expr:
-          type: flowExpr
-          value: attributes["lod"]
+        valueAttribute: lod
       - attribute: gml_id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: issue
         expr:
           type: string
@@ -2749,15 +2591,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "unf")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", 1)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["gmlFilename"]
+          value: attributes.get("gmlFilename", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
@@ -2773,11 +2615,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "2")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: エラー数
         expr:
           type: string
@@ -2833,15 +2675,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "unf")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", 1)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["gmlFilename"]
+          value: attributes.get("gmlFilename", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
@@ -2857,11 +2699,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "3")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: エラー数
         expr:
           type: string
@@ -2917,15 +2759,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "unf")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", 1)
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes["gmlFilename"]
+          value: attributes.get("gmlFilename", "")
       - attribute: FeatureType
         expr:
           type: flowExpr
@@ -2941,11 +2783,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "3")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes["gmlId"]
+          value: attributes.get("gmlId", "")
       - attribute: 不連続パート数
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
@@ -520,12 +520,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
@@ -3192,7 +3192,9 @@ graphs:
       - attribute: udxDirs
         expr:
           type: flowExpr
-          value: attributes["path"].split("/")[-2]
+          value: |
+            parts = attributes["path"].split("/");
+            if len(parts) >= 2 { parts[-2] } else { attributes.get("udxDirs", "") }
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5c
     name: FeatureCityGmlReader
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
@@ -3348,7 +3348,9 @@ graphs:
       - attribute: schemas
         valueAttribute: schemas
       - attribute: udxDirs
-        valueAttribute: path.split("/")[-2]
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5c
     name: FeatureCityGmlReader
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
@@ -3338,29 +3338,17 @@ graphs:
     with:
       mappers:
       - attribute: gmlPath
-        expr:
-          type: flowExpr
-          value: attributes["path"]
+        valueAttribute: path
       - attribute: gmlFilename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: fileIndex
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: codelists
-        expr:
-          type: flowExpr
-          value: attributes["codelists"]
+        valueAttribute: codelists
       - attribute: schemas
-        expr:
-          type: flowExpr
-          value: attributes["schemas"]
+        valueAttribute: schemas
       - attribute: udxDirs
-        expr:
-          type: flowExpr
-          value: attributes["path"].split("/")[-2]
+        valueAttribute: path.split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5c
     name: FeatureCityGmlReader
     type: action
@@ -3437,29 +3425,17 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: udxDirs
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: gmlFilename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: featureTypeName
-        expr:
-          type: flowExpr
-          value: attributes["featureTypeName"]
+        valueAttribute: featureTypeName
       - attribute: instanceCount
-        expr:
-          type: flowExpr
-          value: attributes["instanceCount"]
+        valueAttribute: instanceCount
       - attribute: lod
         expr:
           type: flowExpr
@@ -3493,9 +3469,7 @@ graphs:
           type: flowExpr
           value: attributes.get("fileIndex", attributes.get("index"))
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/unf.yml
@@ -36,31 +36,41 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value").udxDirs ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: FeatureType
-          expr: |
-            let ft = env.get("__value").featureType ?? "UndergroundFacility";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "UndergroundFacility"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: LOD
-          expr: |
-            env.get("__value").lod ?? "2"
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value").gmlId ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: "無効な空間属性の型"
-          expr: |
-            env.get("__value").geometryName ?? "Unknown"
+          expr:
+            type: flowExpr
+            value: attributes.get("geometryName", "Unknown")
 
   # ===== LOD3-4: Detect non-Surface geometry using GeometryFilter =====
   - id: c3d4e5f6-a7b8-9c0d-1e2f-3a4b5c6d7e91
@@ -78,31 +88,41 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value").udxDirs ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex ?? 0
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: FeatureType
-          expr: |
-            let ft = env.get("__value").featureType ?? "UndergroundFacility";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "UndergroundFacility"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: LOD
-          expr: |
-            env.get("__value").lod ?? "3"
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value").gmlId ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: "無効な空間属性の型"
-          expr: |
-            env.get("__value").geometryName ?? "Unknown"
+          expr:
+            type: flowExpr
+            value: attributes.get("geometryName", "Unknown")
 
   - id: e5f6a7b8-c9d0-1e2f-3a4b-5c6d7e8f9a0c
     name: FeatureWriterInvalidSpatialAttr
@@ -161,25 +181,33 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            let ft = env.get("__value").featureType ?? "UndergroundFacility";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "UndergroundFacility"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: issue
-          expr: |
-            "SurfaceNotClosed"
+          expr:
+            type: string
+            value: SurfaceNotClosed
 
   - id: f2a3b4c5-d6e7-8f9a-0b1c-2d3e4f5a6b7d
     name: FeatureWriterNotClosed
@@ -218,25 +246,33 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr: |
-            env.get("__value").gmlFilename
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: feature_type
-          expr: |
-            let ft = env.get("__value").featureType ?? "UndergroundFacility";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "UndergroundFacility"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: lod
-          expr: |
-            env.get("__value").lod
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: gml_id
-          expr: |
-            env.get("__value").gmlId
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: issue
-          expr: |
-            "Invalid Solid Boundaries"
+          expr:
+            type: string
+            value: Invalid Solid Boundaries
 
   - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f1b
     name: FeatureWriterOtherSolidErrors
@@ -280,41 +316,53 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value").udxDirs ?? "unf"
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex ?? 1
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: FeatureType
-          expr: |
-            let ft = env.get("__value").featureType ?? "UndergroundFacility";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "UndergroundFacility"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: LOD
-          expr: |
-            env.get("__value").lod ?? "2"
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value").gmlId ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: エラー数
-          expr: |
-            1
+          expr:
+            type: string
+            value: "1"
         - attribute: エラー内容
-          expr: |
-            let value = env.get("__value");
-            if value.validationResult?.details != () {
-              return value.validationResult.details[0][0];
-            }
-            if "issue" in value {
-              return value.issue;
-            }
-            "UnknownError"
+          expr:
+            type: flowExpr
+            value: |
+              vr = attributes.get("validationResult");
+              if vr != null and "details" in vr {
+                vr["details"][0][0]
+              } else if "issue" in attributes {
+                attributes["issue"]
+              } else {
+                "UnknownError"
+              }
 
   - id: 03a3b3c3-d3e3-f3a3-b3c3-d3e3f3a3b3c4
     name: FeatureWriterBoundarySurfaceErrors
@@ -358,41 +406,53 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value").udxDirs ?? "unf"
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex ?? 1
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: FeatureType
-          expr: |
-            let ft = env.get("__value").featureType ?? "UndergroundFacility";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "UndergroundFacility"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: LOD
-          expr: |
-            env.get("__value").lod ?? "3"
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value").gmlId ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: エラー数
-          expr: |
-            1
+          expr:
+            type: string
+            value: "1"
         - attribute: エラー内容
-          expr: |
-            let value = env.get("__value");
-            if value.validationResult?.details != () {
-              return value.validationResult.details[0][0];
-            }
-            if "issue" in value {
-              return value.issue;
-            }
-            "UnknownError"
+          expr:
+            type: flowExpr
+            value: |
+              vr = attributes.get("validationResult");
+              if vr != null and "details" in vr {
+                vr["details"][0][0]
+              } else if "issue" in attributes {
+                attributes["issue"]
+              } else {
+                "UnknownError"
+              }
 
   - id: 12a3b3c3-d3e3-f3a3-b3c3-d3e3f3a3b3c4
     name: FeatureWriterLod34SurfaceErrors
@@ -436,31 +496,41 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value").udxDirs ?? "unf"
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value").fileIndex ?? 1
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value").gmlFilename ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlFilename"]
         - attribute: FeatureType
-          expr: |
-            let ft = env.get("__value").featureType ?? "UndergroundFacility";
-            if ft.contains(":") {
-              ft.split(":")[1]
-            } else {
-              ft
-            }
+          expr:
+            type: flowExpr
+            value: |
+              ft = attributes.get("featureType");
+              if ft == null {
+                "UndergroundFacility"
+              } else if ":" in ft {
+                ft.split(":")[1]
+              } else {
+                ft
+              }
         - attribute: LOD
-          expr: |
-            env.get("__value").lod ?? "3"
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value").gmlId ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["gmlId"]
         - attribute: 不連続パート数
-          expr: |
-            env.get("__value").discontinuous_parts_count ?? 0
+          expr:
+            type: flowExpr
+            value: attributes.get("discontinuous_parts_count", 0)
 
   - id: 22a3b3c3-d3e3-f3a3-b3c3-d3e3f3a3b3c4
     name: FeatureWriterDiscontinuousCS

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/unf.yml
@@ -38,15 +38,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", 0)
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes["gmlFilename"]
+            value: attributes.get("gmlFilename", "")
         - attribute: FeatureType
           expr:
             type: flowExpr
@@ -62,11 +62,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "2")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes["gmlId"]
+            value: attributes.get("gmlId", "")
         - attribute: "無効な空間属性の型"
           expr:
             type: flowExpr
@@ -90,15 +90,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", 0)
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes["gmlFilename"]
+            value: attributes.get("gmlFilename", "")
         - attribute: FeatureType
           expr:
             type: flowExpr
@@ -114,11 +114,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "3")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes["gmlId"]
+            value: attributes.get("gmlId", "")
         - attribute: "無効な空間属性の型"
           expr:
             type: flowExpr
@@ -181,9 +181,7 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
           expr:
             type: flowExpr
@@ -197,13 +195,9 @@ nodes:
                 ft
               }
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: issue
           expr:
             type: string
@@ -246,9 +240,7 @@ nodes:
     with:
       mappers:
         - attribute: filename
-          expr:
-            type: flowExpr
-            value: attributes["gmlFilename"]
+          valueAttribute: gmlFilename
         - attribute: feature_type
           expr:
             type: flowExpr
@@ -262,13 +254,9 @@ nodes:
                 ft
               }
         - attribute: lod
-          expr:
-            type: flowExpr
-            value: attributes["lod"]
+          valueAttribute: lod
         - attribute: gml_id
-          expr:
-            type: flowExpr
-            value: attributes["gmlId"]
+          valueAttribute: gmlId
         - attribute: issue
           expr:
             type: string
@@ -318,15 +306,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "unf")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", 1)
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes["gmlFilename"]
+            value: attributes.get("gmlFilename", "")
         - attribute: FeatureType
           expr:
             type: flowExpr
@@ -342,11 +330,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "2")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes["gmlId"]
+            value: attributes.get("gmlId", "")
         - attribute: エラー数
           expr:
             type: string
@@ -408,15 +396,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "unf")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", 1)
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes["gmlFilename"]
+            value: attributes.get("gmlFilename", "")
         - attribute: FeatureType
           expr:
             type: flowExpr
@@ -432,11 +420,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "3")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes["gmlId"]
+            value: attributes.get("gmlId", "")
         - attribute: エラー数
           expr:
             type: string
@@ -498,15 +486,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "unf")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", 1)
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes["gmlFilename"]
+            value: attributes.get("gmlFilename", "")
         - attribute: FeatureType
           expr:
             type: flowExpr
@@ -522,11 +510,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "3")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes["gmlId"]
+            value: attributes.get("gmlId", "")
         - attribute: 不連続パート数
           expr:
             type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/workflow.yml
@@ -108,32 +108,29 @@ graphs:
         with:
           mappers:
             - attribute: gmlPath
-              expr: |
-                env.get("__value").path
+              expr:
+                type: flowExpr
+                value: attributes["path"]
             - attribute: gmlFilename
-              expr: |
-                env.get("__value").name
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: fileIndex
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: codelists
-              expr: |
-                env.get("__value").codelists
+              expr:
+                type: flowExpr
+                value: attributes["codelists"]
             - attribute: schemas
-              expr: |
-                env.get("__value").schemas
+              expr:
+                type: flowExpr
+                value: attributes["schemas"]
             - attribute: udxDirs
-              expr: |
-                // Extract folder from path (e.g., "file://path/unf/file.gml" -> "unf")
-                // The folder is the second-to-last segment of the path
-                let path = env.get("__value").path;
-                let parts = path.split("/");
-                let len = parts.len();
-                if len >= 2 {
-                  parts[len - 2]
-                } else {
-                  env.get("__value").udxDirs ?? ""
-                }
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5c
         name: FeatureCityGmlReader
@@ -224,26 +221,33 @@ graphs:
         with:
           mappers:
             - attribute: index
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: filename
-              expr: |
-                env.get("__value").gmlFilename
+              expr:
+                type: flowExpr
+                value: attributes["gmlFilename"]
             - attribute: udxDirs
-              expr: |
-                env.get("__value").udxDirs
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: gmlFilename
-              expr: |
-                env.get("__value").gmlFilename
+              expr:
+                type: flowExpr
+                value: attributes["gmlFilename"]
             - attribute: featureTypeName
-              expr: |
-                env.get("__value").featureTypeName
+              expr:
+                type: flowExpr
+                value: attributes["featureTypeName"]
             - attribute: instanceCount
-              expr: |
-                env.get("__value").instanceCount
+              expr:
+                type: flowExpr
+                value: attributes["instanceCount"]
             - attribute: lod
-              expr: |
-                env.get("__value").lod ?? "0"
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "0")
 
       - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f1c
         name: GeometryRemoverForErrorSummary
@@ -273,41 +277,53 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex ?? env.get("__value").index
+              expr:
+                type: flowExpr
+                value: attributes.get("fileIndex", attributes.get("index"))
             - attribute: Folder
-              expr: |
-                env.get("__value").udxDirs
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: Filename
-              expr: |
-                env.get("__value").gmlFilename ?? env.get("__value").filename
+              expr:
+                type: flowExpr
+                value: attributes.get("gmlFilename", attributes.get("filename"))
             - attribute: フィーチャータイプ
-              expr: |
-                env.get("__value").featureTypeName ?? "UndergroundFacility"
+              expr:
+                type: flowExpr
+                value: attributes.get("featureTypeName", "UndergroundFacility")
             - attribute: LOD
-              expr: |
-                env.get("__value").lod ?? "0"
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "0")
             - attribute: インスタンス数
-              expr: |
-                env.get("__value").instanceCount ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("instanceCount", 0)
             - attribute: 無効な空間属性の型
-              expr: |
-                env.get("__value")._num_invalid_spatial_attr ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_invalid_spatial_attr", 0)
             - attribute: 非水密立体
-              expr: |
-                env.get("__value")._num_not_closed_solid ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_not_closed_solid", 0)
             - attribute: 立体のその他のエラー
-              expr: |
-                env.get("__value")._num_other_solid_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_other_solid_errors", 0)
             - attribute: 立体の境界面のエラー
-              expr: |
-                env.get("__value")._num_boundary_surface_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_boundary_surface_errors", 0)
             - attribute: 面のエラー
-              expr: |
-                env.get("__value")._num_lod34_surface_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_lod34_surface_errors", 0)
             - attribute: 不連続なCompositeSurface
-              expr: |
-                env.get("__value")._num_discontinuous_cs ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_discontinuous_cs", 0)
 
       - id: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e61
         name: CSVSummaryWriter

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/workflow.yml
@@ -118,7 +118,9 @@ graphs:
             - attribute: schemas
               valueAttribute: schemas
             - attribute: udxDirs
-              valueAttribute: path.split("/")[-2]
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5c
         name: FeatureCityGmlReader

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/workflow.yml
@@ -120,7 +120,9 @@ graphs:
             - attribute: udxDirs
               expr:
                 type: flowExpr
-                value: attributes["path"].split("/")[-2]
+                value: |
+                  parts = attributes["path"].split("/");
+                  if len(parts) >= 2 { parts[-2] } else { attributes.get("udxDirs", "") }
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5c
         name: FeatureCityGmlReader

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf/workflow.yml
@@ -108,29 +108,17 @@ graphs:
         with:
           mappers:
             - attribute: gmlPath
-              expr:
-                type: flowExpr
-                value: attributes["path"]
+              valueAttribute: path
             - attribute: gmlFilename
-              expr:
-                type: flowExpr
-                value: attributes["name"]
+              valueAttribute: name
             - attribute: fileIndex
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: codelists
-              expr:
-                type: flowExpr
-                value: attributes["codelists"]
+              valueAttribute: codelists
             - attribute: schemas
-              expr:
-                type: flowExpr
-                value: attributes["schemas"]
+              valueAttribute: schemas
             - attribute: udxDirs
-              expr:
-                type: flowExpr
-                value: attributes["path"].split("/")[-2]
+              valueAttribute: path.split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5c
         name: FeatureCityGmlReader
@@ -221,29 +209,17 @@ graphs:
         with:
           mappers:
             - attribute: index
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: filename
-              expr:
-                type: flowExpr
-                value: attributes["gmlFilename"]
+              valueAttribute: gmlFilename
             - attribute: udxDirs
-              expr:
-                type: flowExpr
-                value: attributes["udxDirs"]
+              valueAttribute: udxDirs
             - attribute: gmlFilename
-              expr:
-                type: flowExpr
-                value: attributes["gmlFilename"]
+              valueAttribute: gmlFilename
             - attribute: featureTypeName
-              expr:
-                type: flowExpr
-                value: attributes["featureTypeName"]
+              valueAttribute: featureTypeName
             - attribute: instanceCount
-              expr:
-                type: flowExpr
-                value: attributes["instanceCount"]
+              valueAttribute: instanceCount
             - attribute: lod
               expr:
                 type: flowExpr
@@ -281,9 +257,7 @@ graphs:
                 type: flowExpr
                 value: attributes.get("fileIndex", attributes.get("index"))
             - attribute: Folder
-              expr:
-                type: flowExpr
-                value: attributes["udxDirs"]
+              valueAttribute: udxDirs
             - attribute: Filename
               expr:
                 type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
@@ -3099,29 +3099,17 @@ graphs:
     with:
       mappers:
       - attribute: gmlPath
-        expr:
-          type: flowExpr
-          value: attributes["path"]
+        valueAttribute: path
       - attribute: gmlFilename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: fileIndex
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: codelists
-        expr:
-          type: flowExpr
-          value: attributes["codelists"]
+        valueAttribute: codelists
       - attribute: schemas
-        expr:
-          type: flowExpr
-          value: attributes["schemas"]
+        valueAttribute: schemas
       - attribute: udxDirs
-        expr:
-          type: flowExpr
-          value: attributes["path"].split("/")[-2]
+        valueAttribute: path.split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
     name: FeatureCityGmlReader
     type: action
@@ -3163,25 +3151,15 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr:
-          type: flowExpr
-          value: attributes["fileIndex"]
+        valueAttribute: fileIndex
       - attribute: filename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: udxDirs
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: gmlFilename
-        expr:
-          type: flowExpr
-          value: attributes["gmlFilename"]
+        valueAttribute: gmlFilename
       - attribute: GenericCityObject
-        expr:
-          type: flowExpr
-          value: attributes["GenericCityObject"]
+        valueAttribute: GenericCityObject
       - attribute: lod
         expr:
           type: flowExpr
@@ -3228,9 +3206,7 @@ graphs:
           type: flowExpr
           value: attributes.get("fileIndex", attributes.get("index"))
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
@@ -414,17 +414,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: type
         expr:
           type: flowExpr
@@ -448,17 +442,11 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: line
         expr:
           type: flowExpr
@@ -508,13 +496,9 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
         expr:
           type: flowExpr
@@ -533,33 +517,29 @@ graphs:
               "Over"
             }
       - attribute: XML検証結果
-        expr:
-          type: flowExpr
-          value: attributes["status"]
+        valueAttribute: status
       - attribute: L01エラー
         expr:
           type: flowExpr
-          value: attributes["L01Errors"]
+          value: attributes.get("L01Errors", 0)
       - attribute: L02エラー
         expr:
           type: flowExpr
-          value: attributes["L02Errors"]
+          value: attributes.get("L02Errors", 0)
       - attribute: L03エラー
         expr:
           type: flowExpr
-          value: attributes["invalidFeatureTypesNum"]
+          value: attributes.get("invalidFeatureTypesNum", 0)
       - attribute: L03エラー詳細
-        expr:
-          type: flowExpr
-          value: attributes["invalidFeatureTypesDetail"]
+        valueAttribute: invalidFeatureTypesDetail
       - attribute: L04エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeValue"]
+          value: attributes.get("inCorrectCodeValue", 0)
       - attribute: 不正なcodeSpace数
         expr:
           type: flowExpr
-          value: attributes["inCorrectCodeSpace"]
+          value: attributes.get("inCorrectCodeSpace", 0)
       - attribute: L05CRS識別子
         expr:
           type: flowExpr
@@ -581,27 +561,25 @@ graphs:
       - attribute: L06エラー
         expr:
           type: flowExpr
-          value: attributes["inCorrectExtents"]
+          value: attributes.get("inCorrectExtents", 0)
       - attribute: T03エラー
         expr:
           type: flowExpr
-          value: attributes["xlinkInvalidObjectType"]
+          value: attributes.get("xlinkInvalidObjectType", 0)
       - attribute: xlink参照先なし
         expr:
           type: flowExpr
-          value: attributes["xlinkHasNoReference"]
+          value: attributes.get("xlinkHasNoReference", 0)
       - attribute: gml:id重複
-        expr:
-          type: flowExpr
-          value: attributes["duplicateGmlIdCount"]
+        valueAttribute: duplicateGmlIdCount
       - attribute: gml:id書式不正
         expr:
           type: flowExpr
-          value: attributes["gmlIdNotWellformed"]
+          value: attributes.get("gmlIdNotWellformed", 0)
       - attribute: L-frn-01エラー
         expr:
           type: flowExpr
-          value: attributes["invalidLodXGeometry"]
+          value: attributes.get("invalidLodXGeometry", 0)
       - attribute: 補足
         expr:
           type: flowExpr
@@ -686,25 +664,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -720,25 +688,15 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -754,69 +712,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: Min Latitude
-        expr:
-          type: flowExpr
-          value: attributes["minLatitude"]
+        valueAttribute: minLatitude
       - attribute: Min Longitude
-        expr:
-          type: flowExpr
-          value: attributes["minLongitude"]
+        valueAttribute: minLongitude
       - attribute: Min Elevation
-        expr:
-          type: flowExpr
-          value: attributes["minElevation"]
+        valueAttribute: minElevation
       - attribute: Max Latitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLatitude"]
+        valueAttribute: maxLatitude
       - attribute: Max Longitude
-        expr:
-          type: flowExpr
-          value: attributes["maxLongitude"]
+        valueAttribute: maxLongitude
       - attribute: Max Elevation
-        expr:
-          type: flowExpr
-          value: attributes["maxElevation"]
+        valueAttribute: maxElevation
       - attribute: Lower Latitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLatitude"]
+        valueAttribute: lowerLatitude
       - attribute: Lower Longitude
-        expr:
-          type: flowExpr
-          value: attributes["lowerLongitude"]
+        valueAttribute: lowerLongitude
       - attribute: Lower Elevation
-        expr:
-          type: flowExpr
-          value: attributes["lowerElevation"]
+        valueAttribute: lowerElevation
       - attribute: Upper Latitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLatitude"]
+        valueAttribute: upperLatitude
       - attribute: Upper Longitude
-        expr:
-          type: flowExpr
-          value: attributes["upperLongitude"]
+        valueAttribute: upperLongitude
       - attribute: Upper Elevation
-        expr:
-          type: flowExpr
-          value: attributes["upperElevation"]
+        valueAttribute: upperElevation
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -832,37 +758,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
       - attribute: Code
-        expr:
-          type: flowExpr
-          value: attributes["codeSpaceValue"]
+        valueAttribute: codeSpaceValue
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -878,37 +788,21 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
-        expr:
-          type: flowExpr
-          value: attributes["featureType"]
+        valueAttribute: featureType
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: CodeSpace
-        expr:
-          type: flowExpr
-          value: attributes["codeSpace"]
+        valueAttribute: codeSpace
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -946,29 +840,17 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -984,41 +866,23 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: XPath
-        expr:
-          type: flowExpr
-          value: attributes["xpath"]
+        valueAttribute: xpath
       - attribute: XML Tag
-        expr:
-          type: flowExpr
-          value: attributes["tag"]
+        valueAttribute: tag
       - attribute: xlink:href
-        expr:
-          type: flowExpr
-          value: attributes["xlinkHref"]
+        valueAttribute: xlinkHref
       - attribute: ref XPath
-        expr:
-          type: flowExpr
-          value: attributes["refGmlXpath"]
+        valueAttribute: refGmlXpath
       - attribute: ref Tag
-        expr:
-          type: flowExpr
-          value: attributes["refGmlTag"]
+        valueAttribute: refGmlTag
       - attribute: ref gml:id
-        expr:
-          type: flowExpr
-          value: attributes["refGmlId"]
+        valueAttribute: refGmlId
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -1034,29 +898,19 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr:
-          type: flowExpr
-          value: attributes["index"]
+        valueAttribute: index
       - attribute: Folder
-        expr:
-          type: flowExpr
-          value: attributes["udxDirs"]
+        valueAttribute: udxDirs
       - attribute: Filename
-        expr:
-          type: flowExpr
-          value: attributes["name"]
+        valueAttribute: name
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes["parentTag"]
+          value: attributes.get("parentTag", attributes["featureType"])
       - attribute: gml:id
-        expr:
-          type: flowExpr
-          value: attributes["gmlId"]
+        valueAttribute: gmlId
       - attribute: InvalidGeometry
-        expr:
-          type: flowExpr
-          value: attributes["invalidGeometry"]
+        valueAttribute: invalidGeometry
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -2504,15 +2358,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "gen")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes.get("gmlFilename", attributes.get("name"))
+          value: attributes.get("gmlFilename", attributes.get("name", ""))
       - attribute: FeatureType
         expr:
           type: string
@@ -2520,11 +2374,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes.get("gmlId", attributes.get("featureId"))
+          value: attributes.get("gmlId", attributes.get("featureId", ""))
       - attribute: エラー数
         expr:
           type: string
@@ -2591,15 +2445,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "gen")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes.get("gmlFilename", attributes.get("name"))
+          value: attributes.get("gmlFilename", attributes.get("name", ""))
       - attribute: FeatureType
         expr:
           type: string
@@ -2607,11 +2461,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes.get("gmlId", attributes.get("featureId"))
+          value: attributes.get("gmlId", attributes.get("featureId", ""))
       - attribute: エラー数
         expr:
           type: string
@@ -2653,15 +2507,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "gen")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes.get("gmlFilename", attributes.get("name"))
+          value: attributes.get("gmlFilename", attributes.get("name", ""))
       - attribute: FeatureType
         expr:
           type: string
@@ -2669,11 +2523,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes.get("gmlId", attributes.get("featureId"))
+          value: attributes.get("gmlId", attributes.get("featureId", ""))
       - attribute: エラー数
         expr:
           type: string
@@ -2709,15 +2563,15 @@ graphs:
       - attribute: Folder
         expr:
           type: flowExpr
-          value: attributes["udxDirs"]
+          value: attributes.get("udxDirs", "gen")
       - attribute: Index
         expr:
           type: flowExpr
-          value: attributes["fileIndex"]
+          value: attributes.get("fileIndex", "")
       - attribute: Filename
         expr:
           type: flowExpr
-          value: attributes.get("gmlFilename", attributes.get("name"))
+          value: attributes.get("gmlFilename", attributes.get("name", ""))
       - attribute: FeatureType
         expr:
           type: string
@@ -2725,11 +2579,11 @@ graphs:
       - attribute: LOD
         expr:
           type: flowExpr
-          value: attributes["lod"]
+          value: attributes.get("lod", "0")
       - attribute: gml:id
         expr:
           type: flowExpr
-          value: attributes.get("gmlId", attributes.get("featureId"))
+          value: attributes.get("gmlId", attributes.get("featureId", ""))
       - attribute: エラー数
         expr:
           type: string

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
@@ -3109,7 +3109,9 @@ graphs:
       - attribute: schemas
         valueAttribute: schemas
       - attribute: udxDirs
-        valueAttribute: path.split("/")[-2]
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
     name: FeatureCityGmlReader
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
@@ -414,15 +414,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: d9e8f7a6-5b4c-4a3d-9e2f-1c8b7a6e5d4c
     name: FeatureWriterNotWellFormedXmlCsv
     type: action
@@ -438,17 +448,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: line
-        expr: env.get("__value").xmlError[0].line
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["line"]
       - attribute: type
-        expr: env.get("__value").xmlError[0].errorType
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["errorType"]
       - attribute: desc
-        expr: env.get("__value").xmlError[0].message
+        expr:
+          type: flowExpr
+          value: attributes["xmlError"][0]["message"]
   - id: f8e2a1b4-7c3d-4e9f-a2b5-8f6c9d3e1a7b
     name: FeatureWriterInvalidXmlCsv
     type: action
@@ -486,80 +508,104 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          file::extract_filename(env.get("__value").path)
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: サイズ[KB]
-        expr: |
-          env.get("__value").fileSize / 1024
+        expr:
+          type: flowExpr
+          value: attributes["fileSize"] / 1024
       - attribute: 1GB以下
-        expr: |
-          if env.get("__value").fileSize / 1024 / 1024 / 1024 <= 1 {
-            "OK"
-          } else {
-            "Over"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+              "OK"
+            } else {
+              "Over"
+            }
       - attribute: XML検証結果
-        expr: |
-          env.get("__value").status
+        expr:
+          type: flowExpr
+          value: attributes["status"]
       - attribute: L01エラー
-        expr: |
-          env.get("__value").L01Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L01Errors"]
       - attribute: L02エラー
-        expr: |
-          env.get("__value").L02Errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["L02Errors"]
       - attribute: L03エラー
-        expr: |
-          env.get("__value").invalidFeatureTypesNum ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesNum"]
       - attribute: L03エラー詳細
-        expr: |
-          env.get("__value").invalidFeatureTypesDetail
+        expr:
+          type: flowExpr
+          value: attributes["invalidFeatureTypesDetail"]
       - attribute: L04エラー
-        expr: |
-          env.get("__value").inCorrectCodeValue ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeValue"]
       - attribute: 不正なcodeSpace数
-        expr: |
-          env.get("__value").inCorrectCodeSpace ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectCodeSpace"]
       - attribute: L05CRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            "OK"
-          } else {
-            "Wrong"
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              "OK"
+            } else {
+              "Wrong"
+            }
       - attribute: 不正なCRS識別子
-        expr: |
-          if env.get("__value").isCorrectSrsName {
-            ""
-          } else {
-            env.get("__value").srsName
-          }
+        expr:
+          type: flowExpr
+          value: |
+            if attributes["isCorrectSrsName"] {
+              ""
+            } else {
+              attributes["srsName"]
+            }
       - attribute: L06エラー
-        expr: |
-          env.get("__value").inCorrectExtents ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["inCorrectExtents"]
       - attribute: T03エラー
-        expr: |
-          env.get("__value").xlinkInvalidObjectType ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkInvalidObjectType"]
       - attribute: xlink参照先なし
-        expr: |
-          env.get("__value").xlinkHasNoReference ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHasNoReference"]
       - attribute: gml:id重複
-        expr: |
-          env.get("__value").duplicateGmlIdCount
+        expr:
+          type: flowExpr
+          value: attributes["duplicateGmlIdCount"]
       - attribute: gml:id書式不正
-        expr: |
-          env.get("__value").gmlIdNotWellformed ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["gmlIdNotWellformed"]
       - attribute: L-frn-01エラー
-        expr: |
-          env.get("__value").invalidLodXGeometry ?? 0
+        expr:
+          type: flowExpr
+          value: attributes["invalidLodXGeometry"]
       - attribute: 補足
-        expr: |
-          env.get("__value").miscellaneous ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("miscellaneous", "")
   - id: 0e9fd0ce-4607-44be-8cdd-b4b2cc2ae04b
     name: FeatureWriterCsv
     type: action
@@ -640,15 +686,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 8e5f9a2b-4c3d-4e7f-b8a5-9d6e4f3a2b1c
     name: FeatureWriterGmlIdNotWellFormed
     type: action
@@ -664,15 +720,25 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
   - id: 9d6e4f3a-2b1c-4e0f-9d8c-7b6a5e4d3c2b
     name: FeatureWriterGmlIdNotUnique
     type: action
@@ -688,37 +754,69 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: Min Latitude
-        expr: env.get("__value").minLatitude
+        expr:
+          type: flowExpr
+          value: attributes["minLatitude"]
       - attribute: Min Longitude
-        expr: env.get("__value").minLongitude
+        expr:
+          type: flowExpr
+          value: attributes["minLongitude"]
       - attribute: Min Elevation
-        expr: env.get("__value").minElevation
+        expr:
+          type: flowExpr
+          value: attributes["minElevation"]
       - attribute: Max Latitude
-        expr: env.get("__value").maxLatitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLatitude"]
       - attribute: Max Longitude
-        expr: env.get("__value").maxLongitude
+        expr:
+          type: flowExpr
+          value: attributes["maxLongitude"]
       - attribute: Max Elevation
-        expr: env.get("__value").maxElevation
+        expr:
+          type: flowExpr
+          value: attributes["maxElevation"]
       - attribute: Lower Latitude
-        expr: env.get("__value").lowerLatitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLatitude"]
       - attribute: Lower Longitude
-        expr: env.get("__value").lowerLongitude
+        expr:
+          type: flowExpr
+          value: attributes["lowerLongitude"]
       - attribute: Lower Elevation
-        expr: env.get("__value").lowerElevation
+        expr:
+          type: flowExpr
+          value: attributes["lowerElevation"]
       - attribute: Upper Latitude
-        expr: env.get("__value").upperLatitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLatitude"]
       - attribute: Upper Longitude
-        expr: env.get("__value").upperLongitude
+        expr:
+          type: flowExpr
+          value: attributes["upperLongitude"]
       - attribute: Upper Elevation
-        expr: env.get("__value").upperElevation
+        expr:
+          type: flowExpr
+          value: attributes["upperElevation"]
   - id: 1df16bdd-a8f2-5ace-b503-98a877daa7e3
     name: FeatureWriterExtentsValidation
     type: action
@@ -734,21 +832,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
       - attribute: Code
-        expr: env.get("__value").codeSpaceValue
+        expr:
+          type: flowExpr
+          value: attributes["codeSpaceValue"]
   - id: 7d9e0f3a-5b6c-4d8e-9f0a-3b4c5d6e7f8a
     name: FeatureWriterCodeValidation
     type: action
@@ -764,21 +878,37 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["featureType"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: CodeSpace
-        expr: env.get("__value").codeSpace
+        expr:
+          type: flowExpr
+          value: attributes["codeSpace"]
   - id: 9f0a4b5c-7d6e-4f9a-a0b1-5c6d7e8f9a0b
     name: FeatureWriterInCorrectCodeSpace
     type: action
@@ -794,13 +924,21 @@ graphs:
     with:
       mappers:
       - attribute: flag
-        expr: env.get("__value").flag
+        expr:
+          type: flowExpr
+          value: attributes.get("flag")
       - attribute: filename
-        expr: env.get("__value").filename ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("filename", "")
       - attribute: fileCount
-        expr: env.get("__value").fileCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("fileCount", 0)
       - attribute: duplicateGmlIdCount
-        expr: env.get("__value").duplicateGmlIdCount ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("duplicateGmlIdCount", 0)
   - id: b4c5d6e7-8f9a-0b1c-2d3e-4f5a6b7c8d9e
     name: AttributeMapperXlinkNoReference
     type: action
@@ -808,17 +946,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
   - id: c5d6e7f8-9a0b-1c2d-3e4f-5a6b7c8d9e0f
     name: FeatureWriterXlinkNoReference
     type: action
@@ -834,23 +984,41 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: XPath
-        expr: env.get("__value").xpath
+        expr:
+          type: flowExpr
+          value: attributes["xpath"]
       - attribute: XML Tag
-        expr: env.get("__value").tag
+        expr:
+          type: flowExpr
+          value: attributes["tag"]
       - attribute: xlink:href
-        expr: env.get("__value").xlinkHref
+        expr:
+          type: flowExpr
+          value: attributes["xlinkHref"]
       - attribute: ref XPath
-        expr: env.get("__value").refGmlXpath
+        expr:
+          type: flowExpr
+          value: attributes["refGmlXpath"]
       - attribute: ref Tag
-        expr: env.get("__value").refGmlTag
+        expr:
+          type: flowExpr
+          value: attributes["refGmlTag"]
       - attribute: ref gml:id
-        expr: env.get("__value").refGmlId
+        expr:
+          type: flowExpr
+          value: attributes["refGmlId"]
   - id: e7f8a9b0-1c2d-3e4f-5a6b-7c8d9e0f1a2b
     name: FeatureWriterXlinkInvalidObjectType
     type: action
@@ -866,18 +1034,29 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes["index"]
       - attribute: Folder
-        expr: env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: FeatureType
-        expr: |
-          env.get("__value").parentTag ?? env.get("__value").featureType
+        expr:
+          type: flowExpr
+          value: attributes["parentTag"]
       - attribute: gml:id
-        expr: env.get("__value").gmlId
+        expr:
+          type: flowExpr
+          value: attributes["gmlId"]
       - attribute: InvalidGeometry
-        expr: env.get("__value").invalidGeometry
+        expr:
+          type: flowExpr
+          value: attributes["invalidGeometry"]
   - id: a9b0c1d2-3e4f-5a6b-7c8d-9e0f1a2b3c4d
     name: FeatureWriterInvalidLodXGeometry
     type: action
@@ -1301,8 +1480,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: severity
@@ -1350,8 +1530,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -1379,8 +1560,9 @@ graphs:
       - attribute: dirs
         valueAttribute: udxDirs
       - attribute: filename
-        expr: |
-          file::extract_filename(env.get("__value")["path"])
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-1]
       - attribute: gml_id
         valueAttribute: gmlId
       - attribute: feature_type
@@ -2320,36 +2502,45 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? "gen"
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlFilename", attributes.get("name"))
       - attribute: FeatureType
-        expr: |
-          "GenericCityObject"
+        expr:
+          type: string
+          value: GenericCityObject
       - attribute: LOD
-        expr: |
-          env.get("__value")["lod"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value")["gmlId"] ?? env.get("__value")["featureId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlId", attributes.get("featureId"))
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: エラー内容
-        expr: |
-          let value = env.get("__value");
-          if value.validationResult?.details != () {
-            return value.validationResult.details[0][0];
-          }
-          if "issue" in value {
-            return value.issue;
-          }
-          "UnknownError"
+        expr:
+          type: flowExpr
+          value: |
+            vr = attributes.get("validationResult");
+            if vr != null and "details" in vr {
+              vr["details"][0][0]
+            } else if "issue" in attributes {
+              attributes["issue"]
+            } else {
+              "UnknownError"
+            }
   - id: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6a
     name: CsvWriterSurfaceErrors
     type: action
@@ -2398,29 +2589,37 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? "gen"
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlFilename", attributes.get("name"))
       - attribute: FeatureType
-        expr: |
-          "GenericCityObject"
+        expr:
+          type: string
+          value: GenericCityObject
       - attribute: LOD
-        expr: |
-          env.get("__value")["lod"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value")["gmlId"] ?? env.get("__value")["featureId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlId", attributes.get("featureId"))
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: エラー内容
-        expr: |
-          "SurfaceNotClosed"
+        expr:
+          type: string
+          value: SurfaceNotClosed
   - id: a104d5e6-f7a8-b9c0-d1e2-f3a4b5c6d7e8
     name: FeatureWriterNotClosed
     type: action
@@ -2452,29 +2651,37 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? "gen"
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlFilename", attributes.get("name"))
       - attribute: FeatureType
-        expr: |
-          "GenericCityObject"
+        expr:
+          type: string
+          value: GenericCityObject
       - attribute: LOD
-        expr: |
-          env.get("__value")["lod"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value")["gmlId"] ?? env.get("__value")["featureId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlId", attributes.get("featureId"))
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: エラー内容
-        expr: |
-          "InvalidSolidBoundaries"
+        expr:
+          type: string
+          value: InvalidSolidBoundaries
   - id: a120e2f3-a4b5-c6d7-e8f9-f0a1b2c3d4e5
     name: FeatureWriterSolidIssues
     type: action
@@ -2500,29 +2707,37 @@ graphs:
     with:
       mappers:
       - attribute: Folder
-        expr: |
-          env.get("__value")["udxDirs"] ?? "gen"
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Index
-        expr: |
-          env.get("__value")["fileIndex"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: Filename
-        expr: |
-          env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlFilename", attributes.get("name"))
       - attribute: FeatureType
-        expr: |
-          "GenericCityObject"
+        expr:
+          type: string
+          value: GenericCityObject
       - attribute: LOD
-        expr: |
-          env.get("__value")["lod"] ?? "0"
+        expr:
+          type: flowExpr
+          value: attributes["lod"]
       - attribute: gml:id
-        expr: |
-          env.get("__value")["gmlId"] ?? env.get("__value")["featureId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlId", attributes.get("featureId"))
       - attribute: エラー数
-        expr: |
-          1
+        expr:
+          type: string
+          value: '1'
       - attribute: エラー内容
-        expr: |
-          "IncorrectOrientation"
+        expr:
+          type: string
+          value: IncorrectOrientation
   - id: e3f4a5b6-c7d8-9e0f-1a2b-3c4d5e6f7a8e
     name: CsvWriterOrientationErrors
     type: action
@@ -2884,32 +3099,29 @@ graphs:
     with:
       mappers:
       - attribute: gmlPath
-        expr: |
-          env.get("__value").path
+        expr:
+          type: flowExpr
+          value: attributes["path"]
       - attribute: gmlFilename
-        expr: |
-          env.get("__value").name
+        expr:
+          type: flowExpr
+          value: attributes["name"]
       - attribute: fileIndex
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: codelists
-        expr: |
-          env.get("__value").codelists
+        expr:
+          type: flowExpr
+          value: attributes["codelists"]
       - attribute: schemas
-        expr: |
-          env.get("__value").schemas
+        expr:
+          type: flowExpr
+          value: attributes["schemas"]
       - attribute: udxDirs
-        expr: |
-          // Extract folder from path (e.g., "file://path/gen/file.gml" -> "gen")
-          // The folder is the second-to-last segment of the path
-          let path = env.get("__value").path;
-          let parts = path.split("/");
-          let len = parts.len();
-          if len >= 2 {
-            parts[len - 2]
-          } else {
-            env.get("__value").udxDirs ?? ""
-          }
+        expr:
+          type: flowExpr
+          value: attributes["path"].split("/")[-2]
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
     name: FeatureCityGmlReader
     type: action
@@ -2951,23 +3163,29 @@ graphs:
     with:
       mappers:
       - attribute: index
-        expr: |
-          env.get("__value").fileIndex
+        expr:
+          type: flowExpr
+          value: attributes["fileIndex"]
       - attribute: filename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: udxDirs
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: gmlFilename
-        expr: |
-          env.get("__value").gmlFilename
+        expr:
+          type: flowExpr
+          value: attributes["gmlFilename"]
       - attribute: GenericCityObject
-        expr: |
-          env.get("__value").GenericCityObject
+        expr:
+          type: flowExpr
+          value: attributes["GenericCityObject"]
       - attribute: lod
-        expr: |
-          env.get("__value").lod ?? "0"
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "0")
   - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f1b
     name: GeometryRemoverForErrorSummary
     type: action
@@ -3006,38 +3224,49 @@ graphs:
     with:
       mappers:
       - attribute: Index
-        expr: |
-          env.get("__value").fileIndex ?? env.get("__value").index
+        expr:
+          type: flowExpr
+          value: attributes.get("fileIndex", attributes.get("index"))
       - attribute: Folder
-        expr: |
-          env.get("__value").udxDirs
+        expr:
+          type: flowExpr
+          value: attributes["udxDirs"]
       - attribute: Filename
-        expr: |
-          env.get("__value").gmlFilename ?? env.get("__value").filename
+        expr:
+          type: flowExpr
+          value: attributes.get("gmlFilename", attributes.get("filename"))
       - attribute: フィーチャータイプ
-        expr: |
-          "GenericCityObject"
+        expr:
+          type: string
+          value: GenericCityObject
       - attribute: LOD
-        expr: |
-          env.get("__value").lod ?? "0"
+        expr:
+          type: flowExpr
+          value: attributes.get("lod", "0")
       - attribute: インスタンス数
-        expr: |
-          env.get("__value").GenericCityObject ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("GenericCityObject", 0)
       - attribute: 面のエラー
-        expr: |
-          env.get("__value")._num_surface_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_surface_errors", 0)
       - attribute: 面の向き不正
-        expr: |
-          env.get("__value")._num_orientation_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_orientation_errors", 0)
       - attribute: 非水密立体
-        expr: |
-          env.get("__value")._num_not_closed_solid ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_not_closed_solid", 0)
       - attribute: 立体のエラー
-        expr: |
-          env.get("__value")._num_solid_errors ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_solid_errors", 0)
       - attribute: コード化されていないgml:name
-        expr: |
-          env.get("__value")._num_uncoded_gml_name ?? 0
+        expr:
+          type: flowExpr
+          value: attributes.get("_num_uncoded_gml_name", 0)
   - id: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e60
     name: CSVSummaryWriter
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
@@ -522,12 +522,12 @@ graphs:
       - attribute: サイズ[KB]
         expr:
           type: flowExpr
-          value: attributes["fileSize"] / 1024
+          value: attributes["fileSize"] // 1024
       - attribute: 1GB以下
         expr:
           type: flowExpr
           value: |
-            if attributes["fileSize"] / 1024 / 1024 / 1024 <= 1 {
+            if attributes["fileSize"] // 1024 // 1024 // 1024 <= 1 {
               "OK"
             } else {
               "Over"

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
@@ -906,7 +906,7 @@ graphs:
       - attribute: FeatureType
         expr:
           type: flowExpr
-          value: attributes.get("parentTag", attributes["featureType"])
+          value: attributes.get("parentTag") or attributes.get("featureType")
       - attribute: gml:id
         valueAttribute: gmlId
       - attribute: InvalidGeometry

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
@@ -2965,7 +2965,9 @@ graphs:
       - attribute: udxDirs
         expr:
           type: flowExpr
-          value: attributes["path"].split("/")[-2]
+          value: |
+            parts = attributes["path"].split("/");
+            if len(parts) >= 2 { parts[-2] } else { attributes.get("udxDirs", "") }
   - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
     name: FeatureCityGmlReader
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/gen.yml
@@ -52,36 +52,45 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value")["udxDirs"] ?? "gen"
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value")["fileIndex"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("gmlFilename", attributes.get("name"))
         - attribute: FeatureType
-          expr: |
-            "GenericCityObject"
+          expr:
+            type: string
+            value: GenericCityObject
         - attribute: LOD
-          expr: |
-            env.get("__value")["lod"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value")["gmlId"] ?? env.get("__value")["featureId"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("gmlId", attributes.get("featureId"))
         - attribute: エラー数
-          expr: |
-            1
+          expr:
+            type: string
+            value: "1"
         - attribute: エラー内容
-          expr: |
-            let value = env.get("__value");
-            if value.validationResult?.details != () {
-              return value.validationResult.details[0][0];
-            }
-            if "issue" in value {
-              return value.issue;
-            }
-            "UnknownError"
+          expr:
+            type: flowExpr
+            value: |
+              vr = attributes.get("validationResult");
+              if vr != null and "details" in vr {
+                vr["details"][0][0]
+              } else if "issue" in attributes {
+                attributes["issue"]
+              } else {
+                "UnknownError"
+              }
 
   # ===== CSV Writer for surface errors =====
   - id: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6a
@@ -142,29 +151,37 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value")["udxDirs"] ?? "gen"
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value")["fileIndex"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("gmlFilename", attributes.get("name"))
         - attribute: FeatureType
-          expr: |
-            "GenericCityObject"
+          expr:
+            type: string
+            value: GenericCityObject
         - attribute: LOD
-          expr: |
-            env.get("__value")["lod"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value")["gmlId"] ?? env.get("__value")["featureId"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("gmlId", attributes.get("featureId"))
         - attribute: エラー数
-          expr: |
-            1
+          expr:
+            type: string
+            value: "1"
         - attribute: エラー内容
-          expr: |
-            "SurfaceNotClosed"
+          expr:
+            type: string
+            value: SurfaceNotClosed
 
   # CSV Writer for NotClosed errors
   - id: a104d5e6-f7a8-b9c0-d1e2-f3a4b5c6d7e8
@@ -204,29 +221,37 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value")["udxDirs"] ?? "gen"
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value")["fileIndex"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("gmlFilename", attributes.get("name"))
         - attribute: FeatureType
-          expr: |
-            "GenericCityObject"
+          expr:
+            type: string
+            value: GenericCityObject
         - attribute: LOD
-          expr: |
-            env.get("__value")["lod"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value")["gmlId"] ?? env.get("__value")["featureId"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("gmlId", attributes.get("featureId"))
         - attribute: エラー数
-          expr: |
-            1
+          expr:
+            type: string
+            value: "1"
         - attribute: エラー内容
-          expr: |
-            "InvalidSolidBoundaries"
+          expr:
+            type: string
+            value: InvalidSolidBoundaries
 
   # CSV Writer for Solid Issues (立体のエラー)
   - id: a120e2f3-a4b5-c6d7-e8f9-f0a1b2c3d4e5
@@ -258,29 +283,37 @@ nodes:
     with:
       mappers:
         - attribute: Folder
-          expr: |
-            env.get("__value")["udxDirs"] ?? "gen"
+          expr:
+            type: flowExpr
+            value: attributes["udxDirs"]
         - attribute: Index
-          expr: |
-            env.get("__value")["fileIndex"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes["fileIndex"]
         - attribute: Filename
-          expr: |
-            env.get("__value")["gmlFilename"] ?? env.get("__value")["name"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("gmlFilename", attributes.get("name"))
         - attribute: FeatureType
-          expr: |
-            "GenericCityObject"
+          expr:
+            type: string
+            value: GenericCityObject
         - attribute: LOD
-          expr: |
-            env.get("__value")["lod"] ?? "0"
+          expr:
+            type: flowExpr
+            value: attributes["lod"]
         - attribute: "gml:id"
-          expr: |
-            env.get("__value")["gmlId"] ?? env.get("__value")["featureId"] ?? ""
+          expr:
+            type: flowExpr
+            value: attributes.get("gmlId", attributes.get("featureId"))
         - attribute: エラー数
-          expr: |
-            1
+          expr:
+            type: string
+            value: "1"
         - attribute: エラー内容
-          expr: |
-            "IncorrectOrientation"
+          expr:
+            type: string
+            value: IncorrectOrientation
 
   - id: e3f4a5b6-c7d8-9e0f-1a2b-3c4d5e6f7a8e
     name: CsvWriterOrientationErrors

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/gen.yml
@@ -54,15 +54,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "gen")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", "")
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes.get("gmlFilename", attributes.get("name"))
+            value: attributes.get("gmlFilename", attributes.get("name", ""))
         - attribute: FeatureType
           expr:
             type: string
@@ -70,11 +70,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes.get("gmlId", attributes.get("featureId"))
+            value: attributes.get("gmlId", attributes.get("featureId", ""))
         - attribute: エラー数
           expr:
             type: string
@@ -153,15 +153,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "gen")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", "")
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes.get("gmlFilename", attributes.get("name"))
+            value: attributes.get("gmlFilename", attributes.get("name", ""))
         - attribute: FeatureType
           expr:
             type: string
@@ -169,11 +169,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes.get("gmlId", attributes.get("featureId"))
+            value: attributes.get("gmlId", attributes.get("featureId", ""))
         - attribute: エラー数
           expr:
             type: string
@@ -223,15 +223,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "gen")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", "")
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes.get("gmlFilename", attributes.get("name"))
+            value: attributes.get("gmlFilename", attributes.get("name", ""))
         - attribute: FeatureType
           expr:
             type: string
@@ -239,11 +239,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes.get("gmlId", attributes.get("featureId"))
+            value: attributes.get("gmlId", attributes.get("featureId", ""))
         - attribute: エラー数
           expr:
             type: string
@@ -285,15 +285,15 @@ nodes:
         - attribute: Folder
           expr:
             type: flowExpr
-            value: attributes["udxDirs"]
+            value: attributes.get("udxDirs", "gen")
         - attribute: Index
           expr:
             type: flowExpr
-            value: attributes["fileIndex"]
+            value: attributes.get("fileIndex", "")
         - attribute: Filename
           expr:
             type: flowExpr
-            value: attributes.get("gmlFilename", attributes.get("name"))
+            value: attributes.get("gmlFilename", attributes.get("name", ""))
         - attribute: FeatureType
           expr:
             type: string
@@ -301,11 +301,11 @@ nodes:
         - attribute: LOD
           expr:
             type: flowExpr
-            value: attributes["lod"]
+            value: attributes.get("lod", "0")
         - attribute: "gml:id"
           expr:
             type: flowExpr
-            value: attributes.get("gmlId", attributes.get("featureId"))
+            value: attributes.get("gmlId", attributes.get("featureId", ""))
         - attribute: エラー数
           expr:
             type: string

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/workflow.yml
@@ -120,32 +120,29 @@ graphs:
         with:
           mappers:
             - attribute: gmlPath
-              expr: |
-                env.get("__value").path
+              expr:
+                type: flowExpr
+                value: attributes["path"]
             - attribute: gmlFilename
-              expr: |
-                env.get("__value").name
+              expr:
+                type: flowExpr
+                value: attributes["name"]
             - attribute: fileIndex
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: codelists
-              expr: |
-                env.get("__value").codelists
+              expr:
+                type: flowExpr
+                value: attributes["codelists"]
             - attribute: schemas
-              expr: |
-                env.get("__value").schemas
+              expr:
+                type: flowExpr
+                value: attributes["schemas"]
             - attribute: udxDirs
-              expr: |
-                // Extract folder from path (e.g., "file://path/gen/file.gml" -> "gen")
-                // The folder is the second-to-last segment of the path
-                let path = env.get("__value").path;
-                let parts = path.split("/");
-                let len = parts.len();
-                if len >= 2 {
-                  parts[len - 2]
-                } else {
-                  env.get("__value").udxDirs ?? ""
-                }
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
         name: FeatureCityGmlReader
@@ -195,23 +192,29 @@ graphs:
         with:
           mappers:
             - attribute: index
-              expr: |
-                env.get("__value").fileIndex
+              expr:
+                type: flowExpr
+                value: attributes["fileIndex"]
             - attribute: filename
-              expr: |
-                env.get("__value").gmlFilename
+              expr:
+                type: flowExpr
+                value: attributes["gmlFilename"]
             - attribute: udxDirs
-              expr: |
-                env.get("__value").udxDirs
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: gmlFilename
-              expr: |
-                env.get("__value").gmlFilename
+              expr:
+                type: flowExpr
+                value: attributes["gmlFilename"]
             - attribute: GenericCityObject
-              expr: |
-                env.get("__value").GenericCityObject
+              expr:
+                type: flowExpr
+                value: attributes["GenericCityObject"]
             - attribute: lod
-              expr: |
-                env.get("__value").lod ?? "0"
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "0")
 
       - id: d6e7f8a9-b0c1-2d3e-4f5a-6b7c8d9e0f1b
         name: GeometryRemoverForErrorSummary
@@ -256,38 +259,49 @@ graphs:
         with:
           mappers:
             - attribute: Index
-              expr: |
-                env.get("__value").fileIndex ?? env.get("__value").index
+              expr:
+                type: flowExpr
+                value: attributes.get("fileIndex", attributes.get("index"))
             - attribute: Folder
-              expr: |
-                env.get("__value").udxDirs
+              expr:
+                type: flowExpr
+                value: attributes["udxDirs"]
             - attribute: Filename
-              expr: |
-                env.get("__value").gmlFilename ?? env.get("__value").filename
+              expr:
+                type: flowExpr
+                value: attributes.get("gmlFilename", attributes.get("filename"))
             - attribute: フィーチャータイプ
-              expr: |
-                "GenericCityObject"
+              expr:
+                type: string
+                value: GenericCityObject
             - attribute: LOD
-              expr: |
-                env.get("__value").lod ?? "0"
+              expr:
+                type: flowExpr
+                value: attributes.get("lod", "0")
             - attribute: インスタンス数
-              expr: |
-                env.get("__value").GenericCityObject ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("GenericCityObject", 0)
             - attribute: 面のエラー
-              expr: |
-                env.get("__value")._num_surface_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_surface_errors", 0)
             - attribute: 面の向き不正
-              expr: |
-                env.get("__value")._num_orientation_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_orientation_errors", 0)
             - attribute: 非水密立体
-              expr: |
-                env.get("__value")._num_not_closed_solid ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_not_closed_solid", 0)
             - attribute: 立体のエラー
-              expr: |
-                env.get("__value")._num_solid_errors ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_solid_errors", 0)
             - attribute: コード化されていないgml:name
-              expr: |
-                env.get("__value")._num_uncoded_gml_name ?? 0
+              expr:
+                type: flowExpr
+                value: attributes.get("_num_uncoded_gml_name", 0)
 
       - id: c1d2e3f4-a5b6-7c8d-9e0f-1a2b3c4d5e60
         name: CSVSummaryWriter

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/workflow.yml
@@ -130,7 +130,9 @@ graphs:
             - attribute: schemas
               valueAttribute: schemas
             - attribute: udxDirs
-              valueAttribute: path.split("/")[-2]
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
         name: FeatureCityGmlReader

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/workflow.yml
@@ -132,7 +132,9 @@ graphs:
             - attribute: udxDirs
               expr:
                 type: flowExpr
-                value: attributes["path"].split("/")[-2]
+                value: |
+                  parts = attributes["path"].split("/");
+                  if len(parts) >= 2 { parts[-2] } else { attributes.get("udxDirs", "") }
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
         name: FeatureCityGmlReader

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen/workflow.yml
@@ -120,29 +120,17 @@ graphs:
         with:
           mappers:
             - attribute: gmlPath
-              expr:
-                type: flowExpr
-                value: attributes["path"]
+              valueAttribute: path
             - attribute: gmlFilename
-              expr:
-                type: flowExpr
-                value: attributes["name"]
+              valueAttribute: name
             - attribute: fileIndex
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: codelists
-              expr:
-                type: flowExpr
-                value: attributes["codelists"]
+              valueAttribute: codelists
             - attribute: schemas
-              expr:
-                type: flowExpr
-                value: attributes["schemas"]
+              valueAttribute: schemas
             - attribute: udxDirs
-              expr:
-                type: flowExpr
-                value: attributes["path"].split("/")[-2]
+              valueAttribute: path.split("/")[-2]
 
       - id: d0e1f2a3-b4c5-6d7e-8f9a-0b1c2d3e4f5b
         name: FeatureCityGmlReader
@@ -192,25 +180,15 @@ graphs:
         with:
           mappers:
             - attribute: index
-              expr:
-                type: flowExpr
-                value: attributes["fileIndex"]
+              valueAttribute: fileIndex
             - attribute: filename
-              expr:
-                type: flowExpr
-                value: attributes["gmlFilename"]
+              valueAttribute: gmlFilename
             - attribute: udxDirs
-              expr:
-                type: flowExpr
-                value: attributes["udxDirs"]
+              valueAttribute: udxDirs
             - attribute: gmlFilename
-              expr:
-                type: flowExpr
-                value: attributes["gmlFilename"]
+              valueAttribute: gmlFilename
             - attribute: GenericCityObject
-              expr:
-                type: flowExpr
-                value: attributes["GenericCityObject"]
+              valueAttribute: GenericCityObject
             - attribute: lod
               expr:
                 type: flowExpr
@@ -263,9 +241,7 @@ graphs:
                 type: flowExpr
                 value: attributes.get("fileIndex", attributes.get("index"))
             - attribute: Folder
-              expr:
-                type: flowExpr
-                value: attributes["udxDirs"]
+              valueAttribute: udxDirs
             - attribute: Filename
               expr:
                 type: flowExpr

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/adequate_place_judgement.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/adequate_place_judgement.yml
@@ -582,31 +582,31 @@ nodes:
     with:
       mappers:
         - attribute: 建物ID
-          expr: env.get("__value")["gmlId"]
+          valueAttribute: gmlId
         - attribute: 優先度
-          expr: env.get("__value")["priority"]
+          valueAttribute: priority
         - attribute: 適否1_1_1
-          expr: env.get("__value")["result_1_1_1"]
+          valueAttribute: result_1_1_1
         - attribute: 適否1_1_2
-          expr: env.get("__value")["result_1_1_2"]
+          valueAttribute: result_1_1_2
         - attribute: 適否1_2
-          expr: env.get("__value")["result_1_2"]
+          valueAttribute: result_1_2
         - attribute: 適否1_3
-          expr: env.get("__value")["result_1_3"]
+          valueAttribute: result_1_3
         - attribute: 適否2_1
-          expr: env.get("__value")["result_2_1"]
+          valueAttribute: result_2_1
         - attribute: 適否2_2
-          expr: env.get("__value")["result_2_2"]
+          valueAttribute: result_2_2
         - attribute: 適否2_3
-          expr: env.get("__value")["result_2_3"]
+          valueAttribute: result_2_3
         - attribute: 適否2_4
-          expr: env.get("__value")["result_2_4"]
+          valueAttribute: result_2_4
         - attribute: 適否3_1
-          expr: env.get("__value")["result_3_1"]
+          valueAttribute: result_3_1
         - attribute: 適否3_2
-          expr: env.get("__value")["result_3_2"]
+          valueAttribute: result_3_2
         - attribute: 適否3_3
-          expr: env.get("__value")["result_3_3"]
+          valueAttribute: result_3_3
 
   - id: 00000005-0000-0000-0000-000000000062
     name: BuildingJudgmentWriter
@@ -821,31 +821,31 @@ nodes:
     with:
       mappers:
         - attribute: 土地ID
-          expr: env.get("__value")["gmlId"]
+          valueAttribute: gmlId
         - attribute: 優先度
-          expr: env.get("__value")["priority"]
+          valueAttribute: priority
         - attribute: 適否1_1_1
-          expr: env.get("__value")["result_1_1_1"]
+          valueAttribute: result_1_1_1
         - attribute: 適否1_1_2
-          expr: env.get("__value")["result_1_1_2"]
+          valueAttribute: result_1_1_2
         - attribute: 適否1_2
-          expr: env.get("__value")["result_1_2"]
+          valueAttribute: result_1_2
         - attribute: 適否1_3
-          expr: env.get("__value")["result_1_3"]
+          valueAttribute: result_1_3
         - attribute: 適否2_1
-          expr: env.get("__value")["result_2_1"]
+          valueAttribute: result_2_1
         - attribute: 適否2_2
-          expr: env.get("__value")["result_2_2"]
+          valueAttribute: result_2_2
         - attribute: 適否2_3
-          expr: env.get("__value")["result_2_3"]
+          valueAttribute: result_2_3
         - attribute: 適否2_4
-          expr: env.get("__value")["result_2_4"]
+          valueAttribute: result_2_4
         - attribute: 適否3_1
-          expr: env.get("__value")["result_3_1"]
+          valueAttribute: result_3_1
         - attribute: 適否3_2
-          expr: env.get("__value")["result_3_2"]
+          valueAttribute: result_3_2
         - attribute: 適否3_3
-          expr: env.get("__value")["result_3_3"]
+          valueAttribute: result_3_3
 
   - id: 00000006-0000-0000-0000-000000000005
     name: LandJudgmentWriter

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/cloud_factor.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/cloud_factor.yml
@@ -38,34 +38,41 @@ nodes:
       mappers:
         # Parse year from 年月日 (format "YYYY/MM/DD")
         - attribute: year
-          expr: |
-            env.get("__value")["年月日"].split("/")[0]
+          expr:
+            type: flowExpr
+            value: attributes["年月日"].split("/")[0]
         # Parse month from 年月日
         - attribute: month
-          expr: |
-            let month = env.get("__value")["年月日"].split("/")[1];
-            if month[0] == "0" { month[1..] } else { month }
+          expr:
+            type: flowExpr
+            value: |
+              month = attributes["年月日"].split("/")[1];
+              if month[0] == "0" { month[1:] } else { month }
         # Parse day from 年月日
         - attribute: day
-          expr: |
-            let day = env.get("__value")["年月日"].split("/")[2];
-            if day[0] == "0" { day[1..] } else { day }
+          expr:
+            type: flowExpr
+            value: |
+              day = attributes["年月日"].split("/")[2];
+              if day[0] == "0" { day[1:] } else { day }
         # Calculate dayTime (sunset - sunrise in hours)
         # 出 (sunrise) format: "HH:MM"
         # 入り (sunset) format: "HH:MM"
         - attribute: dayTime
-          expr: |
-            let sunrise_str = env.get("__value")["出"];
-            let sunset_str = env.get("__value")["入り"];
-            let sunrise_parts = sunrise_str.split(":");
-            let sunset_parts = sunset_str.split(":");
-            let sunrise_hour = if sunrise_parts.len() > 0 { parse_float(sunrise_parts[0]) } else { 0.0 };
-            let sunrise_min = if sunrise_parts.len() > 1 { parse_float(sunrise_parts[1]) } else { 0.0 };
-            let sunset_hour = if sunset_parts.len() > 0 { parse_float(sunset_parts[0]) } else { 0.0 };
-            let sunset_min = if sunset_parts.len() > 1 { parse_float(sunset_parts[1]) } else { 0.0 };
-            let sunrise_hours = sunrise_hour + sunrise_min / 60.0;
-            let sunset_hours = sunset_hour + sunset_min / 60.0;
-            sunset_hours - sunrise_hours
+          expr:
+            type: flowExpr
+            value: |
+              sunrise_str = attributes["出"];
+              sunset_str = attributes["入り"];
+              sunrise_parts = sunrise_str.split(":");
+              sunset_parts = sunset_str.split(":");
+              sunrise_hour = if len(sunrise_parts) > 0 { float(sunrise_parts[0]) } else { 0.0 };
+              sunrise_min = if len(sunrise_parts) > 1 { float(sunrise_parts[1]) } else { 0.0 };
+              sunset_hour = if len(sunset_parts) > 0 { float(sunset_parts[0]) } else { 0.0 };
+              sunset_min = if len(sunset_parts) > 1 { float(sunset_parts[1]) } else { 0.0 };
+              sunrise_hours = sunrise_hour + sunrise_min / 60.0;
+              sunset_hours = sunset_hour + sunset_min / 60.0;
+              sunset_hours - sunrise_hours
 
   # ========================================
   # Node 3: Aggregate DayTime by Year/Month
@@ -109,16 +116,13 @@ nodes:
       mappers:
         # Copy 年 to year for merge compatibility
         - attribute: year
-          expr: |
-            env.get("__value")["年"]
+          valueAttribute: 年
         # Copy 月 to month for merge compatibility
         - attribute: month
-          expr: |
-            env.get("__value")["月"]
+          valueAttribute: 月
         # Extract 日照時間(時間) - actual sunshine hours
         - attribute: 日照時間(時間)
-          expr: |
-            env.get("__value")["日照時間(時間)"]
+          valueAttribute: 日照時間(時間)
 
   # ========================================
   # Node 6: Merge Daily Aggregates with Monthly Weather

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
@@ -186,29 +186,36 @@ graphs:
     with:
       mappers:
       - attribute: year
-        expr: |
-          env.get("__value")["年月日"].split("/")[0]
+        expr:
+          type: flowExpr
+          value: attributes["年月日"].split("/")[0]
       - attribute: month
-        expr: |
-          let month = env.get("__value")["年月日"].split("/")[1];
-          if month[0] == "0" { month[1..] } else { month }
+        expr:
+          type: flowExpr
+          value: |
+            month = attributes["年月日"].split("/")[1];
+            if month[0] == "0" { month[1:] } else { month }
       - attribute: day
-        expr: |
-          let day = env.get("__value")["年月日"].split("/")[2];
-          if day[0] == "0" { day[1..] } else { day }
+        expr:
+          type: flowExpr
+          value: |
+            day = attributes["年月日"].split("/")[2];
+            if day[0] == "0" { day[1:] } else { day }
       - attribute: dayTime
-        expr: |
-          let sunrise_str = env.get("__value")["出"];
-          let sunset_str = env.get("__value")["入り"];
-          let sunrise_parts = sunrise_str.split(":");
-          let sunset_parts = sunset_str.split(":");
-          let sunrise_hour = if sunrise_parts.len() > 0 { parse_float(sunrise_parts[0]) } else { 0.0 };
-          let sunrise_min = if sunrise_parts.len() > 1 { parse_float(sunrise_parts[1]) } else { 0.0 };
-          let sunset_hour = if sunset_parts.len() > 0 { parse_float(sunset_parts[0]) } else { 0.0 };
-          let sunset_min = if sunset_parts.len() > 1 { parse_float(sunset_parts[1]) } else { 0.0 };
-          let sunrise_hours = sunrise_hour + sunrise_min / 60.0;
-          let sunset_hours = sunset_hour + sunset_min / 60.0;
-          sunset_hours - sunrise_hours
+        expr:
+          type: flowExpr
+          value: |
+            sunrise_str = attributes["出"];
+            sunset_str = attributes["入り"];
+            sunrise_parts = sunrise_str.split(":");
+            sunset_parts = sunset_str.split(":");
+            sunrise_hour = if len(sunrise_parts) > 0 { float(sunrise_parts[0]) } else { 0.0 };
+            sunrise_min = if len(sunrise_parts) > 1 { float(sunrise_parts[1]) } else { 0.0 };
+            sunset_hour = if len(sunset_parts) > 0 { float(sunset_parts[0]) } else { 0.0 };
+            sunset_min = if len(sunset_parts) > 1 { float(sunset_parts[1]) } else { 0.0 };
+            sunrise_hours = sunrise_hour + sunrise_min / 60.0;
+            sunset_hours = sunset_hour + sunset_min / 60.0;
+            sunset_hours - sunrise_hours
   - id: c3d4e5f6-a7b8-4c9d-0e1f-2a3b4c5d6e7f
     name: MonthlyDayTimeAggregator
     type: action
@@ -239,14 +246,11 @@ graphs:
     with:
       mappers:
       - attribute: year
-        expr: |
-          env.get("__value")["年"]
+        valueAttribute: 年
       - attribute: month
-        expr: |
-          env.get("__value")["月"]
+        valueAttribute: 月
       - attribute: 日照時間(時間)
-        expr: |
-          env.get("__value")["日照時間(時間)"]
+        valueAttribute: 日照時間(時間)
   - id: f6a7b8c9-d0e1-4f2a-3b4c-5d6e7f8a9b0c
     name: MergeMonthlyData
     type: action
@@ -806,31 +810,31 @@ graphs:
     with:
       mappers:
       - attribute: 建物ID
-        expr: env.get("__value")["gmlId"]
+        valueAttribute: gmlId
       - attribute: 優先度
-        expr: env.get("__value")["priority"]
+        valueAttribute: priority
       - attribute: 適否1_1_1
-        expr: env.get("__value")["result_1_1_1"]
+        valueAttribute: result_1_1_1
       - attribute: 適否1_1_2
-        expr: env.get("__value")["result_1_1_2"]
+        valueAttribute: result_1_1_2
       - attribute: 適否1_2
-        expr: env.get("__value")["result_1_2"]
+        valueAttribute: result_1_2
       - attribute: 適否1_3
-        expr: env.get("__value")["result_1_3"]
+        valueAttribute: result_1_3
       - attribute: 適否2_1
-        expr: env.get("__value")["result_2_1"]
+        valueAttribute: result_2_1
       - attribute: 適否2_2
-        expr: env.get("__value")["result_2_2"]
+        valueAttribute: result_2_2
       - attribute: 適否2_3
-        expr: env.get("__value")["result_2_3"]
+        valueAttribute: result_2_3
       - attribute: 適否2_4
-        expr: env.get("__value")["result_2_4"]
+        valueAttribute: result_2_4
       - attribute: 適否3_1
-        expr: env.get("__value")["result_3_1"]
+        valueAttribute: result_3_1
       - attribute: 適否3_2
-        expr: env.get("__value")["result_3_2"]
+        valueAttribute: result_3_2
       - attribute: 適否3_3
-        expr: env.get("__value")["result_3_3"]
+        valueAttribute: result_3_3
   - id: 00000005-0000-0000-0000-000000000062
     name: BuildingJudgmentWriter
     type: action
@@ -1011,31 +1015,31 @@ graphs:
     with:
       mappers:
       - attribute: 土地ID
-        expr: env.get("__value")["gmlId"]
+        valueAttribute: gmlId
       - attribute: 優先度
-        expr: env.get("__value")["priority"]
+        valueAttribute: priority
       - attribute: 適否1_1_1
-        expr: env.get("__value")["result_1_1_1"]
+        valueAttribute: result_1_1_1
       - attribute: 適否1_1_2
-        expr: env.get("__value")["result_1_1_2"]
+        valueAttribute: result_1_1_2
       - attribute: 適否1_2
-        expr: env.get("__value")["result_1_2"]
+        valueAttribute: result_1_2
       - attribute: 適否1_3
-        expr: env.get("__value")["result_1_3"]
+        valueAttribute: result_1_3
       - attribute: 適否2_1
-        expr: env.get("__value")["result_2_1"]
+        valueAttribute: result_2_1
       - attribute: 適否2_2
-        expr: env.get("__value")["result_2_2"]
+        valueAttribute: result_2_2
       - attribute: 適否2_3
-        expr: env.get("__value")["result_2_3"]
+        valueAttribute: result_2_3
       - attribute: 適否2_4
-        expr: env.get("__value")["result_2_4"]
+        valueAttribute: result_2_4
       - attribute: 適否3_1
-        expr: env.get("__value")["result_3_1"]
+        valueAttribute: result_3_1
       - attribute: 適否3_2
-        expr: env.get("__value")["result_3_2"]
+        valueAttribute: result_3_2
       - attribute: 適否3_3
-        expr: env.get("__value")["result_3_3"]
+        valueAttribute: result_3_3
   - id: 00000006-0000-0000-0000-000000000005
     name: LandJudgmentWriter
     type: action
@@ -1662,9 +1666,9 @@ graphs:
     with:
       mappers:
       - attribute: featureType
-        expr: env.get("__value").featureType
+        valueAttribute: featureType
       - attribute: gmlId
-        expr: env.get("__value").gmlId
+        valueAttribute: gmlId
   - id: 00000001-0000-0000-0000-000000000004
     name: GeometryPartExtractor
     type: action

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
@@ -1819,59 +1819,59 @@ graphs:
     with:
       mappers:
       - attribute: gmlId
-        expr: env.get("__value").gmlId
+        valueAttribute: gmlId
       - attribute: surfaceId
-        expr: env.get("__value").surfaceId
+        valueAttribute: surfaceId
       - attribute: cellId
-        expr: env.get("__value").cellId
+        valueAttribute: cellId
       - attribute: year
-        expr: env.get("__value").year
+        valueAttribute: year
       - attribute: month
-        expr: env.get("__value").month
+        valueAttribute: month
       - attribute: slope
-        expr: env.get("__value").slope
+        valueAttribute: slope
       - attribute: solarAltitude
-        expr: env.get("__value").solarAltitude
+        valueAttribute: solarAltitude
       - attribute: solarTime
-        expr: env.get("__value").solarTime
+        valueAttribute: solarTime
       - attribute: cellArea
-        expr: env.get("__value").cellArea
+        valueAttribute: cellArea
       - attribute: cosTheta
-        expr: env.get("__value").cosTheta
+        valueAttribute: cosTheta
       - attribute: groundReflectivity
-        expr: env.get("__value").groundReflectivity
+        valueAttribute: groundReflectivity
       - attribute: rayOriginX
-        expr: env.get("__value").rayOriginX
+        valueAttribute: rayOriginX
       - attribute: rayOriginY
-        expr: env.get("__value").rayOriginY
+        valueAttribute: rayOriginY
       - attribute: rayOriginZ
-        expr: env.get("__value").rayOriginZ
+        valueAttribute: rayOriginZ
       - attribute: solarDirectionX
-        expr: env.get("__value").solarDirectionX
+        valueAttribute: solarDirectionX
       - attribute: solarDirectionY
-        expr: env.get("__value").solarDirectionY
+        valueAttribute: solarDirectionY
       - attribute: solarDirectionZ
-        expr: env.get("__value").solarDirectionZ
+        valueAttribute: solarDirectionZ
       - attribute: normalX
-        expr: env.get("__value").normalX
+        valueAttribute: normalX
       - attribute: normalY
-        expr: env.get("__value").normalY
+        valueAttribute: normalY
       - attribute: normalZ
-        expr: env.get("__value").normalZ
+        valueAttribute: normalZ
       - attribute: featureType
-        expr: env.get("__value").featureType
+        valueAttribute: featureType
       - attribute: azimuth
-        expr: env.get("__value").azimuth
+        valueAttribute: azimuth
       - attribute: dirMatch1
-        expr: env.get("__value").dirMatch1
+        valueAttribute: dirMatch1
       - attribute: dirMatch2
-        expr: env.get("__value").dirMatch2
+        valueAttribute: dirMatch2
       - attribute: dirMatch3
-        expr: env.get("__value").dirMatch3
+        valueAttribute: dirMatch3
       - attribute: _grid_col
-        expr: env.get("__value")._grid_col
+        valueAttribute: _grid_col
       - attribute: _grid_row
-        expr: env.get("__value")._grid_row
+        valueAttribute: _grid_row
   - id: 00000001-0000-0000-0000-000000000010
     name: RayIntersectorShadow
     type: action
@@ -1917,14 +1917,18 @@ graphs:
     with:
       mappers:
       - attribute: month
-        expr: |
-          parse_int(env.get("__value")["column2"])
+        expr:
+          type: flowExpr
+          value: int(attributes["column2"])
       - attribute: date
-        expr: |
-          parse_int(env.get("__value")["column3"])
+        expr:
+          type: flowExpr
+          value: int(attributes["column3"])
       - attribute: groundReflectivity
-        expr: |
-          if parse_float(env.get("__value")["column29"]) < 10.0 { 0.1 } else { 0.7 }
+        expr:
+          type: flowExpr
+          value: |
+            if float(attributes["column29"]) < 10.0 { 0.1 } else { 0.7 }
   - id: 00000003-0000-0000-0000-000000000004
     name: SnowFactorMerger
     type: action
@@ -2455,21 +2459,25 @@ graphs:
     with:
       mappers:
       - attribute: 建物ID
-        expr: env.get("__value")["gmlId"]
+        valueAttribute: gmlId
       - attribute: 太陽日射量(kWh)
-        expr: env.get("__value")["totalSolarRadiation"]
+        valueAttribute: totalSolarRadiation
       - attribute: 太陽日射量(kWh/m2)
-        expr: |
-          let area = env.get("__value")["totalRoofArea"] ?? 0.0;
-          if area > 0.0 { env.get("__value")["totalSolarRadiation"] / area } else { 0.0 }
+        expr:
+          type: flowExpr
+          value: |
+            area = attributes["totalRoofArea"];
+            if area > 0.0 { attributes["totalSolarRadiation"] / area } else { 0.0 }
       - attribute: 太陽発電量(kWh)
-        expr: env.get("__value")["totalSolarPower"]
+        valueAttribute: totalSolarPower
       - attribute: 太陽発電量(kWh/m2)
-        expr: |
-          let area = env.get("__value")["totalRoofArea"] ?? 0.0;
-          if area > 0.0 { env.get("__value")["totalSolarPower"] / area } else { 0.0 }
+        expr:
+          type: flowExpr
+          value: |
+            area = attributes["totalRoofArea"];
+            if area > 0.0 { attributes["totalSolarPower"] / area } else { 0.0 }
       - attribute: 受光面積(m2)
-        expr: env.get("__value")["totalRoofArea"] ?? 0.0
+        valueAttribute: totalRoofArea
   - id: 00000001-0000-0000-0000-0000000000c1
     name: BuildingPotentialWriter
     type: action
@@ -2485,19 +2493,21 @@ graphs:
     with:
       mappers:
       - attribute: 建物ID
-        expr: env.get("__value")["gmlId"]
+        valueAttribute: gmlId
       - attribute: 屋根ID
-        expr: env.get("__value")["surfaceId"]
+        valueAttribute: surfaceId
       - attribute: 単位面積あたりの日射量(kWh/m2)
-        expr: |
-          let area = env.get("__value")["totalSurfaceArea"] ?? 0.0;
-          if area > 0.0 { env.get("__value")["totalSolarRadiation"] / area } else { 0.0 }
+        expr:
+          type: flowExpr
+          value: |
+            area = attributes["totalSurfaceArea"];
+            if area > 0.0 { attributes["totalSolarRadiation"] / area } else { 0.0 }
       - attribute: 対象面全体の日射量(kWh)
-        expr: env.get("__value")["totalSolarRadiation"]
+        valueAttribute: totalSolarRadiation
       - attribute: 太陽発電量(kWh)
-        expr: env.get("__value")["totalSolarPower"]
+        valueAttribute: totalSolarPower
       - attribute: 受光面積(m2)
-        expr: env.get("__value")["totalSurfaceArea"] ?? 0.0
+        valueAttribute: totalSurfaceArea
   - id: 00000001-0000-0000-0000-0000000000c2
     name: SurfaceRadiationWriter
     type: action
@@ -2513,25 +2523,27 @@ graphs:
     with:
       mappers:
       - attribute: 建物/土地ID
-        expr: env.get("__value")["gmlId"] ?? ""
+        valueAttribute: gmlId
       - attribute: 屋根ID
-        expr: env.get("__value")["surfaceId"] ?? ""
+        valueAttribute: surfaceId
       - attribute: 日時
-        expr: env.get("__value")["solarTime"] ?? ""
+        valueAttribute: solarTime
       - attribute: 反射元_座標.X(m)
-        expr: env.get("__value")["rayOriginX"]
+        valueAttribute: rayOriginX
       - attribute: 反射元_座標.Y(m)
-        expr: env.get("__value")["rayOriginY"]
+        valueAttribute: rayOriginY
       - attribute: 反射元_座標.Z(m)
-        expr: env.get("__value")["rayOriginZ"]
+        valueAttribute: rayOriginZ
       - attribute: 反射先_座標.X(m)
-        expr: env.get("__value")["reflectHitX"]
+        valueAttribute: reflectHitX
       - attribute: 反射先_座標.Y(m)
-        expr: env.get("__value")["reflectHitY"]
+        valueAttribute: reflectHitY
       - attribute: 反射先_座標.Z(m)
-        expr: env.get("__value")["reflectHitZ"]
+        valueAttribute: reflectHitZ
       - attribute: 反射先
-        expr: env.get("__value")["geomId"] ?? ""
+        expr:
+          type: flowExpr
+          value: attributes.get("geomId", "")
   - id: 00000001-0000-0000-0000-0000000000c3
     name: AreaAggregator
     type: action
@@ -2558,13 +2570,15 @@ graphs:
     with:
       mappers:
       - attribute: 対象範囲内建物数
-        expr: env.get("__value")["buildingCount"]
+        valueAttribute: buildingCount
       - attribute: 太陽放射量推計(kWh/m2)
-        expr: |
-          let area = env.get("__value")["areaTotalRoofArea"] ?? 0.0;
-          if area > 0.0 { env.get("__value")["areaTotalSolarRadiation"] / area } else { 0.0 }
+        expr:
+          type: flowExpr
+          value: |
+            area = attributes["areaTotalRoofArea"];
+            if area > 0.0 { attributes["areaTotalSolarRadiation"] / area } else { 0.0 }
       - attribute: 太陽発電量推計(kWh)
-        expr: env.get("__value")["areaTotalSolarPower"]
+        valueAttribute: areaTotalSolarPower
   - id: 00000001-0000-0000-0000-0000000000c4
     name: AreaAggregationWriter
     type: action
@@ -2764,40 +2778,55 @@ graphs:
     with:
       mappers:
       - attribute: gmlId
-        expr: env.get("__value")["gmlId"]
+        valueAttribute: gmlId
       - attribute: bldgHeight
-        expr: |
-          let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-          cga["bldg:measuredHeight"] ?? -1.0
+        expr:
+          type: flowExpr
+          value: |
+            cga = attributes.get("cityGmlAttributes", {});
+            cga.get("bldg:measuredHeight", -1.0)
       - attribute: structureType
-        expr: |
-          let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-          let detail = cga["uro:BuildingDetailAttribute"] ?? [];
-          if detail.len() > 0 { detail[0]["uro:buildingStructureType_code"] ?? -1 } else { -1 }
+        expr:
+          type: flowExpr
+          value: |
+            cga = attributes.get("cityGmlAttributes", {});
+            detail = cga.get("uro:BuildingDetailAttribute", []);
+            if len(detail) > 0 { detail[0].get("uro:buildingStructureType_code", -1) } else { -1 }
       - attribute: floodDepth
-        expr: |
-          let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-          let max_d = 0.0;
-          for list in [cga["uro:RiverFloodingRiskAttribute"] ?? [], cga["uro:InlandFloodingRiskAttribute"] ?? [], cga["uro:HighTideRiskAttribute"] ?? []] {
-            for item in list { let d = item["uro:depth"] ?? 0.0; if d > max_d { max_d = d; } }
-          }
-          max_d
+        expr:
+          type: flowExpr
+          value: |
+            cga = attributes.get("cityGmlAttributes", {});
+            max_d = 0.0;
+            for item in cga.get("uro:RiverFloodingRiskAttribute", []) + cga.get("uro:InlandFloodingRiskAttribute", []) + cga.get("uro:HighTideRiskAttribute", []) {
+              d = item.get("uro:depth", 0.0);
+              if d > max_d { max_d = d }
+            }
+            max_d
       - attribute: tsunamiHeight
-        expr: |
-          let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-          let list = cga["uro:TsunamiRiskAttribute"] ?? [];
-          let max_d = 0.0;
-          for item in list { let d = item["uro:depth"] ?? 0.0; if d > max_d { max_d = d; } }
-          max_d
+        expr:
+          type: flowExpr
+          value: |
+            cga = attributes.get("cityGmlAttributes", {});
+            list = cga.get("uro:TsunamiRiskAttribute", []);
+            max_d = 0.0;
+            for item in list {
+              d = item.get("uro:depth", 0.0);
+              if d > max_d { max_d = d }
+            }
+            max_d
       - attribute: landslideFlag
-        expr: |
-          let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-          let v = cga["uro:LandSlideRiskAttribute"] ?? ();
-          v != ()
+        expr:
+          type: flowExpr
+          value: |
+            cga = attributes.get("cityGmlAttributes", {});
+            "uro:LandSlideRiskAttribute" in cga
       - attribute: floorCount
-        expr: |
-          let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-          cga["bldg:storeysAboveGround"] ?? -1
+        expr:
+          type: flowExpr
+          value: |
+            cga = attributes.get("cityGmlAttributes", {});
+            cga.get("bldg:storeysAboveGround", -1)
   - id: 00000002-0000-0000-0000-000000000013
     name: DEMConsiderFilter
     type: action

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
@@ -2466,7 +2466,7 @@ graphs:
         expr:
           type: flowExpr
           value: |
-            area = attributes["totalRoofArea"];
+            area = attributes.get("totalRoofArea", 0.0);
             if area > 0.0 { attributes["totalSolarRadiation"] / area } else { 0.0 }
       - attribute: 太陽発電量(kWh)
         valueAttribute: totalSolarPower
@@ -2474,7 +2474,7 @@ graphs:
         expr:
           type: flowExpr
           value: |
-            area = attributes["totalRoofArea"];
+            area = attributes.get("totalRoofArea", 0.0);
             if area > 0.0 { attributes["totalSolarPower"] / area } else { 0.0 }
       - attribute: 受光面積(m2)
         valueAttribute: totalRoofArea
@@ -2500,7 +2500,7 @@ graphs:
         expr:
           type: flowExpr
           value: |
-            area = attributes["totalSurfaceArea"];
+            area = attributes.get("totalSurfaceArea", 0.0);
             if area > 0.0 { attributes["totalSolarRadiation"] / area } else { 0.0 }
       - attribute: 対象面全体の日射量(kWh)
         valueAttribute: totalSolarRadiation
@@ -2575,7 +2575,7 @@ graphs:
         expr:
           type: flowExpr
           value: |
-            area = attributes["areaTotalRoofArea"];
+            area = attributes.get("areaTotalRoofArea", 0.0);
             if area > 0.0 { attributes["areaTotalSolarRadiation"] / area } else { 0.0 }
       - attribute: 太陽発電量推計(kWh)
         valueAttribute: areaTotalSolarPower

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/time-to-time-value/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/time-to-time-value/workflow.yml
@@ -33,21 +33,29 @@ nodes:
           valueAttribute: 南中
         # Add the extracted time parts directly in the AttributeMapper
         - attribute: 出_H
-          expr: |
-            let time_parts = env.get("__value")["出"].split(":");
-            if time_parts.len() > 0 { time_parts[0] } else { "" }
+          expr:
+            type: flowExpr
+            value: |
+              time_parts = attributes["出"].split(":");
+              if len(time_parts) > 0 { time_parts[0] } else { "" }
         - attribute: 出_M
-          expr: |
-            let time_parts = env.get("__value")["出"].split(":");
-            if time_parts.len() > 1 { time_parts[1] } else { "" }
+          expr:
+            type: flowExpr
+            value: |
+              time_parts = attributes["出"].split(":");
+              if len(time_parts) > 1 { time_parts[1] } else { "" }
         - attribute: 入り_H
-          expr: |
-            let time_parts = env.get("__value")["入り"].split(":");
-            if time_parts.len() > 0 { time_parts[0] } else { "" }
+          expr:
+            type: flowExpr
+            value: |
+              time_parts = attributes["入り"].split(":");
+              if len(time_parts) > 0 { time_parts[0] } else { "" }
         - attribute: 入り_M
-          expr: |
-            let time_parts = env.get("__value")["入り"].split(":");
-            if time_parts.len() > 1 { time_parts[1] } else { "" }
+          expr:
+            type: flowExpr
+            value: |
+              time_parts = attributes["入り"].split(":");
+              if len(time_parts) > 1 { time_parts[1] } else { "" }
 
   - id: 57d8a9b1-8e7b-4c23-9e6d-9f70db10a7e4
     name: ConvertToSeconds

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/workflow.yml
@@ -1162,7 +1162,7 @@ graphs:
               expr:
                 type: flowExpr
                 value: |
-                  area = attributes["totalRoofArea"];
+                  area = attributes.get("totalRoofArea", 0.0);
                   if area > 0.0 { attributes["totalSolarRadiation"] / area } else { 0.0 }
             - attribute: 太陽発電量(kWh)
               valueAttribute: totalSolarPower
@@ -1170,7 +1170,7 @@ graphs:
               expr:
                 type: flowExpr
                 value: |
-                  area = attributes["totalRoofArea"];
+                  area = attributes.get("totalRoofArea", 0.0);
                   if area > 0.0 { attributes["totalSolarPower"] / area } else { 0.0 }
             - attribute: 受光面積(m2)
               valueAttribute: totalRoofArea
@@ -1204,7 +1204,7 @@ graphs:
               expr:
                 type: flowExpr
                 value: |
-                  area = attributes["totalSurfaceArea"];
+                  area = attributes.get("totalSurfaceArea", 0.0);
                   if area > 0.0 { attributes["totalSolarRadiation"] / area } else { 0.0 }
             - attribute: 対象面全体の日射量(kWh)
               valueAttribute: totalSolarRadiation
@@ -1294,7 +1294,7 @@ graphs:
               expr:
                 type: flowExpr
                 value: |
-                  area = attributes["areaTotalRoofArea"];
+                  area = attributes.get("areaTotalRoofArea", 0.0);
                   if area > 0.0 { attributes["areaTotalSolarRadiation"] / area } else { 0.0 }
             - attribute: 太陽発電量推計(kWh)
               valueAttribute: areaTotalSolarPower

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/workflow.yml
@@ -397,59 +397,59 @@ graphs:
         with:
           mappers:
             - attribute: gmlId
-              expr: env.get("__value").gmlId
+              valueAttribute: gmlId
             - attribute: surfaceId
-              expr: env.get("__value").surfaceId
+              valueAttribute: surfaceId
             - attribute: cellId
-              expr: env.get("__value").cellId
+              valueAttribute: cellId
             - attribute: year
-              expr: env.get("__value").year
+              valueAttribute: year
             - attribute: month
-              expr: env.get("__value").month
+              valueAttribute: month
             - attribute: slope
-              expr: env.get("__value").slope
+              valueAttribute: slope
             - attribute: solarAltitude
-              expr: env.get("__value").solarAltitude
+              valueAttribute: solarAltitude
             - attribute: solarTime
-              expr: env.get("__value").solarTime
+              valueAttribute: solarTime
             - attribute: cellArea
-              expr: env.get("__value").cellArea
+              valueAttribute: cellArea
             - attribute: cosTheta
-              expr: env.get("__value").cosTheta
+              valueAttribute: cosTheta
             - attribute: groundReflectivity
-              expr: env.get("__value").groundReflectivity
+              valueAttribute: groundReflectivity
             - attribute: rayOriginX
-              expr: env.get("__value").rayOriginX
+              valueAttribute: rayOriginX
             - attribute: rayOriginY
-              expr: env.get("__value").rayOriginY
+              valueAttribute: rayOriginY
             - attribute: rayOriginZ
-              expr: env.get("__value").rayOriginZ
+              valueAttribute: rayOriginZ
             - attribute: solarDirectionX
-              expr: env.get("__value").solarDirectionX
+              valueAttribute: solarDirectionX
             - attribute: solarDirectionY
-              expr: env.get("__value").solarDirectionY
+              valueAttribute: solarDirectionY
             - attribute: solarDirectionZ
-              expr: env.get("__value").solarDirectionZ
+              valueAttribute: solarDirectionZ
             - attribute: normalX
-              expr: env.get("__value").normalX
+              valueAttribute: normalX
             - attribute: normalY
-              expr: env.get("__value").normalY
+              valueAttribute: normalY
             - attribute: normalZ
-              expr: env.get("__value").normalZ
+              valueAttribute: normalZ
             - attribute: featureType
-              expr: env.get("__value").featureType
+              valueAttribute: featureType
             - attribute: azimuth
-              expr: env.get("__value").azimuth
+              valueAttribute: azimuth
             - attribute: dirMatch1
-              expr: env.get("__value").dirMatch1
+              valueAttribute: dirMatch1
             - attribute: dirMatch2
-              expr: env.get("__value").dirMatch2
+              valueAttribute: dirMatch2
             - attribute: dirMatch3
-              expr: env.get("__value").dirMatch3
+              valueAttribute: dirMatch3
             - attribute: _grid_col
-              expr: env.get("__value")._grid_col
+              valueAttribute: _grid_col
             - attribute: _grid_row
-              expr: env.get("__value")._grid_row
+              valueAttribute: _grid_row
 
       # ========================================
       # Section 5: Shadow Detection
@@ -509,14 +509,18 @@ graphs:
         with:
           mappers:
             - attribute: month
-              expr: |
-                parse_int(env.get("__value")["column2"])
+              expr:
+                type: flowExpr
+                value: int(attributes["column2"])
             - attribute: date
-              expr: |
-                parse_int(env.get("__value")["column3"])
+              expr:
+                type: flowExpr
+                value: int(attributes["column3"])
             - attribute: groundReflectivity
-              expr: |
-                if parse_float(env.get("__value")["column29"]) < 10.0 { 0.1 } else { 0.7 }
+              expr:
+                type: flowExpr
+                value: |
+                  if float(attributes["column29"]) < 10.0 { 0.1 } else { 0.7 }
 
       - id: 00000003-0000-0000-0000-000000000004
         name: SnowFactorMerger
@@ -1151,21 +1155,25 @@ graphs:
         with:
           mappers:
             - attribute: 建物ID
-              expr: env.get("__value")["gmlId"]
+              valueAttribute: gmlId
             - attribute: 太陽日射量(kWh)
-              expr: env.get("__value")["totalSolarRadiation"]
+              valueAttribute: totalSolarRadiation
             - attribute: 太陽日射量(kWh/m2)
-              expr: |
-                let area = env.get("__value")["totalRoofArea"] ?? 0.0;
-                if area > 0.0 { env.get("__value")["totalSolarRadiation"] / area } else { 0.0 }
+              expr:
+                type: flowExpr
+                value: |
+                  area = attributes["totalRoofArea"];
+                  if area > 0.0 { attributes["totalSolarRadiation"] / area } else { 0.0 }
             - attribute: 太陽発電量(kWh)
-              expr: env.get("__value")["totalSolarPower"]
+              valueAttribute: totalSolarPower
             - attribute: 太陽発電量(kWh/m2)
-              expr: |
-                let area = env.get("__value")["totalRoofArea"] ?? 0.0;
-                if area > 0.0 { env.get("__value")["totalSolarPower"] / area } else { 0.0 }
+              expr:
+                type: flowExpr
+                value: |
+                  area = attributes["totalRoofArea"];
+                  if area > 0.0 { attributes["totalSolarPower"] / area } else { 0.0 }
             - attribute: 受光面積(m2)
-              expr: env.get("__value")["totalRoofArea"] ?? 0.0
+              valueAttribute: totalRoofArea
 
       # Write building potential CSV
       - id: 00000001-0000-0000-0000-0000000000c1
@@ -1189,19 +1197,21 @@ graphs:
         with:
           mappers:
             - attribute: 建物ID
-              expr: env.get("__value")["gmlId"]
+              valueAttribute: gmlId
             - attribute: 屋根ID
-              expr: env.get("__value")["surfaceId"]
+              valueAttribute: surfaceId
             - attribute: 単位面積あたりの日射量(kWh/m2)
-              expr: |
-                let area = env.get("__value")["totalSurfaceArea"] ?? 0.0;
-                if area > 0.0 { env.get("__value")["totalSolarRadiation"] / area } else { 0.0 }
+              expr:
+                type: flowExpr
+                value: |
+                  area = attributes["totalSurfaceArea"];
+                  if area > 0.0 { attributes["totalSolarRadiation"] / area } else { 0.0 }
             - attribute: 対象面全体の日射量(kWh)
-              expr: env.get("__value")["totalSolarRadiation"]
+              valueAttribute: totalSolarRadiation
             - attribute: 太陽発電量(kWh)
-              expr: env.get("__value")["totalSolarPower"]
+              valueAttribute: totalSolarPower
             - attribute: 受光面積(m2)
-              expr: env.get("__value")["totalSurfaceArea"] ?? 0.0
+              valueAttribute: totalSurfaceArea
 
       # Write surface radiation CSV
       - id: 00000001-0000-0000-0000-0000000000c2
@@ -1224,25 +1234,27 @@ graphs:
         with:
           mappers:
             - attribute: 建物/土地ID
-              expr: env.get("__value")["gmlId"] ?? ""
+              valueAttribute: gmlId
             - attribute: 屋根ID
-              expr: env.get("__value")["surfaceId"] ?? ""
+              valueAttribute: surfaceId
             - attribute: 日時
-              expr: env.get("__value")["solarTime"] ?? ""
+              valueAttribute: solarTime
             - attribute: 反射元_座標.X(m)
-              expr: env.get("__value")["rayOriginX"]
+              valueAttribute: rayOriginX
             - attribute: 反射元_座標.Y(m)
-              expr: env.get("__value")["rayOriginY"]
+              valueAttribute: rayOriginY
             - attribute: 反射元_座標.Z(m)
-              expr: env.get("__value")["rayOriginZ"]
+              valueAttribute: rayOriginZ
             - attribute: 反射先_座標.X(m)
-              expr: env.get("__value")["reflectHitX"]
+              valueAttribute: reflectHitX
             - attribute: 反射先_座標.Y(m)
-              expr: env.get("__value")["reflectHitY"]
+              valueAttribute: reflectHitY
             - attribute: 反射先_座標.Z(m)
-              expr: env.get("__value")["reflectHitZ"]
+              valueAttribute: reflectHitZ
             - attribute: 反射先
-              expr: env.get("__value")["geomId"] ?? ""
+              expr:
+                type: flowExpr
+                value: attributes.get("geomId", "")
 
       # ========================================
       # CSV 6: Area Aggregation Results
@@ -1277,13 +1289,15 @@ graphs:
         with:
           mappers:
             - attribute: 対象範囲内建物数
-              expr: env.get("__value")["buildingCount"]
+              valueAttribute: buildingCount
             - attribute: 太陽放射量推計(kWh/m2)
-              expr: |
-                let area = env.get("__value")["areaTotalRoofArea"] ?? 0.0;
-                if area > 0.0 { env.get("__value")["areaTotalSolarRadiation"] / area } else { 0.0 }
+              expr:
+                type: flowExpr
+                value: |
+                  area = attributes["areaTotalRoofArea"];
+                  if area > 0.0 { attributes["areaTotalSolarRadiation"] / area } else { 0.0 }
             - attribute: 太陽発電量推計(kWh)
-              expr: env.get("__value")["areaTotalSolarPower"]
+              valueAttribute: areaTotalSolarPower
 
       # Write area aggregation CSV
       - id: 00000001-0000-0000-0000-0000000000c4
@@ -1518,40 +1532,55 @@ graphs:
         with:
           mappers:
             - attribute: gmlId
-              expr: env.get("__value")["gmlId"]
+              valueAttribute: gmlId
             - attribute: bldgHeight
-              expr: |
-                let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-                cga["bldg:measuredHeight"] ?? -1.0
+              expr:
+                type: flowExpr
+                value: |
+                  cga = attributes.get("cityGmlAttributes", {});
+                  cga.get("bldg:measuredHeight", -1.0)
             - attribute: structureType
-              expr: |
-                let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-                let detail = cga["uro:BuildingDetailAttribute"] ?? [];
-                if detail.len() > 0 { detail[0]["uro:buildingStructureType_code"] ?? -1 } else { -1 }
+              expr:
+                type: flowExpr
+                value: |
+                  cga = attributes.get("cityGmlAttributes", {});
+                  detail = cga.get("uro:BuildingDetailAttribute", []);
+                  if len(detail) > 0 { detail[0].get("uro:buildingStructureType_code", -1) } else { -1 }
             - attribute: floodDepth
-              expr: |
-                let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-                let max_d = 0.0;
-                for list in [cga["uro:RiverFloodingRiskAttribute"] ?? [], cga["uro:InlandFloodingRiskAttribute"] ?? [], cga["uro:HighTideRiskAttribute"] ?? []] {
-                  for item in list { let d = item["uro:depth"] ?? 0.0; if d > max_d { max_d = d; } }
-                }
-                max_d
+              expr:
+                type: flowExpr
+                value: |
+                  cga = attributes.get("cityGmlAttributes", {});
+                  max_d = 0.0;
+                  for item in cga.get("uro:RiverFloodingRiskAttribute", []) + cga.get("uro:InlandFloodingRiskAttribute", []) + cga.get("uro:HighTideRiskAttribute", []) {
+                    d = item.get("uro:depth", 0.0);
+                    if d > max_d { max_d = d }
+                  }
+                  max_d
             - attribute: tsunamiHeight
-              expr: |
-                let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-                let list = cga["uro:TsunamiRiskAttribute"] ?? [];
-                let max_d = 0.0;
-                for item in list { let d = item["uro:depth"] ?? 0.0; if d > max_d { max_d = d; } }
-                max_d
+              expr:
+                type: flowExpr
+                value: |
+                  cga = attributes.get("cityGmlAttributes", {});
+                  list = cga.get("uro:TsunamiRiskAttribute", []);
+                  max_d = 0.0;
+                  for item in list {
+                    d = item.get("uro:depth", 0.0);
+                    if d > max_d { max_d = d }
+                  }
+                  max_d
             - attribute: landslideFlag
-              expr: |
-                let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-                let v = cga["uro:LandSlideRiskAttribute"] ?? ();
-                v != ()
+              expr:
+                type: flowExpr
+                value: |
+                  cga = attributes.get("cityGmlAttributes", {});
+                  "uro:LandSlideRiskAttribute" in cga
             - attribute: floorCount
-              expr: |
-                let cga = env.get("__value")["cityGmlAttributes"] ?? #{};
-                cga["bldg:storeysAboveGround"] ?? -1
+              expr:
+                type: flowExpr
+                value: |
+                  cga = attributes.get("cityGmlAttributes", {});
+                  cga.get("bldg:storeysAboveGround", -1)
 
       # ========================================
       # Section 2c: DEM Triangle Pipeline

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/workflow.yml
@@ -208,9 +208,9 @@ graphs:
         with:
           mappers:
           - attribute: featureType
-            expr: env.get("__value").featureType
+            valueAttribute: featureType
           - attribute: gmlId
-            expr: env.get("__value").gmlId
+            valueAttribute: gmlId
 
       - id: 00000001-0000-0000-0000-000000000004
         name: GeometryPartExtractor

--- a/engine/runtime/expr/docs/design.md
+++ b/engine/runtime/expr/docs/design.md
@@ -20,3 +20,12 @@ Reviewers sometimes flag the lack of cycle detection on `Rc`-backed `Array` and 
 **Why not a GC?** A tracing GC would require arena-backing all values and replacing `Rc` entirely, adding significant implementation complexity and runtime overhead. Given that realistic workflow expressions have no use case for cyclic references, that complexity is not justified.
 
 **`Rc` is the right fit**: `Rc` covers all legitimate use cases. Cycle avoidance is the same contract users already accept in any `Rc`-based system without a tracing GC. Constructing cyclic values is an unsupported use case and the behavior is undefined.
+
+## `find()` null-as-falsy is intentional; empty-string matches indicate a broken pattern {#regex-find-null-falsy}
+
+`find()` returns `null` on no match, so callers can use it directly as a boolean condition. The edge case of a pattern that matches an empty string (e.g. `".*"`) produces a falsy result even though technically something was "found". This is intentional:
+
+- If the pattern has a capture group that captures an empty string, the pattern matches every input — that is a malformed pattern, not a legitimate result.
+- If the pattern has no capture group and the full match is empty, the input string itself is empty, and a validator that "passes" on an empty input is again a malformed pattern.
+
+In both cases the empty match signals a broken pattern, and returning a falsy value is the correct behavior. Users who need an explicit boolean should write `find() != null`, which also handles this case correctly.

--- a/engine/runtime/expr/src/core/builtins.rs
+++ b/engine/runtime/expr/src/core/builtins.rs
@@ -9,22 +9,7 @@ pub use math::builtin_math;
 pub use regex::builtin_regex;
 pub use url::builtin_url;
 
-use crate::core::error::{InnerError, InnerResult};
+use crate::core::error::InnerResult;
 use crate::core::value::Value;
 
 pub(super) type MethodFn = fn(&[Value]) -> InnerResult<Value>;
-
-/// Check that the number of user-visible arguments (i.e. `args` minus the
-/// implicit receiver at index 0) is within `[min, max]`.
-pub(super) fn expect_arity(args: &[Value], min: usize, max: usize) -> InnerResult<()> {
-    let n = args.len().saturating_sub(1);
-    if n >= min && n <= max {
-        return Ok(());
-    }
-    let msg = if min == max {
-        format!("expected {min} argument(s), got {n}")
-    } else {
-        format!("expected {min} to {max} argument(s), got {n}")
-    };
-    Err(InnerError::new(msg))
-}

--- a/engine/runtime/expr/src/core/builtins.rs
+++ b/engine/runtime/expr/src/core/builtins.rs
@@ -9,7 +9,36 @@ pub use math::builtin_math;
 pub use regex::builtin_regex;
 pub use url::builtin_url;
 
-use crate::core::error::InnerResult;
+use crate::core::error::{InnerError, InnerResult};
 use crate::core::value::Value;
 
 pub(super) type MethodFn = fn(&[Value]) -> InnerResult<Value>;
+
+pub(super) fn expect_str(v: &Value) -> InnerResult<&str> {
+    match v {
+        Value::String(s) => Ok(s.as_str()),
+        other => Err(InnerError::new(format!("expected string, got {}", other.type_name()))),
+    }
+}
+
+pub(super) fn expect_int(v: &Value) -> InnerResult<i64> {
+    match v {
+        Value::Int(n) => Ok(*n),
+        other => Err(InnerError::new(format!("expected int, got {}", other.type_name()))),
+    }
+}
+
+/// Check that the number of user-visible arguments (i.e. `args` minus the
+/// implicit receiver at index 0) is within `[min, max]`.
+pub(super) fn expect_arity(args: &[Value], min: usize, max: usize) -> InnerResult<()> {
+    let n = args.len().saturating_sub(1);
+    if n >= min && n <= max {
+        return Ok(());
+    }
+    let msg = if min == max {
+        format!("expected {min} argument(s), got {n}")
+    } else {
+        format!("expected {min} to {max} argument(s), got {n}")
+    };
+    Err(InnerError::new(msg))
+}

--- a/engine/runtime/expr/src/core/builtins.rs
+++ b/engine/runtime/expr/src/core/builtins.rs
@@ -14,20 +14,6 @@ use crate::core::value::Value;
 
 pub(super) type MethodFn = fn(&[Value]) -> InnerResult<Value>;
 
-pub(super) fn expect_str(v: &Value) -> InnerResult<&str> {
-    match v {
-        Value::String(s) => Ok(s.as_str()),
-        other => Err(InnerError::new(format!("expected string, got {}", other.type_name()))),
-    }
-}
-
-pub(super) fn expect_int(v: &Value) -> InnerResult<i64> {
-    match v {
-        Value::Int(n) => Ok(*n),
-        other => Err(InnerError::new(format!("expected int, got {}", other.type_name()))),
-    }
-}
-
 /// Check that the number of user-visible arguments (i.e. `args` minus the
 /// implicit receiver at index 0) is within `[min, max]`.
 pub(super) fn expect_arity(args: &[Value], min: usize, max: usize) -> InnerResult<()> {

--- a/engine/runtime/expr/src/core/builtins/array.rs
+++ b/engine/runtime/expr/src/core/builtins/array.rs
@@ -7,7 +7,9 @@ use crate::core::error::{InnerError, InnerResult};
 use crate::core::eval::eval_eq;
 use crate::core::value::{NativeFn, Value};
 
-use super::{expect_arity, MethodFn};
+use crate::expect_arity;
+
+use super::MethodFn;
 
 static METHODS: LazyLock<HashMap<&'static str, MethodFn>> =
     LazyLock::new(|| HashMap::from([("get", get as MethodFn)]));
@@ -35,7 +37,7 @@ pub fn resolve_index(i: i64, len: usize) -> Option<usize> {
 }
 
 fn get(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 1, 2)?;
+    expect_arity("list.get", &args[1..], 1, 2)?;
     let Value::Array(rc) = &args[0] else {
         return Err(InnerError::new("expected array receiver"));
     };

--- a/engine/runtime/expr/src/core/builtins/array.rs
+++ b/engine/runtime/expr/src/core/builtins/array.rs
@@ -7,7 +7,7 @@ use crate::core::error::{InnerError, InnerResult};
 use crate::core::eval::eval_eq;
 use crate::core::value::{NativeFn, Value};
 
-use super::MethodFn;
+use super::{expect_arity, expect_int, MethodFn};
 
 static METHODS: LazyLock<HashMap<&'static str, MethodFn>> =
     LazyLock::new(|| HashMap::from([("get", get as MethodFn)]));
@@ -35,19 +35,14 @@ pub fn resolve_index(i: i64, len: usize) -> Option<usize> {
 }
 
 fn get(args: &[Value]) -> InnerResult<Value> {
-    let (recv, idx, fallback) = match args {
-        [recv, idx] => (recv, idx, None),
-        [recv, idx, fallback] => (recv, idx, Some(fallback)),
-        _ => return Err(InnerError::new("array.get() requires 1 or 2 arguments")),
-    };
-    let Value::Array(rc) = recv else {
+    expect_arity(args, 1, 2)?;
+    let Value::Array(rc) = &args[0] else {
         return Err(InnerError::new("expected array receiver"));
     };
-    let Value::Int(i) = idx else {
-        return Err(InnerError::new("array.get() index must be an integer"));
-    };
+    let i = expect_int(&args[1])?;
+    let fallback = args.get(2);
     let arr = rc.borrow();
-    let elem = resolve_index(*i, arr.len()).map(|pos| arr[pos].clone());
+    let elem = resolve_index(i, arr.len()).map(|pos| arr[pos].clone());
     Ok(elem.unwrap_or_else(|| fallback.cloned().unwrap_or(Value::Null)))
 }
 

--- a/engine/runtime/expr/src/core/builtins/array.rs
+++ b/engine/runtime/expr/src/core/builtins/array.rs
@@ -7,7 +7,7 @@ use crate::core::error::{InnerError, InnerResult};
 use crate::core::eval::eval_eq;
 use crate::core::value::{NativeFn, Value};
 
-use super::{expect_arity, expect_int, MethodFn};
+use super::{expect_arity, MethodFn};
 
 static METHODS: LazyLock<HashMap<&'static str, MethodFn>> =
     LazyLock::new(|| HashMap::from([("get", get as MethodFn)]));
@@ -39,7 +39,7 @@ fn get(args: &[Value]) -> InnerResult<Value> {
     let Value::Array(rc) = &args[0] else {
         return Err(InnerError::new("expected array receiver"));
     };
-    let i = expect_int(&args[1])?;
+    let i = args[1].as_int()?;
     let fallback = args.get(2);
     let arr = rc.borrow();
     let elem = resolve_index(i, arr.len()).map(|pos| arr[pos].clone());

--- a/engine/runtime/expr/src/core/builtins/map.rs
+++ b/engine/runtime/expr/src/core/builtins/map.rs
@@ -8,7 +8,6 @@ use indexmap::IndexMap;
 use crate::core::error::{InnerError, InnerResult};
 use crate::core::eval::eval_eq;
 use crate::core::value::{NativeFn, Value};
-use crate::unpack_args;
 
 use super::{expect_arity, MethodFn};
 
@@ -34,8 +33,8 @@ pub fn resolve_method(recv: Value, method: &str) -> InnerResult<NativeFn> {
 }
 
 fn keys(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => recv);
-    let Value::Map(rc) = recv else {
+    expect_arity(args, 0, 0)?;
+    let Value::Map(rc) = &args[0] else {
         return Err(InnerError::new("expected map receiver"));
     };
     Ok(Value::array(
@@ -47,16 +46,16 @@ fn keys(args: &[Value]) -> InnerResult<Value> {
 }
 
 fn values(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => recv);
-    let Value::Map(rc) = recv else {
+    expect_arity(args, 0, 0)?;
+    let Value::Map(rc) = &args[0] else {
         return Err(InnerError::new("expected map receiver"));
     };
     Ok(Value::array(rc.borrow().values().cloned().collect()))
 }
 
 fn items(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => recv);
-    let Value::Map(rc) = recv else {
+    expect_arity(args, 0, 0)?;
+    let Value::Map(rc) = &args[0] else {
         return Err(InnerError::new("expected map receiver"));
     };
     Ok(Value::array(

--- a/engine/runtime/expr/src/core/builtins/map.rs
+++ b/engine/runtime/expr/src/core/builtins/map.rs
@@ -10,7 +10,7 @@ use crate::core::eval::eval_eq;
 use crate::core::value::{NativeFn, Value};
 use crate::unpack_args;
 
-use super::MethodFn;
+use super::{expect_arity, expect_str, MethodFn};
 
 static METHODS: LazyLock<HashMap<&'static str, MethodFn>> = LazyLock::new(|| {
     HashMap::from([
@@ -68,20 +68,15 @@ fn items(args: &[Value]) -> InnerResult<Value> {
 }
 
 fn get(args: &[Value]) -> InnerResult<Value> {
-    let (recv, key, fallback) = match args {
-        [recv, key] => (recv, key, None),
-        [recv, key, fallback] => (recv, key, Some(fallback)),
-        _ => return Err(InnerError::new("map.get() requires 1 or 2 arguments")),
-    };
-    let Value::Map(rc) = recv else {
+    expect_arity(args, 1, 2)?;
+    let Value::Map(rc) = &args[0] else {
         return Err(InnerError::new("expected map receiver"));
     };
-    let Value::String(k) = key else {
-        return Err(InnerError::new("map.get() key must be a string"));
-    };
+    let k = expect_str(&args[1])?;
+    let fallback = args.get(2);
     Ok(rc
         .borrow()
-        .get(k.as_str())
+        .get(k)
         .cloned()
         .unwrap_or_else(|| fallback.cloned().unwrap_or(Value::Null)))
 }

--- a/engine/runtime/expr/src/core/builtins/map.rs
+++ b/engine/runtime/expr/src/core/builtins/map.rs
@@ -10,7 +10,7 @@ use crate::core::eval::eval_eq;
 use crate::core::value::{NativeFn, Value};
 use crate::unpack_args;
 
-use super::{expect_arity, expect_str, MethodFn};
+use super::{expect_arity, MethodFn};
 
 static METHODS: LazyLock<HashMap<&'static str, MethodFn>> = LazyLock::new(|| {
     HashMap::from([
@@ -72,7 +72,7 @@ fn get(args: &[Value]) -> InnerResult<Value> {
     let Value::Map(rc) = &args[0] else {
         return Err(InnerError::new("expected map receiver"));
     };
-    let k = expect_str(&args[1])?;
+    let k = args[1].as_str()?;
     let fallback = args.get(2);
     Ok(rc
         .borrow()

--- a/engine/runtime/expr/src/core/builtins/map.rs
+++ b/engine/runtime/expr/src/core/builtins/map.rs
@@ -8,8 +8,9 @@ use indexmap::IndexMap;
 use crate::core::error::{InnerError, InnerResult};
 use crate::core::eval::eval_eq;
 use crate::core::value::{NativeFn, Value};
+use crate::expect_arity;
 
-use super::{expect_arity, MethodFn};
+use super::MethodFn;
 
 static METHODS: LazyLock<HashMap<&'static str, MethodFn>> = LazyLock::new(|| {
     HashMap::from([
@@ -33,7 +34,7 @@ pub fn resolve_method(recv: Value, method: &str) -> InnerResult<NativeFn> {
 }
 
 fn keys(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 0, 0)?;
+    expect_arity("map.keys", &args[1..], 0, 0)?;
     let Value::Map(rc) = &args[0] else {
         return Err(InnerError::new("expected map receiver"));
     };
@@ -46,7 +47,7 @@ fn keys(args: &[Value]) -> InnerResult<Value> {
 }
 
 fn values(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 0, 0)?;
+    expect_arity("map.values", &args[1..], 0, 0)?;
     let Value::Map(rc) = &args[0] else {
         return Err(InnerError::new("expected map receiver"));
     };
@@ -54,7 +55,7 @@ fn values(args: &[Value]) -> InnerResult<Value> {
 }
 
 fn items(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 0, 0)?;
+    expect_arity("map.items", &args[1..], 0, 0)?;
     let Value::Map(rc) = &args[0] else {
         return Err(InnerError::new("expected map receiver"));
     };
@@ -67,7 +68,7 @@ fn items(args: &[Value]) -> InnerResult<Value> {
 }
 
 fn get(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 1, 2)?;
+    expect_arity("map.get", &args[1..], 1, 2)?;
     let Value::Map(rc) = &args[0] else {
         return Err(InnerError::new("expected map receiver"));
     };

--- a/engine/runtime/expr/src/core/builtins/math.rs
+++ b/engine/runtime/expr/src/core/builtins/math.rs
@@ -1,13 +1,10 @@
-use crate::core::error::InnerError;
 use crate::core::value::{Module, NativeFn, Value};
+use crate::expect_arity;
 
 fn unary_float(name: &'static str, f: fn(f64) -> f64) -> Value {
-    Value::Fn(NativeFn::new(move |args| match args {
-        [x] => Ok(Value::Float(f(x.as_f64()?))),
-        _ => Err(InnerError::new(format!(
-            "math.{name}() expected 1 argument, got {}",
-            args.len()
-        ))),
+    Value::Fn(NativeFn::new(move |args| {
+        expect_arity(&format!("math.{name}"), args, 1, 1)?;
+        Ok(Value::Float(f(args[0].as_f64()?)))
     }))
 }
 
@@ -20,13 +17,14 @@ pub fn builtin_math() -> Value {
     m.insert("round".into(), unary_float("round", f64::round));
     m.insert(
         "log".into(),
-        Value::Fn(NativeFn::new(|args| match args {
-            [x] => Ok(Value::Float(x.as_f64()?.ln())),
-            [x, base] => Ok(Value::Float(x.as_f64()?.log(base.as_f64()?))),
-            _ => Err(InnerError::new(format!(
-                "math.log() expected 1 or 2 arguments, got {}",
-                args.len()
-            ))),
+        Value::Fn(NativeFn::new(|args| {
+            expect_arity("math.log", args, 1, 2)?;
+            let x = args[0].as_f64()?;
+            if args.len() == 1 {
+                Ok(Value::Float(x.ln()))
+            } else {
+                Ok(Value::Float(x.log(args[1].as_f64()?)))
+            }
         })),
     );
     m.insert("log2".into(), unary_float("log2", f64::log2));

--- a/engine/runtime/expr/src/core/builtins/math.rs
+++ b/engine/runtime/expr/src/core/builtins/math.rs
@@ -2,8 +2,9 @@ use crate::core::value::{Module, NativeFn, Value};
 use crate::expect_arity;
 
 fn unary_float(name: &'static str, f: fn(f64) -> f64) -> Value {
+    let full_name = format!("math.{name}");
     Value::Fn(NativeFn::new(move |args| {
-        expect_arity(&format!("math.{name}"), args, 1, 1)?;
+        expect_arity(&full_name, args, 1, 1)?;
         Ok(Value::Float(f(args[0].as_f64()?)))
     }))
 }

--- a/engine/runtime/expr/src/core/builtins/math.rs
+++ b/engine/runtime/expr/src/core/builtins/math.rs
@@ -1,20 +1,9 @@
 use crate::core::error::{InnerError, InnerResult};
 use crate::core::value::{Module, NativeFn, Value};
 
-fn to_f64(v: &Value) -> InnerResult<f64> {
-    match v {
-        Value::Float(x) => Ok(*x),
-        Value::Int(x) => Ok(*x as f64),
-        other => Err(InnerError::new(format!(
-            "expected float, got {}",
-            other.type_name()
-        ))),
-    }
-}
-
 fn unary_float(name: &'static str, f: fn(f64) -> f64) -> Value {
     Value::Fn(NativeFn::new(move |args| match args {
-        [x] => Ok(Value::Float(f(to_f64(x)?))),
+        [x] => Ok(Value::Float(f(x.as_f64()?))),
         _ => Err(InnerError::new(format!(
             "math.{name}() expected 1 argument, got {}",
             args.len()
@@ -32,8 +21,8 @@ pub fn builtin_math() -> Value {
     m.insert(
         "log".into(),
         Value::Fn(NativeFn::new(|args| match args {
-            [x] => Ok(Value::Float(to_f64(x)?.ln())),
-            [x, base] => Ok(Value::Float(to_f64(x)?.log(to_f64(base)?))),
+            [x] => Ok(Value::Float(x.as_f64()?.ln())),
+            [x, base] => Ok(Value::Float(x.as_f64()?.log(base.as_f64()?))),
             _ => Err(InnerError::new(format!(
                 "math.log() expected 1 or 2 arguments, got {}",
                 args.len()

--- a/engine/runtime/expr/src/core/builtins/math.rs
+++ b/engine/runtime/expr/src/core/builtins/math.rs
@@ -1,4 +1,4 @@
-use crate::core::error::{InnerError, InnerResult};
+use crate::core::error::InnerError;
 use crate::core::value::{Module, NativeFn, Value};
 
 fn unary_float(name: &'static str, f: fn(f64) -> f64) -> Value {

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -60,8 +60,7 @@ fn capture_to_value(cap: &regex::Captures, num_groups: usize) -> Value {
     }
 }
 
-// note that `if Regex(".*").find("1")` is falsy even though constructing patterns that match empty string is considered bad practice
-// Still, for dynamic/user input pattern, it is safer to test with `== null`
+// null-as-falsy is intentional — see docs/design.md#regex-find-null-falsy
 fn regex_find(regex: &Regex, s: &str) -> Value {
     let num_groups = regex.captures_len() - 1;
     if num_groups == 0 {

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -3,8 +3,6 @@ use crate::core::value::{ImmutableObject, Value};
 use crate::unpack_args;
 use regex::Regex;
 
-use super::expect_str;
-
 #[derive(Debug, Clone)]
 pub struct RegexObject {
     pattern: String,
@@ -24,11 +22,11 @@ impl ImmutableObject for RegexObject {
         match method {
             "find" => {
                 unpack_args!(args => s);
-                Ok(regex_find(&self.regex, expect_str(s)?))
+                Ok(regex_find(&self.regex, s.as_str()?))
             }
             "find_all" => {
                 unpack_args!(args => s);
-                Ok(Value::array(regex_find_all(&self.regex, expect_str(s)?)))
+                Ok(Value::array(regex_find_all(&self.regex, s.as_str()?)))
             }
             m => Err(InnerError::new(format!("Regex has no method '{m}'"))),
         }
@@ -101,7 +99,7 @@ pub fn builtin_regex(args: &[Value]) -> InnerResult<Value> {
             args.len()
         )));
     }
-    let pattern = expect_str(&args[0])?.to_string();
+    let pattern = args[0].as_str()?.to_string();
     // FlowExpr is general-purpose. Do not do implicit caching for Regex patterns here.
     // Compile-time constant folding might be a proper future solution, but currently it is overkill.
     let regex = Regex::new(&pattern).map_err(|e| InnerError::new(format!("invalid regex: {e}")))?;

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -3,6 +3,8 @@ use crate::core::value::{ImmutableObject, Value};
 use crate::unpack_args;
 use regex::Regex;
 
+use super::expect_str;
+
 #[derive(Debug, Clone)]
 pub struct RegexObject {
     pattern: String,
@@ -22,19 +24,11 @@ impl ImmutableObject for RegexObject {
         match method {
             "find" => {
                 unpack_args!(args => s);
-                let Value::String(s) = s else {
-                    return Err(InnerError::new("Regex.find() requires a string argument"));
-                };
-                Ok(regex_find(&self.regex, s))
+                Ok(regex_find(&self.regex, expect_str(s)?))
             }
             "find_all" => {
                 unpack_args!(args => s);
-                let Value::String(s) = s else {
-                    return Err(InnerError::new(
-                        "Regex.find_all() requires a string argument",
-                    ));
-                };
-                Ok(Value::array(regex_find_all(&self.regex, s)))
+                Ok(Value::array(regex_find_all(&self.regex, expect_str(s)?)))
             }
             m => Err(InnerError::new(format!("Regex has no method '{m}'"))),
         }
@@ -107,15 +101,7 @@ pub fn builtin_regex(args: &[Value]) -> InnerResult<Value> {
             args.len()
         )));
     }
-    let pattern = match &args[0] {
-        Value::String(s) => s.clone(),
-        v => {
-            return Err(InnerError::new(format!(
-                "Regex() expects a string, got {}",
-                v.type_name()
-            )))
-        }
-    };
+    let pattern = expect_str(&args[0])?.to_string();
     // FlowExpr is general-purpose. Do not do implicit caching for Regex patterns here.
     // Compile-time constant folding might be a proper future solution, but currently it is overkill.
     let regex = Regex::new(&pattern).map_err(|e| InnerError::new(format!("invalid regex: {e}")))?;

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -1,6 +1,7 @@
 use crate::core::error::{InnerError, InnerResult};
 use crate::core::value::{ImmutableObject, Value};
-use crate::unpack_args;
+
+use crate::expect_arity;
 use regex::Regex;
 
 #[derive(Debug, Clone)]
@@ -21,12 +22,12 @@ impl ImmutableObject for RegexObject {
     fn call_method(&self, method: &str, args: &[Value]) -> InnerResult<Value> {
         match method {
             "find" => {
-                unpack_args!(args => s);
-                Ok(regex_find(&self.regex, s.as_str()?))
+                expect_arity("Regex.find", args, 1, 1)?;
+                Ok(regex_find(&self.regex, args[0].as_str()?))
             }
             "find_all" => {
-                unpack_args!(args => s);
-                Ok(Value::array(regex_find_all(&self.regex, s.as_str()?)))
+                expect_arity("Regex.find_all", args, 1, 1)?;
+                Ok(Value::array(regex_find_all(&self.regex, args[0].as_str()?)))
             }
             m => Err(InnerError::new(format!("Regex has no method '{m}'"))),
         }

--- a/engine/runtime/expr/src/core/builtins/str.rs
+++ b/engine/runtime/expr/src/core/builtins/str.rs
@@ -5,7 +5,7 @@ use crate::core::error::{InnerError, InnerResult};
 use crate::core::value::{NativeFn, Value};
 use crate::unpack_args;
 
-use super::{expect_arity, expect_int, expect_str, MethodFn};
+use super::{expect_arity, MethodFn};
 
 static METHODS: LazyLock<HashMap<&'static str, MethodFn>> = LazyLock::new(|| {
     HashMap::from([
@@ -35,11 +35,11 @@ pub fn resolve_method(recv: Value, method: &str) -> InnerResult<NativeFn> {
 
 fn trim(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s);
-    Ok(Value::String(expect_str(s)?.trim().to_string()))
+    Ok(Value::String(s.as_str()?.trim().to_string()))
 }
 
 fn split_limit(v: &Value) -> InnerResult<usize> {
-    let n = expect_int(v)?;
+    let n = v.as_int()?;
     if n < 0 {
         return Err(InnerError::new("limit must be non-negative"));
     }
@@ -48,11 +48,14 @@ fn split_limit(v: &Value) -> InnerResult<usize> {
 
 fn split(args: &[Value]) -> InnerResult<Value> {
     expect_arity(args, 1, 2)?;
-    let s = expect_str(&args[0])?;
-    let sep = expect_str(&args[1])?;
+    let s = args[0].as_str()?;
+    let sep = args[1].as_str()?;
     let n = args.get(2).map(split_limit).transpose()?;
     let parts: Vec<Value> = match n {
-        Some(n) => s.splitn(n + 1, sep).map(|p| Value::String(p.to_string())).collect(),
+        Some(n) => s
+            .splitn(n + 1, sep)
+            .map(|p| Value::String(p.to_string()))
+            .collect(),
         None => s.split(sep).map(|p| Value::String(p.to_string())).collect(),
     };
     Ok(Value::array(parts))
@@ -60,11 +63,14 @@ fn split(args: &[Value]) -> InnerResult<Value> {
 
 fn rsplit(args: &[Value]) -> InnerResult<Value> {
     expect_arity(args, 1, 2)?;
-    let s = expect_str(&args[0])?;
-    let sep = expect_str(&args[1])?;
+    let s = args[0].as_str()?;
+    let sep = args[1].as_str()?;
     let n = args.get(2).map(split_limit).transpose()?;
     let mut parts: Vec<Value> = match n {
-        Some(n) => s.rsplitn(n + 1, sep).map(|p| Value::String(p.to_string())).collect(),
+        Some(n) => s
+            .rsplitn(n + 1, sep)
+            .map(|p| Value::String(p.to_string()))
+            .collect(),
         None => s.split(sep).map(|p| Value::String(p.to_string())).collect(),
     };
     if n.is_some() {
@@ -75,32 +81,34 @@ fn rsplit(args: &[Value]) -> InnerResult<Value> {
 
 fn starts_with(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s, prefix);
-    Ok(Value::Bool(expect_str(s)?.starts_with(expect_str(prefix)?)))
+    Ok(Value::Bool(s.as_str()?.starts_with(prefix.as_str()?)))
 }
 
 fn ends_with(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s, suffix);
-    Ok(Value::Bool(expect_str(s)?.ends_with(expect_str(suffix)?)))
+    Ok(Value::Bool(s.as_str()?.ends_with(suffix.as_str()?)))
 }
 
 fn remove_prefix(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s, prefix);
-    let s = expect_str(s)?;
-    let prefix = expect_str(prefix)?;
-    Ok(Value::String(s.strip_prefix(prefix).unwrap_or(s).to_string()))
+    let s = s.as_str()?;
+    let prefix = prefix.as_str()?;
+    Ok(Value::String(
+        s.strip_prefix(prefix).unwrap_or(s).to_string(),
+    ))
 }
 
 fn replace(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s, from, to);
-    let s = expect_str(s)?;
-    let from = expect_str(from)?;
-    let to = expect_str(to)?;
+    let s = s.as_str()?;
+    let from = from.as_str()?;
+    let to = to.as_str()?;
     Ok(Value::String(s.replace(from, to)))
 }
 
 fn join(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => sep, list);
-    let sep = expect_str(sep)?;
+    let sep = sep.as_str()?;
     let Value::Array(list) = list else {
         return Err(InnerError::new(format!(
             "join() argument must be an array, got {}",
@@ -123,9 +131,11 @@ fn join(args: &[Value]) -> InnerResult<Value> {
 
 fn remove_suffix(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s, suffix);
-    let s = expect_str(s)?;
-    let suffix = expect_str(suffix)?;
-    Ok(Value::String(s.strip_suffix(suffix).unwrap_or(s).to_string()))
+    let s = s.as_str()?;
+    let suffix = suffix.as_str()?;
+    Ok(Value::String(
+        s.strip_suffix(suffix).unwrap_or(s).to_string(),
+    ))
 }
 
 #[cfg(test)]

--- a/engine/runtime/expr/src/core/builtins/str.rs
+++ b/engine/runtime/expr/src/core/builtins/str.rs
@@ -232,11 +232,7 @@ mod tests {
 
     #[test]
     fn test_join() {
-        assert_eval(
-            r#"", ".join(["a", "b", "c"])"#,
-            &[],
-            Value::from("a, b, c"),
-        );
+        assert_eval(r#"", ".join(["a", "b", "c"])"#, &[], Value::from("a, b, c"));
         assert_eval(r#""".join(["x", "y"])"#, &[], Value::from("xy"));
         assert_eval(r#""-".join([])"#, &[], Value::from(""));
     }

--- a/engine/runtime/expr/src/core/builtins/str.rs
+++ b/engine/runtime/expr/src/core/builtins/str.rs
@@ -16,6 +16,7 @@ static METHODS: LazyLock<HashMap<&'static str, MethodFn>> = LazyLock::new(|| {
         ("replace", replace as MethodFn),
         ("remove_prefix", remove_prefix as MethodFn),
         ("remove_suffix", remove_suffix as MethodFn),
+        ("join", join as MethodFn),
     ])
 });
 
@@ -114,6 +115,31 @@ fn replace(args: &[Value]) -> InnerResult<Value> {
     Ok(Value::String(s.replace(from.as_str(), to.as_str())))
 }
 
+fn join(args: &[Value]) -> InnerResult<Value> {
+    unpack_args!(args => sep, list);
+    let Value::String(sep) = sep else {
+        return Err(InnerError::new("expected string receiver"));
+    };
+    let Value::Array(list) = list else {
+        return Err(InnerError::new(format!(
+            "join() argument must be an array, got {}",
+            list.type_name()
+        )));
+    };
+    let parts = list
+        .borrow()
+        .iter()
+        .map(|v| match v {
+            Value::String(s) => Ok(s.clone()),
+            other => Err(InnerError::new(format!(
+                "join() array elements must be strings, got {}",
+                other.type_name()
+            ))),
+        })
+        .collect::<InnerResult<Vec<_>>>()?;
+    Ok(Value::String(parts.join(sep.as_str())))
+}
+
 fn remove_suffix(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s, suffix);
     let Value::String(s) = s else {
@@ -202,6 +228,17 @@ mod tests {
             Value::from("foo/bar/baz"),
         );
         assert_eval(r#""hello".replace("x", "y")"#, &[], Value::from("hello"));
+    }
+
+    #[test]
+    fn test_join() {
+        assert_eval(
+            r#"", ".join(["a", "b", "c"])"#,
+            &[],
+            Value::from("a, b, c"),
+        );
+        assert_eval(r#""".join(["x", "y"])"#, &[], Value::from("xy"));
+        assert_eval(r#""-".join([])"#, &[], Value::from(""));
     }
 
     #[test]

--- a/engine/runtime/expr/src/core/builtins/str.rs
+++ b/engine/runtime/expr/src/core/builtins/str.rs
@@ -3,7 +3,6 @@ use std::sync::LazyLock;
 
 use crate::core::error::{InnerError, InnerResult};
 use crate::core::value::{NativeFn, Value};
-use crate::unpack_args;
 
 use super::{expect_arity, MethodFn};
 
@@ -34,8 +33,8 @@ pub fn resolve_method(recv: Value, method: &str) -> InnerResult<NativeFn> {
 }
 
 fn trim(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => s);
-    Ok(Value::String(s.as_str()?.trim().to_string()))
+    expect_arity(args, 0, 0)?;
+    Ok(Value::String(args[0].as_str()?.trim().to_string()))
 }
 
 fn split_limit(v: &Value) -> InnerResult<usize> {
@@ -80,39 +79,41 @@ fn rsplit(args: &[Value]) -> InnerResult<Value> {
 }
 
 fn starts_with(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => s, prefix);
-    Ok(Value::Bool(s.as_str()?.starts_with(prefix.as_str()?)))
+    expect_arity(args, 1, 1)?;
+    Ok(Value::Bool(
+        args[0].as_str()?.starts_with(args[1].as_str()?),
+    ))
 }
 
 fn ends_with(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => s, suffix);
-    Ok(Value::Bool(s.as_str()?.ends_with(suffix.as_str()?)))
+    expect_arity(args, 1, 1)?;
+    Ok(Value::Bool(args[0].as_str()?.ends_with(args[1].as_str()?)))
 }
 
 fn remove_prefix(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => s, prefix);
-    let s = s.as_str()?;
-    let prefix = prefix.as_str()?;
+    expect_arity(args, 1, 1)?;
+    let s = args[0].as_str()?;
+    let prefix = args[1].as_str()?;
     Ok(Value::String(
         s.strip_prefix(prefix).unwrap_or(s).to_string(),
     ))
 }
 
 fn replace(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => s, from, to);
-    let s = s.as_str()?;
-    let from = from.as_str()?;
-    let to = to.as_str()?;
+    expect_arity(args, 2, 2)?;
+    let s = args[0].as_str()?;
+    let from = args[1].as_str()?;
+    let to = args[2].as_str()?;
     Ok(Value::String(s.replace(from, to)))
 }
 
 fn join(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => sep, list);
-    let sep = sep.as_str()?;
-    let Value::Array(list) = list else {
+    expect_arity(args, 1, 1)?;
+    let sep = args[0].as_str()?;
+    let Value::Array(list) = &args[1] else {
         return Err(InnerError::new(format!(
             "join() argument must be an array, got {}",
-            list.type_name()
+            args[1].type_name()
         )));
     };
     let parts = list
@@ -130,9 +131,9 @@ fn join(args: &[Value]) -> InnerResult<Value> {
 }
 
 fn remove_suffix(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => s, suffix);
-    let s = s.as_str()?;
-    let suffix = suffix.as_str()?;
+    expect_arity(args, 1, 1)?;
+    let s = args[0].as_str()?;
+    let suffix = args[1].as_str()?;
     Ok(Value::String(
         s.strip_suffix(suffix).unwrap_or(s).to_string(),
     ))

--- a/engine/runtime/expr/src/core/builtins/str.rs
+++ b/engine/runtime/expr/src/core/builtins/str.rs
@@ -5,12 +5,13 @@ use crate::core::error::{InnerError, InnerResult};
 use crate::core::value::{NativeFn, Value};
 use crate::unpack_args;
 
-use super::MethodFn;
+use super::{expect_arity, expect_int, expect_str, MethodFn};
 
 static METHODS: LazyLock<HashMap<&'static str, MethodFn>> = LazyLock::new(|| {
     HashMap::from([
         ("trim", trim as MethodFn),
         ("split", split as MethodFn),
+        ("rsplit", rsplit as MethodFn),
         ("starts_with", starts_with as MethodFn),
         ("ends_with", ends_with as MethodFn),
         ("replace", replace as MethodFn),
@@ -34,92 +35,72 @@ pub fn resolve_method(recv: Value, method: &str) -> InnerResult<NativeFn> {
 
 fn trim(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s);
-    let Value::String(s) = s else {
-        return Err(InnerError::new("expected string receiver"));
-    };
-    Ok(Value::String(s.trim().to_string()))
+    Ok(Value::String(expect_str(s)?.trim().to_string()))
+}
+
+fn split_limit(v: &Value) -> InnerResult<usize> {
+    let n = expect_int(v)?;
+    if n < 0 {
+        return Err(InnerError::new("limit must be non-negative"));
+    }
+    Ok(n as usize)
 }
 
 fn split(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => s, sep);
-    let Value::String(s) = s else {
-        return Err(InnerError::new("expected string receiver"));
+    expect_arity(args, 1, 2)?;
+    let s = expect_str(&args[0])?;
+    let sep = expect_str(&args[1])?;
+    let n = args.get(2).map(split_limit).transpose()?;
+    let parts: Vec<Value> = match n {
+        Some(n) => s.splitn(n + 1, sep).map(|p| Value::String(p.to_string())).collect(),
+        None => s.split(sep).map(|p| Value::String(p.to_string())).collect(),
     };
-    let Value::String(sep) = sep else {
-        return Err(InnerError::new(format!(
-            "split() separator must be a string, got {}",
-            sep.type_name()
-        )));
+    Ok(Value::array(parts))
+}
+
+fn rsplit(args: &[Value]) -> InnerResult<Value> {
+    expect_arity(args, 1, 2)?;
+    let s = expect_str(&args[0])?;
+    let sep = expect_str(&args[1])?;
+    let n = args.get(2).map(split_limit).transpose()?;
+    let mut parts: Vec<Value> = match n {
+        Some(n) => s.rsplitn(n + 1, sep).map(|p| Value::String(p.to_string())).collect(),
+        None => s.split(sep).map(|p| Value::String(p.to_string())).collect(),
     };
-    Ok(Value::array(
-        s.split(sep.as_str())
-            .map(|p| Value::String(p.to_string()))
-            .collect(),
-    ))
+    if n.is_some() {
+        parts.reverse();
+    }
+    Ok(Value::array(parts))
 }
 
 fn starts_with(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s, prefix);
-    let Value::String(s) = s else {
-        return Err(InnerError::new("expected string receiver"));
-    };
-    let Value::String(prefix) = prefix else {
-        return Err(InnerError::new(format!(
-            "starts_with() argument must be a string, got {}",
-            prefix.type_name()
-        )));
-    };
-    Ok(Value::Bool(s.starts_with(prefix.as_str())))
+    Ok(Value::Bool(expect_str(s)?.starts_with(expect_str(prefix)?)))
 }
 
 fn ends_with(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s, suffix);
-    let Value::String(s) = s else {
-        return Err(InnerError::new("expected string receiver"));
-    };
-    let Value::String(suffix) = suffix else {
-        return Err(InnerError::new(format!(
-            "ends_with() argument must be a string, got {}",
-            suffix.type_name()
-        )));
-    };
-    Ok(Value::Bool(s.ends_with(suffix.as_str())))
+    Ok(Value::Bool(expect_str(s)?.ends_with(expect_str(suffix)?)))
 }
 
 fn remove_prefix(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s, prefix);
-    let Value::String(s) = s else {
-        return Err(InnerError::new("expected string receiver"));
-    };
-    let Value::String(prefix) = prefix else {
-        return Err(InnerError::new(format!(
-            "remove_prefix() argument must be a string, got {}",
-            prefix.type_name()
-        )));
-    };
-    Ok(Value::String(
-        s.strip_prefix(prefix.as_str()).unwrap_or(s).to_string(),
-    ))
+    let s = expect_str(s)?;
+    let prefix = expect_str(prefix)?;
+    Ok(Value::String(s.strip_prefix(prefix).unwrap_or(s).to_string()))
 }
 
 fn replace(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s, from, to);
-    let Value::String(s) = s else {
-        return Err(InnerError::new("expected string receiver"));
-    };
-    let (Value::String(from), Value::String(to)) = (from, to) else {
-        return Err(InnerError::new(
-            "replace() requires two string arguments: replace(from, to)",
-        ));
-    };
-    Ok(Value::String(s.replace(from.as_str(), to.as_str())))
+    let s = expect_str(s)?;
+    let from = expect_str(from)?;
+    let to = expect_str(to)?;
+    Ok(Value::String(s.replace(from, to)))
 }
 
 fn join(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => sep, list);
-    let Value::String(sep) = sep else {
-        return Err(InnerError::new("expected string receiver"));
-    };
+    let sep = expect_str(sep)?;
     let Value::Array(list) = list else {
         return Err(InnerError::new(format!(
             "join() argument must be an array, got {}",
@@ -137,23 +118,14 @@ fn join(args: &[Value]) -> InnerResult<Value> {
             ))),
         })
         .collect::<InnerResult<Vec<_>>>()?;
-    Ok(Value::String(parts.join(sep.as_str())))
+    Ok(Value::String(parts.join(sep)))
 }
 
 fn remove_suffix(args: &[Value]) -> InnerResult<Value> {
     unpack_args!(args => s, suffix);
-    let Value::String(s) = s else {
-        return Err(InnerError::new("expected string receiver"));
-    };
-    let Value::String(suffix) = suffix else {
-        return Err(InnerError::new(format!(
-            "remove_suffix() argument must be a string, got {}",
-            suffix.type_name()
-        )));
-    };
-    Ok(Value::String(
-        s.strip_suffix(suffix.as_str()).unwrap_or(s).to_string(),
-    ))
+    let s = expect_str(s)?;
+    let suffix = expect_str(suffix)?;
+    Ok(Value::String(s.strip_suffix(suffix).unwrap_or(s).to_string()))
 }
 
 #[cfg(test)]
@@ -217,6 +189,20 @@ mod tests {
     fn test_split() {
         assert_eval(r#""foo:bar".split(":")[0]"#, &[], Value::from("foo"));
         assert_eval(r#""foo:bar".split(":")[-1]"#, &[], Value::from("bar"));
+        assert_eval(r#""a/b/c".split("/", 1)[0]"#, &[], Value::from("a"));
+        assert_eval(r#""a/b/c".split("/", 1)[1]"#, &[], Value::from("b/c"));
+    }
+
+    #[test]
+    fn test_rsplit() {
+        assert_eval(r#""a/b/c".rsplit("/")[-1]"#, &[], Value::from("c"));
+        assert_eval(r#""a/b/c".rsplit("/", 1)[-1]"#, &[], Value::from("c"));
+        assert_eval(r#""a/b/c".rsplit("/", 1)[0]"#, &[], Value::from("a/b"));
+        assert_eval(
+            r#""path/to/file.txt".rsplit("/", 1)[-1]"#,
+            &[],
+            Value::from("file.txt"),
+        );
     }
 
     #[test]

--- a/engine/runtime/expr/src/core/builtins/str.rs
+++ b/engine/runtime/expr/src/core/builtins/str.rs
@@ -3,8 +3,9 @@ use std::sync::LazyLock;
 
 use crate::core::error::{InnerError, InnerResult};
 use crate::core::value::{NativeFn, Value};
+use crate::expect_arity;
 
-use super::{expect_arity, MethodFn};
+use super::MethodFn;
 
 static METHODS: LazyLock<HashMap<&'static str, MethodFn>> = LazyLock::new(|| {
     HashMap::from([
@@ -33,7 +34,7 @@ pub fn resolve_method(recv: Value, method: &str) -> InnerResult<NativeFn> {
 }
 
 fn trim(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 0, 0)?;
+    expect_arity("str.trim", &args[1..], 0, 0)?;
     Ok(Value::String(args[0].as_str()?.trim().to_string()))
 }
 
@@ -46,7 +47,7 @@ fn split_limit(v: &Value) -> InnerResult<usize> {
 }
 
 fn split(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 1, 2)?;
+    expect_arity("str.split", &args[1..], 1, 2)?;
     let s = args[0].as_str()?;
     let sep = args[1].as_str()?;
     let n = args.get(2).map(split_limit).transpose()?;
@@ -61,7 +62,7 @@ fn split(args: &[Value]) -> InnerResult<Value> {
 }
 
 fn rsplit(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 1, 2)?;
+    expect_arity("str.rsplit", &args[1..], 1, 2)?;
     let s = args[0].as_str()?;
     let sep = args[1].as_str()?;
     let n = args.get(2).map(split_limit).transpose()?;
@@ -79,36 +80,35 @@ fn rsplit(args: &[Value]) -> InnerResult<Value> {
 }
 
 fn starts_with(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 1, 1)?;
+    expect_arity("str.starts_with", &args[1..], 1, 1)?;
     Ok(Value::Bool(
         args[0].as_str()?.starts_with(args[1].as_str()?),
     ))
 }
 
 fn ends_with(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 1, 1)?;
+    expect_arity("str.ends_with", &args[1..], 1, 1)?;
     Ok(Value::Bool(args[0].as_str()?.ends_with(args[1].as_str()?)))
 }
 
 fn remove_prefix(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 1, 1)?;
+    expect_arity("str.remove_prefix", &args[1..], 1, 1)?;
     let s = args[0].as_str()?;
-    let prefix = args[1].as_str()?;
-    Ok(Value::String(
-        s.strip_prefix(prefix).unwrap_or(s).to_string(),
-    ))
+    let p = args[1].as_str()?;
+    Ok(Value::String(s.strip_prefix(p).unwrap_or(s).to_string()))
 }
 
 fn replace(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 2, 2)?;
-    let s = args[0].as_str()?;
-    let from = args[1].as_str()?;
-    let to = args[2].as_str()?;
-    Ok(Value::String(s.replace(from, to)))
+    expect_arity("str.replace", &args[1..], 2, 2)?;
+    Ok(Value::String(
+        args[0]
+            .as_str()?
+            .replace(args[1].as_str()?, args[2].as_str()?),
+    ))
 }
 
 fn join(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 1, 1)?;
+    expect_arity("str.join", &args[1..], 1, 1)?;
     let sep = args[0].as_str()?;
     let Value::Array(list) = &args[1] else {
         return Err(InnerError::new(format!(
@@ -131,12 +131,10 @@ fn join(args: &[Value]) -> InnerResult<Value> {
 }
 
 fn remove_suffix(args: &[Value]) -> InnerResult<Value> {
-    expect_arity(args, 1, 1)?;
+    expect_arity("str.remove_suffix", &args[1..], 1, 1)?;
     let s = args[0].as_str()?;
-    let suffix = args[1].as_str()?;
-    Ok(Value::String(
-        s.strip_suffix(suffix).unwrap_or(s).to_string(),
-    ))
+    let suf = args[1].as_str()?;
+    Ok(Value::String(s.strip_suffix(suf).unwrap_or(s).to_string()))
 }
 
 #[cfg(test)]

--- a/engine/runtime/expr/src/core/builtins/url.rs
+++ b/engine/runtime/expr/src/core/builtins/url.rs
@@ -3,6 +3,8 @@ use crate::core::value::{ImmutableObject, Value};
 use crate::unpack_args;
 use url::Url;
 
+use super::expect_str;
+
 fn parse_url(s: &str) -> Result<UrlObject, String> {
     let url = if s.contains("://") {
         Url::parse(s).map_err(|e| format!("not a valid URI: {e}"))?
@@ -86,9 +88,7 @@ impl ImmutableObject for UrlObject {
             }
             "__div__" => {
                 unpack_args!(args => rhs);
-                let Value::String(rhs) = rhs else {
-                    return Err(InnerError::new("Url / requires a string"));
-                };
+                let rhs = expect_str(rhs)?;
                 let new_path = format!("{}/{rhs}", self.url.path().trim_end_matches('/'));
                 let mut url = self.url.clone();
                 url.set_path(&new_path);

--- a/engine/runtime/expr/src/core/builtins/url.rs
+++ b/engine/runtime/expr/src/core/builtins/url.rs
@@ -3,8 +3,6 @@ use crate::core::value::{ImmutableObject, Value};
 use crate::unpack_args;
 use url::Url;
 
-use super::expect_str;
-
 fn parse_url(s: &str) -> Result<UrlObject, String> {
     let url = if s.contains("://") {
         Url::parse(s).map_err(|e| format!("not a valid URI: {e}"))?
@@ -88,7 +86,7 @@ impl ImmutableObject for UrlObject {
             }
             "__div__" => {
                 unpack_args!(args => rhs);
-                let rhs = expect_str(rhs)?;
+                let rhs = rhs.as_str()?;
                 let new_path = format!("{}/{rhs}", self.url.path().trim_end_matches('/'));
                 let mut url = self.url.clone();
                 url.set_path(&new_path);

--- a/engine/runtime/expr/src/core/builtins/url.rs
+++ b/engine/runtime/expr/src/core/builtins/url.rs
@@ -1,6 +1,7 @@
 use crate::core::error::{InnerError, InnerResult};
 use crate::core::value::{ImmutableObject, Value};
-use crate::unpack_args;
+
+use crate::expect_arity;
 use url::Url;
 
 fn parse_url(s: &str) -> Result<UrlObject, String> {
@@ -72,8 +73,8 @@ impl ImmutableObject for UrlObject {
     fn call_method(&self, method: &str, args: &[Value]) -> InnerResult<Value> {
         match method {
             "__eq__" => {
-                unpack_args!(args => rhs);
-                match rhs {
+                expect_arity("Url.__eq__", args, 1, 1)?;
+                match &args[0] {
                     Value::Object(obj) if obj.type_name() == "Url" => {
                         Ok(Value::Bool(self.url.as_str() == obj.display()))
                     }
@@ -81,12 +82,12 @@ impl ImmutableObject for UrlObject {
                 }
             }
             "__str__" => {
-                unpack_args!(args =>);
+                expect_arity("Url.__str__", args, 0, 0)?;
                 Ok(Value::String(self.url.to_string()))
             }
             "__div__" => {
-                unpack_args!(args => rhs);
-                let rhs = rhs.as_str()?;
+                expect_arity("Url.__div__", args, 1, 1)?;
+                let rhs = args[0].as_str()?;
                 let new_path = format!("{}/{rhs}", self.url.path().trim_end_matches('/'));
                 let mut url = self.url.clone();
                 url.set_path(&new_path);

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -433,6 +433,15 @@ fn contains_inner(left: Value, right: Value) -> InnerResult<bool> {
                 l.type_name()
             ))),
         },
+        Value::Object(rc) => rc
+            .call_method("__contains__", &[left])
+            .and_then(|v| match v {
+                Value::Bool(b) => Ok(b),
+                other => Err(InnerError::new(format!(
+                    "__contains__ must return bool, got {}",
+                    other.type_name()
+                ))),
+            }),
         r => Err(InnerError::new(format!(
             "'in' not supported between {} and {}",
             left.type_name(),

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -8,7 +8,7 @@ use super::builtins::{array as array_methods, map as map_methods, str as str_met
 use super::builtins::{builtin_math, builtin_regex, builtin_url};
 use super::error::{Error, InnerError, InnerResult, Result};
 use super::value::{format_float, NativeFn, Value};
-use crate::unpack_args;
+use crate::expect_arity;
 
 #[cfg(debug_assertions)]
 const MAX_EVAL_DEPTH: usize = 64;
@@ -120,7 +120,7 @@ fn resolve_attr(recv: Value, attr: &str) -> InnerResult<Value> {
             .ok_or_else(|| InnerError::new(format!("module has no attribute '{attr}'"))),
         Value::Int(n) => match attr {
             "bit_length" => Ok(Value::Fn(NativeFn::new(move |args| {
-                unpack_args!(args =>);
+                expect_arity("int.bit_length", args, 0, 0)?;
                 if n < 0 {
                     return Err(InnerError::new(
                         "bit_length() not supported for negative integers",
@@ -1148,13 +1148,13 @@ fn builtin_map(args: &[Value]) -> InnerResult<Value> {
 }
 
 fn builtin_type(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => v);
-    Ok(Value::String(v.type_name().to_string()))
+    expect_arity("type", args, 1, 1)?;
+    Ok(Value::String(args[0].type_name().to_string()))
 }
 
 fn builtin_len(args: &[Value]) -> InnerResult<Value> {
-    unpack_args!(args => v);
-    match v {
+    expect_arity("len", args, 1, 1)?;
+    match &args[0] {
         Value::String(s) => Ok(Value::Int(s.chars().count() as i64)),
         Value::Array(rc) => Ok(Value::Int(rc.borrow().len() as i64)),
         Value::Map(rc) => Ok(Value::Int(rc.borrow().len() as i64)),

--- a/engine/runtime/expr/src/core/value.rs
+++ b/engine/runtime/expr/src/core/value.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 
 pub type Module = IndexMap<String, Value>;
 
-use crate::core::error::InnerResult;
+use crate::core::error::{InnerError, InnerResult};
 
 /// Trait for typed objects that can respond to method calls.
 ///
@@ -110,6 +110,37 @@ impl Value {
 
     pub fn module(m: Module) -> Self {
         Value::Module(Rc::new(m))
+    }
+
+    pub fn as_str(&self) -> InnerResult<&str> {
+        match self {
+            Value::String(s) => Ok(s.as_str()),
+            other => Err(InnerError::new(format!(
+                "expected string, got {}",
+                other.type_name()
+            ))),
+        }
+    }
+
+    pub fn as_int(&self) -> InnerResult<i64> {
+        match self {
+            Value::Int(n) => Ok(*n),
+            other => Err(InnerError::new(format!(
+                "expected int, got {}",
+                other.type_name()
+            ))),
+        }
+    }
+
+    pub fn as_f64(&self) -> InnerResult<f64> {
+        match self {
+            Value::Float(x) => Ok(*x),
+            Value::Int(x) => Ok(*x as f64),
+            other => Err(InnerError::new(format!(
+                "expected number, got {}",
+                other.type_name()
+            ))),
+        }
     }
 }
 

--- a/engine/runtime/expr/src/lib.rs
+++ b/engine/runtime/expr/src/lib.rs
@@ -4,7 +4,7 @@ pub use core::error::{Error, InnerError, InnerResult, Result};
 pub use core::eval::{bool_cast, default_env, str_cast, Env};
 pub use core::value::{ImmutableObject, NativeFn, Value};
 
-pub(crate) fn expect_arity(name: &str, args: &[Value], min: usize, max: usize) -> InnerResult<()> {
+pub fn expect_arity(name: &str, args: &[Value], min: usize, max: usize) -> InnerResult<()> {
     let n = args.len();
     if n >= min && n <= max {
         return Ok(());

--- a/engine/runtime/expr/src/lib.rs
+++ b/engine/runtime/expr/src/lib.rs
@@ -1,37 +1,21 @@
 mod core;
 
-/// Unpack a fixed number of arguments from a method `args: &[Value]` slice,
-/// binding each to a named variable. Generates an arity error if the count
-/// doesn't match.
-///
-/// Usage:
-/// - `unpack_args!(args =>)` — expect 0 arguments
-/// - `unpack_args!(args => x)` — expect 1, bind to `x: &Value`
-/// - `unpack_args!(args => x, y)` — expect 2, bind to `x`, `y`
-#[macro_export]
-macro_rules! unpack_args {
-    ($args:expr =>) => {
-        if !$args.is_empty() {
-            return Err($crate::InnerError::new(format!(
-                "expected 0 argument(s), got {}",
-                $args.len()
-            )));
-        }
-    };
-    ($args:expr => $($var:ident),+) => {
-        let [$($var),+] = $args else {
-            return Err($crate::InnerError::new(format!(
-                "expected {} argument(s), got {}",
-                [$(stringify!($var)),+].len(),
-                $args.len()
-            )));
-        };
-    };
-}
-
 pub use core::error::{Error, InnerError, InnerResult, Result};
 pub use core::eval::{bool_cast, default_env, str_cast, Env};
 pub use core::value::{ImmutableObject, NativeFn, Value};
+
+pub(crate) fn expect_arity(name: &str, args: &[Value], min: usize, max: usize) -> InnerResult<()> {
+    let n = args.len();
+    if n >= min && n <= max {
+        return Ok(());
+    }
+    let msg = if min == max {
+        format!("{name}() expected {min} argument(s), got {n}")
+    } else {
+        format!("{name}() expected {min} to {max} argument(s), got {n}")
+    };
+    Err(InnerError::new(msg))
+}
 
 /// Compile an expression string into an opaque [`CompiledExpr`].
 pub fn compile(input: &str) -> Result<CompiledExpr> {

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use reearth_flow_expr::{
-    bool_cast, compile, eval, str_cast, Error as ExprError, InnerError, InnerResult,
+    bool_cast, compile, eval, expect_arity, str_cast, Error as ExprError, InnerError, InnerResult,
     Value as ExprValue,
 };
 
@@ -152,32 +152,25 @@ impl reearth_flow_expr::ImmutableObject for AttributesObject {
     fn call_method(&self, method: &str, args: &[ExprValue]) -> InnerResult<ExprValue> {
         match method {
             "__getitem__" => {
-                reearth_flow_expr::unpack_args!(args => key);
-                let ExprValue::String(name) = key else {
+                expect_arity("Attributes.__getitem__", args, 1, 1)?;
+                let ExprValue::String(name) = &args[0] else {
                     return Err(InnerError::new(format!(
                         "attributes index must be a string, got {}",
-                        key.type_name()
+                        args[0].type_name()
                     )));
                 };
                 self.get_value(name)
                     .ok_or_else(|| InnerError::new(format!("attribute '{name}' not found")))
             }
             "get" => {
-                let (key, fallback) = match args {
-                    [key] => (key, None),
-                    [key, fallback] => (key, Some(fallback)),
-                    _ => {
-                        return Err(InnerError::new(
-                            "attributes.get() requires 1 or 2 arguments",
-                        ))
-                    }
-                };
-                let ExprValue::String(name) = key else {
+                expect_arity("Attributes.get", args, 1, 2)?;
+                let ExprValue::String(name) = &args[0] else {
                     return Err(InnerError::new(format!(
-                        "attributes.get() key must be a string, got {}",
-                        key.type_name()
+                        "Attributes.get() key must be a string, got {}",
+                        args[0].type_name()
                     )));
                 };
+                let fallback = args.get(1);
                 Ok(self
                     .get_value(name)
                     .unwrap_or_else(|| fallback.cloned().unwrap_or(ExprValue::Null)))
@@ -189,11 +182,11 @@ impl reearth_flow_expr::ImmutableObject for AttributesObject {
                     .collect(),
             )),
             "__contains__" => {
-                reearth_flow_expr::unpack_args!(args => key);
-                let ExprValue::String(name) = key else {
+                expect_arity("Attributes.__contains__", args, 1, 1)?;
+                let ExprValue::String(name) = &args[0] else {
                     return Err(InnerError::new(format!(
                         "'in attributes' key must be a string, got {}",
-                        key.type_name()
+                        args[0].type_name()
                     )));
                 };
                 Ok(ExprValue::Bool(self.0.contains_key(&Attribute::new(name))))
@@ -220,28 +213,25 @@ impl reearth_flow_expr::ImmutableObject for EnvObject {
     fn call_method(&self, method: &str, args: &[ExprValue]) -> InnerResult<ExprValue> {
         match method {
             "__getitem__" => {
-                reearth_flow_expr::unpack_args!(args => key);
-                let ExprValue::String(name) = key else {
+                expect_arity("Env.__getitem__", args, 1, 1)?;
+                let ExprValue::String(name) = &args[0] else {
                     return Err(InnerError::new(format!(
                         "env index must be a string, got {}",
-                        key.type_name()
+                        args[0].type_name()
                     )));
                 };
                 self.get_value(name)
                     .ok_or_else(|| InnerError::new(format!("env var '{name}' not found")))
             }
             "get" => {
-                let (key, fallback) = match args {
-                    [key] => (key, None),
-                    [key, fallback] => (key, Some(fallback)),
-                    _ => return Err(InnerError::new("env.get() requires 1 or 2 arguments")),
-                };
-                let ExprValue::String(name) = key else {
+                expect_arity("Env.get", args, 1, 2)?;
+                let ExprValue::String(name) = &args[0] else {
                     return Err(InnerError::new(format!(
-                        "env.get() key must be a string, got {}",
-                        key.type_name()
+                        "Env.get() key must be a string, got {}",
+                        args[0].type_name()
                     )));
                 };
+                let fallback = args.get(1);
                 Ok(self
                     .get_value(name)
                     .unwrap_or_else(|| fallback.cloned().unwrap_or(ExprValue::Null)))

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -196,7 +196,7 @@ impl reearth_flow_expr::ImmutableObject for AttributesObject {
                         key.type_name()
                     )));
                 };
-                Ok(ExprValue::Bool(self.get_value(name).is_some()))
+                Ok(ExprValue::Bool(self.0.contains_key(&Attribute::new(name))))
             }
             m => Err(InnerError::new(format!("Attributes has no method '{m}'"))),
         }

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -188,6 +188,16 @@ impl reearth_flow_expr::ImmutableObject for AttributesObject {
                     .map(|k| ExprValue::String(k.as_ref().to_string()))
                     .collect(),
             )),
+            "__contains__" => {
+                reearth_flow_expr::unpack_args!(args => key);
+                let ExprValue::String(name) = key else {
+                    return Err(InnerError::new(format!(
+                        "'in attributes' key must be a string, got {}",
+                        key.type_name()
+                    )));
+                };
+                Ok(ExprValue::Bool(self.get_value(name).is_some()))
+            }
             m => Err(InnerError::new(format!("Attributes has no method '{m}'"))),
         }
     }
@@ -297,5 +307,39 @@ fn attribute_value_from_eval(v: ExprValue) -> reearth_flow_expr::Result<Attribut
                 )))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use indexmap::indexmap;
+
+    use super::*;
+    use crate::attribute::AttributeValue;
+    use crate::feature::Feature;
+
+    fn eval_bool(expr: &str, feature: &Feature) -> bool {
+        let code = Code {
+            ty: CodeType::FlowExpr,
+            value: expr.to_string(),
+        };
+        let env_vars = Arc::new(serde_json::Map::new());
+        code.compile()
+            .unwrap()
+            .eval_bool(feature, env_vars)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_attributes_in_operator() {
+        let feature = Feature::from(indexmap! {
+            "foo".to_string() => AttributeValue::String("bar".to_string()),
+        });
+        assert!(eval_bool(r#""foo" in attributes"#, &feature));
+        assert!(!eval_bool(r#""missing" in attributes"#, &feature));
+        assert!(!eval_bool(r#""foo" not in attributes"#, &feature));
+        assert!(eval_bool(r#""missing" not in attributes"#, &feature));
     }
 }

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -716,8 +716,27 @@
           }
         },
         "definitions": {
-          "Expr": {
-            "type": "string"
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
           },
           "Mapper": {
             "type": "object",
@@ -740,7 +759,7 @@
                 "title": "Expression to evaluate",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"
@@ -751,7 +770,7 @@
                 "title": "Expression to evaluate multiple attributes",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -716,8 +716,27 @@
           }
         },
         "definitions": {
-          "Expr": {
-            "type": "string"
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
           },
           "Mapper": {
             "type": "object",
@@ -740,7 +759,7 @@
                 "title": "Expression to evaluate",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"
@@ -751,7 +770,7 @@
                 "title": "Expression to evaluate multiple attributes",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -716,8 +716,27 @@
           }
         },
         "definitions": {
-          "Expr": {
-            "type": "string"
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
           },
           "Mapper": {
             "type": "object",
@@ -740,7 +759,7 @@
                 "title": "Expression to evaluate",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"
@@ -751,7 +770,7 @@
                 "title": "Expression to evaluate multiple attributes",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -716,8 +716,27 @@
           }
         },
         "definitions": {
-          "Expr": {
-            "type": "string"
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
           },
           "Mapper": {
             "type": "object",
@@ -740,7 +759,7 @@
                 "title": "Expression to evaluate",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"
@@ -751,7 +770,7 @@
                 "title": "Expression to evaluate multiple attributes",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -719,8 +719,27 @@
           }
         },
         "definitions": {
-          "Expr": {
-            "type": "string"
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
           },
           "Mapper": {
             "type": "object",
@@ -743,7 +762,7 @@
                 "title": "評価する式",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"
@@ -754,7 +773,7 @@
                 "title": "複数属性を評価する式",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -716,8 +716,27 @@
           }
         },
         "definitions": {
-          "Expr": {
-            "type": "string"
+          "Code": {
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "$ref": "#/definitions/CodeType"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "CodeType": {
+            "type": "string",
+            "enum": [
+              "flowExpr",
+              "string"
+            ]
           },
           "Mapper": {
             "type": "object",
@@ -740,7 +759,7 @@
                 "title": "Expression to evaluate",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"
@@ -751,7 +770,7 @@
                 "title": "Expression to evaluate multiple attributes",
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/Expr"
+                    "$ref": "#/definitions/Code"
                   },
                   {
                     "type": "null"

--- a/engine/schema/i18n/actions/en.json
+++ b/engine/schema/i18n/actions/en.json
@@ -243,6 +243,10 @@
         }
       },
       "definitionI18n": {
+        "Code": {
+          "type": {},
+          "value": {}
+        },
         "Mapper": {
           "attribute": {
             "title": "Attribute name"

--- a/engine/schema/i18n/actions/es.json
+++ b/engine/schema/i18n/actions/es.json
@@ -245,6 +245,10 @@
         }
       },
       "definitionI18n": {
+        "Code": {
+          "type": {},
+          "value": {}
+        },
         "Mapper": {
           "attribute": {
             "title": "Attribute name"

--- a/engine/schema/i18n/actions/fr.json
+++ b/engine/schema/i18n/actions/fr.json
@@ -245,6 +245,10 @@
         }
       },
       "definitionI18n": {
+        "Code": {
+          "type": {},
+          "value": {}
+        },
         "Mapper": {
           "attribute": {
             "title": "Attribute name"

--- a/engine/schema/i18n/actions/ja.json
+++ b/engine/schema/i18n/actions/ja.json
@@ -248,6 +248,10 @@
         }
       },
       "definitionI18n": {
+        "Code": {
+          "type": {},
+          "value": {}
+        },
         "Mapper": {
           "attribute": {
             "title": "属性名"

--- a/engine/schema/i18n/actions/zh.json
+++ b/engine/schema/i18n/actions/zh.json
@@ -245,6 +245,10 @@
         }
       },
       "definitionI18n": {
+        "Code": {
+          "type": {},
+          "value": {}
+        },
         "Mapper": {
           "attribute": {
             "title": "Attribute name"


### PR DESCRIPTION
# Overview

This PR continues #2030, #2087, #2109, #2122 to migrate `AttributeMapper` to FlowExpr.

## Changes

- migrate AttributeMapper mapper fields to use FlowExpr, update schema.
- migrate workflows AttributeMapper code to FlowExpr.
- add containment check for attributes like `key in attributes`.
- add string `join` and `rsplit` methods. `split` and `rsplit` now optionally take split count.
- reduce Url() usage for filename extraction in workflows.
- log error before null fallback in attribute mapper.
- streamline arity and type checking in flow-expr using shared helpers for error message construction.
- add a design note for Regex.find.
- consolidate and improve arity mismatch error message.

## Notes

- all direct attribute access are migrated to use `valueAttribute` which has same null fallback logic.
- in solar-radiation workflow, invalid AMeDAS CSV (missing column) will cause error log in workflow instead of producing null.