### PR TITLE
fix(ui): prevent multiple debug run starts by using a ref to track state [FLOW-DEV-164]

### DIFF
--- a/ui/src/features/Editor/components/OverlayUI/components/DebugActionBar/hooks.ts
+++ b/ui/src/features/Editor/components/OverlayUI/components/DebugActionBar/hooks.ts
@@ -104,8 +104,13 @@ export default ({
         handleShowDebugWorkflowVariablesDialog();
       } else {
         setDebugRunStarted(true);
-        await onDebugRunStart();
         handlePopoverClose();
+        try {
+          await onDebugRunStart();
+        } catch (e) {
+          setDebugRunStarted(false);
+          throw e;
+        }
       }
     } finally {
       isStartingRef.current = false;
@@ -139,7 +144,7 @@ export default ({
 
   return {
     showOverlayElement,
-    debugRunStarted: isStartingRef.current || debugRunStarted,
+    debugRunStarted,
     jobStatus,
     debugJob,
     handleDebugRunStart,

--- a/ui/src/features/Editor/components/OverlayUI/components/DebugActionBar/hooks.ts
+++ b/ui/src/features/Editor/components/OverlayUI/components/DebugActionBar/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useJob } from "@flow/lib/gql/job";
 import { useSubscription } from "@flow/lib/gql/subscriptions/useSubscription";
@@ -49,6 +49,7 @@ export default ({
     setshowOverlayElement(undefined);
   };
   const [debugRunStarted, setDebugRunStarted] = useState(false);
+  const isStartingRef = useRef(false);
 
   const { useGetJob } = useJob();
 
@@ -93,15 +94,21 @@ export default ({
   }, [debugJob, jobStatus, debugRunStarted]);
 
   const handleDebugRunStart = async () => {
-    if (
-      customDebugRunWorkflowVariables &&
-      customDebugRunWorkflowVariables.length > 0
-    ) {
-      handleShowDebugWorkflowVariablesDialog();
-    } else {
-      setDebugRunStarted(true);
-      await onDebugRunStart();
-      handlePopoverClose();
+    if (isStartingRef.current) return;
+    isStartingRef.current = true;
+    try {
+      if (
+        customDebugRunWorkflowVariables &&
+        customDebugRunWorkflowVariables.length > 0
+      ) {
+        handleShowDebugWorkflowVariablesDialog();
+      } else {
+        setDebugRunStarted(true);
+        await onDebugRunStart();
+        handlePopoverClose();
+      }
+    } finally {
+      isStartingRef.current = false;
     }
   };
 
@@ -132,7 +139,7 @@ export default ({
 
   return {
     showOverlayElement,
-    debugRunStarted,
+    debugRunStarted: isStartingRef.current || debugRunStarted,
     jobStatus,
     debugJob,
     handleDebugRunStart,


### PR DESCRIPTION
# Overview
Prevents users from triggering multiple debug-run start requests from the Editor overlay UI by adding an in-flight guard around the debug start handler.
## What I've done
- Add a `useRef`-backed “starting” flag to block re-entrant `handleDebugRunStart` calls.
- Wrap the debug start flow in `try/finally` to ensure the “starting” flag is cleared.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
