### PR TITLE
chore(ui): remove creditContainer from defaultCesiumProps [FLOW-DEV-190]

### DIFF
--- a/ui/src/components/visualizations/Cesium/index.tsx
+++ b/ui/src/components/visualizations/Cesium/index.tsx
@@ -31,7 +31,6 @@ const defaultCesiumProps: Partial<ViewerProps> = {
   requestRenderMode: true,
   maximumRenderTimeChange: Infinity,
   navigationHelpButton: false,
-  creditContainer: document.createElement("none"),
 };
 
 type Props = {


### PR DESCRIPTION
# Overview
Removes creditContainer prop from defaultCesiumProps
## What I've done

- Removed creditContainer: document.createElement("none") from defaultCesiumProps.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
