### PR TITLE
perf(engine): cut CI from ~32m to ~5m (drop executor sleeps, fix XSD fetch herd, parallelize CI)

### DIFF
--- a/.github/actions/setup-engine-ci/action.yml
+++ b/.github/actions/setup-engine-ci/action.yml
@@ -1,0 +1,51 @@
+name: Set up engine CI environment
+description: |
+  Shared post-checkout setup for engine CI jobs: frees disk space, installs the
+  pinned Rust toolchain, restores the cargo cache, and installs the small CLI
+  tools needed by every job (taplo-cli, cargo-make, cargo-edit).
+
+  The calling job MUST run `step-security/harden-runner` and `actions/checkout`
+  before invoking this action — checkout is required for GitHub to locate this
+  local composite action, and harden-runner must precede any network egress.
+
+  Node.js, glb-decompress, and yaml-include are intentionally NOT installed
+  here — only the jobs that need them install them, to keep setup time minimal.
+
+inputs:
+  shared-key:
+    description: |
+      Rust cache shared-key. All engine CI jobs use the same key so that the
+      first job to finish a clean build seeds the cache for the others on the
+      next run.
+    required: false
+    default: engine-ci
+  rust-components:
+    description: Optional extra rustup components to install (comma-separated).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Maximize build space
+      uses: AdityaGarg8/remove-unwanted-software@8831c82abf29b34eb2caac48d5f999ecfc0d8eef # v4.1
+      with:
+        remove-dotnet: 'true'
+        remove-android: 'true'
+        remove-haskell: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
+        remove-swapfile: 'true'
+        remove-cached-tools: 'true'
+    - uses: dtolnay/rust-toolchain@2ea1b3bdd0261867664fd125505456a7b9c3385c # 1.93.1
+      with:
+        components: ${{ inputs.rust-components }}
+    - name: Cache cargo registry
+      uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        workspaces: engine
+        shared-key: ${{ inputs.shared-key }}
+    - name: install required tools
+      uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2.75.20
+      with:
+        tool: taplo-cli,cargo-make,cargo-edit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,14 @@ on:
     branches: [main, release/*, release]
   pull_request:
 
+# Cancel a previous in-progress run when a new commit is pushed to the same
+# pull request, so rapid pushes don't queue up duplicate runs. Pushes to
+# main/release branches are NOT cancelled — every released commit must be
+# fully validated.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -124,7 +124,12 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/setup-engine-ci
       - name: test-qc
-        run: cargo make test-qc
+        # `--test-threads=16` is a CI-specific override (4× oversubscription
+        # on the 4-vCPU runner; safe now that the executor's polling-backoff
+        # uses sleep(100µs) instead of yield_now and the XSD cache shifts
+        # tests toward CPU-bound). Kept on the caller side so `cargo make
+        # test-qc` defaults to N_CPUs for local development.
+        run: cargo make test-qc -- --test-threads=16
 
   test-conv:
     name: test-conv (tile output validation)

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -19,8 +19,14 @@ defaults:
   run:
     working-directory: engine
 
+# All jobs share the same Rust cache (shared-key: engine-ci). The first run
+# after Cargo.lock changes pays a cache-miss cost in every job; subsequent
+# runs hit the cache the seeding job populated. Net wall clock is bounded by
+# the slowest single job (test-conv, ~7-8 min) instead of the sum of all
+# suites (~18 min on the previous monolithic layout).
 jobs:
-  ci:
+  lint:
+    name: lint (clippy / fmt / taplo)
     runs-on: blacksmith-4vcpu-ubuntu-2204
     steps:
       - name: Harden Runner
@@ -30,36 +36,9 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - name: Maximize build space
-        uses: AdityaGarg8/remove-unwanted-software@8831c82abf29b34eb2caac48d5f999ecfc0d8eef # v4.1
+      - uses: ./.github/actions/setup-engine-ci
         with:
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          remove-docker-images: 'true'
-          remove-swapfile: 'true'
-          remove-cached-tools: 'true'
-      - uses: dtolnay/rust-toolchain@2ea1b3bdd0261867664fd125505456a7b9c3385c # 1.93.1
-        with:
-          components: clippy, rustfmt
-      - name: Cache cargo registry
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: engine
-          shared-key: "engine-ci"
-      - name: install required tools
-        uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2.75.20
-        with:
-          tool: taplo-cli,cargo-make,cargo-edit
-      - name: install yaml-include
-        run: cargo install yaml-include
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '20'
-      - name: Install glb-decompress
-        run: npm install -g github:asrcpq/glb_decompress_draco#d0dc30683ae65bb60dda96192b8c1b1d8a80a771
+          rust-components: clippy, rustfmt
       - name: Compare version with previous commit
         if: ${{ !(github.ref == 'refs/heads/main') }}
         run: |
@@ -76,30 +55,108 @@ jobs:
             exit 1
           fi
 
-           echo "Previous version: $PREV_VERSION"
-           echo "Current version:  $CURR_VERSION"
+          echo "Previous version: $PREV_VERSION"
+          echo "Current version:  $CURR_VERSION"
 
-           if [ "$PREV_VERSION" = "$CURR_VERSION" ]; then
-             echo "Error: The version of Cargo.toml has not been changed."
-             echo "       To increase the patch version, run 'cargo set-version --bump patch'."
-             echo "       To bump the version, run one of:"
-             echo "       - 'cargo set-version --bump major'  # For breaking changes"
-             echo "       - 'cargo set-version --bump minor'  # For new features"
-             echo "       - 'cargo set-version --bump patch'  # For bug fixes"
-             exit 1
-           fi
-
-      - name: check
-        run: cargo make check
-      - name: rustfmt
-        run: cargo make format -- --check
+          if [ "$PREV_VERSION" = "$CURR_VERSION" ]; then
+            echo "Error: The version of Cargo.toml has not been changed."
+            echo "       To increase the patch version, run 'cargo set-version --bump patch'."
+            echo "       To bump the version, run one of:"
+            echo "       - 'cargo set-version --bump major'  # For breaking changes"
+            echo "       - 'cargo set-version --bump minor'  # For new features"
+            echo "       - 'cargo set-version --bump patch'  # For bug fixes"
+            exit 1
+          fi
+      # NOTE: `cargo make check` was previously a separate step. It is a
+      # strict subset of `cargo make clippy` (clippy implies check), so it is
+      # not run here.
       - name: clippy
         run: cargo make clippy
+      - name: rustfmt
+        run: cargo make format -- --check
       - name: taplo
-        run: cargo make format-taplo --check
+        run: cargo make format-taplo -- --check
+
+  validate-generated:
+    name: validate generated files (schema + cms workflows)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-engine-ci
+      - name: install yaml-include
+        run: cargo install yaml-include
       - name: check generated schema
         run: cargo make check-schema
       - name: check generated cms workflows
         run: cargo make check-generate-examples-cms-workflow
-      - name: run tests
-        run: cargo make test
+
+  test-rs:
+    name: test-rs (workspace unit + integration tests)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-engine-ci
+      - name: test-rs
+        run: cargo make test-rs
+
+  test-qc:
+    name: test-qc (workflow integration tests)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-engine-ci
+      - name: test-qc
+        run: cargo make test-qc
+
+  test-conv:
+    name: test-conv (tile output validation)
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-engine-ci
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '20'
+      - name: Install glb-decompress
+        # glb_decompress_draco transitively depends on `sharp`, whose postinstall
+        # script downloads libvips binaries from GitHub Releases. That download
+        # has flaked with 504s during peak GitHub traffic; retry up to 3 times
+        # before giving up so a single transient CDN blip doesn't fail CI.
+        run: |
+          for attempt in 1 2 3; do
+            if npm install -g github:asrcpq/glb_decompress_draco#d0dc30683ae65bb60dda96192b8c1b1d8a80a771; then
+              echo "glb-decompress install succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Attempt $attempt failed; sleeping 15s before retry..."
+            sleep 15
+          done
+          echo "glb-decompress install failed after 3 attempts" >&2
+          exit 1
+      - name: test-conv
+        run: cargo make test-conv

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -123,6 +123,21 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-engine-ci
+      - name: Cache XSD schema downloads
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          # The XML validator persists remote XSDs (the CityGML/GML base
+          # schemas fetched from schemas.opengis.net) under this directory. A
+          # warm run restores it and skips the downloads entirely; the first
+          # cold run repopulates it, and the in-process single-flight fetcher
+          # keeps that cold run from stampeding the remote server. The run_id
+          # in the key means each run saves a fresh entry while restore-keys
+          # falls back to the most recent prior cache, so newly seen schemas
+          # are persisted instead of frozen at v1.
+          path: /tmp/reearth-flow-xml-schema-cache
+          key: xsd-schemas-v1-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            xsd-schemas-v1-${{ runner.os }}-
       - name: test-qc
         # `--test-threads=16` is a CI-specific override (4× oversubscription
         # on the 4-vCPU runner; safe now that the executor's polling-backoff

--- a/.github/workflows/ci_policies.yml
+++ b/.github/workflows/ci_policies.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Setup Cerbos
         uses: cerbos/cerbos-setup-action@53d0a0d03111685bd355b2be6d75a2d0948c22de # v1.9.8
         with:
-          version: '0.40.0'
+          # cerbos-setup-action v1.9.x requires a leading `v` in the version
+          # string (Zod regex `^v\d+\.\d+\.\d+`). Bare `0.40.0` fails parse.
+          version: 'v0.40.0'
 
       - name: Validate Cerbos policies
         run: |

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.337"
+version = "0.0.338"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.49"
+version = "0.2.50"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.396"
+version = "0.0.397"
 dependencies = [
  "async-trait",
  "axum",
@@ -11220,7 +11220,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.239"
+version = "0.1.240"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.336"
+version = "0.0.337"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.48"
+version = "0.2.49"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.395"
+version = "0.0.396"
 dependencies = [
  "async-trait",
  "axum",
@@ -11220,7 +11220,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.238"
+version = "0.1.239"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.324"
+version = "0.0.325"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.383"
+version = "0.0.384"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.226"
+version = "0.1.227"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.333"
+version = "0.0.334"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.45"
+version = "0.2.46"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.392"
+version = "0.0.393"
 dependencies = [
  "async-trait",
  "axum",
@@ -11220,7 +11220,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.235"
+version = "0.1.236"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.322"
+version = "0.0.323"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.381"
+version = "0.0.382"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.224"
+version = "0.1.225"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.328"
+version = "0.0.329"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.387"
+version = "0.0.388"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.230"
+version = "0.1.231"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.335"
+version = "0.0.336"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.47"
+version = "0.2.48"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.394"
+version = "0.0.395"
 dependencies = [
  "async-trait",
  "axum",
@@ -11220,7 +11220,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.237"
+version = "0.1.238"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.323"
+version = "0.0.324"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.35"
+version = "0.2.36"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.382"
+version = "0.0.383"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.225"
+version = "0.1.226"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.320"
+version = "0.0.321"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.32"
+version = "0.2.33"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.222"
+version = "0.1.223"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.399"
+version = "0.0.400"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.334"
+version = "0.0.335"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.46"
+version = "0.2.47"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.393"
+version = "0.0.394"
 dependencies = [
  "async-trait",
  "axum",
@@ -11220,7 +11220,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.236"
+version = "0.1.237"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.327"
+version = "0.0.328"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.386"
+version = "0.0.387"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.229"
+version = "0.1.230"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.338"
+version = "0.0.339"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.50"
+version = "0.2.51"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.397"
+version = "0.0.398"
 dependencies = [
  "async-trait",
  "axum",
@@ -11220,7 +11220,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.240"
+version = "0.1.241"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.331"
+version = "0.0.332"
 dependencies = [
  "directories",
  "log",
@@ -5835,13 +5835,15 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.43"
+version = "0.2.44"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
  "image 0.25.10",
  "indexmap 2.13.0",
+ "num_cpus",
  "prost",
+ "rayon",
  "reearth-flow-action-log",
  "reearth-flow-action-plateau-processor",
  "reearth-flow-action-processor",
@@ -6629,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.390"
+version = "0.0.391"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11220,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.233"
+version = "0.1.234"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.330"
+version = "0.0.331"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.389"
+version = "0.0.390"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.232"
+version = "0.1.233"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.326"
+version = "0.0.327"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.385"
+version = "0.0.386"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.228"
+version = "0.1.229"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.398"
+version = "0.0.399"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.325"
+version = "0.0.326"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.384"
+version = "0.0.385"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.227"
+version = "0.1.228"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.321"
+version = "0.0.322"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.380"
+version = "0.0.381"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.223"
+version = "0.1.224"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.332"
+version = "0.0.333"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.44"
+version = "0.2.45"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.391"
+version = "0.0.392"
 dependencies = [
  "async-trait",
  "axum",
@@ -11220,7 +11220,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.234"
+version = "0.1.235"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.329"
+version = "0.0.330"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6629,7 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "futures",
  "once_cell",
@@ -6649,7 +6649,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "approx",
  "async-trait",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "Inflector",
  "approx",
@@ -6753,7 +6753,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6774,7 +6774,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6842,7 +6842,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "bytes",
  "clap",
@@ -6942,7 +6942,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6982,7 +6982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "chrono",
  "futures",
@@ -6996,7 +6996,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "approx",
  "bvh",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7102,7 +7102,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7192,7 +7192,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7204,7 +7204,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "bytes",
  "futures",
@@ -7221,7 +7221,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "bytes",
  "futures",
@@ -7240,7 +7240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7254,7 +7254,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7289,7 +7289,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7327,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.388"
+version = "0.0.389"
 dependencies = [
  "async-trait",
  "axum",
@@ -11218,7 +11218,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.231"
+version = "0.1.232"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.380"
+version = "0.0.381"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.384"
+version = "0.0.385"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.396"
+version = "0.0.397"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.388"
+version = "0.0.389"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.390"
+version = "0.0.391"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.383"
+version = "0.0.384"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.387"
+version = "0.0.388"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.393"
+version = "0.0.394"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.398"
+version = "0.0.399"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.399"
+version = "0.0.400"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.381"
+version = "0.0.382"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.392"
+version = "0.0.393"
 
 [profile.dev]
 opt-level = 0
@@ -46,6 +46,26 @@ strip = true
 codegen-units = 8
 inherits = "release"
 lto = "fat"
+
+# `release-test` — runtime perf close to release, compile time close to dev.
+# Used by `cargo make test-conv` so the Draco / mesh-compression code in
+# `plateau-tiles-test` runs at near-release speed without paying the full
+# release profile's LTO + codegen-units=1 cost in CI.
+#
+# Overrides vs release:
+#   - codegen-units = 16     (vs release's 1) → parallel codegen, much faster compile
+#   - lto = false            (vs release's "fat") → skips multi-minute whole-program LTO
+#   - debug = true           (vs release's stripped) → keeps stack traces on panic
+#   - panic = "unwind"       (vs release's "abort") → required by the
+#     `panic::catch_unwind` in plateau-tiles-test's parallel testcase loop
+#   - strip = "none"
+[profile.release-test]
+inherits = "release"
+codegen-units = 16
+lto = false
+debug = true
+panic = "unwind"
+strip = "none"
 
 [workspace.dependencies]
 reearth-flow-action-log = { path = "runtime/action-log" }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.394"
+version = "0.0.395"
 
 [profile.dev]
 opt-level = 0
@@ -46,26 +46,6 @@ strip = true
 codegen-units = 8
 inherits = "release"
 lto = "fat"
-
-# `release-test` — runtime perf close to release, compile time close to dev.
-# Used by `cargo make test-conv` so the Draco / mesh-compression code in
-# `plateau-tiles-test` runs at near-release speed without paying the full
-# release profile's LTO + codegen-units=1 cost in CI.
-#
-# Overrides vs release:
-#   - codegen-units = 16     (vs release's 1) → parallel codegen, much faster compile
-#   - lto = false            (vs release's "fat") → skips multi-minute whole-program LTO
-#   - debug = true           (vs release's stripped) → keeps stack traces on panic
-#   - panic = "unwind"       (vs release's "abort") → required by the
-#     `panic::catch_unwind` in plateau-tiles-test's parallel testcase loop
-#   - strip = "none"
-[profile.release-test]
-inherits = "release"
-codegen-units = 16
-lto = false
-debug = true
-panic = "unwind"
-strip = "none"
 
 [workspace.dependencies]
 reearth-flow-action-log = { path = "runtime/action-log" }

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.385"
+version = "0.0.386"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.386"
+version = "0.0.387"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.382"
+version = "0.0.383"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.397"
+version = "0.0.398"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.395"
+version = "0.0.396"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.389"
+version = "0.0.390"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.391"
+version = "0.0.392"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -54,12 +54,10 @@ cargo test --workspace --all-targets --all-features --exclude plateau-gis-qualit
 [tasks.test-qc]
 script = ['''
 #!/usr/bin/env bash -eux
-# EXPERIMENT: --test-threads=8 to probe whether workflow-tests is CPU-bound
-# at the default of N_CPUS (=4 on the CI runner) or whether spare CPU
-# capacity exists. If wall-clock drops materially with 8 threads on a
-# 4-vCPU runner, tests are I/O-bound and per-runner thread count is the
-# cheaper lever than sharding. If wall-clock is unchanged or worse, tests
-# are CPU-bound at 4 threads and sharding has a real case.
+# `--test-threads=8` because workflow-tests is I/O-bound at 4 threads on
+# the CI runner. Doubling threads on a 4-vCPU runner cut test-qc wall-
+# clock from 12m26s to 6m22s with no shard complexity. Override locally
+# (e.g. via `cargo make test-qc -- --test-threads=N`) if needed.
 cargo test -p workflow-tests -- --test-threads=8 ${@:-}
 ''']
 

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -54,15 +54,15 @@ cargo test --workspace --all-targets --all-features --exclude plateau-gis-qualit
 [tasks.test-qc]
 script = ['''
 #!/usr/bin/env bash -eux
-# `--test-threads=8` is the highest oversubscription the 4-vCPU CI runner
-# can sustain. 16 threads previously caused the runner agent to lose
-# heartbeat with GitHub (CPU starvation from 4× context switching on
-# only 4 cores). 8 threads (2× oversubscription) absorbed I/O slack
-# without thrashing. Combined with the XSD schema disk cache (added in
-# this PR) this is enough to keep workflow-tests well under previous
-# baselines. Override locally (e.g. `cargo make test-qc -- --test-threads=N`)
-# if you have more cores available.
-cargo test -p workflow-tests -- --test-threads=8 ${@:-}
+# `--test-threads=16` (4× oversubscription on the 4-vCPU CI runner).
+# An earlier attempt at 16 threads crashed the Blacksmith runner because
+# the executor's polling-backoff used `yield_now()` which spun at 100%
+# CPU, competing with the runner agent itself. That has since been
+# replaced with `thread::sleep(Duration::from_micros(100))`, so the
+# polling loop no longer hogs a core. With the spin gone + the XSD
+# schema disk cache shifting tests from I/O-bound toward CPU-bound, 16
+# threads should run cleanly. Override locally if needed.
+cargo test -p workflow-tests -- --test-threads=16 ${@:-}
 ''']
 
 [tasks.test-conv]
@@ -70,7 +70,12 @@ script = ['''
 #!/usr/bin/env bash -eux
 export RUST_LOG=warn,plateau_tiles_test=info # avoid engine info log flooding
 export PLATEAU_TILES_TEST_CLEANUP=1
-cargo run -p plateau-tiles-test --bin plateau-tiles-test ${@:-}
+# `--profile release-test` gives near-release runtime perf (notably for the
+# Draco mesh-compression kernels) without the full release profile's LTO +
+# codegen-units=1 compile-time cost. See engine/Cargo.toml for the profile
+# definition. The profile preserves `panic = "unwind"` which the parallel
+# testcase loop's `panic::catch_unwind` requires.
+cargo run --profile release-test -p plateau-tiles-test --bin plateau-tiles-test ${@:-}
 ''']
 
 [tasks.doc]

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -65,12 +65,7 @@ script = ['''
 #!/usr/bin/env bash -eux
 export RUST_LOG=warn,plateau_tiles_test=info # avoid engine info log flooding
 export PLATEAU_TILES_TEST_CLEANUP=1
-# `--profile release-test` gives near-release runtime perf (notably for the
-# Draco mesh-compression kernels) without the full release profile's LTO +
-# codegen-units=1 compile-time cost. See engine/Cargo.toml for the profile
-# definition. The profile preserves `panic = "unwind"` which the parallel
-# testcase loop's `panic::catch_unwind` requires.
-cargo run --profile release-test -p plateau-tiles-test --bin plateau-tiles-test ${@:-}
+cargo run -p plateau-tiles-test --bin plateau-tiles-test ${@:-}
 ''']
 
 [tasks.doc]

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -54,11 +54,13 @@ cargo test --workspace --all-targets --all-features --exclude plateau-gis-qualit
 [tasks.test-qc]
 script = ['''
 #!/usr/bin/env bash -eux
-# `--test-threads=8` because workflow-tests is I/O-bound at 4 threads on
-# the CI runner. Doubling threads on a 4-vCPU runner cut test-qc wall-
-# clock from 12m26s to 6m22s with no shard complexity. Override locally
+# Oversubscribe the 4-vCPU CI runner with `--test-threads=16` because the
+# workflow-tests suite has historically been I/O-bound on schema fetches
+# and process-startup. Once the XSD schema disk cache (added in this PR)
+# warms within a run, the bottleneck shifts toward CPU; oversubscription
+# still helps absorb residual I/O wait without thrashing. Override locally
 # (e.g. via `cargo make test-qc -- --test-threads=N`) if needed.
-cargo test -p workflow-tests -- --test-threads=8 ${@:-}
+cargo test -p workflow-tests -- --test-threads=16 ${@:-}
 ''']
 
 [tasks.test-conv]

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -54,7 +54,13 @@ cargo test --workspace --all-targets --all-features --exclude plateau-gis-qualit
 [tasks.test-qc]
 script = ['''
 #!/usr/bin/env bash -eux
-cargo test -p workflow-tests ${@:-}
+# EXPERIMENT: --test-threads=8 to probe whether workflow-tests is CPU-bound
+# at the default of N_CPUS (=4 on the CI runner) or whether spare CPU
+# capacity exists. If wall-clock drops materially with 8 threads on a
+# 4-vCPU runner, tests are I/O-bound and per-runner thread count is the
+# cheaper lever than sharding. If wall-clock is unchanged or worse, tests
+# are CPU-bound at 4 threads and sharding has a real case.
+cargo test -p workflow-tests -- --test-threads=8 ${@:-}
 ''']
 
 [tasks.test-conv]

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -54,15 +54,10 @@ cargo test --workspace --all-targets --all-features --exclude plateau-gis-qualit
 [tasks.test-qc]
 script = ['''
 #!/usr/bin/env bash -eux
-# `--test-threads=16` (4× oversubscription on the 4-vCPU CI runner).
-# An earlier attempt at 16 threads crashed the Blacksmith runner because
-# the executor's polling-backoff used `yield_now()` which spun at 100%
-# CPU, competing with the runner agent itself. That has since been
-# replaced with `thread::sleep(Duration::from_micros(100))`, so the
-# polling loop no longer hogs a core. With the spin gone + the XSD
-# schema disk cache shifting tests from I/O-bound toward CPU-bound, 16
-# threads should run cleanly. Override locally if needed.
-cargo test -p workflow-tests -- --test-threads=16 ${@:-}
+# Defaults to cargo's normal thread count (= N_CPUs). CI overrides via
+# `cargo make test-qc -- --test-threads=16` so local development is not
+# forced to a CI-specific value.
+cargo test -p workflow-tests ${@:-}
 ''']
 
 [tasks.test-conv]

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -54,13 +54,15 @@ cargo test --workspace --all-targets --all-features --exclude plateau-gis-qualit
 [tasks.test-qc]
 script = ['''
 #!/usr/bin/env bash -eux
-# Oversubscribe the 4-vCPU CI runner with `--test-threads=16` because the
-# workflow-tests suite has historically been I/O-bound on schema fetches
-# and process-startup. Once the XSD schema disk cache (added in this PR)
-# warms within a run, the bottleneck shifts toward CPU; oversubscription
-# still helps absorb residual I/O wait without thrashing. Override locally
-# (e.g. via `cargo make test-qc -- --test-threads=N`) if needed.
-cargo test -p workflow-tests -- --test-threads=16 ${@:-}
+# `--test-threads=8` is the highest oversubscription the 4-vCPU CI runner
+# can sustain. 16 threads previously caused the runner agent to lose
+# heartbeat with GitHub (CPU starvation from 4× context switching on
+# only 4 cores). 8 threads (2× oversubscription) absorbed I/O slack
+# without thrashing. Combined with the XSD schema disk cache (added in
+# this PR) this is enough to keep workflow-tests well under previous
+# baselines. Override locally (e.g. `cargo make test-qc -- --test-threads=N`)
+# if you have more cores available.
+cargo test -p workflow-tests -- --test-threads=8 ${@:-}
 ''']
 
 [tasks.test-conv]

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.335"
+version = "0.0.336"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.331"
+version = "0.0.332"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.325"
+version = "0.0.326"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.320"
+version = "0.0.321"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.333"
+version = "0.0.334"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.327"
+version = "0.0.328"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.336"
+version = "0.0.337"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.334"
+version = "0.0.335"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.322"
+version = "0.0.323"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.338"
+version = "0.0.339"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.330"
+version = "0.0.331"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.332"
+version = "0.0.333"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.337"
+version = "0.0.338"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.323"
+version = "0.0.324"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.326"
+version = "0.0.327"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.328"
+version = "0.0.329"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.329"
+version = "0.0.330"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.324"
+version = "0.0.325"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.321"
+version = "0.0.322"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/runtime/action-processor/src/xml/validator.rs
+++ b/engine/runtime/action-processor/src/xml/validator.rs
@@ -73,20 +73,42 @@ impl DiskCachingFetcher {
 impl SchemaFetcher for DiskCachingFetcher {
     fn fetch(&self, url: &str) -> fastxml::error::Result<FetchResult> {
         let path = self.cache_path(url);
-        if let Ok(content) = std::fs::read(&path) {
-            return Ok(FetchResult {
-                content,
-                final_url: url.to_string(),
-                redirected: false,
-            });
+
+        // Only read the cache file if it exists and is a regular file. The
+        // cache directory lives under a shared temp dir, so guard against
+        // a symlink at the cache path being followed to read or write
+        // arbitrary content elsewhere on the filesystem.
+        if let Ok(meta) = std::fs::symlink_metadata(&path) {
+            if meta.file_type().is_file() {
+                if let Ok(content) = std::fs::read(&path) {
+                    return Ok(FetchResult {
+                        content,
+                        final_url: url.to_string(),
+                        redirected: false,
+                    });
+                }
+            }
         }
 
         let result = self.inner.fetch(url)?;
 
         // Only cache direct (non-redirected) responses so a cached entry's
-        // `final_url` stays correct for relative-import resolution.
+        // `final_url` stays correct for relative-import resolution. Write via
+        // a sibling temp file + atomic rename so that:
+        //   * A pre-existing symlink at the destination is not followed.
+        //   * Concurrent readers either see the old content or the new
+        //     content, never a partial write.
         if !result.redirected && result.final_url == url {
-            let _ = std::fs::write(&path, &result.content);
+            if let Some(parent) = path.parent() {
+                let tmp = parent.join(format!(
+                    ".{}.{}.tmp",
+                    path.file_name().and_then(|n| n.to_str()).unwrap_or("cache"),
+                    std::process::id()
+                ));
+                if std::fs::write(&tmp, &result.content).is_ok() {
+                    let _ = std::fs::rename(&tmp, &path);
+                }
+            }
         }
 
         Ok(result)

--- a/engine/runtime/action-processor/src/xml/validator.rs
+++ b/engine/runtime/action-processor/src/xml/validator.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use bytes::Bytes;
-use fastxml::schema::fetcher::{DefaultFetcher, FileCachingFetcher, SchemaFetcher};
+use fastxml::schema::fetcher::{DefaultFetcher, FetchResult, SchemaFetcher};
 use fastxml::schema::types::CompiledSchema;
 use fastxml::schema::xsd::{compile_schemas, register_builtin_types, SchemaResolver};
 use once_cell::sync::Lazy;
@@ -28,6 +28,70 @@ use super::types::{ValidationResult, ValidationType, XmlInputType, XmlValidatorP
 
 static SUCCESS_PORT: Lazy<Port> = Lazy::new(|| Port::new("success"));
 static FAILED_PORT: Lazy<Port> = Lazy::new(|| Port::new("failed"));
+
+/// Persistent on-disk cache directory for fetched XSD schemas.
+///
+/// Remote GML/CityGML base schemas (e.g. `http://schemas.opengis.net/...`) are
+/// referenced by absolute URL and are not shipped in the local schema bundle, so
+/// without a persistent cache every validation run re-downloads them. Pointing the
+/// `FileCachingFetcher` at a stable directory makes those downloads happen once and
+/// be reused across documents, workflow runs, and processes.
+///
+/// Override the location with `FLOW_RUNTIME_XML_SCHEMA_CACHE_DIR`.
+static SCHEMA_CACHE_DIR: Lazy<PathBuf> = Lazy::new(|| {
+    let dir = std::env::var("FLOW_RUNTIME_XML_SCHEMA_CACHE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir().join("reearth-flow-xml-schema-cache"));
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!(dir = ?dir, error = ?e, "Failed to create XML schema cache directory");
+    }
+    dir
+});
+
+/// Persistent, cross-process disk cache for fetched XSD schemas.
+///
+/// `fastxml`'s own `FileCachingFetcher` only consults its in-memory index, which
+/// starts empty on every process, so its on-disk files are never re-read across
+/// runs. This wrapper keys directly off a deterministic filename: a fresh process
+/// finds the existing file on disk and skips the network entirely.
+struct DiskCachingFetcher {
+    inner: DefaultFetcher,
+    dir: PathBuf,
+}
+
+impl DiskCachingFetcher {
+    fn cache_path(&self, url: &str) -> PathBuf {
+        use std::hash::{Hash, Hasher};
+        // DefaultHasher uses fixed keys (not randomized), so the filename is
+        // stable across processes and machines.
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        url.hash(&mut hasher);
+        self.dir.join(format!("{:016x}.xsd", hasher.finish()))
+    }
+}
+
+impl SchemaFetcher for DiskCachingFetcher {
+    fn fetch(&self, url: &str) -> fastxml::error::Result<FetchResult> {
+        let path = self.cache_path(url);
+        if let Ok(content) = std::fs::read(&path) {
+            return Ok(FetchResult {
+                content,
+                final_url: url.to_string(),
+                redirected: false,
+            });
+        }
+
+        let result = self.inner.fetch(url)?;
+
+        // Only cache direct (non-redirected) responses so a cached entry's
+        // `final_url` stays correct for relative-import resolution.
+        if !result.redirected && result.final_url == url {
+            let _ = std::fs::write(&path, &result.content);
+        }
+
+        Ok(result)
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct XmlValidatorFactory;
@@ -456,9 +520,12 @@ impl XmlValidator {
                 Some(dir) => DefaultFetcher::with_base_dir(dir),
                 None => DefaultFetcher::new(),
             };
-            let fetcher = FileCachingFetcher::new(inner).map_err(|e| {
-                XmlProcessorError::Validator(format!("Failed to create caching fetcher: {e:?}"))
-            })?;
+            // Persistent on-disk cache: fetched remote schemas are reused across
+            // documents/runs/processes instead of being re-downloaded each time.
+            let fetcher = DiskCachingFetcher {
+                inner,
+                dir: SCHEMA_CACHE_DIR.clone(),
+            };
 
             let mut resolver = SchemaResolver::new(&fetcher);
             for (_namespace, location) in &schema_locations {

--- a/engine/runtime/action-processor/src/xml/validator.rs
+++ b/engine/runtime/action-processor/src/xml/validator.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Debug, Formatter},
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
 };
@@ -48,12 +48,75 @@ static SCHEMA_CACHE_DIR: Lazy<PathBuf> = Lazy::new(|| {
     dir
 });
 
+/// Per-URL locks used to coalesce concurrent fetches of the same schema URL
+/// within a process ("single-flight").
+///
+/// On a cold runner the on-disk cache is empty, so every worker thread that
+/// starts a workflow at once races to download the same handful of remote
+/// XSDs (the CityGML/GML base schemas). Sixteen threads hitting
+/// `schemas.opengis.net` simultaneously trips its rate limiter and turns a
+/// few-second download into minutes of retries. Electing a single thread per
+/// URL to do the fetch — while the rest wait and then read the file it wrote —
+/// removes the herd without touching the warm-cache fast path.
+///
+/// The map only ever grows by the number of distinct schema URLs seen in a
+/// process (a few dozen), so it is not a meaningful leak.
+static FETCH_LOCKS: Lazy<parking_lot::Mutex<HashMap<String, Arc<parking_lot::Mutex<()>>>>> =
+    Lazy::new(|| parking_lot::Mutex::new(HashMap::new()));
+
+fn fetch_lock_for(url: &str) -> Arc<parking_lot::Mutex<()>> {
+    let mut locks = FETCH_LOCKS.lock();
+    Arc::clone(
+        locks
+            .entry(url.to_string())
+            .or_insert_with(|| Arc::new(parking_lot::Mutex::new(()))),
+    )
+}
+
+/// Read a previously cached schema from disk, if present.
+///
+/// Only a regular file is served: the cache directory lives under a shared
+/// temp dir, so a symlink planted at the cache path must not be followed to
+/// read arbitrary content elsewhere on the filesystem.
+fn read_cached_schema(path: &Path, url: &str) -> Option<FetchResult> {
+    let meta = std::fs::symlink_metadata(path).ok()?;
+    if !meta.file_type().is_file() {
+        return None;
+    }
+    let content = std::fs::read(path).ok()?;
+    Some(FetchResult {
+        content,
+        final_url: url.to_string(),
+        redirected: false,
+    })
+}
+
+/// Atomically write a fetched schema to the disk cache.
+///
+/// Writing via a sibling temp file + rename means a pre-existing symlink at the
+/// destination is not followed, and concurrent readers see either the old or
+/// the new content, never a partial write.
+fn write_cached_schema(path: &Path, content: &[u8]) {
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    let tmp = parent.join(format!(
+        ".{}.{}.tmp",
+        path.file_name().and_then(|n| n.to_str()).unwrap_or("cache"),
+        std::process::id()
+    ));
+    if std::fs::write(&tmp, content).is_ok() {
+        let _ = std::fs::rename(&tmp, path);
+    }
+}
+
 /// Persistent, cross-process disk cache for fetched XSD schemas.
 ///
 /// `fastxml`'s own `FileCachingFetcher` only consults its in-memory index, which
 /// starts empty on every process, so its on-disk files are never re-read across
 /// runs. This wrapper keys directly off a deterministic filename: a fresh process
-/// finds the existing file on disk and skips the network entirely.
+/// finds the existing file on disk and skips the network entirely. Concurrent
+/// misses for the same URL are coalesced into a single network fetch.
 struct DiskCachingFetcher {
     inner: DefaultFetcher,
     dir: PathBuf,
@@ -68,50 +131,47 @@ impl DiskCachingFetcher {
         url.hash(&mut hasher);
         self.dir.join(format!("{:016x}.xsd", hasher.finish()))
     }
+
+    /// Serve `url` from the disk cache, or fetch it via `fetch_uncached` and
+    /// populate the cache. Concurrent callers for the same URL are serialized
+    /// so only one runs `fetch_uncached`; the rest read the file it wrote.
+    fn fetch_with_cache(
+        &self,
+        url: &str,
+        fetch_uncached: impl FnOnce() -> fastxml::error::Result<FetchResult>,
+    ) -> fastxml::error::Result<FetchResult> {
+        let path = self.cache_path(url);
+
+        // Fast path: serve directly from disk without taking any lock.
+        if let Some(result) = read_cached_schema(&path, url) {
+            return Ok(result);
+        }
+
+        // Cache miss: coalesce concurrent fetches of this URL (see FETCH_LOCKS).
+        let url_lock = fetch_lock_for(url);
+        let _guard = url_lock.lock();
+
+        // Re-check: the elected thread may have populated the cache while we
+        // waited for the lock.
+        if let Some(result) = read_cached_schema(&path, url) {
+            return Ok(result);
+        }
+
+        let result = fetch_uncached()?;
+
+        // Only cache direct (non-redirected) responses so a cached entry's
+        // `final_url` stays correct for relative-import resolution.
+        if !result.redirected && result.final_url == url {
+            write_cached_schema(&path, &result.content);
+        }
+
+        Ok(result)
+    }
 }
 
 impl SchemaFetcher for DiskCachingFetcher {
     fn fetch(&self, url: &str) -> fastxml::error::Result<FetchResult> {
-        let path = self.cache_path(url);
-
-        // Only read the cache file if it exists and is a regular file. The
-        // cache directory lives under a shared temp dir, so guard against
-        // a symlink at the cache path being followed to read or write
-        // arbitrary content elsewhere on the filesystem.
-        if let Ok(meta) = std::fs::symlink_metadata(&path) {
-            if meta.file_type().is_file() {
-                if let Ok(content) = std::fs::read(&path) {
-                    return Ok(FetchResult {
-                        content,
-                        final_url: url.to_string(),
-                        redirected: false,
-                    });
-                }
-            }
-        }
-
-        let result = self.inner.fetch(url)?;
-
-        // Only cache direct (non-redirected) responses so a cached entry's
-        // `final_url` stays correct for relative-import resolution. Write via
-        // a sibling temp file + atomic rename so that:
-        //   * A pre-existing symlink at the destination is not followed.
-        //   * Concurrent readers either see the old content or the new
-        //     content, never a partial write.
-        if !result.redirected && result.final_url == url {
-            if let Some(parent) = path.parent() {
-                let tmp = parent.join(format!(
-                    ".{}.{}.tmp",
-                    path.file_name().and_then(|n| n.to_str()).unwrap_or("cache"),
-                    std::process::id()
-                ));
-                if std::fs::write(&tmp, &result.content).is_ok() {
-                    let _ = std::fs::rename(&tmp, &path);
-                }
-            }
-        }
-
-        Ok(result)
+        self.fetch_with_cache(url, || self.inner.fetch(url))
     }
 }
 
@@ -918,6 +978,73 @@ mod tests {
             port, *SUCCESS_PORT,
             "Should succeed when remote schema URL is unreachable"
         );
+    }
+
+    #[test]
+    fn test_disk_caching_fetcher_coalesces_concurrent_fetches() {
+        use std::sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc, Barrier,
+        };
+
+        // Each thread fetches the same URL through a temp-dir-backed disk cache.
+        // The "network" fetch is a counting closure, so we can assert that the
+        // single-flight lock collapses the herd into exactly one real fetch
+        // (the rest are served from the file that fetch wrote). This is the
+        // cold-runner scenario that previously stampeded schemas.opengis.net.
+        let tmp = tempfile::tempdir().expect("create temp cache dir");
+        let fetcher = Arc::new(DiskCachingFetcher {
+            inner: DefaultFetcher::new(),
+            dir: tmp.path().to_path_buf(),
+        });
+
+        // Unique URL so neither the process-global FETCH_LOCKS map nor the
+        // per-test temp dir can be warmed by another test.
+        let url = "http://example.test/coalesce/unique-schema-aa17.xsd";
+        let network_calls = Arc::new(AtomicUsize::new(0));
+
+        const THREADS: usize = 16;
+        let barrier = Arc::new(Barrier::new(THREADS));
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                let fetcher = Arc::clone(&fetcher);
+                let network_calls = Arc::clone(&network_calls);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    // Release all threads together so they genuinely contend.
+                    barrier.wait();
+                    fetcher
+                        .fetch_with_cache(url, || {
+                            network_calls.fetch_add(1, Ordering::SeqCst);
+                            // Widen the race window so the late threads are
+                            // forced through the lock + disk re-check path.
+                            std::thread::sleep(std::time::Duration::from_millis(50));
+                            Ok(FetchResult {
+                                content: b"<xsd:schema/>".to_vec(),
+                                final_url: url.to_string(),
+                                redirected: false,
+                            })
+                        })
+                        .expect("fetch_with_cache should succeed")
+                })
+            })
+            .collect();
+
+        let results: Vec<FetchResult> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+        assert_eq!(
+            network_calls.load(Ordering::SeqCst),
+            1,
+            "concurrent fetches of the same URL must coalesce into one network call"
+        );
+        for result in results {
+            assert_eq!(
+                result.content,
+                b"<xsd:schema/>".to_vec(),
+                "every caller must receive the fetched content"
+            );
+        }
     }
 
     // Regression test for L02 false positive:

--- a/engine/runtime/runner/src/executor.rs
+++ b/engine/runtime/runner/src/executor.rs
@@ -78,7 +78,14 @@ pub fn run_dag_executor(
     let result = join_handle
         .join((*runtime).clone())
         .map_err(Error::ExecutionError);
-    std::thread::sleep(Duration::from_millis(1000));
+    // Settle delay between join completion and notify. The historical 1000ms
+    // was a defensive value (likely waiting for in-flight async tasks / output
+    // flushes to drain). 100ms is enough headroom in practice and turns the
+    // 1s × N-tests overhead into a much smaller cost. A proper fix would
+    // replace this with explicit async-drain logic before notify, but that's
+    // a bigger refactor; this is the minimal change that recovers most of the
+    // wall-clock cost without exposing the underlying race.
+    std::thread::sleep(Duration::from_millis(100));
     join_handle.notify();
     result
 }

--- a/engine/runtime/runner/src/executor.rs
+++ b/engine/runtime/runner/src/executor.rs
@@ -75,9 +75,7 @@ pub fn run_dag_executor(
         event_handlers,
         executor_id,
     ))?;
-    let result = join_handle
-        .join((*runtime).clone())
-        .map_err(Error::ExecutionError);
+    let result = join_handle.join().map_err(Error::ExecutionError);
     // Settle delay between join completion and notify. The historical 1000ms
     // was a defensive value (likely waiting for in-flight async tasks / output
     // flushes to drain). 100ms is enough headroom in practice and turns the

--- a/engine/runtime/runtime/src/event.rs
+++ b/engine/runtime/runtime/src/event.rs
@@ -122,7 +122,6 @@ impl EventHub {
         });
     }
 
-
     pub fn warn_log<T: ToString>(&self, span: Option<Span>, message: T) {
         self.send(Event::Log {
             level: Level::WARN,

--- a/engine/runtime/runtime/src/event.rs
+++ b/engine/runtime/runtime/src/event.rs
@@ -122,31 +122,6 @@ impl EventHub {
         });
     }
 
-    pub async fn simple_flush(&self, delay_ms: u64) {
-        tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
-    }
-
-    pub async fn enhanced_flush(&self, max_wait_ms: u64) {
-        let start = std::time::Instant::now();
-        let max_duration = tokio::time::Duration::from_millis(max_wait_ms);
-
-        // Poll the broadcast sender at 10ms intervals (was 100ms) so we
-        // detect receivers draining without imposing a fixed-latency floor
-        // on every flush call.
-        while start.elapsed() < max_duration {
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-
-            if self.sender.receiver_count() == 0 {
-                break;
-            }
-        }
-
-        // Trailing settle delay — receiver_count() == 0 doesn't guarantee that
-        // every in-flight broadcast task has finished processing. 20ms (was
-        // 200ms) is enough headroom in practice without making the flush
-        // itself a wall-clock bottleneck.
-        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
-    }
 
     pub fn warn_log<T: ToString>(&self, span: Option<Span>, message: T) {
         self.send(Event::Log {

--- a/engine/runtime/runtime/src/event.rs
+++ b/engine/runtime/runtime/src/event.rs
@@ -130,15 +130,22 @@ impl EventHub {
         let start = std::time::Instant::now();
         let max_duration = tokio::time::Duration::from_millis(max_wait_ms);
 
+        // Poll the broadcast sender at 10ms intervals (was 100ms) so we
+        // detect receivers draining without imposing a fixed-latency floor
+        // on every flush call.
         while start.elapsed() < max_duration {
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
             if self.sender.receiver_count() == 0 {
                 break;
             }
         }
 
-        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        // Trailing settle delay — receiver_count() == 0 doesn't guarantee that
+        // every in-flight broadcast task has finished processing. 20ms (was
+        // 200ms) is enough headroom in practice without making the flush
+        // itself a wall-clock bottleneck.
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
     }
 
     pub fn warn_log<T: ToString>(&self, span: Option<Span>, message: T) {

--- a/engine/runtime/runtime/src/executor/dag_executor.rs
+++ b/engine/runtime/runtime/src/executor/dag_executor.rs
@@ -39,7 +39,6 @@ pub struct DagExecutor {
 }
 
 pub struct DagExecutorJoinHandle {
-    event_hub: EventHub,
     join_handles: Vec<JoinHandle<Result<(), ExecutionError>>>,
     notify: Arc<Notify>,
     executor_id: uuid::Uuid,
@@ -110,8 +109,6 @@ impl DagExecutor {
                 .collect()
         };
         let node_indexes = execution_dag.graph().node_indices().collect::<Vec<_>>();
-
-        let event_hub = execution_dag.event_hub().clone();
 
         let ctx = NodeContext::new(
             Arc::clone(&expr_engine),
@@ -249,7 +246,6 @@ impl DagExecutor {
         }
 
         Ok(DagExecutorJoinHandle {
-            event_hub,
             join_handles,
             notify: notify_publish.clone(),
             executor_id,
@@ -266,7 +262,7 @@ async fn subscribe_event(
 }
 
 impl DagExecutorJoinHandle {
-    pub fn join(&mut self, runtime: Handle) -> Result<(), ExecutionError> {
+    pub fn join(&mut self) -> Result<(), ExecutionError> {
         loop {
             let Some(finished) = self
                 .join_handles
@@ -282,17 +278,16 @@ impl DagExecutorJoinHandle {
             handle.join().unwrap()?;
 
             if self.join_handles.is_empty() {
-                // All threads have completed, add a delay before returning
-                tracing::info!("Workflow complete, waiting for final events to be published...");
-
-                // Enhanced delay approach - use improved flush with dynamic waiting
-                runtime.block_on(self.event_hub.enhanced_flush(5000));
-
-                // Cleanup executor cache directory (includes channel buffers and processor temp files)
+                // `enhanced_flush(5000)` used to live here. Its early-break
+                // condition (`sender.receiver_count() == 0`) never fired in
+                // practice because broadcast subscribers stay attached for
+                // the lifetime of the workflow, so the call effectively
+                // waited the full 5 seconds on every workflow execution
+                // (~11+ minutes across the 141 workflow-tests). The runner-
+                // level shutdown sleep + the trailing settle in any caller
+                // that needs one provides enough of a drain window without
+                // this 5s tax.
                 cleanup_executor_cache(self.executor_id);
-
-                tracing::info!("Proceeding with workflow termination");
-
                 return Ok(());
             }
         }

--- a/engine/runtime/runtime/src/executor/processor_node.rs
+++ b/engine/runtime/runtime/src/executor/processor_node.rs
@@ -323,9 +323,13 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for ProcessorNode<F> {
                     return terminate_result;
                 }
                 // Polling-backoff for the busy-wait that drains `thread_counter`
-                // after all inputs have terminated. `yield_now` gives the scheduler
-                // a chance to run other threads without a fixed sleep window.
-                std::thread::yield_now();
+                // after all inputs have terminated. A 100µs sleep keeps CPU usage
+                // negligible (~10,000 polls/sec at most) while still being fast
+                // enough that detection latency for the counter reaching 0 is
+                // imperceptible. `yield_now()` would spin at ~100% CPU on cores
+                // with no other runnable threads, which can stretch into seconds
+                // for large processors.
+                std::thread::sleep(Duration::from_micros(100));
                 continue;
             }
             let index = sel.ready();

--- a/engine/runtime/runtime/src/executor/processor_node.rs
+++ b/engine/runtime/runtime/src/executor/processor_node.rs
@@ -33,7 +33,12 @@ use super::receiver_loop::init_select;
 use super::source_intermediate::SourceIntermediateRecorder;
 use super::{execution_dag::ExecutionDag, receiver_loop::ReceiverLoop};
 
-// See sink_node.rs for rationale on the 500ms -> 5ms default change.
+// Backoff for the busy-wait loop that polls thread_counter waiting for
+// in-flight processor work to drain. NOT a propagation delay — the original
+// post-status sleeps with the same name have been removed; this remaining
+// use is purely a CPU-throttle on the polling loop. 5ms gives 200 polls/sec
+// at negligible CPU cost. The historical env var name is preserved for
+// backward compatibility.
 static NODE_STATUS_PROPAGATION_DELAY: Lazy<Duration> = Lazy::new(|| {
     env::var("FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS")
         .ok()
@@ -310,12 +315,6 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for ProcessorNode<F> {
                         status: final_status,
                         feature_id: None,
                     });
-
-                    tracing::info!(
-                        "Waiting for final status to propagate for processor node {}",
-                        self.node_handle.id
-                    );
-                    std::thread::sleep(*NODE_STATUS_PROPAGATION_DELAY);
 
                     let terminate_result = self.on_terminate(NodeContext::new(
                         self.expr_engine.clone(),

--- a/engine/runtime/runtime/src/executor/processor_node.rs
+++ b/engine/runtime/runtime/src/executor/processor_node.rs
@@ -33,11 +33,6 @@ use super::receiver_loop::init_select;
 use super::source_intermediate::SourceIntermediateRecorder;
 use super::{execution_dag::ExecutionDag, receiver_loop::ReceiverLoop};
 
-// CPU-throttle for the busy-wait loop that polls `thread_counter` waiting
-// for in-flight processor work to drain. 5ms gives ~200 polls/sec at
-// negligible CPU cost. Not related to node-status propagation.
-const POLL_BACKOFF: Duration = Duration::from_millis(5);
-
 static SLOW_ACTION_THRESHOLD: Lazy<Duration> = Lazy::new(|| {
     env::var("FLOW_RUNTIME_SLOW_ACTION_THRESHOLD")
         .ok()
@@ -327,7 +322,10 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for ProcessorNode<F> {
 
                     return terminate_result;
                 }
-                std::thread::sleep(POLL_BACKOFF);
+                // Polling-backoff for the busy-wait that drains `thread_counter`
+                // after all inputs have terminated. `yield_now` gives the scheduler
+                // a chance to run other threads without a fixed sleep window.
+                std::thread::yield_now();
                 continue;
             }
             let index = sel.ready();

--- a/engine/runtime/runtime/src/executor/processor_node.rs
+++ b/engine/runtime/runtime/src/executor/processor_node.rs
@@ -33,12 +33,13 @@ use super::receiver_loop::init_select;
 use super::source_intermediate::SourceIntermediateRecorder;
 use super::{execution_dag::ExecutionDag, receiver_loop::ReceiverLoop};
 
+// See sink_node.rs for rationale on the 500ms -> 5ms default change.
 static NODE_STATUS_PROPAGATION_DELAY: Lazy<Duration> = Lazy::new(|| {
     env::var("FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS")
         .ok()
         .and_then(|v| v.parse().ok())
         .map(Duration::from_millis)
-        .unwrap_or(Duration::from_millis(500))
+        .unwrap_or(Duration::from_millis(5))
 });
 
 static SLOW_ACTION_THRESHOLD: Lazy<Duration> = Lazy::new(|| {

--- a/engine/runtime/runtime/src/executor/processor_node.rs
+++ b/engine/runtime/runtime/src/executor/processor_node.rs
@@ -33,19 +33,10 @@ use super::receiver_loop::init_select;
 use super::source_intermediate::SourceIntermediateRecorder;
 use super::{execution_dag::ExecutionDag, receiver_loop::ReceiverLoop};
 
-// Backoff for the busy-wait loop that polls thread_counter waiting for
-// in-flight processor work to drain. NOT a propagation delay — the original
-// post-status sleeps with the same name have been removed; this remaining
-// use is purely a CPU-throttle on the polling loop. 5ms gives 200 polls/sec
-// at negligible CPU cost. The historical env var name is preserved for
-// backward compatibility.
-static NODE_STATUS_PROPAGATION_DELAY: Lazy<Duration> = Lazy::new(|| {
-    env::var("FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(Duration::from_millis(5))
-});
+// CPU-throttle for the busy-wait loop that polls `thread_counter` waiting
+// for in-flight processor work to drain. 5ms gives ~200 polls/sec at
+// negligible CPU cost. Not related to node-status propagation.
+const POLL_BACKOFF: Duration = Duration::from_millis(5);
 
 static SLOW_ACTION_THRESHOLD: Lazy<Duration> = Lazy::new(|| {
     env::var("FLOW_RUNTIME_SLOW_ACTION_THRESHOLD")
@@ -336,7 +327,7 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for ProcessorNode<F> {
 
                     return terminate_result;
                 }
-                std::thread::sleep(*NODE_STATUS_PROPAGATION_DELAY);
+                std::thread::sleep(POLL_BACKOFF);
                 continue;
             }
             let index = sel.ready();

--- a/engine/runtime/runtime/src/executor/sink_node.rs
+++ b/engine/runtime/runtime/src/executor/sink_node.rs
@@ -1,16 +1,14 @@
 use std::{
     borrow::Cow,
-    env,
     fmt::Debug,
     io::BufRead,
     mem::swap,
     sync::{atomic::AtomicU64, Arc},
-    time::{self, Duration},
+    time,
 };
 
 use crossbeam::channel::Receiver;
 use futures::Future;
-use once_cell::sync::Lazy;
 use petgraph::graph::NodeIndex;
 use reearth_flow_eval_expr::engine::Engine;
 use reearth_flow_state::State;
@@ -32,20 +30,6 @@ use crate::{
 use super::receiver_loop::ReceiverLoop;
 use super::source_intermediate::SourceIntermediateRecorder;
 use super::{execution_dag::ExecutionDag, receiver_loop::init_select};
-
-// Reduced from the historical 500ms default. The sleep is here to let
-// asynchronous node-status events propagate before the next executor step;
-// 5ms is empirically enough on observed test workloads while reclaiming the
-// 495ms × N-nodes per workflow that was dominating test-qc wall-clock.
-// The env var override (`FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS`)
-// stays as a safety valve for any caller that still needs the old behaviour.
-static NODE_STATUS_PROPAGATION_DELAY: Lazy<Duration> = Lazy::new(|| {
-    env::var("FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(Duration::from_millis(5))
-});
 
 /// A sink in the execution DAG.
 #[derive(Debug)]
@@ -361,8 +345,6 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for SinkNode<F> {
                             status: final_status,
                             feature_id: None,
                         });
-
-                        std::thread::sleep(*NODE_STATUS_PROPAGATION_DELAY);
 
                         let terminate_result = self.on_terminate(ctx);
 

--- a/engine/runtime/runtime/src/executor/sink_node.rs
+++ b/engine/runtime/runtime/src/executor/sink_node.rs
@@ -33,12 +33,18 @@ use super::receiver_loop::ReceiverLoop;
 use super::source_intermediate::SourceIntermediateRecorder;
 use super::{execution_dag::ExecutionDag, receiver_loop::init_select};
 
+// Reduced from the historical 500ms default. The sleep is here to let
+// asynchronous node-status events propagate before the next executor step;
+// 5ms is empirically enough on observed test workloads while reclaiming the
+// 495ms × N-nodes per workflow that was dominating test-qc wall-clock.
+// The env var override (`FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS`)
+// stays as a safety valve for any caller that still needs the old behaviour.
 static NODE_STATUS_PROPAGATION_DELAY: Lazy<Duration> = Lazy::new(|| {
     env::var("FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS")
         .ok()
         .and_then(|v| v.parse().ok())
         .map(Duration::from_millis)
-        .unwrap_or(Duration::from_millis(500))
+        .unwrap_or(Duration::from_millis(5))
 });
 
 /// A sink in the execution DAG.

--- a/engine/runtime/runtime/src/executor/source_node.rs
+++ b/engine/runtime/runtime/src/executor/source_node.rs
@@ -35,12 +35,13 @@ use crate::{
 use super::execution_dag::ExecutionDag;
 use super::node::Node;
 
+// See sink_node.rs for rationale on the 500ms -> 5ms default change.
 static NODE_STATUS_PROPAGATION_DELAY: Lazy<Duration> = Lazy::new(|| {
     env::var("FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS")
         .ok()
         .and_then(|v| v.parse().ok())
         .map(Duration::from_millis)
-        .unwrap_or(Duration::from_millis(500))
+        .unwrap_or(Duration::from_millis(5))
 });
 
 /// The source operation collector.

--- a/engine/runtime/runtime/src/executor/source_node.rs
+++ b/engine/runtime/runtime/src/executor/source_node.rs
@@ -1,14 +1,12 @@
 use std::{
     collections::HashSet,
-    env,
     fmt::Debug,
     future::Future,
     pin::pin,
     sync::{atomic::AtomicU64, Arc},
-    time::{self, Duration},
+    time,
 };
 
-use once_cell::sync::Lazy;
 use petgraph::visit::IntoNodeIdentifiers;
 
 use async_stream::stream;
@@ -34,15 +32,6 @@ use crate::{
 
 use super::execution_dag::ExecutionDag;
 use super::node::Node;
-
-// See sink_node.rs for rationale on the 500ms -> 5ms default change.
-static NODE_STATUS_PROPAGATION_DELAY: Lazy<Duration> = Lazy::new(|| {
-    env::var("FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(Duration::from_millis(5))
-});
 
 /// The source operation collector.
 #[derive(Debug)]
@@ -145,9 +134,6 @@ impl<F: Future + Unpin> Node for SourceNode<F> {
                         status: NodeStatus::Completed,
                         feature_id: None,
                     });
-
-                    tracing::info!("Waiting for final status to propagate for all source nodes");
-                    std::thread::sleep(*NODE_STATUS_PROPAGATION_DELAY);
                 } else if let Err(ref e) = result {
                     event_hub.error_log_with_node_info(
                         Some(node_span.clone()),
@@ -194,9 +180,6 @@ impl<F: Future + Unpin> Node for SourceNode<F> {
                         });
                     }
 
-                    tracing::info!("Waiting for final status to propagate for all source nodes");
-                    std::thread::sleep(*NODE_STATUS_PROPAGATION_DELAY);
-
                     send_to_all_nodes(&self.sources, ctx)?;
                     self.event_hub.send(Event::SourceFlushed);
                     return Ok(());
@@ -230,9 +213,6 @@ impl<F: Future + Unpin> Node for SourceNode<F> {
                                         });
                                     }
 
-                                    tracing::info!("Waiting for final status to propagate for all source nodes");
-                                    std::thread::sleep(*NODE_STATUS_PROPAGATION_DELAY);
-
                                     send_to_all_nodes(&self.sources, ctx)?;
                                     self.event_hub.send(Event::SourceFlushed);
                                     return Ok(());
@@ -248,12 +228,6 @@ impl<F: Future + Unpin> Node for SourceNode<F> {
                                     status: NodeStatus::Failed,
                                     feature_id: None,
                                 });
-
-                                tracing::info!(
-                                    "Waiting for failed status to propagate for source node {}",
-                                    self.sources[index].channel_manager.owner().id
-                                );
-                                std::thread::sleep(*NODE_STATUS_PROPAGATION_DELAY);
 
                                 return Err(ExecutionError::Source(e));
                             }

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.40"
+version = "0.2.41"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.42"
+version = "0.2.43"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.41"
+version = "0.2.42"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.37"
+version = "0.2.38"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.43"
+version = "0.2.44"
 edition = "2021"
 
 [dependencies]
@@ -34,6 +34,8 @@ tinymvt.workspace = true
 prost.workspace = true
 indexmap.workspace = true
 image.workspace = true
+rayon.workspace = true
+num_cpus.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.36"
+version = "0.2.37"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.39"
+version = "0.2.40"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.50"
+version = "0.2.51"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.49"
+version = "0.2.50"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.35"
+version = "0.2.36"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.38"
+version = "0.2.39"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.32"
+version = "0.2.33"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.47"
+version = "0.2.48"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.44"
+version = "0.2.45"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.48"
+version = "0.2.49"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.45"
+version = "0.2.46"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.33"
+version = "0.2.34"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.34"
+version = "0.2.35"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.46"
+version = "0.2.47"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/src/main.rs
+++ b/engine/testing/plateau-tiles-test/src/main.rs
@@ -476,8 +476,60 @@ fn main() {
 
         run_testcase(&testcases_dir, &results_dir, &test_name, stages);
     } else {
-        for name in DEFAULT_TESTS {
-            run_testcase(&testcases_dir, &results_dir, name, "re");
+        // Run testcases concurrently across the testcase set. Each testcase
+        // writes to its own output directory and spawns its own Runner with
+        // isolated state/storage/logger, so they are safe to interleave.
+        //
+        // Concurrency is bounded because each Runner internally spawns ~4
+        // worker threads for its DAG; running too many testcases at once
+        // oversubscribes the CPU and causes the runner agent to lose
+        // heartbeat (same failure mode we saw with --test-threads=16 in
+        // workflow-tests). On a 4-vCPU CI runner, 2 concurrent testcases is
+        // the safe ceiling. Override via PLATEAU_TILES_TEST_CONCURRENCY for
+        // larger machines.
+        let concurrency = env::var("PLATEAU_TILES_TEST_CONCURRENCY")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or_else(|| (num_cpus::get() / 2).clamp(1, 4));
+
+        eprintln!(
+            "Running {} testcases with concurrency={}",
+            DEFAULT_TESTS.len(),
+            concurrency
+        );
+
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(concurrency)
+            .thread_name(|i| format!("plateau-tiles-test-{i}"))
+            .build()
+            .expect("failed to build rayon thread pool");
+
+        // Collect outcomes so a single panic doesn't abort the whole run —
+        // we still surface every failure, but only after all testcases have
+        // had a chance to run (and after their isolated state is cleaned up).
+        let failures: Vec<String> = pool.install(|| {
+            use rayon::prelude::*;
+            DEFAULT_TESTS
+                .par_iter()
+                .filter_map(|name| {
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        run_testcase(&testcases_dir, &results_dir, name, "re");
+                    }));
+                    if result.is_err() {
+                        Some((*name).to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        });
+
+        if !failures.is_empty() {
+            eprintln!("\n{} testcases failed:", failures.len());
+            for name in &failures {
+                eprintln!("  - {name}");
+            }
+            std::process::exit(1);
         }
     }
 }

--- a/engine/testing/plateau-tiles-test/src/main.rs
+++ b/engine/testing/plateau-tiles-test/src/main.rs
@@ -490,6 +490,7 @@ fn main() {
         let concurrency = env::var("PLATEAU_TILES_TEST_CONCURRENCY")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
+            .map(|n| n.max(1)) // 0 would panic rayon::ThreadPoolBuilder::num_threads
             .unwrap_or_else(|| (num_cpus::get() / 2).clamp(1, 4));
 
         eprintln!(

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.225"
+version = "0.1.226"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.240"
+version = "0.1.241"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.235"
+version = "0.1.236"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.233"
+version = "0.1.234"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.226"
+version = "0.1.227"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.234"
+version = "0.1.235"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.228"
+version = "0.1.229"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.227"
+version = "0.1.228"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.230"
+version = "0.1.231"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.237"
+version = "0.1.238"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.236"
+version = "0.1.237"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.222"
+version = "0.1.223"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.224"
+version = "0.1.225"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.232"
+version = "0.1.233"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.231"
+version = "0.1.232"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.229"
+version = "0.1.230"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.239"
+version = "0.1.240"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.238"
+version = "0.1.239"
 edition = "2021"
 
 [[bin]]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.223"
+version = "0.1.224"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary

Cuts engine CI from **~32 min to ~5 min** for a typical run, and — just as important — **removes a ~26 min cold-cache tail** that could hit any run starting on a fresh runner. Levers, in rough order of impact:

1. Remove dead per-action sleeps in the executor (including a 5s unconditional `enhanced_flush` on every workflow).
2. Cache fetched XSD schemas on disk **and coalesce concurrent fetches** so a cold cache can't stampede the remote schema server.
3. Persist that schema cache across CI runs via `actions/cache`.
4. Split the monolithic ci-engine job into 5 concurrent jobs + 16-thread oversubscription on the 4-vCPU runner.
5. Parallelize the `plateau-tiles-test` binary internally.

| Layer | Mechanism |
|---|---|
| Sleep cleanup | Remove `NODE_STATUS_PROPAGATION_DELAY` + its 6 propagation-window `thread::sleep` calls; **remove the `enhanced_flush(5000)` call that blocked up to 5s on every workflow** (its early-exit never fired — broadcast subscribers stay attached for the workflow's lifetime) plus the now-unused flush helpers; shorten the runner shutdown sleep 1000ms→100ms; replace the processor polling-backoff `yield_now()` with `sleep(100µs)` |
| XSD schema disk cache | Replace buggy `FileCachingFetcher` (its in-memory index resets per process, so on-disk files are never re-read) with `DiskCachingFetcher` keyed by deterministic per-URL filenames |
| **XSD fetch coalescing (single-flight)** | On a cold cache, 16 test threads otherwise download the *same* CityGML/GML base schemas from `schemas.opengis.net` at once → rate-limited → minutes of backoff. A per-URL lock elects one thread to fetch while the rest wait and read the file it wrote: 16 concurrent fetches → **1** request. Unit-tested. |
| **`actions/cache` for the schema dir** | Persist `/tmp/reearth-flow-xml-schema-cache` across runs (`key: xsd-schemas-v1-<os>-<run_id>` + `restore-keys` prefix) so warm runs skip the downloads entirely |
| `--test-threads=16` for `test-qc` | 4× oversubscription on the 4-vCPU runner; passed in from the CI caller so local `cargo make test-qc` keeps cargo's default |
| Parallel-jobs split | 5 concurrent jobs (lint / validate-generated / test-rs / test-qc / test-conv) |
| `plateau-tiles-test` internal parallelism | bounded `rayon` concurrency instead of a serial `for` loop |
| Concurrency cancellation in `ci.yml` | rapid PR pushes auto-cancel the previous in-progress run |
| Cerbos workflow fix | drive-by: `cerbos-setup-action` now requires a `v` prefix on the version |

## The cold-cache tail — and what actually fixed it

A `test-qc` run on this branch once took **26.3 min** while sibling runs took ~4 min on the *same code*. The cause was **not** compile time: the Swatinem rust-cache was a **full hit on both runs** (the cache key is byte-identical across workspace version bumps — they don't move it). It was the **XSD fetch thundering herd** — a cold runner has an empty schema cache, so all 16 test threads request the same schemas from `schemas.opengis.net` simultaneously and get rate-limited into long backoffs.

The single-flight coalescing is what fixes it. Controlled comparison — same 141 tests, same rust-cache (full hit), **both with a cold XSD cache**, only difference is the coalescing:

```
without coalescing:  test result: ok. 141 passed ... finished in 1104.65s   (18.4 min)
with    coalescing:  test result: ok. 141 passed ... finished in  116.75s   ( 1.9 min)
```

`actions/cache` is the second, complementary layer: it makes runs start *warm* (zero fetches) so the cold path is rare; single-flight bounds the cold path when it does occur (first run on a new cache key, or a cache eviction).

> This corrects a hypothesis raised in review that a "rust-cache miss from the version bump" contributed to the 26-min run. It did not — the rust-cache was a full hit even there. The herd was the whole story, and the planned `sccache` follow-up would not have rescued that run.

## Timing is an envelope, not a point

CI wall-clock here is **not deterministic**: 16 threads on 4 vCPUs makes the suite CPU-bound and sensitive to runner contention. Across four recent runs of identical engine code, `test-qc`'s own harness time ranged **96.66s / 116.75s / 147.17s / 218.22s**, and total ci-engine wall-clock ranged **~5–7 min**. Cold-vs-warm ordering is within that noise (the warm run was actually the slowest of the set). What's robust is the floor: every run is ~5 min, none anywhere near the old 26-min tail. We removed the catastrophic tail — we did not make an oversubscribed suite deterministic.

Recent runs (all identical engine code; last one rebased on current `main`):

| Run | XSD cache | test-qc harness | test-qc job | total ci-engine |
|---|---|---:|---:|---:|
| [`27268241058`](https://github.com/reearth/reearth-flow/actions/runs/27268241058) — before coalescing (cold herd) | none | 1104.65s | 21.3m | ~28m |
| [`27323548061`](https://github.com/reearth/reearth-flow/actions/runs/27323548061) — + coalescing (cold) | miss | 116.75s | 3.8m | **5.3m** |
| [`27324106784`](https://github.com/reearth/reearth-flow/actions/runs/27324106784) — warm | restored | 218.22s | 5.2m | 6.7m |
| [`27325866601`](https://github.com/reearth/reearth-flow/actions/runs/27325866601) — rebased on main, warm | restored | 96.66s\* | 4.4m | **4.9m** |

\* first attempt flaked on a single pre-existing non-deterministic test (see *Known flake*); passed on re-run.

### Earlier structural progression

Each row is a real CI run; this is the journey before the cold-tail fix above.

| Configuration | test-rs | test-qc | test-conv | Total ci-engine |
|---|---:|---:|---:|---:|
| Baseline (monolithic, 500ms sleeps, default threads) [`27113434283`](https://github.com/reearth/reearth-flow/actions/runs/27113434283) | 3m17s | 19m30s | 6m58s | **31m48s** |
| + reduce 500→5ms | 2m58s | 12m14s | 7m27s | 26m25s |
| + delete propagation sleeps | 2m48s | 12m26s | 7m12s | 26m49s |
| + `--test-threads=8` | 2m49s | 6m22s | 7m59s | 19m07s |
| + remove the delay constant entirely + concurrency block | 2m57s | 6m50s | 7m01s | 20m28s |
| + XSD disk cache [`27195146745`](https://github.com/reearth/reearth-flow/actions/runs/27195146745) | 2m50s | 3m57s | 7m08s | 17m56s |
| + 5-job parallel split [`27196555430`](https://github.com/reearth/reearth-flow/actions/runs/27196555430) | 4m30s | 5m24s | 8m52s | 10m28s |
| + `plateau-tiles-test` internal parallelism [`27256505864`](https://github.com/reearth/reearth-flow/actions/runs/27256505864) | 4m02s | 4m58s | 5m32s | 9m15s |
| + Copilot fixes + 16 threads + smaller residual sleeps [`27265552331`](https://github.com/reearth/reearth-flow/actions/runs/27265552331) | 4m00s | 3m52s | 5m10s | **6m31s** |

The parallel split converts wall-clock from sum-of-suites to max-of-suites; the thread oversubscription + `plateau-tiles-test` parallelism flatten the per-job durations into the ~4-5 min range; and the XSD work (disk cache + coalescing + `actions/cache`) is what removes both the per-run fetch cost *and* the cold-herd tail.

## Engine runtime changes

**`NODE_STATUS_PROPAGATION_DELAY` removed entirely**, in stages:
1. Six `thread::sleep(*NODE_STATUS_PROPAGATION_DELAY)` calls in sink/source/processor nodes deleted — `event_hub` is a broadcast channel; the sleeps added latency for subscribers, they didn't enforce ordering.
2. The static + `FLOW_RUNTIME_NODE_STATUS_PROPAGATION_DELAY_MS` env var removed.
3. The remaining polling-backoff site in `processor_node.rs` uses `thread::sleep(Duration::from_micros(100))` — trivial CPU without spinning.

**`enhanced_flush(5000)` removed**: it blocked up to 5s on *every* workflow execution. Its early-exit (`receiver_count() == 0`) never fired because broadcast subscribers remain attached for the workflow's lifetime, so it always waited the full window. The call site and the now-unused `enhanced_flush`/`simple_flush` helpers were deleted. Runner shutdown sleep shortened 1000ms→100ms.

**XSD schema disk cache + coalescing** (`engine/runtime/action-processor/src/xml/validator.rs`): `DiskCachingFetcher` uses deterministic per-URL filenames under `/tmp/reearth-flow-xml-schema-cache/` (configurable via `FLOW_RUNTIME_XML_SCHEMA_CACHE_DIR`). Reads are guarded with `symlink_metadata`; writes use a sibling tempfile + atomic rename (no symlink attacks on the shared temp dir). A process-global per-URL lock (`fetch_with_cache`) coalesces concurrent misses for the same URL into a single network fetch via double-checked locking — fast path is a lockless disk read, so warm runs take no lock at all. Covered by a unit test asserting 16 concurrent fetches → 1 network call.

**`plateau-tiles-test` internal parallelism**: serial `for name in DEFAULT_TESTS` loop replaced with `DEFAULT_TESTS.par_iter()` on a bounded `rayon` pool. Each testcase writes to its own output dir and spawns its own isolated `Runner`, so concurrency is safe. Defaults to `num_cpus / 2` clamped `[1, 4]` (= 2 on the 4-vCPU runner), overridable via `PLATEAU_TILES_TEST_CONCURRENCY` (`max(1)` clamp so a 0 can't panic `ThreadPoolBuilder`). Per-testcase panics are caught so one failure doesn't abort the rest.

## CI changes

- **`engine/Makefile.toml`**: `test-qc` body is bare `cargo test -p workflow-tests ${@:-}`. CI overrides via `cargo make test-qc -- --test-threads=16` so local dev keeps cargo's `N_CPUs` default.
- **`.github/workflows/ci_engine.yml`**: split into 5 parallel jobs; **`actions/cache` step** added to `test-qc` for the XSD schema directory. **No sharding, no nextest** — measured data shows test-qc is CPU-bound at 16 threads once schemas are cached, so sharding would only multiply compile overhead.
- **`.github/actions/setup-engine-ci/`**: new composite action for shared post-checkout setup (toolchain, rust-cache, taplo/cargo-make/cargo-edit).
- **`.github/workflows/ci.yml`**: workflow-level `concurrency:` block — cancel in-progress on PR pushes, preserve main/release.
- **`.github/workflows/ci_policies.yml`**: `version: 'v0.40.0'` (was `'0.40.0'`).

## Test plan

- [x] All 141 `workflow-tests` pass with `--test-threads=16` and the XSD cache
- [x] All 33 `plateau-tiles-test` testcases pass with `concurrency=2` (no races surfaced)
- [x] `test-rs` and `test-conv` pass
- [x] Single-flight coalescing covered by a unit test (16 threads → 1 network fetch)
- [x] Cold-cache CI run verified (`Cache not found` → saved) and warm-cache run verified (`Cache restored from key` via the `restore-keys` prefix → re-saved)
- [x] `FLOW_RUNTIME_XML_SCHEMA_CACHE_DIR` and `PLATEAU_TILES_TEST_CONCURRENCY` overrides work
- [x] Local `cargo make test-qc` defaults to cargo's `N_CPUs` (no CI value baked in)
- [x] Rebased on current `main` and green

## Known flake (pre-existing, out of scope)

`test_quality_check_plateau4_02_bldg_z_bldg_00_no_error_01` intermittently reports a spurious L02 schema error (`expected 0, got 1`) — observed once across these four identical-code runs, passes on re-run. Confirmed **independent of this PR's caching**: the cached schema bytes are byte-identical across all runs, so it's runtime non-determinism in schema resolution, not a cache-content issue. The exact trigger (per-process `HashMap`-seed ordering vs. cross-thread contention) is unconfirmed. Tracked in #2155.

## Out of scope

- Draco compression speedup — handled separately by another reviewer; the `release-test` profile experiment that briefly lived here has been reverted.
- The 250ms `dag_executor.rs` polling-backoff is kept as a CPU throttle in the `join_handles` wait loop.
- PR #2145 (parallel + sharded CI) was the earlier draft superseded by this approach — closed.
- The L02 flake above — tracked in #2155.
- Further wall-clock work deferred to follow-ups: nextest for `test-rs`, `mold` linker, `sccache` (GitHub Actions Cache backend) for compile times. Note `sccache` targets compile time, not the schema herd this PR fixes.
