### PR TITLE
fix(ui): prevent backspace deletion for nodes/edges when project is locked [FLOW-DEV-189]

### DIFF
--- a/ui/src/features/Canvas/index.tsx
+++ b/ui/src/features/Canvas/index.tsx
@@ -147,6 +147,7 @@ const Canvas: React.FC<Props> = ({
       nodesConnectable={!readonly}
       nodesDraggable={!readonly}
       nodesFocusable={!readonly}
+      deleteKeyCode={readonly ? null : undefined}
       // elementsSelectable={!readonly}
 
       reconnectRadius={!readonly ? 10 : 0}


### PR DESCRIPTION
# Overview
This PR disables ReactFlow’s keyboard-driven element deletion when the editor is in a locked (read-only) state, preventing nodes/edges from being removed via Backspace/Delete while a project is locked.
## What I've done
- Set `deleteKeyCode` to `null` when `isLocked`/`readonly` to disable ReactFlow’s delete hotkey handling in read-only mode.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
