### PR TITLE
fix(ui): update default order by to 'UpdatedAt' in useProjectPagination hook

### DIFF
--- a/ui/src/hooks/useProjectPagination.ts
+++ b/ui/src/hooks/useProjectPagination.ts
@@ -26,7 +26,7 @@ export default ({ workspace }: { workspace?: Workspace }) => {
   } = usePagination({
     useDataQuery: useGetWorkspaceProjects,
     workspaceId: workspace?.id,
-    defaultOrderBy: ProjectOrderBy.CreatedAt,
+    defaultOrderBy: ProjectOrderBy.UpdatedAt,
   });
 
   const projects = useMemo(() => page?.projects, [page]);


### PR DESCRIPTION
# Overview
Updates the project list pagination hook to sort projects by most recently updated by default, aligning the UI’s initial ordering with “Latest Updated” behavior.
## What I've done
- Changed `useProjectPagination` default `orderBy` from `CreatedAt` to `UpdatedAt`.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
