### PR TITLE
chore(ui): enhance FlowExpr handling with dynamic type support in FlowExprField and FlowExprEditorDialog [FLOW-DEV-193]

### DIFF
--- a/ui/src/components/SchemaForm/Fields/FlowExprField.tsx
+++ b/ui/src/components/SchemaForm/Fields/FlowExprField.tsx
@@ -56,7 +56,13 @@ const FlowExprField = <
   const awarenessStyle = paramsAwarenessStyles(focusedUsers);
 
   const codeValue = formData as CodeValue | undefined;
-  const isExpression = codeValue?.type === "flowExpr";
+
+  const allowedTypes = (schema as any)?.properties?.type?.enum as
+    | string[]
+    | undefined;
+  const stringAllowed = !allowedTypes || allowedTypes.includes("string");
+  const fallbackType: CodeValue["type"] = stringAllowed ? "string" : "flowExpr";
+  const isExpression = codeValue?.type === "flowExpr" || !stringAllowed;
   const label = schema.title || name;
   const defaultValue = useRef<CodeValue | undefined>(codeValue);
 
@@ -76,12 +82,12 @@ const FlowExprField = <
 
   const handleReset = useCallback(() => {
     onChange(
-      (defaultValue.current ?? { type: "string", value: "" }) as any,
+      (defaultValue.current ?? { type: fallbackType, value: "" }) as any,
       fieldPathId.path,
       undefined,
       id,
     );
-  }, [onChange, fieldPathId.path, id]);
+  }, [onChange, fieldPathId.path, id, fallbackType]);
 
   const handleEditorOpen = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -91,12 +97,20 @@ const FlowExprField = <
       const fieldContext: FieldContext = createFieldContext({
         id,
         name,
-        value: codeValue ?? { type: "string", value: "" },
+        value: codeValue ?? { type: fallbackType, value: "" },
         schema,
       });
       onFlowExprEditorOpen(fieldContext);
     },
-    [id, name, codeValue, schema, onFlowExprEditorOpen, onFieldFocus],
+    [
+      id,
+      name,
+      codeValue,
+      schema,
+      fallbackType,
+      onFlowExprEditorOpen,
+      onFieldFocus,
+    ],
   );
 
   const labelNode = (

--- a/ui/src/components/SchemaForm/index.tsx
+++ b/ui/src/components/SchemaForm/index.tsx
@@ -50,7 +50,7 @@ const buildExprUiSchema = (
   }
 
   const isCodeType =
-    schemaObj.$ref === "#/definitions/Code" ||
+    schemaObj.format === "code" ||
     schemaObj.allOf?.some((item: any) => item.$ref === "#/definitions/Code") ||
     schemaObj.anyOf?.some((item: any) => item.$ref === "#/definitions/Code");
 

--- a/ui/src/features/Editor/components/ParamsDialog/components/FlowExprEditorDialog/index.tsx
+++ b/ui/src/features/Editor/components/ParamsDialog/components/FlowExprEditorDialog/index.tsx
@@ -67,8 +67,16 @@ const FlowExprEditorDialog: React.FC<Props> = ({
     | undefined;
   const flowExprAllowed = !allowedTypes || allowedTypes.includes("flowExpr");
   const stringAllowed = !allowedTypes || allowedTypes.includes("string");
+
+  const defaultType: "flowExpr" | "string" = flowExprAllowed
+    ? "flowExpr"
+    : "string";
   const [codeType, setCodeType] = useState<"flowExpr" | "string">(
-    initialCode?.type ?? (flowExprAllowed ? "flowExpr" : "string"),
+    initialCode?.type === "flowExpr" && flowExprAllowed
+      ? "flowExpr"
+      : initialCode?.type === "string" && stringAllowed
+        ? "string"
+        : defaultType,
   );
   const [codeValue, setCodeValue] = useState(initialCode?.value ?? "");
   const [isFullscreen, setIsFullscreen] = useState(false);

--- a/ui/src/features/Editor/components/ParamsDialog/components/FlowExprEditorDialog/index.tsx
+++ b/ui/src/features/Editor/components/ParamsDialog/components/FlowExprEditorDialog/index.tsx
@@ -61,8 +61,14 @@ const FlowExprEditorDialog: React.FC<Props> = ({
   const t = useT();
 
   const initialCode = fieldContext.value as CodeValue | undefined;
+
+  const allowedTypes = (fieldContext.schema as any)?.properties?.type?.enum as
+    | string[]
+    | undefined;
+  const flowExprAllowed = !allowedTypes || allowedTypes.includes("flowExpr");
+  const stringAllowed = !allowedTypes || allowedTypes.includes("string");
   const [codeType, setCodeType] = useState<"flowExpr" | "string">(
-    initialCode?.type ?? "flowExpr",
+    initialCode?.type ?? (flowExprAllowed ? "flowExpr" : "string"),
   );
   const [codeValue, setCodeValue] = useState(initialCode?.value ?? "");
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -205,13 +211,17 @@ const FlowExprEditorDialog: React.FC<Props> = ({
             value={codeType}
             onValueChange={(v) => setCodeType(v as "flowExpr" | "string")}
             className={`flex flex-col ${isFullscreen ? "h-[calc(100vh-52px)]" : "h-[70vh]"}`}>
-            {/* Mode toggle */}
-            <div className="flex shrink-0 gap-1 border-b px-4 py-2">
-              <TabsList className="flex gap-2">
-                <TabsTrigger value="flowExpr">{t("Expression")}</TabsTrigger>
-                <TabsTrigger value="string">{t("Literal string")}</TabsTrigger>
-              </TabsList>
-            </div>
+            {/* Mode toggle — only shown when more than one type is allowed */}
+            {flowExprAllowed && stringAllowed && (
+              <div className="flex shrink-0 gap-1 border-b px-4 py-2">
+                <TabsList className="flex gap-2">
+                  <TabsTrigger value="flowExpr">{t("Expression")}</TabsTrigger>
+                  <TabsTrigger value="string">
+                    {t("Literal string")}
+                  </TabsTrigger>
+                </TabsList>
+              </div>
+            )}
 
             {/* Editor areas */}
             <TabsContent


### PR DESCRIPTION
# Overview

## What I've done

## What I haven't done

## How I tested

## Screenshot
AttributeManager has only FlowExpr and not ability to now have a literal string for condition expression

<img width="999" height="727" alt="Screenshot 2026-06-15 at 15 39 11" src="https://github.com/user-attachments/assets/6797e493-0274-441f-9788-583e19de4237" />

Where as readers (file path) allow for both as you may want to use env["key"] or a literal string

<img width="999" height="722" alt="Screenshot 2026-06-15 at 15 39 42" src="https://github.com/user-attachments/assets/998d038a-8c4d-4c57-b6a4-1bd0c38789b1" />

## Which point I want you to review particularly

## Memo
