### PR TITLE
fix(engine): let fetcher take absolute path in XML validator

### DIFF
--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -11,6 +11,7 @@ env:
   # from transient network timeouts or other issues.
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
+  RUST_LOG: warn
   # Don't emit giant backtraces in the CI logs.
   RUST_BACKTRACE: short
   FLOW_RUNTIME_ACTION_LOG_DISABLE: true

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6906,7 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7177,7 +7177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7194,7 +7194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "bytes",
  "futures",
@@ -7223,7 +7223,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "bytes",
  "futures",
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7256,7 +7256,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7291,7 +7291,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7329,7 +7329,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.403"
+version = "0.0.404"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.403"
+version = "0.0.404"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/xml/validator.rs
+++ b/engine/runtime/action-processor/src/xml/validator.rs
@@ -587,7 +587,26 @@ impl XmlValidator {
         }
 
         // --- Step 2: Fetch + resolve + compile schemas (with cache) ---
-        let cache_key = schema_cache_key(&schema_locations);
+
+        // Pre-resolve all xsi:schemaLocation entries to absolute URIs so that:
+        // (a) the in-memory cache key is stable across different base directories, and
+        // (b) the disk cache key (URL hash) is never a raw relative path.
+        let base_file_uri = base_dir
+            .as_ref()
+            .and_then(|dir| url::Url::from_directory_path(dir).ok())
+            .map(|u| u.to_string());
+        let resolved_locations: Vec<(String, String)> = schema_locations
+            .iter()
+            .map(|(ns, loc)| {
+                let resolved = base_file_uri
+                    .as_deref()
+                    .and_then(|base| resolve_uri(base, loc).ok())
+                    .unwrap_or_else(|| loc.clone());
+                (ns.clone(), resolved)
+            })
+            .collect();
+
+        let cache_key = schema_cache_key(&resolved_locations);
 
         // Check cache first
         let cached = {
@@ -599,32 +618,20 @@ impl XmlValidator {
             compiled
         } else {
             // Cache miss - compile from scratch.
-            // DefaultFetcher::new() handles both http(s):// and file:// URLs;
-            // relative paths are pre-resolved below so base_dir is not baked in.
+            // DefaultFetcher::new() handles both http(s):// and file:// URLs.
             let fetcher = DiskCachingFetcher {
                 inner: DefaultFetcher::new(),
                 dir: SCHEMA_CACHE_DIR.clone(),
             };
 
-            // Resolve relative xsi:schemaLocation paths to absolute file:// URLs
-            // so the disk cache key is always absolute and unique per base directory.
-            let base_file_uri = base_dir.as_ref().map(|dir| {
-                let s = dir.to_string_lossy();
-                format!("file://{}/", s.trim_end_matches('/'))
-            });
-
             let mut resolver = SchemaResolver::new(&fetcher);
-            for (_namespace, location) in &schema_locations {
+            for (_namespace, resolved_location) in &resolved_locations {
                 // Per W3C spec, xsi:schemaLocation URLs are hints.
                 // Remote schemas that are unreachable (404, DNS failure, etc.)
                 // are skipped. This may cause false positives if the skipped
                 // schema defines types used elsewhere.
-                let is_remote = location.starts_with("http://") || location.starts_with("https://");
-
-                let resolved_location = base_file_uri
-                    .as_deref()
-                    .and_then(|base| resolve_uri(base, location).ok())
-                    .unwrap_or_else(|| location.clone());
+                let is_remote = resolved_location.starts_with("http://")
+                    || resolved_location.starts_with("https://");
 
                 let fetch_result = match fetcher.fetch(&resolved_location) {
                     Ok(r) => r,

--- a/engine/runtime/action-processor/src/xml/validator.rs
+++ b/engine/runtime/action-processor/src/xml/validator.rs
@@ -633,7 +633,7 @@ impl XmlValidator {
                 let is_remote = resolved_location.starts_with("http://")
                     || resolved_location.starts_with("https://");
 
-                let fetch_result = match fetcher.fetch(&resolved_location) {
+                let fetch_result = match fetcher.fetch(resolved_location) {
                     Ok(r) => r,
                     Err(e) if is_remote => {
                         tracing::warn!(url = %resolved_location, error = ?e, "Skipping unreachable remote schema");

--- a/engine/runtime/action-processor/src/xml/validator.rs
+++ b/engine/runtime/action-processor/src/xml/validator.rs
@@ -10,7 +10,7 @@ use std::{
 use bytes::Bytes;
 use fastxml::schema::fetcher::{DefaultFetcher, FetchResult, SchemaFetcher};
 use fastxml::schema::types::CompiledSchema;
-use fastxml::schema::xsd::{compile_schemas, register_builtin_types, SchemaResolver};
+use fastxml::schema::xsd::{compile_schemas, register_builtin_types, resolve_uri, SchemaResolver};
 use once_cell::sync::Lazy;
 use reearth_flow_common::{uri::Uri, xml};
 use reearth_flow_runtime::{
@@ -598,17 +598,19 @@ impl XmlValidator {
         let compiled = if let Some(compiled) = cached {
             compiled
         } else {
-            // Cache miss - compile from scratch
-            let inner = match &base_dir {
-                Some(dir) => DefaultFetcher::with_base_dir(dir),
-                None => DefaultFetcher::new(),
-            };
-            // Persistent on-disk cache: fetched remote schemas are reused across
-            // documents/runs/processes instead of being re-downloaded each time.
+            // Cache miss - compile from scratch.
+            // DefaultFetcher::new() handles both http(s):// and file:// URLs;
+            // relative paths are pre-resolved below so base_dir is not baked in.
             let fetcher = DiskCachingFetcher {
-                inner,
+                inner: DefaultFetcher::new(),
                 dir: SCHEMA_CACHE_DIR.clone(),
             };
+
+            // Resolve relative xsi:schemaLocation paths to absolute file:// URLs
+            // so the disk cache key is always absolute and unique per base directory.
+            let base_file_uri = base_dir
+                .as_ref()
+                .map(|dir| format!("file://{}/", dir.display()));
 
             let mut resolver = SchemaResolver::new(&fetcher);
             for (_namespace, location) in &schema_locations {
@@ -618,15 +620,20 @@ impl XmlValidator {
                 // schema defines types used elsewhere.
                 let is_remote = location.starts_with("http://") || location.starts_with("https://");
 
-                let fetch_result = match fetcher.fetch(location) {
+                let resolved_location = base_file_uri
+                    .as_deref()
+                    .and_then(|base| resolve_uri(base, location).ok())
+                    .unwrap_or_else(|| location.clone());
+
+                let fetch_result = match fetcher.fetch(&resolved_location) {
                     Ok(r) => r,
                     Err(e) if is_remote => {
-                        tracing::warn!(url = %location, error = ?e, "Skipping unreachable remote schema");
+                        tracing::warn!(url = %resolved_location, error = ?e, "Skipping unreachable remote schema");
                         continue;
                     }
                     Err(e) => {
                         return Err(XmlProcessorError::Validator(format!(
-                            "Failed to fetch schema {location}: {e:?}"
+                            "Failed to fetch schema {resolved_location}: {e:?}"
                         )));
                     }
                 };
@@ -635,12 +642,12 @@ impl XmlValidator {
                 match resolver.resolve_entry(&fetch_result.content, base_uri) {
                     Ok(()) => {}
                     Err(e) if is_remote => {
-                        tracing::warn!(url = %location, error = ?e, "Skipping unresolvable remote schema");
+                        tracing::warn!(url = %resolved_location, error = ?e, "Skipping unresolvable remote schema");
                         continue;
                     }
                     Err(e) => {
                         return Err(XmlProcessorError::Validator(format!(
-                            "Failed to resolve schema imports for {location}: {e:?}"
+                            "Failed to resolve schema imports for {resolved_location}: {e:?}"
                         )));
                     }
                 }

--- a/engine/runtime/action-processor/src/xml/validator.rs
+++ b/engine/runtime/action-processor/src/xml/validator.rs
@@ -1357,6 +1357,86 @@ mod tests {
         }
     }
 
+    /// Two XML files with the same relative xsi:schemaLocation but different base
+    /// directories must each be compiled against their own schema, not share a
+    /// cached entry built for the other directory.
+    #[test]
+    fn test_schema_cache_no_collision_across_base_dirs() {
+        // Both schemas share the same namespace and relative filename — only content differs.
+        // Schema A defines <Foo>; schema B defines <Bar>.
+        // This ensures the raw cache key ("urn:test:ns=./schema.xsd") is identical for both,
+        // which is exactly the collision scenario.
+        let xsd_a = r#"<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:test:ns">
+    <xs:element name="Foo" type="xs:string"/>
+</xs:schema>"#;
+        let xsd_b = r#"<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:test:ns">
+    <xs:element name="Bar" type="xs:string"/>
+</xs:schema>"#;
+
+        // Same namespace, same relative schemaLocation — cache key is identical for both.
+        let xml_a = r#"<?xml version="1.0" encoding="UTF-8"?>
+<tns:Foo xmlns:tns="urn:test:ns"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="urn:test:ns ./schema.xsd">content</tns:Foo>"#;
+        let xml_b = r#"<?xml version="1.0" encoding="UTF-8"?>
+<tns:Bar xmlns:tns="urn:test:ns"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="urn:test:ns ./schema.xsd">content</tns:Bar>"#;
+
+        let dir_a = tempfile::tempdir().unwrap();
+        let dir_b = tempfile::tempdir().unwrap();
+        std::fs::write(dir_a.path().join("schema.xsd"), xsd_a).unwrap();
+        std::fs::write(dir_b.path().join("schema.xsd"), xsd_b).unwrap();
+        let path_a = dir_a.path().join("doc.xml");
+        let path_b = dir_b.path().join("doc.xml");
+        std::fs::write(&path_a, xml_a).unwrap();
+        std::fs::write(&path_b, xml_b).unwrap();
+
+        let validator = XmlValidator {
+            params: XmlValidatorParam {
+                attribute: Attribute::new("xml_path"),
+                input_type: XmlInputType::File,
+                validation_type: ValidationType::SyntaxAndSchema,
+            },
+            schema_cache: Arc::new(parking_lot::RwLock::new(HashMap::new())),
+        };
+
+        let make_feature = |path: &std::path::Path| {
+            let mut attrs = IndexMap::new();
+            attrs.insert(
+                Attribute::new("xml_path"),
+                AttributeValue::String(format!("file://{}", path.display())),
+            );
+            Feature::new_with_attributes_and_geometry(attrs, Geometry::new())
+        };
+
+        let feature_a = make_feature(&path_a);
+        let feature_b = make_feature(&path_b);
+
+        // Process A first — populates the in-memory schema cache.
+        let errors_a = validator
+            .check_schema_streaming(&feature_a, xml_a.as_bytes())
+            .unwrap();
+        assert!(
+            errors_a.is_empty(),
+            "doc_a should be valid against schema A, got: {errors_a:?}"
+        );
+
+        // Process B — must NOT reuse A's cached schema.
+        // If the cache key collided, <Bar> would be unknown (schema A only defines <Foo>).
+        let errors_b = validator
+            .check_schema_streaming(&feature_b, xml_b.as_bytes())
+            .unwrap();
+        assert!(
+            errors_b.is_empty(),
+            "doc_b should be valid against schema B, got: {errors_b:?}"
+        );
+    }
+
     /// Link (or copy on non-unix) a fixture subdirectory into the temp directory.
     fn link_fixture_dir(fixture_src: &Path, dest: &Path) {
         #[cfg(unix)]

--- a/engine/runtime/action-processor/src/xml/validator.rs
+++ b/engine/runtime/action-processor/src/xml/validator.rs
@@ -608,9 +608,10 @@ impl XmlValidator {
 
             // Resolve relative xsi:schemaLocation paths to absolute file:// URLs
             // so the disk cache key is always absolute and unique per base directory.
-            let base_file_uri = base_dir
-                .as_ref()
-                .map(|dir| format!("file://{}/", dir.display()));
+            let base_file_uri = base_dir.as_ref().map(|dir| {
+                let s = dir.to_string_lossy();
+                format!("file://{}/", s.trim_end_matches('/'))
+            });
 
             let mut resolver = SchemaResolver::new(&fetcher);
             for (_namespace, location) in &schema_locations {


### PR DESCRIPTION
# Overview

A regression was introduced in #2147. In schema caching the input `url` is used as caching path, which may contain relative path. During parallel testing, the caching is corrupted with file of same relative path but different content. This caused the nondeterminstic error reported in #2153.

Fix: do resolution in `validator.rs`. Fetcher takes `url` which implies absolute URL only, so cache key never collides.

## How I tested

I add an assert in schema cache which proved currently relative paths are being used as keys for caching.

In current fix branch, I rerun CI five times successfully without error.