### PR TITLE
ci(engine): split monolithic ci-engine into 5 parallel jobs

### DIFF
--- a/.github/actions/setup-engine-ci/action.yml
+++ b/.github/actions/setup-engine-ci/action.yml
@@ -1,0 +1,51 @@
+name: Set up engine CI environment
+description: |
+  Shared post-checkout setup for engine CI jobs: frees disk space, installs the
+  pinned Rust toolchain, restores the cargo cache, and installs the small CLI
+  tools needed by every job (taplo-cli, cargo-make, cargo-edit).
+
+  The calling job MUST run `step-security/harden-runner` and `actions/checkout`
+  before invoking this action — checkout is required for GitHub to locate this
+  local composite action, and harden-runner must precede any network egress.
+
+  Node.js, glb-decompress, and yaml-include are intentionally NOT installed
+  here — only the jobs that need them install them, to keep setup time minimal.
+
+inputs:
+  shared-key:
+    description: |
+      Rust cache shared-key. All engine CI jobs use the same key so that the
+      first job to finish a clean build seeds the cache for the others on the
+      next run.
+    required: false
+    default: engine-ci
+  rust-components:
+    description: Optional extra rustup components to install (comma-separated).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Maximize build space
+      uses: AdityaGarg8/remove-unwanted-software@8831c82abf29b34eb2caac48d5f999ecfc0d8eef # v4.1
+      with:
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
+        remove-swapfile: 'true'
+        remove-cached-tools: 'true'
+    - uses: dtolnay/rust-toolchain@2ea1b3bdd0261867664fd125505456a7b9c3385c # 1.93.1
+      with:
+        components: ${{ inputs.rust-components }}
+    - name: Cache cargo registry
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        workspaces: engine
+        shared-key: ${{ inputs.shared-key }}
+    - name: install required tools
+      uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2.75.20
+      with:
+        tool: taplo-cli,cargo-make,cargo-edit

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -111,9 +111,18 @@ jobs:
       - name: test-rs
         run: cargo make test-rs
 
+  # test-qc is the long pole: 141 workflow integration tests, each running a
+  # full end-to-end DAG (~30s/test). On a single 4-vCPU runner the test
+  # execution alone is ~19 min regardless of test framework. We split the
+  # suite across 3 nextest partitions running on independent runners, which
+  # brings the slowest shard down to ~8-10 min wall-clock.
   test-qc:
-    name: test-qc (workflow integration tests, via nextest)
+    name: test-qc shard ${{ matrix.shard }}/3 (nextest)
     runs-on: blacksmith-4vcpu-ubuntu-2204
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
@@ -127,8 +136,8 @@ jobs:
         uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2.75.20
         with:
           tool: cargo-nextest
-      - name: test-qc (nextest)
-        run: cargo make test-qc-nextest
+      - name: test-qc (nextest partition ${{ matrix.shard }}/3)
+        run: cargo make test-qc-nextest -- --partition count:${{ matrix.shard }}/3
 
   test-conv:
     name: test-conv (tile output validation)

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -137,7 +137,11 @@ jobs:
         with:
           tool: cargo-nextest
       - name: test-qc (nextest partition ${{ matrix.shard }}/3)
-        run: cargo make test-qc-nextest -- --partition count:${{ matrix.shard }}/3
+        # NOTE: no `--` before `--partition` — cargo-make would forward the
+        # literal `--` to the task script, which would then land between
+        # `cargo nextest run` and `--partition`, and nextest would treat it
+        # as a test-binary arg separator and reject `--partition`.
+        run: cargo make test-qc-nextest --partition count:${{ matrix.shard }}/3
 
   test-conv:
     name: test-conv (tile output validation)

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -19,8 +19,14 @@ defaults:
   run:
     working-directory: engine
 
+# All jobs share the same Rust cache (shared-key: engine-ci). The first run
+# after Cargo.lock changes pays a cache-miss cost in every job; subsequent
+# runs hit the cache the seeding job populated. Net wall clock is bounded by
+# the slowest single job (typically test-rs / test-qc / test-conv at ~10 min
+# each) instead of their sum (~30 min on the previous monolithic layout).
 jobs:
-  ci:
+  lint:
+    name: lint (clippy / fmt / taplo)
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Harden Runner
@@ -30,36 +36,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - name: Maximize build space
-        uses: AdityaGarg8/remove-unwanted-software@8831c82abf29b34eb2caac48d5f999ecfc0d8eef # v4.1
+      - uses: ./.github/actions/setup-engine-ci
         with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
-          remove-swapfile: 'true'
-          remove-cached-tools: 'true'
-      - uses: dtolnay/rust-toolchain@2ea1b3bdd0261867664fd125505456a7b9c3385c # 1.93.1
-        with:
-          components: clippy, rustfmt
-      - name: Cache cargo registry
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: engine
-          shared-key: "engine-ci"
-      - name: install required tools
-        uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2.75.20
-        with:
-          tool: taplo-cli,cargo-make,cargo-edit
-      - name: install yaml-include
-        run: cargo install yaml-include
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '20'
-      - name: Install glb-decompress
-        run: npm install -g github:asrcpq/glb_decompress_draco#d0dc30683ae65bb60dda96192b8c1b1d8a80a771
+          rust-components: clippy, rustfmt
       - name: Compare version with previous commit
         if: ${{ !(github.ref == 'refs/heads/main') }}
         run: |
@@ -76,30 +55,94 @@ jobs:
             exit 1
           fi
 
-           echo "Previous version: $PREV_VERSION"
-           echo "Current version:  $CURR_VERSION"
+          echo "Previous version: $PREV_VERSION"
+          echo "Current version:  $CURR_VERSION"
 
-           if [ "$PREV_VERSION" = "$CURR_VERSION" ]; then
-             echo "Error: The version of Cargo.toml has not been changed."
-             echo "       To increase the patch version, run 'cargo set-version --bump patch'."
-             echo "       To bump the version, run one of:"
-             echo "       - 'cargo set-version --bump major'  # For breaking changes"
-             echo "       - 'cargo set-version --bump minor'  # For new features"
-             echo "       - 'cargo set-version --bump patch'  # For bug fixes"
-             exit 1
-           fi
-
-      - name: check
-        run: cargo make check
-      - name: rustfmt
-        run: cargo make format -- --check
+          if [ "$PREV_VERSION" = "$CURR_VERSION" ]; then
+            echo "Error: The version of Cargo.toml has not been changed."
+            echo "       To increase the patch version, run 'cargo set-version --bump patch'."
+            echo "       To bump the version, run one of:"
+            echo "       - 'cargo set-version --bump major'  # For breaking changes"
+            echo "       - 'cargo set-version --bump minor'  # For new features"
+            echo "       - 'cargo set-version --bump patch'  # For bug fixes"
+            exit 1
+          fi
+      # NOTE: `cargo make check` was previously a separate step. It is a
+      # strict subset of `cargo make clippy` (clippy implies check), so it is
+      # not run here.
       - name: clippy
         run: cargo make clippy
+      - name: rustfmt
+        run: cargo make format -- --check
       - name: taplo
         run: cargo make format-taplo --check
+
+  validate-generated:
+    name: validate generated files (schema + cms workflows)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-engine-ci
+      - name: install yaml-include
+        run: cargo install yaml-include
       - name: check generated schema
         run: cargo make check-schema
       - name: check generated cms workflows
         run: cargo make check-generate-examples-cms-workflow
-      - name: run tests
-        run: cargo make test
+
+  test-rs:
+    name: test-rs (workspace unit + integration tests)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-engine-ci
+      - name: test-rs
+        run: cargo make test-rs
+
+  test-qc:
+    name: test-qc (workflow integration tests)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-engine-ci
+      - name: test-qc
+        run: cargo make test-qc
+
+  test-conv:
+    name: test-conv (tile output validation)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-engine-ci
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+      - name: Install glb-decompress
+        run: npm install -g github:asrcpq/glb_decompress_draco#d0dc30683ae65bb60dda96192b8c1b1d8a80a771
+      - name: test-conv
+        run: cargo make test-conv

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -160,6 +160,20 @@ jobs:
         with:
           node-version: '20'
       - name: Install glb-decompress
-        run: npm install -g github:asrcpq/glb_decompress_draco#d0dc30683ae65bb60dda96192b8c1b1d8a80a771
+        # glb_decompress_draco transitively depends on `sharp`, whose postinstall
+        # script downloads libvips binaries from GitHub Releases. That download
+        # has flaked with 504s during peak GitHub traffic; retry up to 3 times
+        # before giving up so a single transient CDN blip doesn't fail CI.
+        run: |
+          for attempt in 1 2 3; do
+            if npm install -g github:asrcpq/glb_decompress_draco#d0dc30683ae65bb60dda96192b8c1b1d8a80a771; then
+              echo "glb-decompress install succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Attempt $attempt failed; sleeping 15s before retry..."
+            sleep 15
+          done
+          echo "glb-decompress install failed after 3 attempts" >&2
+          exit 1
       - name: test-conv
         run: cargo make test-conv

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -112,7 +112,7 @@ jobs:
         run: cargo make test-rs
 
   test-qc:
-    name: test-qc (workflow integration tests)
+    name: test-qc (workflow integration tests, via nextest)
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Harden Runner
@@ -123,8 +123,12 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-engine-ci
-      - name: test-qc
-        run: cargo make test-qc
+      - name: install cargo-nextest
+        uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2.75.20
+        with:
+          tool: cargo-nextest
+      - name: test-qc (nextest)
+        run: cargo make test-qc-nextest
 
   test-conv:
     name: test-conv (tile output validation)

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -114,15 +114,19 @@ jobs:
   # test-qc is the long pole: 141 workflow integration tests, each running a
   # full end-to-end DAG (~30s/test). On a single 4-vCPU runner the test
   # execution alone is ~19 min regardless of test framework. We split the
-  # suite across 3 nextest partitions running on independent runners, which
-  # brings the slowest shard down to ~8-10 min wall-clock.
+  # suite across 4 nextest partitions running on independent runners, which
+  # brings the slowest shard down to ~7-9 min wall-clock (cache-cold) or
+  # ~5-7 min (cache-warm). 4 shards (instead of 3) keep the slowest shard at
+  # parity with test-conv (~9m15s), so the overall ci-engine wall-clock is
+  # no longer dominated by test-qc; it also gives headroom as the workflow
+  # test suite grows.
   test-qc:
-    name: test-qc shard ${{ matrix.shard }}/3 (nextest)
+    name: test-qc shard ${{ matrix.shard }}/4 (nextest)
     runs-on: blacksmith-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
@@ -136,12 +140,12 @@ jobs:
         uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2.75.20
         with:
           tool: cargo-nextest
-      - name: test-qc (nextest partition ${{ matrix.shard }}/3)
+      - name: test-qc (nextest partition ${{ matrix.shard }}/4)
         # NOTE: no `--` before `--partition` — cargo-make would forward the
         # literal `--` to the task script, which would then land between
         # `cargo nextest run` and `--partition`, and nextest would treat it
         # as a test-binary arg separator and reject `--partition`.
-        run: cargo make test-qc-nextest --partition count:${{ matrix.shard }}/3
+        run: cargo make test-qc-nextest --partition count:${{ matrix.shard }}/4
 
   test-conv:
     name: test-conv (tile output validation)

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -75,7 +75,7 @@ jobs:
       - name: rustfmt
         run: cargo make format -- --check
       - name: taplo
-        run: cargo make format-taplo --check
+        run: cargo make format-taplo -- --check
 
   validate-generated:
     name: validate generated files (schema + cms workflows)

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.324"
+version = "0.0.325"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.322"
+version = "0.0.323"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.224"
+version = "0.1.225"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.323"
+version = "0.0.324"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.35"
+version = "0.2.36"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.225"
+version = "0.1.226"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.325"
+version = "0.0.326"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.227"
+version = "0.1.228"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.321"
+version = "0.0.322"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.223"
+version = "0.1.224"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.320"
+version = "0.0.321"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.32"
+version = "0.2.33"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.379"
+version = "0.0.380"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.222"
+version = "0.1.223"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.380"
+version = "0.0.381"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.384"
+version = "0.0.385"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.383"
+version = "0.0.384"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.379"
+version = "0.0.380"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.381"
+version = "0.0.382"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.382"
+version = "0.0.383"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -57,6 +57,17 @@ script = ['''
 cargo test -p workflow-tests ${@:-}
 ''']
 
+# Same coverage as `test-qc`, executed via cargo-nextest's process-per-test
+# parallelism. workflow-tests gives every test its own TempDir-rooted sandbox,
+# so the tests are already isolated and safe to parallelise. CI uses this task
+# to cut the test-qc step from the bottleneck job (~14m -> ~6-8m). Local devs
+# can keep using `cargo make test-qc` with plain `cargo test`.
+[tasks.test-qc-nextest]
+script = ['''
+#!/usr/bin/env bash -eux
+cargo nextest run -p workflow-tests ${@:-}
+''']
+
 [tasks.test-conv]
 script = ['''
 #!/usr/bin/env bash -eux

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -57,11 +57,12 @@ script = ['''
 cargo test -p workflow-tests ${@:-}
 ''']
 
-# Same coverage as `test-qc`, executed via cargo-nextest's process-per-test
-# parallelism. workflow-tests gives every test its own TempDir-rooted sandbox,
-# so the tests are already isolated and safe to parallelise. CI uses this task
-# to cut the test-qc step from the bottleneck job (~14m -> ~6-8m). Local devs
-# can keep using `cargo make test-qc` with plain `cargo test`.
+# Same coverage as `test-qc`, executed via cargo-nextest. CI uses this with
+# `--partition count:N/M` to shard the 141 workflow integration tests across
+# multiple runners (see .github/workflows/ci_engine.yml test-qc matrix). The
+# per-test work (~30s/test end-to-end) makes 4-vCPU thread parallelism alone
+# insufficient — sharding is the only way to bring this job under ~10 min.
+# Local devs can keep using `cargo make test-qc` with plain `cargo test`.
 [tasks.test-qc-nextest]
 script = ['''
 #!/usr/bin/env bash -eux

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.325"
+version = "0.0.326"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.320"
+version = "0.0.321"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.322"
+version = "0.0.323"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.323"
+version = "0.0.324"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.324"
+version = "0.0.325"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.321"
+version = "0.0.322"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.37"
+version = "0.2.38"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.36"
+version = "0.2.37"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.35"
+version = "0.2.36"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.32"
+version = "0.2.33"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.33"
+version = "0.2.34"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.34"
+version = "0.2.35"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.225"
+version = "0.1.226"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.226"
+version = "0.1.227"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.227"
+version = "0.1.228"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.222"
+version = "0.1.223"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.224"
+version = "0.1.225"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.223"
+version = "0.1.224"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary

Cuts engine PR feedback time from **~32m to ~11m** (measured) by:

1. Running lint, schema/cms validation, and the three test suites **concurrently** instead of sequentially.
2. **Sharding** the long-pole test-qc job across 4 nextest partitions, each on its own runner.

## Measured results

| Run | Wall-clock | Total compute | Notes |
|---|---:|---:|---|
| Baseline monolith (main, [`27113434283`](https://github.com/reearth/reearth-flow/actions/runs/27113434283)) | **31m48s** | ~32 runner-min | one sequential job |
| Parallel split, 3 shards ([`27120578959`](https://github.com/reearth/reearth-flow/actions/runs/27120578959)) | 12m44s | ~53 runner-min | first sharded attempt |
| **Parallel split, 4 shards** ([`27121246547`](https://github.com/reearth/reearth-flow/actions/runs/27121246547)) | **11m27s** | **~54 runner-min** | **current — −64% wall-clock vs baseline** |

Per-job breakdown from the latest 4-shard run:

| Job | Conclusion | Duration |
|---|---|---:|
| test-qc shard 2/4 (slowest) | ✅ | 9m59s |
| test-conv | ✅ | 9m51s |
| test-qc shard 1/4 | ✅ | 8m54s |
| test-qc shard 4/4 | ✅ | 7m54s |
| test-qc shard 3/4 | ✅ | 7m09s |
| test-rs | ✅ | 5m52s |
| validate-generated | ✅ | 2m42s |
| lint | ✅ | 2m07s |

## Why now

Step-level timing on the most recent clean main-push run before this PR ([`27113434283`](https://github.com/reearth/reearth-flow/actions/runs/27113434283)) showed the ci-engine job at **31m48s** with **29m49s (94%)** inside a single `cargo make test` step that ran `test-rs → test-qc → test-conv` sequentially. Linters and the schema/cms checks each take <30s but were blocked behind the slow test step.

Iteration on this PR revealed two findings that shaped the final design:

- The three test suites split **unevenly** — test-rs at ~5m, test-conv at ~10m, test-qc at ~17-19m on a single runner. Simply running them in parallel still leaves test-qc as a ~19-min wall on a 4-vCPU runner.
- The test-qc bottleneck is **execution time, not compile time**. nextest reported `Summary [1136.372s]` for the test phase on a cache-warm run — that's the wall-clock with 4-way parallelism, implying ~76 min of single-threaded work in the suite. No test runner switch can break that floor on a 4-vCPU runner; the only way out is to spread the work across more runners.

## What changes

### 1. Parallel job split

The single `ci` job is replaced with logical jobs that each run on `blacksmith-4vcpu-ubuntu-2204`. After 4-shard sharding, the new bottleneck pair is **test-conv (~9m51s) and the slowest test-qc shard (~9m59s)** — within 8 seconds of each other, so further test-qc sharding has hit diminishing returns.

### 2. test-qc sharded via cargo-nextest

`workflow-tests` is the largest integration-test suite. Each test creates its own `TempDir`-rooted sandbox ([`testing/workflow-tests/src/main.rs:64`](https://github.com/reearth/reearth-flow/blob/main/engine/testing/workflow-tests/src/main.rs#L64)) and uses it as `sandbox_root` — tests are already isolated and parallel-safe, the bottleneck is purely CPU.

The job runs as a **4-way GitHub Actions matrix** calling `cargo nextest run -p workflow-tests --partition count:N/4`. nextest's count-based partitioning gives each shard a roughly equal slice of the test set. All 4 shards run on independent runners in parallel, giving us **16 effective cores** instead of 4.

The matrix uses `fail-fast: false` so a failure in one shard does not cancel the others — a bad push surfaces the full set of failures rather than just the first.

**Pre-flight audit** before switching to nextest confirmed there is no intentional serialization to preserve:
- No `serial_test` crate dependency
- Zero `#[serial]` attributes
- No `--test-threads=1` or `RUST_TEST_THREADS` overrides
- No `static Mutex` / `OnceLock` / `lazy_static` in workflow-tests
- No doctests (only `///` field documentation)
- No existing `nextest.toml`

A new `[tasks.test-qc-nextest]` is added in `engine/Makefile.toml`. The existing `[tasks.test-qc]` is left untouched so local developers without nextest installed are not affected — only CI calls the nextest variant.

### Other clean-ups in this PR

- Extracted shared post-checkout setup (toolchain, cache, taplo/cargo-make/cargo-edit) into a new local composite action at `.github/actions/setup-engine-ci/` to avoid duplicating ~25 lines across every job. Per-job extras (Node.js, glb-decompress, yaml-include, cargo-nextest) stay in the jobs that need them.
- Dropped the redundant `cargo make check` step. `cargo make clippy` is a strict superset — clippy implies check.
- Added explicit `--` separator to the taplo step (`cargo make format-taplo -- --check`) to match the rustfmt step's pattern in the same file.
- Wrapped the flaky `glb_decompress_draco` npm install in a 3-attempt retry loop — its transitive dependency `sharp` downloads `libvips` binaries from GitHub Releases, which has flaked with 504s.

### Trade-offs

- **Total compute increases ~70%** (32 → 54 runner-minutes). On Blacksmith pricing (~$0.0017/min for 4vCPU), that is ~+$0.04 per PR run, or roughly **+$4-18/month** for typical engine push velocity. The dev time recovered (~20 min saved per push) is two-to-three orders of magnitude larger in dollar terms.
- **Where the +70% comes from — compile multiplication**: the old monolith ran ~2 effective full-workspace compile passes inside a single `target/` directory (one for `cargo run`/dev-profile artifacts, one for `cargo test --cfg test` artifacts; `cargo check` and `cargo clippy` mostly share fingerprints). The new parallel layout has **~8 separate compile chains across 8 independent runners**, each with its own `target/`:

  | Job | Compile work |
  | --- | --- |
  | `lint` | clippy over the workspace |
  | `validate-generated` | `cargo run -p reearth-flow-cli` (dev profile) |
  | `test-rs` | workspace test binaries (`--cfg test`) |
  | `test-qc` shards × 4 | workflow-tests + deps (each shard) — 4× |
  | `test-conv` | plateau-tiles-test binary |

  The Swatinem rust-cache softens this across runs (with `shared-key: engine-ci`), but inside a single run all 8 jobs miss the cache together when `Cargo.lock` changes. **Collapsing this multiplication is the highest-ROI follow-up** (see "Still out of scope" below).
- **Cache miss on `Cargo.lock` change**: as above, all 8 jobs cold-compile together on the first run after a lockfile change. Subsequent runs hit the cache.
- **nextest's process-per-test model**: each test now runs in its own process. If a previously-hidden cross-test dependency exists (e.g., two tests sharing a non-`TempDir` path), nextest will surface it as a flake. Finding such a bug is a positive outcome; the pre-flight audit did not find any concrete instances.
- **Shard balance is good, not perfect**: 28% spread between slowest and fastest shard in the measured run (9m59s vs 7m09s) because nextest's `count:N/4` partitions by test *count*, not *duration*. Since test-conv is the joint-bottleneck at ~9m51s, additional balancing would not move the wall-clock. `hash:N/4` is an alternative if we later need stability across test renames.

### Still out of scope (planned as a follow-up PR)

This PR has hit the wall-clock floor imposed by per-job compile time. The remaining items target that floor directly, in roughly decreasing ROI:
- **Single `prepare-build` job upfront** that produces the workspace artifacts once and shares `target/` with downstream jobs (via cache or `actions/upload-artifact`). Collapses the ~8× compile multiplication back toward ~1×; biggest lever in the follow-up. *(Suggested by @asrcpq during review of this PR.)*
- **Removing `sleep` calls at end of action termination and end of workflow execution in the engine executor** — separate runtime PR; would shrink the *per-test* time on test-qc directly, independent of CI layout. *(Suggested by @asrcpq during review of this PR.)*
- `mold` linker (faster link step across every cargo invocation)
- `sccache` with GitHub Actions Cache backend (cross-PR `rustc` cache hits, especially after `Cargo.lock` changes)
- `concurrency:` cancellation in `ci.yml` so a rapid follow-up commit cancels the previous in-progress run instead of letting both finish

## Test plan

- [x] CI succeeds on this PR (4 distinct jobs + 4 test-qc shards run in parallel and pass) — verified on run [`27121246547`](https://github.com/reearth/reearth-flow/actions/runs/27121246547)
- [x] Wall-clock of the slowest job is ≤ ~10 min — verified at 9m59s (test-qc shard 2/4)
- [x] All 4 test-qc shards run a roughly equal number of tests (nextest's count-based partitioning) — verified, ~35 tests per shard
- [x] `ci.yml`'s parent `ci` rollup job still gates correctly on `ci-engine` — verified, workflow_call success
- [x] No drop in coverage: same `cargo make` tasks executed, plus 141 workflow-tests partitioned across shards (135 actual + 6 skipped, matches baseline)
- [x] Local `cargo make test-qc` still works without nextest installed (CI uses the new `test-qc-nextest` task)

