### PR TITLE
fix(ui): update WysiwygWidget and NoteNode styles for better responsiveness [FLOW-DEV-188]

### DIFF
--- a/ui/src/components/SchemaForm/Widgets/WysiwygWidget.tsx
+++ b/ui/src/components/SchemaForm/Widgets/WysiwygWidget.tsx
@@ -151,7 +151,7 @@ const WysiwygWidget = <
       style={paramsAwarenessStyles(focusedUsers)}
       aria-describedby={ariaDescribedByIds(id)}
       aria-required={required}
-      className="w-full overflow-hidden rounded-md border shadow-sm [&_.ql-code-block-container_.ql-code-block]:w-[560px] [&_.ql-container]:border-none [&_.ql-container]:bg-transparent [&_.ql-container]:text-sm [&_.ql-editor]:min-h-20 [&_.ql-editor]:text-foreground [&_.ql-editor_p]:w-[560px] [&_.ql-editor:focus]:outline-none [&_.ql-toolbar]:border-0! [&_.ql-toolbar]:border-b! [&_.ql-toolbar]:border-border [&_.ql-toolbar]:bg-transparent [&_.ql-toolbar]:p-1 [&_.ql-tooltip]:left-1/2! [&_.ql-tooltip]:-translate-x-1/2!">
+      className="w-full overflow-hidden rounded-md border shadow-sm [&_.ql-code-block-container_.ql-code-block]:max-w-full [&_.ql-container]:border-none [&_.ql-container]:bg-transparent [&_.ql-container]:text-sm [&_.ql-editor]:min-h-20 [&_.ql-editor]:text-foreground [&_.ql-editor_p]:max-w-full [&_.ql-editor:focus]:outline-none [&_.ql-toolbar]:border-0! [&_.ql-toolbar]:border-b! [&_.ql-toolbar]:border-border [&_.ql-toolbar]:bg-transparent [&_.ql-toolbar]:p-1 [&_.ql-tooltip]:left-1/2! [&_.ql-tooltip]:-translate-x-1/2!">
       <div ref={containerRef} />
     </div>
   );

--- a/ui/src/components/SchemaForm/Widgets/WysiwygWidget.tsx
+++ b/ui/src/components/SchemaForm/Widgets/WysiwygWidget.tsx
@@ -151,7 +151,7 @@ const WysiwygWidget = <
       style={paramsAwarenessStyles(focusedUsers)}
       aria-describedby={ariaDescribedByIds(id)}
       aria-required={required}
-      className="w-full overflow-hidden rounded-md border shadow-sm [&_.ql-container]:border-none [&_.ql-container]:bg-transparent [&_.ql-container]:text-sm [&_.ql-editor]:min-h-20 [&_.ql-editor]:text-foreground [&_.ql-editor:focus]:outline-none [&_.ql-toolbar]:border-0! [&_.ql-toolbar]:border-b! [&_.ql-toolbar]:border-border [&_.ql-toolbar]:bg-transparent [&_.ql-toolbar]:p-1 [&_.ql-tooltip]:left-1/2! [&_.ql-tooltip]:-translate-x-1/2!">
+      className="w-full overflow-hidden rounded-md border shadow-sm [&_.ql-code-block-container_.ql-code-block]:w-[560px] [&_.ql-container]:border-none [&_.ql-container]:bg-transparent [&_.ql-container]:text-sm [&_.ql-editor]:min-h-20 [&_.ql-editor]:text-foreground [&_.ql-editor_p]:w-[560px] [&_.ql-editor:focus]:outline-none [&_.ql-toolbar]:border-0! [&_.ql-toolbar]:border-b! [&_.ql-toolbar]:border-border [&_.ql-toolbar]:bg-transparent [&_.ql-toolbar]:p-1 [&_.ql-tooltip]:left-1/2! [&_.ql-tooltip]:-translate-x-1/2!">
       <div ref={containerRef} />
     </div>
   );

--- a/ui/src/components/visualizations/Cesium/GeoJson.tsx
+++ b/ui/src/components/visualizations/Cesium/GeoJson.tsx
@@ -228,6 +228,12 @@ const GeoJsonData: React.FC<Props> = ({
       });
 
       updateVisibility();
+
+      if (selectedFeatureIdRef.current) {
+        handleHighlightSelectedFeature(selectedFeatureIdRef.current);
+        prevSelectedRef.current = selectedFeatureIdRef.current;
+      }
+
       await flyTo();
 
       // Bail if unmounted during flyTo (e.g. switched to 3D data mid-flight).
@@ -246,7 +252,7 @@ const GeoJsonData: React.FC<Props> = ({
         v.scene.postRender.addEventListener(renderAgain);
       }
     },
-    [updateVisibility, flyTo],
+    [updateVisibility, flyTo, handleHighlightSelectedFeature],
   );
 
   useEffect(() => {

--- a/ui/src/lib/reactFlow/nodeTypes/NoteNode/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/NoteNode/index.tsx
@@ -104,9 +104,9 @@ const NoteNode: React.FC<NoteNodeProps> = ({
           </div>
           <p>{data.customizations?.customName ?? data.officialName}</p>
         </div>
-        <div>
+        <div className="h-full overflow-y-auto">
           <div
-            className="nowheel nodrag size-full resize-none bg-transparent text-xs focus-visible:outline-hidden [&_a]:text-blue-400 [&_a]:underline [&_b]:font-bold [&_i]:italic [&_li]:ml-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_p:empty]:pt-1 [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-1 [&_pre]:font-mono [&_s]:line-through [&_u]:underline [&_ul]:list-disc [&_ul]:pl-4"
+            className="nowheel nodrag w-full resize-none bg-transparent text-xs wrap-break-word focus-visible:outline-hidden [&_a]:text-blue-400 [&_a]:underline [&_b]:font-bold [&_i]:italic [&_li]:ml-1 [&_ol]:list-decimal [&_ol]:pl-4 [&_p:empty]:pt-1 [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-1 [&_pre]:font-mono [&_pre]:whitespace-pre-wrap [&_s]:line-through [&_u]:underline [&_ul]:list-disc [&_ul]:pl-4"
             dangerouslySetInnerHTML={{
               __html: DOMPurify.sanitize(data.customizations?.content ?? "", {
                 ALLOWED_TAGS: [


### PR DESCRIPTION
# Overview
This PR updates UI styling for rich-text note rendering and the schema form WYSIWYG editor, aiming to improve responsiveness/overflow behavior in the Flow UI.
## What I've done
- Make `NoteNode` content area scrollable and adjust rich-text rendering styles (wrapping / preformatted text behavior).
- Adjust `WysiwygWidget` Quill styling via Tailwind arbitrary selectors (including new width rules for paragraphs/code blocks).
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
