### PR TITLE
fix(ui): correct edge creation logic in paste handling [FLOW-DEV-167]

### DIFF
--- a/ui/e2e/pages/editorPage.ts
+++ b/ui/e2e/pages/editorPage.ts
@@ -232,6 +232,14 @@ export class EditorPage {
     await this.page.keyboard.press("ControlOrMeta+Shift+z");
   }
 
+  async selectAll() {
+    await this.page.keyboard.press("ControlOrMeta+a");
+  }
+
+  async copySelected() {
+    await this.page.keyboard.press("ControlOrMeta+c");
+  }
+
   contextMenuItem(label: string): Locator {
     return this.page.getByText(label, { exact: true });
   }

--- a/ui/e2e/tests/editor.spec.ts
+++ b/ui/e2e/tests/editor.spec.ts
@@ -115,6 +115,30 @@ test.describe.serial("Editor canvas", { tag: "@regression" }, () => {
     await expect(editor.nodeByName(name)).toHaveCount(2);
   });
 
+  test("copies connected nodes including a subworkflow node and preserves the edge", async () => {
+    await editor.addActionNode(
+      "transformer",
+      await editor.canvasPoint(0.3, 0.45),
+    );
+    await editor.dragToolToCanvas(
+      "subworkflow",
+      await editor.canvasPoint(0.65, 0.45),
+    );
+    await expect(editor.nodes).toHaveCount(2);
+
+    await editor.connectNodes(editor.nodes.nth(0), editor.nodes.nth(1));
+    await expect(editor.edges).toHaveCount(1);
+
+    await editor.clickPane();
+    await editor.selectAll();
+    await editor.copySelected();
+
+    await editor.pasteAtPane(await editor.canvasPoint(0.5, 0.75));
+
+    await expect(editor.nodes).toHaveCount(4);
+    await expect(editor.edges).toHaveCount(2);
+  });
+
   test("deletes a node and its connected edge", async () => {
     await editor.addActionNode(
       "transformer",

--- a/ui/src/features/Editor/useCanvasCopyPaste.ts
+++ b/ui/src/features/Editor/useCanvasCopyPaste.ts
@@ -415,7 +415,6 @@ export default ({
           mousePosition,
           isCutByShortCut,
         );
-        const newEdges = newEdgeCreation(pastedEdges, pastedNodes, newNodes);
 
         // Compute the current workflow path for pasted subworkflows
         const currentPath = computeWorkflowPath(
@@ -426,6 +425,12 @@ export default ({
           newNodes,
           pastedWorkflows,
           currentPath,
+        );
+
+        const newEdges = newEdgeCreation(
+          pastedEdges,
+          pastedNodes,
+          processedNewNodes,
         );
 
         // deselect all previously selected nodes


### PR DESCRIPTION
# Overview
This PR adjusts paste handling in the Editor so that edges are created *after* pasted nodes have been post-processed for subworkflow creation, ensuring edges reference the final node IDs.
## What I've done
- Move `newEdgeCreation(...)` to run after `newWorkflowCreation(...)`.
- Use `processedNewNodes` (finalized node IDs/paths) when creating pasted edges.
- Added new tests
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
