### PR TITLE
test(web): add e2e test for PLATEAU CityGML to GeoJSON pipeline

### DIFF
--- a/ui/e2e/tests/fixtures/workflows/csv-to-geojson.yml
+++ b/ui/e2e/tests/fixtures/workflows/csv-to-geojson.yml
@@ -53,8 +53,9 @@ graphs:
         with:
           # Sink outputs must be relative paths; the engine resolves them
           # against the job's artifact sandbox and rejects absolute URIs.
-          output: |
-            "stations.geojson"
+          output:
+            type: string
+            value: stations.geojson
 
     edges:
       - id: 0b12ab32-6f2a-427c-8459-f31fcf7f0f92

--- a/ui/e2e/tests/fixtures/workflows/csv-to-geojson.yml
+++ b/ui/e2e/tests/fixtures/workflows/csv-to-geojson.yml
@@ -1,12 +1,7 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/workflow.json
-#   CsvReader ──> AttributeManager ──> GeoJsonWriter
-#
 id: 90676d36-d8c4-43ad-993d-ae17ece1b7e6
 name: "CSV to GeoJSON"
 entryGraphId: c1b7e77b-05b3-420b-8013-a9272f8c7576
 with:
-  # Injected by the worker at runtime; points at the job's artifact sandbox.
-  workerArtifactPath: null
   stations: |
     name,line,daily_riders,lon,lat
     Shinjuku,JR Yamanote,775000,139.7006,35.6896
@@ -56,8 +51,10 @@ graphs:
         type: action
         action: GeoJsonWriter
         with:
+          # Sink outputs must be relative paths; the engine resolves them
+          # against the job's artifact sandbox and rejects absolute URIs.
           output: |
-            file::join_path(env.get("workerArtifactPath"), "stations.geojson")
+            "stations.geojson"
 
     edges:
       - id: 0b12ab32-6f2a-427c-8459-f31fcf7f0f92

--- a/ui/e2e/tests/fixtures/workflows/plateau-citygml.yml
+++ b/ui/e2e/tests/fixtures/workflows/plateau-citygml.yml
@@ -80,8 +80,9 @@ graphs:
         with:
           # Sink outputs must be relative paths; the engine resolves them
           # against the job's artifact sandbox and rejects absolute URIs.
-          output: |
-            "toshima-buildings.geojson"
+          output:
+            type: string
+            value: toshima-buildings.geojson
 
     edges:
       - id: a16b6de3-4262-4270-828e-5396dc58ada2

--- a/ui/e2e/tests/fixtures/workflows/plateau-citygml.yml
+++ b/ui/e2e/tests/fixtures/workflows/plateau-citygml.yml
@@ -1,0 +1,116 @@
+id: 780a951c-c774-44fd-91e5-1997a0305b5a
+name: "PLATEAU CityGML to GeoJSON"
+entryGraphId: 111630af-0666-4673-a226-4a914e186a6b
+with:
+  cityGmlPath: https://assets.cms.plateau.reearth.io/assets/45/40a1ee-1e80-4d69-bc6d-d75b77033151/13362_toshima-mura_pref_2024_citygml_1_op.zip
+  targetPackages:
+    - bldg
+graphs:
+  - id: 111630af-0666-4673-a226-4a914e186a6b
+    name: main
+    nodes:
+      - id: 84c5508a-68f0-4726-a868-411c90dd44e7
+        name: Download City Archive
+        type: action
+        action: FilePathExtractor
+        with:
+          sourceDataset: |
+            env.get("cityGmlPath")
+          extractArchive: true
+
+      - id: 8d830d0f-8f5c-4bac-9c5a-0a4f0c68c697
+        name: Keep GML Files
+        type: action
+        action: FeatureFilter
+        with:
+          conditions:
+            - expr:
+                type: flowExpr
+                value: attributes["extension"] == "gml"
+              outputPort: default
+
+      - id: b8bd3903-c1f2-4c66-8c98-54085f1ecc1d
+        name: Extract UDX Folders
+        type: action
+        action: PLATEAU4.UDXFolderExtractor
+        with:
+          cityGmlPath: |
+            env.get("__value")["path"]
+
+      - id: abd47145-383b-4703-8710-e5becfdc055a
+        name: Keep Building Package
+        type: action
+        action: FeatureFilter
+        with:
+          conditions:
+            - expr:
+                type: flowExpr
+                value: attributes["package"] in env["targetPackages"]
+              outputPort: default
+
+      - id: 30a2626c-886c-4bd5-96d4-30e4c9c26f07
+        name: Read Building CityGML
+        type: action
+        action: FeatureCityGmlReader
+        with:
+          dataset: |
+            env.get("__value")["path"]
+
+      - id: 5f5f1dbd-7891-40db-8e4d-629cd5586b0a
+        name: Keep Core Attributes
+        type: action
+        action: AttributeMapper
+        with:
+          mappers:
+            - attribute: gmlId
+              valueAttribute: gmlId
+            - attribute: featureType
+              valueAttribute: featureType
+            - attribute: maxLod
+              valueAttribute: maxLod
+            - attribute: meshcode
+              expr:
+                type: flowExpr
+                value: attributes["path"].split("/")[-1].split("_")[0]
+
+      - id: 7c438ee6-ef16-4462-a7a7-05752e1550ec
+        name: Write Buildings GeoJSON
+        type: action
+        action: GeoJsonWriter
+        with:
+          # Sink outputs must be relative paths; the engine resolves them
+          # against the job's artifact sandbox and rejects absolute URIs.
+          output: |
+            "toshima-buildings.geojson"
+
+    edges:
+      - id: a16b6de3-4262-4270-828e-5396dc58ada2
+        from: 84c5508a-68f0-4726-a868-411c90dd44e7
+        to: 8d830d0f-8f5c-4bac-9c5a-0a4f0c68c697
+        fromPort: default
+        toPort: default
+      - id: 015df6a0-8383-48bc-8c4d-6653d48e0856
+        from: 8d830d0f-8f5c-4bac-9c5a-0a4f0c68c697
+        to: b8bd3903-c1f2-4c66-8c98-54085f1ecc1d
+        fromPort: default
+        toPort: default
+      - id: 7327e079-b453-4016-97a1-15c6ab763687
+        from: b8bd3903-c1f2-4c66-8c98-54085f1ecc1d
+        to: abd47145-383b-4703-8710-e5becfdc055a
+        fromPort: default
+        toPort: default
+      - id: 1448f49f-5aa3-4dd7-a0ee-189c4a0e5c04
+        from: abd47145-383b-4703-8710-e5becfdc055a
+        to: 30a2626c-886c-4bd5-96d4-30e4c9c26f07
+        fromPort: default
+        toPort: default
+      - id: 920dce8f-dae7-4d78-9457-c0b44837b571
+        from: 30a2626c-886c-4bd5-96d4-30e4c9c26f07
+        to: 5f5f1dbd-7891-40db-8e4d-629cd5586b0a
+        fromPort: default
+        toPort: default
+      - id: e6493d04-4e01-4a2c-b3a0-67ca07faf298
+        from: 5f5f1dbd-7891-40db-8e4d-629cd5586b0a
+        to: 7c438ee6-ef16-4462-a7a7-05752e1550ec
+        fromPort: default
+        toPort: default

--- a/ui/e2e/tests/plateau-citygml.spec.ts
+++ b/ui/e2e/tests/plateau-citygml.spec.ts
@@ -24,13 +24,12 @@ test.describe("PLATEAU CityGML pipeline", { tag: "@pipeline" }, () => {
 
   test.afterEach(async () => {
     await deployments.goto();
-    await deployments.deleteDeploymentIfExists(description).catch(() => { });
+    await deployments.deleteDeploymentIfExists(description).catch(() => {});
   });
 
   test("deploys, processes the Toshima-mura city model, and produces the buildings artifact", async ({
     page,
   }) => {
-
     test.setTimeout(1_500_000);
 
     await deployments.createFromFile(WORKFLOW, description);
@@ -52,9 +51,17 @@ test.describe("PLATEAU CityGML pipeline", { tag: "@pipeline" }, () => {
 
     const outputUrl = page.getByText(/toshima-buildings\.geojson/).first();
     await expect(outputUrl).toBeVisible({ timeout: 90_000 });
+    const artifactUrl = (await outputUrl.textContent())?.trim() ?? "";
     test.info().annotations.push({
       type: "output-url",
-      description: (await outputUrl.textContent())?.trim() ?? "",
+      description: artifactUrl,
     });
+
+    const response = await page.request.get(artifactUrl);
+    expect(response.ok()).toBeTruthy();
+    const geojson = await response.json();
+    expect(geojson.type).toBe("FeatureCollection");
+    expect(geojson.features.length).toBeGreaterThan(0);
+    expect(geojson.features[0].properties.featureType).toBe("bldg:Building");
   });
 });

--- a/ui/e2e/tests/plateau-citygml.spec.ts
+++ b/ui/e2e/tests/plateau-citygml.spec.ts
@@ -1,0 +1,60 @@
+import * as path from "path";
+
+import { expect, test } from "@playwright/test";
+
+import {
+  DeploymentsPage,
+  uniqueDeploymentDescription,
+} from "../pages/deploymentsPage";
+
+const WORKFLOW = path.resolve(
+  __dirname,
+  "fixtures/workflows/plateau-citygml.yml",
+);
+
+test.describe("PLATEAU CityGML pipeline", { tag: "@pipeline" }, () => {
+  let deployments: DeploymentsPage;
+  let description: string;
+
+  test.beforeEach(async ({ page }) => {
+    deployments = new DeploymentsPage(page);
+    description = uniqueDeploymentDescription("plateau-citygml");
+    await deployments.goto();
+  });
+
+  test.afterEach(async () => {
+    await deployments.goto();
+    await deployments.deleteDeploymentIfExists(description).catch(() => { });
+  });
+
+  test("deploys, processes the Toshima-mura city model, and produces the buildings artifact", async ({
+    page,
+  }) => {
+
+    test.setTimeout(1_500_000);
+
+    await deployments.createFromFile(WORKFLOW, description);
+
+    await deployments.search(description);
+    await deployments.openDetails(description);
+    await deployments.runFromDetails();
+
+    await expect(page).toHaveURL(/\/workspaces\/[^/]+\/jobs\/[^/]+$/, {
+      timeout: 15_000,
+    });
+    test.info().annotations.push({ type: "job-url", description: page.url() });
+
+    const terminalStatus = page
+      .getByText(/^(completed|failed|cancelled)$/)
+      .first();
+    await expect(terminalStatus).toBeVisible({ timeout: 1_380_000 });
+    await expect(terminalStatus).toHaveText("completed");
+
+    const outputUrl = page.getByText(/toshima-buildings\.geojson/).first();
+    await expect(outputUrl).toBeVisible({ timeout: 90_000 });
+    test.info().annotations.push({
+      type: "output-url",
+      description: (await outputUrl.textContent())?.trim() ?? "",
+    });
+  });
+});


### PR DESCRIPTION
# Overview

## What I've done

- new fixture + spec: downloads the Toshima-mura PLATEAU dataset, extracts the bldg package, and verifies the GeoJSON artifact.
- fix csv-to-geojson fixture: sink outputs must be relative paths since the worker engine upgrade rejects absolute URIs

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
