### PR TITLE
fix(engine): fix PLATEAU workflow migration #2123

### DIFF
--- a/engine/runtime/examples/fixture/workflow/examples/conversion-table/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/conversion-table/workflow.yml
@@ -43,7 +43,7 @@ graphs:
         with:
           format: csv
           output: |
-            file::join_path(env.get("currentPath"), "example-conversion-table.csv")
+            "example-conversion-table.csv"
 
     edges:
       - id: c064cf52-705f-443a-b2de-6795266c540d

--- a/engine/runtime/examples/fixture/workflow/examples/zip-writer/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/examples/zip-writer/workflow.yml
@@ -53,7 +53,7 @@ graphs:
         with:
           format: csv
           output: |
-            file::join_path(env.get("currentPath"), "year-2024.csv")
+            "year-2024.csv"
 
       - id: 3ec90e43-968e-4bcd-863c-f7c80e37f118
         name: FeatureWriter2025
@@ -62,7 +62,7 @@ graphs:
         with:
           format: csv
           output: |
-            file::join_path(env.get("currentPath"), "year-2025.csv")
+            "year-2025.csv"
 
       - id: 5aa001b2-94d4-41c0-8552-58adf04ef66a
         name: ZipFileWriter
@@ -70,7 +70,7 @@ graphs:
         action: ZipFileWriter
         with:
           output: |
-            file::join_path(env.get("currentPath"), "result.zip")
+            "result.zip"
 
     edges:
       - id: c064cf52-705f-443a-b2de-6795266c540d

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
@@ -1634,7 +1634,6 @@ graphs:
             codelists: env.get("codelistsPath") ?? env.get("codelists"),
             schemas: env.get("schemasPath") ?? env.get("schemas"),
             objectListsPath: env.get("objectListsPath") ?? env.get("objectLists"),
-            workerArtifactPath: env.get("workerArtifactPath"),
           },
         ]
   - id: 0aeb935e-bc3e-4867-96f3-122d504fcde6
@@ -1892,7 +1891,7 @@ graphs:
       output: |
         let folder = env.get("__value").Folder;
         if folder == () || folder == "" {
-          return file::join_path(base_path, "06_浸水想定区域_fld.csv");
+          return "06_浸水想定区域_fld.csv";
         }
         // Extract flood type from first path segment (e.g., "htd/12_1" -> "htd", "12_1")
         let slash_pos = folder.index_of("/");

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld/workflow.yml
@@ -33,7 +33,6 @@ graphs:
                 codelists: env.get("codelistsPath") ?? env.get("codelists"),
                 schemas: env.get("schemasPath") ?? env.get("schemas"),
                 objectListsPath: env.get("objectListsPath") ?? env.get("objectLists"),
-                workerArtifactPath: env.get("workerArtifactPath"),
               },
             ]
 
@@ -346,7 +345,7 @@ graphs:
           output: |
             let folder = env.get("__value").Folder;
             if folder == () || folder == "" {
-              return file::join_path(base_path, "06_浸水想定区域_fld.csv");
+              return "06_浸水想定区域_fld.csv";
             }
             // Extract flood type from first path segment (e.g., "htd/12_1" -> "htd", "12_1")
             let slash_pos = folder.index_of("/");


### PR DESCRIPTION
# Overview

This PR completes PLATEAU workflow migration for relative path output requirement introduced in #2123.

PLATEAU3 and requirements/PLATEAU4 workflows are deprecated so not touched.