### PR TITLE
fix(ui): add onWorkflowAdd prop to Toolbox and OverlayUI components [FLOW-DEV-169]

### DIFF
--- a/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
@@ -50,6 +50,7 @@ type Props = {
   onUndo: () => void;
   onLayoutChange: () => void;
   onNodesAdd?: (nodes: Node[]) => void;
+  onWorkflowAdd?: (position?: XYPosition) => void;
   onNodePickerOpen?: (
     position: XYPosition,
     nodeType?: ActionNodeType,
@@ -66,6 +67,7 @@ const Toolbox: React.FC<Props> = ({
   onUndo,
   onLayoutChange,
   onNodesAdd,
+  onWorkflowAdd,
   onNodePickerOpen,
 }) => {
   const t = useT();
@@ -150,7 +152,9 @@ const Toolbox: React.FC<Props> = ({
       x: window.innerWidth / 2,
       y: window.innerHeight / 2,
     });
-    if (actionNodeTypes.includes(nodeType as ActionNodeType)) {
+    if (nodeType === "subworkflow") {
+      onWorkflowAdd?.(getCenter);
+    } else if (actionNodeTypes.includes(nodeType as ActionNodeType)) {
       onNodePickerOpen?.(getCenter, nodeType as ActionNodeType, isMainWorkflow);
     } else {
       const officialName =

--- a/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/Toolbox/index.tsx
@@ -50,7 +50,7 @@ type Props = {
   onUndo: () => void;
   onLayoutChange: () => void;
   onNodesAdd?: (nodes: Node[]) => void;
-  onWorkflowAdd?: (position?: XYPosition) => void;
+  onWorkflowAdd?: (position?: XYPosition) => Promise<void>;
   onNodePickerOpen?: (
     position: XYPosition,
     nodeType?: ActionNodeType,
@@ -153,7 +153,11 @@ const Toolbox: React.FC<Props> = ({
       y: window.innerHeight / 2,
     });
     if (nodeType === "subworkflow") {
-      onWorkflowAdd?.(getCenter);
+      try {
+        await onWorkflowAdd?.(getCenter);
+      } catch (e) {
+        console.error("Failed to add subworkflow:", e);
+      }
     } else if (actionNodeTypes.includes(nodeType as ActionNodeType)) {
       onNodePickerOpen?.(getCenter, nodeType as ActionNodeType, isMainWorkflow);
     } else {

--- a/ui/src/features/Editor/components/OverlayUI/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/index.tsx
@@ -53,7 +53,7 @@ type OverlayUIProps = {
   refetchWorkflowVariables: () => void;
   onNodesAdd: (nodes: Node[]) => void;
   onNodesChange?: (changes: NodeChange<Node>[]) => void;
-  onWorkflowAdd?: (position?: XYPosition) => void;
+  onWorkflowAdd?: (position?: XYPosition) => Promise<void>;
   onNodePickerOpen?: (
     position: XYPosition,
     nodeType?: ActionNodeType,

--- a/ui/src/features/Editor/components/OverlayUI/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/index.tsx
@@ -53,6 +53,7 @@ type OverlayUIProps = {
   refetchWorkflowVariables: () => void;
   onNodesAdd: (nodes: Node[]) => void;
   onNodesChange?: (changes: NodeChange<Node>[]) => void;
+  onWorkflowAdd?: (position?: XYPosition) => void;
   onNodePickerOpen?: (
     position: XYPosition,
     nodeType?: ActionNodeType,
@@ -125,6 +126,7 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
   refetchWorkflowVariables,
   onNodesAdd,
   onNodesChange,
+  onWorkflowAdd,
   onNodePickerOpen,
   onNodePickerClose,
   onEdgesAdd,
@@ -186,6 +188,7 @@ const OverlayUI: React.FC<OverlayUIProps> = ({
                 showLayoutOptions={showDialog === "layout"}
                 onLayoutChange={handleLayoutOptionsToggle}
                 onNodesAdd={onNodesAdd}
+                onWorkflowAdd={onWorkflowAdd}
                 onNodePickerOpen={onNodePickerOpen}
                 onRedo={onWorkflowRedo}
                 onUndo={onWorkflowUndo}

--- a/ui/src/features/Editor/index.tsx
+++ b/ui/src/features/Editor/index.tsx
@@ -175,6 +175,7 @@ export default function Editor({
             onWorkflowClose={handleWorkflowClose}
             onNodesAdd={handleNodesAdd}
             onNodesChange={handleNodesChange}
+            onWorkflowAdd={handleWorkflowAdd}
             onNodePickerOpen={handleNodePickerOpen}
             onNodePickerClose={handleNodePickerClose}
             onEdgesAdd={handleEdgesAdd}


### PR DESCRIPTION
# Overview
This PR wires an `onWorkflowAdd` callback from the main `Editor` feature down through `OverlayUI` into the `Toolbox`, enabling the Toolbox UI to trigger creation of a subworkflow (consistent with existing drag/drop behavior that uses `onWorkflowAdd`).

## What I've done
- Pass `handleWorkflowAdd` into `OverlayUI` via a new `onWorkflowAdd` prop.
- Add `onWorkflowAdd` to `OverlayUI` props and forward it to `Toolbox`.
- Update `Toolbox` double-click handling so `"subworkflow"` triggers `onWorkflowAdd`.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
