### PR TITLE
fix(ui): adjust ResizableHandle height and simplify class names in DebugPanel [FLOW-DEV-191]

### DIFF
--- a/ui/src/components/Resizable/index.tsx
+++ b/ui/src/components/Resizable/index.tsx
@@ -33,7 +33,7 @@ const ResizableHandle = ({
     )}
     {...props}>
     {withHandle && (
-      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border">
+      <div className="z-10 flex h-6 w-3 items-center justify-center rounded-sm border bg-border">
         <DragHandleDots2Icon className="size-2.5" />
       </div>
     )}

--- a/ui/src/features/Editor/components/OverlayUI/components/DebugPanel/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/DebugPanel/index.tsx
@@ -246,7 +246,7 @@ const DebugPanel: React.FC = () => {
                 {visualizerType && (
                   <>
                     {!minimized && (
-                      <ResizableHandle className="data-resize-handle-[state=drag]:border-logo/70 mx-2 h-[30%] w-1 self-center rounded-md border border-accent bg-accent transition hover:border-transparent hover:bg-logo/70" />
+                      <ResizableHandle className="mx-2 w-1" withHandle />
                     )}
                     <ResizablePanel defaultSize={40} minSize={20}>
                       {isLoadingData ? (


### PR DESCRIPTION
# Overview
This PR updates the DebugPanel’s resizable splitter styling by switching to the shared `ResizableHandle` “withHandle” variant and adjusting the default handle grip height in the shared Resizable component.
## What I've done
- Simplified `DebugPanel`’s `ResizableHandle` usage to rely on the shared handle UI (`withHandle`) and minimal layout classes.
- Increased the shared handle “grip” height from `h-4` to `h-6` in `ui/src/components/Resizable`.
## What I haven't done

## How I tested

## Screenshot
<img width="1911" height="963" alt="image" src="https://github.com/user-attachments/assets/436f31e7-18c4-4cd4-b3d0-8e0d7204d7c2" />

## Which point I want you to review particularly

## Memo
