### PR TITLE
chore(ui): refactor and create shared usePagination hook [FLOW-DEV-192]

### DIFF
--- a/ui/src/features/WorkspaceDeployments/hooks.ts
+++ b/ui/src/features/WorkspaceDeployments/hooks.ts
@@ -1,7 +1,7 @@
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
-import { useDebouncedSearch } from "@flow/hooks";
+import { usePagination } from "@flow/hooks";
 import { useDeployment } from "@flow/lib/gql";
 import { useT } from "@flow/lib/i18n";
 import { useCurrentWorkspace } from "@flow/stores";
@@ -26,33 +26,25 @@ export default () => {
   const [deploymentToBeRun, setDeploymentToBeRun] = useState<
     Deployment | undefined
   >(undefined);
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const [currentOrderBy, setCurrentOrderBy] = useState<DeploymentOrderBy>(
-    DeploymentOrderBy.UpdatedAt,
-  );
-  const [currentOrderDir, setCurrentOrderDir] = useState<OrderDirection>(
-    OrderDirection.Desc,
-  );
   const { useGetDeployments, useDeleteDeployment, executeDeployment } =
     useDeployment();
 
-  const { searchTerm, isDebouncingSearch, setSearchTerm } = useDebouncedSearch({
-    initialSearchTerm: "",
-    delay: 300,
-    onDebounced: () => {
-      refetch();
-    },
+  const {
+    page,
+    totalPages,
+    isFetching,
+    currentPage,
+    currentSortValue,
+    isDebouncingSearch,
+    setCurrentPage,
+    setCurrentOrderDir,
+    setSearchTerm,
+    handleSortChange,
+  } = usePagination({
+    useDataQuery: useGetDeployments,
+    workspaceId: currentWorkspace?.id,
+    defaultOrderBy: DeploymentOrderBy.UpdatedAt,
   });
-
-  const { page, refetch, isFetching } = useGetDeployments(
-    currentWorkspace?.id,
-    searchTerm,
-    {
-      page: currentPage,
-      orderDir: currentOrderDir,
-      orderBy: currentOrderBy,
-    },
-  );
 
   const sortOptions = [
     {
@@ -80,25 +72,6 @@ export default () => {
       label: t("Z To A"),
     },
   ];
-
-  useEffect(() => {
-    (async () => {
-      await refetch();
-    })();
-  }, [currentPage, currentOrderDir, currentOrderBy, refetch]);
-
-  const currentSortValue = `${currentOrderBy}_${currentOrderDir}`;
-
-  const handleSortChange = useCallback((newSortValue: string) => {
-    const [orderBy, orderDir] = newSortValue.split("_") as [
-      DeploymentOrderBy,
-      OrderDirection,
-    ];
-    setCurrentOrderBy(orderBy);
-    setCurrentOrderDir(orderDir);
-  }, []);
-
-  const totalPages = page?.totalPages as number;
 
   const {
     location: { pathname },

--- a/ui/src/features/WorkspaceJobs/hooks.ts
+++ b/ui/src/features/WorkspaceJobs/hooks.ts
@@ -1,7 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
-import { useDebouncedSearch } from "@flow/hooks";
+import { usePagination } from "@flow/hooks";
 import { useJob } from "@flow/lib/gql/job";
 import { useT } from "@flow/lib/i18n";
 import { useCurrentWorkspace } from "@flow/stores";
@@ -14,32 +14,27 @@ export default () => {
   const t = useT();
   const [openJobRunDialog, setOpenJobRunDialog] = useState(false);
   const [currentWorkspace] = useCurrentWorkspace();
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const [currentOrderBy, setCurrentOrderBy] = useState<JobOrderBy>(
-    JobOrderBy.StartedAt,
-  );
-  const [currentOrderDir, setCurrentOrderDir] = useState<OrderDirection>(
-    OrderDirection.Desc,
-  );
   const { useGetJobs } = useJob();
 
-  const { searchTerm, isDebouncingSearch, setSearchTerm } = useDebouncedSearch({
-    initialSearchTerm: "",
-    delay: 300,
-    onDebounced: () => {
-      refetch();
-    },
+  const {
+    page,
+    totalPages,
+    isFetching,
+    currentPage,
+    currentSortValue,
+    searchTerm,
+    isDebouncingSearch,
+    setCurrentPage,
+    setCurrentOrderDir,
+    setSearchTerm,
+    handleSortChange,
+  } = usePagination({
+    useDataQuery: useGetJobs,
+    workspaceId: currentWorkspace?.id,
+    defaultOrderBy: JobOrderBy.StartedAt,
   });
 
-  const { page, refetch, isFetching } = useGetJobs(
-    currentWorkspace?.id,
-    searchTerm,
-    {
-      page: currentPage,
-      orderBy: currentOrderBy,
-      orderDir: currentOrderDir,
-    },
-  );
+  const jobs = page?.jobs;
 
   const sortOptions = [
     {
@@ -60,18 +55,6 @@ export default () => {
     },
   ];
 
-  const currentSortValue = `${currentOrderBy}_${currentOrderDir}`;
-
-  useEffect(() => {
-    (async () => {
-      await refetch();
-    })();
-  }, [currentPage, currentOrderDir, currentOrderBy, refetch]);
-
-  const totalPages = page?.totalPages as number;
-
-  const jobs = page?.jobs;
-
   const handleJobSelect = useCallback(
     (job: Job) =>
       navigate({
@@ -79,15 +62,6 @@ export default () => {
       }),
     [currentWorkspace, navigate],
   );
-
-  const handleSortChange = useCallback((newSortValue: string) => {
-    const [orderBy, orderDir] = newSortValue.split("_") as [
-      JobOrderBy,
-      OrderDirection,
-    ];
-    setCurrentOrderBy(orderBy);
-    setCurrentOrderDir(orderDir);
-  }, []);
 
   return {
     ref,

--- a/ui/src/features/WorkspaceTriggers/components/TriggerAddDialog/hooks.ts
+++ b/ui/src/features/WorkspaceTriggers/components/TriggerAddDialog/hooks.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { useToast } from "@flow/features/NotificationSystem/useToast";
-import { useDebouncedSearch } from "@flow/hooks";
+import { usePagination } from "@flow/hooks";
 import { useTrigger, useDeployment } from "@flow/lib/gql";
 import { useT } from "@flow/lib/i18n";
 import { useCurrentWorkspace } from "@flow/stores";
@@ -39,32 +39,23 @@ export default ({
   const [authToken, setAuthToken] = useState<string>("");
   const [description, setDescription] = useState<string>("");
   const [isTriggerEnabled, setIsTriggerEnabled] = useState<boolean>(true);
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const [currentOrderBy, setCurrentOrderBy] = useState<DeploymentOrderBy>(
-    DeploymentOrderBy.UpdatedAt,
-  );
-  const [currentOrderDir, setCurrentOrderDir] = useState<OrderDirection>(
-    OrderDirection.Desc,
-  );
   const { useGetDeployments } = useDeployment();
 
-  const { searchTerm, isDebouncingSearch, setSearchTerm } = useDebouncedSearch({
-    initialSearchTerm: "",
-    delay: 300,
-    onDebounced: () => {
-      refetch();
-    },
+  const {
+    page,
+    totalPages,
+    isFetching,
+    currentPage,
+    currentSortValue,
+    isDebouncingSearch,
+    setCurrentPage,
+    setSearchTerm,
+    handleSortChange,
+  } = usePagination({
+    useDataQuery: useGetDeployments,
+    workspaceId: currentWorkspace?.id,
+    defaultOrderBy: DeploymentOrderBy.UpdatedAt,
   });
-
-  const { page, refetch, isFetching } = useGetDeployments(
-    currentWorkspace?.id,
-    searchTerm,
-    {
-      page: currentPage,
-      orderDir: currentOrderDir,
-      orderBy: currentOrderBy,
-    },
-  );
 
   const sortOptions = [
     {
@@ -93,25 +84,7 @@ export default ({
     },
   ];
 
-  useEffect(() => {
-    (async () => {
-      await refetch();
-    })();
-  }, [currentPage, currentOrderDir, currentOrderBy, refetch]);
-
-  const currentSortValue = `${currentOrderBy}_${currentOrderDir}`;
-
-  const handleSortChange = useCallback((newSortValue: string) => {
-    const [orderBy, orderDir] = newSortValue.split("_") as [
-      DeploymentOrderBy,
-      OrderDirection,
-    ];
-    setCurrentOrderBy(orderBy);
-    setCurrentOrderDir(orderDir);
-  }, []);
-
   const deployments = page?.deployments;
-  const totalPages = page?.totalPages as number;
   const [openSelectDeploymentsDialog, setOpenSelectDeploymentsDialog] =
     useState<boolean>(false);
 

--- a/ui/src/features/WorkspaceTriggers/hooks.ts
+++ b/ui/src/features/WorkspaceTriggers/hooks.ts
@@ -1,7 +1,7 @@
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
-import { useDebouncedSearch } from "@flow/hooks";
+import { usePagination } from "@flow/hooks";
 import { useTrigger } from "@flow/lib/gql";
 import { useT } from "@flow/lib/i18n";
 import { useCurrentWorkspace } from "@flow/stores";
@@ -31,30 +31,23 @@ export default () => {
   } = useRouterState();
 
   const tab = getTab(pathname);
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const [currentOrderBy, setCurrentOrderBy] = useState<TriggerOrderBy>(
-    TriggerOrderBy.UpdatedAt,
-  );
-  const [currentOrderDir, setCurrentOrderDir] = useState<OrderDirection>(
-    OrderDirection.Desc,
-  );
 
-  const { searchTerm, isDebouncingSearch, setSearchTerm } = useDebouncedSearch({
-    initialSearchTerm: "",
-    delay: 300,
-    onDebounced: () => {
-      refetch();
-    },
+  const {
+    page,
+    totalPages,
+    isFetching,
+    currentPage,
+    currentSortValue,
+    isDebouncingSearch,
+    setCurrentPage,
+    setCurrentOrderDir,
+    setSearchTerm,
+    handleSortChange,
+  } = usePagination({
+    useDataQuery: useGetTriggers,
+    workspaceId: currentWorkspace?.id,
+    defaultOrderBy: TriggerOrderBy.UpdatedAt,
   });
-  const { page, refetch, isFetching } = useGetTriggers(
-    currentWorkspace?.id,
-    searchTerm,
-    {
-      page: currentPage,
-      orderDir: currentOrderDir,
-      orderBy: currentOrderBy,
-    },
-  );
 
   const sortOptions = [
     {
@@ -75,24 +68,6 @@ export default () => {
     },
   ];
 
-  useEffect(() => {
-    (async () => {
-      await refetch();
-    })();
-  }, [currentPage, currentOrderDir, currentOrderBy, refetch]);
-
-  const currentSortValue = `${currentOrderBy}_${currentOrderDir}`;
-
-  const handleSortChange = useCallback((newSortValue: string) => {
-    const [orderBy, orderDir] = newSortValue.split("_") as [
-      TriggerOrderBy,
-      OrderDirection,
-    ];
-    setCurrentOrderBy(orderBy);
-    setCurrentOrderDir(orderDir);
-  }, []);
-
-  const totalPages = page?.totalPages as number;
   const triggers = page?.triggers;
 
   const selectedTrigger = useMemo(

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -5,6 +5,7 @@ export { default as useShortcuts } from "./useShortcuts";
 export { default as useProjectDuplicate } from "./useProjectDuplicate";
 export { default as useProjectExport } from "./useProjectExport";
 export { default as useProjectImport } from "./useProjectImport";
+export { default as usePagination } from "./usePagination";
 export { default as useProjectPagination } from "./useProjectPagination";
 export { default as useWorkflowFileUpload } from "./useWorkflowFileUpload";
 export { default as useWorkflowImport } from "./useWorkflowImport";

--- a/ui/src/hooks/useAssets.ts
+++ b/ui/src/hooks/useAssets.ts
@@ -1,8 +1,8 @@
-import { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
+import { ChangeEvent, useCallback, useRef, useState } from "react";
 
 import { useToast } from "@flow/features/NotificationSystem/useToast";
 import { ALLOWED_ASSET_IMPORT_EXTENSIONS } from "@flow/global-constants";
-import { useDebouncedSearch } from "@flow/hooks";
+import { usePagination } from "@flow/hooks";
 import { useAsset } from "@flow/lib/gql/assets";
 import { useT } from "@flow/lib/i18n";
 import { Asset, AssetOrderBy } from "@flow/types";
@@ -25,20 +25,21 @@ export default ({ workspaceId }: { workspaceId: string }) => {
     (ext) => ext.trim(),
   );
 
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const [currentOrderBy, setCurrentOrderBy] = useState<AssetOrderBy>(
-    AssetOrderBy.CreatedAt,
-  );
-  const [currentOrderDir, setCurrentOrderDir] = useState<OrderDirection>(
-    OrderDirection.Desc,
-  );
-
-  const { searchTerm, isDebouncingSearch, setSearchTerm } = useDebouncedSearch({
-    initialSearchTerm: "",
-    delay: 300,
-    onDebounced: () => {
-      refetch();
-    },
+  const {
+    page,
+    totalPages,
+    isFetching,
+    currentPage,
+    currentSortValue,
+    searchTerm,
+    isDebouncingSearch,
+    setCurrentPage,
+    setSearchTerm,
+    handleSortChange,
+  } = usePagination({
+    useDataQuery: useGetAssets,
+    workspaceId,
+    defaultOrderBy: AssetOrderBy.CreatedAt,
   });
 
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
@@ -51,14 +52,6 @@ export default ({ workspaceId }: { workspaceId: string }) => {
   );
 
   const [layoutView, setLayoutView] = useState<"list" | "grid">("grid");
-
-  const { page, refetch, isFetching } = useGetAssets(workspaceId, searchTerm, {
-    page: currentPage,
-    orderDir: currentOrderDir,
-    orderBy: currentOrderBy,
-  });
-
-  const totalPages = page?.totalPages as number;
 
   const assets = page?.assets;
   const sortOptions = [
@@ -84,14 +77,6 @@ export default ({ workspaceId }: { workspaceId: string }) => {
       label: t("Size Large to Small"),
     },
   ];
-
-  const currentSortValue = `${currentOrderBy}_${currentOrderDir}`;
-
-  useEffect(() => {
-    (async () => {
-      await refetch();
-    })();
-  }, [currentPage, currentOrderDir, currentOrderBy, refetch]);
 
   const handleGridView = () => setLayoutView("grid");
 
@@ -136,15 +121,6 @@ export default ({ workspaceId }: { workspaceId: string }) => {
       setIsDeleting(false);
     }
   };
-
-  const handleSortChange = useCallback((newSortValue: string) => {
-    const [orderBy, orderDir] = newSortValue.split("_") as [
-      AssetOrderBy,
-      OrderDirection,
-    ];
-    setCurrentOrderBy(orderBy);
-    setCurrentOrderDir(orderDir);
-  }, []);
 
   const handleCopyUrlToClipBoard = useCallback(
     (url: string) => {

--- a/ui/src/hooks/usePagination.ts
+++ b/ui/src/hooks/usePagination.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  OrderDirection,
+  type PaginationOptions,
+} from "@flow/types/paginationOptions";
+
+import useDebouncedSearch from "./useDebouncedSearch";
+
+type PaginatedPage = { totalPages?: number | null };
+
+type DataQuery = (
+  workspaceId: string | undefined,
+  keyword: string | undefined,
+  paginationOptions: PaginationOptions,
+) => {
+  page?: PaginatedPage;
+  refetch: () => Promise<unknown>;
+  isFetching: boolean;
+};
+
+type Props<TQuery extends DataQuery, TOrderBy extends string> = {
+  useDataQuery: TQuery;
+  workspaceId?: string;
+  defaultOrderBy: TOrderBy;
+  defaultOrderDir?: OrderDirection;
+};
+
+export default function usePagination<
+  TQuery extends DataQuery,
+  TOrderBy extends string = string,
+>({
+  useDataQuery,
+  workspaceId,
+  defaultOrderBy,
+  defaultOrderDir = OrderDirection.Desc,
+}: Props<TQuery, TOrderBy>) {
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [currentOrderBy, setCurrentOrderBy] =
+    useState<TOrderBy>(defaultOrderBy);
+  const [currentOrderDir, setCurrentOrderDir] =
+    useState<OrderDirection>(defaultOrderDir);
+
+  const { searchTerm, isDebouncingSearch, setSearchTerm } = useDebouncedSearch({
+    initialSearchTerm: "",
+    delay: 300,
+    onDebounced: () => {
+      refetch();
+    },
+  });
+
+  const { page, refetch, isFetching } = useDataQuery(workspaceId, searchTerm, {
+    page: currentPage,
+    orderBy: currentOrderBy,
+    orderDir: currentOrderDir,
+  }) as {
+    page: ReturnType<TQuery>["page"];
+    refetch: () => Promise<unknown>;
+    isFetching: boolean;
+  };
+
+  useEffect(() => {
+    (async () => {
+      await refetch();
+    })();
+  }, [currentPage, currentOrderDir, currentOrderBy, refetch]);
+
+  const totalPages = page?.totalPages as number;
+
+  const currentSortValue = `${currentOrderBy}_${currentOrderDir}`;
+
+  const handleSortChange = useCallback((newSortValue: string) => {
+    const [orderBy, orderDir] = newSortValue.split("_") as [
+      TOrderBy,
+      OrderDirection,
+    ];
+    setCurrentOrderBy(orderBy);
+    setCurrentOrderDir(orderDir);
+  }, []);
+
+  return {
+    page,
+    totalPages,
+    isFetching,
+    currentPage,
+    currentOrderBy,
+    currentOrderDir,
+    currentSortValue,
+    searchTerm,
+    isDebouncingSearch,
+    setCurrentPage,
+    setCurrentOrderBy,
+    setCurrentOrderDir,
+    setSearchTerm,
+    handleSortChange,
+  };
+}

--- a/ui/src/hooks/usePagination.ts
+++ b/ui/src/hooks/usePagination.ts
@@ -45,7 +45,8 @@ export default function usePagination<
     initialSearchTerm: "",
     delay: 300,
     onDebounced: () => {
-      refetch();
+      if (!workspaceId) return;
+      void refetch();
     },
   });
 
@@ -60,10 +61,11 @@ export default function usePagination<
   };
 
   useEffect(() => {
-    (async () => {
-      await refetch();
+    (() => {
+      if (!workspaceId) return;
+      void refetch();
     })();
-  }, [currentPage, currentOrderDir, currentOrderBy, refetch]);
+  }, [currentPage, currentOrderDir, currentOrderBy, workspaceId, refetch]);
 
   const totalPages = page?.totalPages as number;
 

--- a/ui/src/hooks/useProjectPagination.ts
+++ b/ui/src/hooks/useProjectPagination.ts
@@ -1,43 +1,33 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import { useProject } from "@flow/lib/gql";
 import { useT } from "@flow/lib/i18n";
 import { ProjectOrderBy, Workspace } from "@flow/types";
 import { OrderDirection } from "@flow/types/paginationOptions";
 
-import useDebouncedSearch from "./useDebouncedSearch";
+import usePagination from "./usePagination";
 
 export default ({ workspace }: { workspace?: Workspace }) => {
   const t = useT();
   const { useGetWorkspaceProjects } = useProject();
 
-  const [currentPage, setCurrentPage] = useState<number>(1);
-  const [currentOrderBy, setCurrentOrderBy] = useState<ProjectOrderBy>(
-    ProjectOrderBy.CreatedAt,
-  );
-  const [currentOrderDir, setCurrentOrderDir] = useState<OrderDirection>(
-    OrderDirection.Desc,
-  );
-
-  const { searchTerm, isDebouncingSearch, setSearchTerm } = useDebouncedSearch({
-    initialSearchTerm: "",
-    delay: 300,
-    onDebounced: () => {
-      refetch();
-    },
-  });
-
-  const { page, refetch, isFetching } = useGetWorkspaceProjects(
-    workspace?.id,
+  const {
+    page,
+    totalPages,
+    isFetching,
+    currentPage,
+    currentOrderBy,
+    currentSortValue,
     searchTerm,
-    {
-      page: currentPage,
-      orderDir: currentOrderDir,
-      orderBy: "updatedAt",
-    },
-  );
-
-  const totalPages = useMemo(() => page?.totalPages as number, [page]);
+    isDebouncingSearch,
+    setCurrentPage,
+    setSearchTerm,
+    handleSortChange,
+  } = usePagination({
+    useDataQuery: useGetWorkspaceProjects,
+    workspaceId: workspace?.id,
+    defaultOrderBy: ProjectOrderBy.CreatedAt,
+  });
 
   const projects = useMemo(() => page?.projects, [page]);
 
@@ -68,32 +58,10 @@ export default ({ workspace }: { workspace?: Workspace }) => {
     },
   ];
 
-  const currentSortValue = `${currentOrderBy}_${currentOrderDir}`;
-
-  useEffect(() => {
-    (async () => {
-      await refetch();
-    })();
-  }, [currentPage, currentOrderDir, currentOrderBy, refetch]);
-
-  const handleSortChange = useCallback((newSortValue: string) => {
-    const [orderBy, orderDir] = newSortValue.split("_") as [
-      ProjectOrderBy,
-      OrderDirection,
-    ];
-    setCurrentOrderBy(orderBy);
-    setCurrentOrderDir(orderDir);
-  }, []);
   const orderDirections: Record<OrderDirection, string> = {
     DESC: t("Newest"),
     ASC: t("Oldest"),
   };
-
-  useEffect(() => {
-    (async () => {
-      await refetch();
-    })();
-  }, [currentPage, currentOrderDir, currentOrderBy, refetch]);
 
   return {
     currentPage,

--- a/ui/src/lib/gql/assets/useApi.ts
+++ b/ui/src/lib/gql/assets/useApi.ts
@@ -27,7 +27,7 @@ export const useAsset = () => {
   const { toast } = useToast();
   const t = useT();
   const useGetAssets = (
-    workspaceId: string,
+    workspaceId?: string,
     keyword?: string,
     paginationOptions?: PaginationOptions,
   ) => {

--- a/ui/src/lib/gql/assets/useQueries.ts
+++ b/ui/src/lib/gql/assets/useQueries.ts
@@ -27,7 +27,7 @@ export const useQueries = () => {
   const queryClient = useQueryClient();
 
   const useGetAssetsQuery = (
-    workspaceId: string,
+    workspaceId?: string,
     keyword?: string,
     paginationOptions?: PaginationOptions,
   ) =>


### PR DESCRIPTION
# Overview
This PR refactors multiple UI feature hooks to centralize common pagination/sorting/search behavior into a new shared `usePagination` hook, and adjusts asset GraphQL hook signatures to tolerate an undefined `workspaceId` during initial renders.
## What I've done
- Added `ui/src/hooks/usePagination.ts` to standardize pagination + sort + debounced search state handling.
- Refactored Assets/Projects/Jobs/Deployments/Triggers hooks to use the shared pagination hook (removing duplicated state/effects).
- Relaxed asset query hook signatures (`workspaceId` optional) to better match “workspace not yet loaded” states.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
