### PR TITLE
feat(ui): add search input for feature details [FLOW-DEV-176]

### DIFF
--- a/ui/src/features/Editor/components/OverlayUI/components/DebugPanel/DebugPreview/components/TableViewer/FeatureDetailsOverlay.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/DebugPanel/DebugPreview/components/TableViewer/FeatureDetailsOverlay.tsx
@@ -10,6 +10,7 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from "react";
 
 import {
@@ -18,6 +19,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
   IconButton,
+  Input,
 } from "@flow/components";
 import { useT } from "@flow/lib/i18n";
 
@@ -142,6 +144,8 @@ const FeatureDetailsOverlay: React.FC<Props> = ({
   detectedGeometryType,
 }) => {
   const t = useT();
+  const [searchTerm, setSearchTerm] = useState<string>("");
+
   // Process feature properties for display
   const processedFeature = useMemo(() => {
     if (!feature) return null;
@@ -170,11 +174,49 @@ const FeatureDetailsOverlay: React.FC<Props> = ({
       geometry: filteredGeometry,
     };
   }, [feature]);
+
+  const filteredFeature = useMemo(() => {
+    if (!processedFeature) return null;
+    if (!searchTerm) return processedFeature;
+
+    const lowerSearch = searchTerm.toLowerCase();
+
+    const filteredAttributes = Object.fromEntries(
+      Object.entries(processedFeature?.attributes || {}).filter(
+        ([key, value]) => {
+          const keyMatch = key.toLowerCase().includes(lowerSearch);
+          const valueStr =
+            typeof value === "object" ? JSON.stringify(value) : String(value);
+          const valueMatch = valueStr.toLowerCase().includes(lowerSearch);
+          return keyMatch || valueMatch;
+        },
+      ),
+    );
+
+    const filteredGeometry = Object.fromEntries(
+      Object.entries(processedFeature?.geometry || {}).filter(
+        ([key, value]) => {
+          const keyMatch = key.toLowerCase().includes(lowerSearch);
+          const valueStr =
+            typeof value === "object" ? JSON.stringify(value) : String(value);
+          const valueMatch = valueStr.toLowerCase().includes(lowerSearch);
+          return keyMatch || valueMatch;
+        },
+      ),
+    );
+
+    return {
+      ...processedFeature,
+      attributes: filteredAttributes,
+      geometry: filteredGeometry,
+    };
+  }, [processedFeature, searchTerm]);
+
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (scrollRef.current) {
-      scrollRef.current.focus();
+      scrollRef.current.focus({ preventScroll: true });
     }
   }, []);
 
@@ -344,8 +386,20 @@ const FeatureDetailsOverlay: React.FC<Props> = ({
   };
 
   return (
-    <div className="absolute inset-y-0 -top-10 left-0 z-10 w-full rounded-md bg-card/95 shadow-xl backdrop-blur-sm">
+    <div className="absolute inset-0 z-10 rounded-md bg-card/95 shadow-xl backdrop-blur-sm">
       {/* Header */}
+      <div className="py-1">
+        <Input
+          placeholder={t("Search") + "..."}
+          value={searchTerm}
+          onChange={(e) => {
+            const value = String(e.target.value);
+            setSearchTerm(value);
+          }}
+          className="max-w-sm"
+        />
+      </div>
+
       <div className="flex items-center justify-between gap-2 border-b border-border p-2 pl-0">
         <div className="flex gap-2">
           <IconButton
@@ -399,7 +453,7 @@ const FeatureDetailsOverlay: React.FC<Props> = ({
             </div>
           )}
           {/* Geometry */}
-          {Object.keys(processedFeature.geometry).length > 0 && (
+          {Object.keys(filteredFeature?.geometry || {}).length > 0 && (
             <div>
               <h4 className="mb-3 text-sm font-medium text-muted-foreground">
                 {t("Geometry")}
@@ -421,24 +475,27 @@ const FeatureDetailsOverlay: React.FC<Props> = ({
             </div>
           )}
           {/* Attributes */}
-          {Object.keys(processedFeature.attributes).length > 0 && (
+          {Object.keys(filteredFeature?.attributes || {}).length > 0 && (
             <div>
               <h4 className="mb-3 text-sm font-medium text-muted-foreground">
                 {t("Attributes")}
               </h4>
               <div className="space-y-3">
-                {Object.entries(processedFeature.attributes).map(
-                  ([key, value]) => {
-                    const valueType = getValueType(value);
-                    const attributeKey = key.replace(/^attributes/, "");
+                {Object.entries(
+                  (filteredFeature?.attributes ?? {}) as Record<
+                    string,
+                    unknown
+                  >,
+                ).map(([key, value]) => {
+                  const valueType = getValueType(value);
+                  const attributeKey = key.replace(/^attributes/, "");
 
-                    return (
-                      <div key={key}>
-                        {renderEntry(attributeKey, value, valueType)}
-                      </div>
-                    );
-                  },
-                )}
+                  return (
+                    <div key={key}>
+                      {renderEntry(attributeKey, value, valueType)}
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/ui/src/features/Editor/components/OverlayUI/components/DebugPanel/DebugPreview/components/TableViewer/FeatureDetailsOverlay.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/DebugPanel/DebugPreview/components/TableViewer/FeatureDetailsOverlay.tsx
@@ -109,6 +109,16 @@ function stringifyItem(item: unknown, indent: string, depth = 0): string {
   return `{\n${inner}\n${indent}}`;
 }
 
+function toSearchableString(value: unknown): string {
+  if (typeof value !== "object" || value === null) return String(value);
+  if (estimateSize(value) > LARGE_VALUE_THRESHOLD) return summarizeValue(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
 /** Build a lightweight summary string for a large value without JSON.stringify */
 function summarizeValue(value: unknown): string {
   const resolved = resolveValue(value);
@@ -185,9 +195,9 @@ const FeatureDetailsOverlay: React.FC<Props> = ({
       Object.entries(processedFeature?.attributes || {}).filter(
         ([key, value]) => {
           const keyMatch = key.toLowerCase().includes(lowerSearch);
-          const valueStr =
-            typeof value === "object" ? JSON.stringify(value) : String(value);
-          const valueMatch = valueStr.toLowerCase().includes(lowerSearch);
+          const valueMatch = toSearchableString(value)
+            .toLowerCase()
+            .includes(lowerSearch);
           return keyMatch || valueMatch;
         },
       ),
@@ -197,9 +207,9 @@ const FeatureDetailsOverlay: React.FC<Props> = ({
       Object.entries(processedFeature?.geometry || {}).filter(
         ([key, value]) => {
           const keyMatch = key.toLowerCase().includes(lowerSearch);
-          const valueStr =
-            typeof value === "object" ? JSON.stringify(value) : String(value);
-          const valueMatch = valueStr.toLowerCase().includes(lowerSearch);
+          const valueMatch = toSearchableString(value)
+            .toLowerCase()
+            .includes(lowerSearch);
           return keyMatch || valueMatch;
         },
       ),

--- a/ui/src/features/Editor/components/OverlayUI/components/DebugPanel/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/DebugPanel/index.tsx
@@ -183,7 +183,7 @@ const DebugPanel: React.FC = () => {
               value="debug-viewer"
               forceMount={true}
               hidden={tabValue !== "debug-viewer"}
-              className="h-[calc(100%-32px)] overflow-scroll">
+              className="h-[calc(100%-32px)] overflow-hidden">
               <ResizablePanelGroup orientation="horizontal">
                 <ResizablePanel
                   defaultSize={60}
@@ -221,12 +221,7 @@ const DebugPanel: React.FC = () => {
                       </SelectContent>
                     </Select>
                   </div>
-                  <div
-                    className={
-                      detailsOverlayOpen && detailsFeature
-                        ? "mt-[42px] min-h-0 flex-1"
-                        : "mt-0 min-h-0 flex-1"
-                    }>
+                  <div className="min-h-0 flex-1">
                     <TableViewer
                       fileContent={selectedOutputData}
                       selectedFeatureId={selectedFeatureId}


### PR DESCRIPTION
# Overview
This PR adds an in-overlay search input to filter the displayed feature details (geometry/attributes) in the DebugPanel’s feature details overlay, alongside some layout/overflow adjustments to better accommodate the overlay.

## What I've done
- Add a search input to `FeatureDetailsOverlay` and filter feature attributes/geometry based on the entered term.
- Adjust overlay sizing/positioning to use `inset-0` and update focus behavior to avoid scroll jumps.
- Simplify `DebugPanel` viewer layout (remove conditional top margin and switch parent overflow to hidden).
## What I haven't done

## How I tested

## Screenshot
<img width="1504" height="856" alt="Screenshot 2026-06-15 at 9 41 17" src="https://github.com/user-attachments/assets/313ff176-1b11-441e-9d13-244af87a227b" />
<img width="1508" height="857" alt="Screenshot 2026-06-15 at 9 42 07" src="https://github.com/user-attachments/assets/0934ffe1-dbae-4b26-a72e-b8adde7de29f" />

## Which point I want you to review particularly

## Memo
