### PR TITLE
chore(engine): introducing the geometry migration feature

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5806,7 +5806,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.340"
+version = "0.0.341"
 dependencies = [
  "directories",
  "log",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.52"
+version = "0.2.53"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "futures",
  "once_cell",
@@ -6651,7 +6651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "approx",
  "async-trait",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "Inflector",
  "approx",
@@ -6755,7 +6755,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6843,7 +6843,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6904,7 +6904,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "bytes",
  "clap",
@@ -6944,7 +6944,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6984,7 +6984,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "chrono",
  "futures",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -7040,7 +7040,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "approx",
  "bvh",
@@ -7070,7 +7070,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -7104,7 +7104,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7180,7 +7180,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7197,7 +7197,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7209,7 +7209,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "bytes",
  "futures",
@@ -7226,7 +7226,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "bytes",
  "futures",
@@ -7245,7 +7245,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7259,7 +7259,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7294,7 +7294,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7332,7 +7332,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.406"
+version = "0.0.407"
 dependencies = [
  "async-trait",
  "axum",
@@ -11223,7 +11223,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.242"
+version = "0.1.243"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.406"
+version = "0.0.407"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -11,29 +11,53 @@ script = ['''
 cargo fmt --all ${@:-}
 ''']
 
+# NOTE: `--all-features` is intentionally avoided. The `new-geometry` migration
+# flag switches `Feature.geometry` to the new
+# type and is mutually exclusive with the default geometry world, so it cannot be
+# co-enabled with the default world's tests. The default world is gated with
+# `memory-stats` here; the `new-geometry` world is built separately (lib/bin only,
+# since un-ported actions hit the loud runtime default and so their tests fail by
+# design until ported). CI builds both.
 [tasks.check]
 script = [
   '''
 #!/usr/bin/env bash -eux
+<<<<<<< Updated upstream
 cargo check --workspace --all-targets --all-features --exclude plateau-gis-quality-checker
 ''',
 ]
+=======
+cargo check --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker
+cargo check -p reearth-flow-cli -p reearth-flow-worker --features new-geometry
+''']
+>>>>>>> Stashed changes
 
 [tasks.clippy]
 script = [
   '''
 #!/usr/bin/env bash -eux
+<<<<<<< Updated upstream
 cargo clippy --workspace --all-targets --all-features --exclude plateau-gis-quality-checker -- -D warnings
 ''',
 ]
+=======
+cargo clippy --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker -- -D warnings
+cargo clippy -p reearth-flow-cli -p reearth-flow-worker --features new-geometry -- -D warnings
+''']
+>>>>>>> Stashed changes
 
 [tasks.clippy-fix]
 script = [
   '''
 #!/usr/bin/env bash -eux
+<<<<<<< Updated upstream
 cargo clippy --workspace --all-targets --all-features --exclude plateau-gis-quality-checker --fix ${@:-}
 ''',
 ]
+=======
+cargo clippy --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker --fix ${@:-}
+''']
+>>>>>>> Stashed changes
 
 [tasks.test]
 script = ['''
@@ -47,9 +71,16 @@ cargo make test-conv ${@:-}
 script = [
   '''
 #!/usr/bin/env bash -eux
+<<<<<<< Updated upstream
 cargo test --workspace --all-targets --all-features --exclude plateau-gis-quality-checker --exclude workflow-tests ${@:-}
 ''',
 ]
+=======
+# Default geometry world only. The `new-geometry` world cannot be tested until
+# actions are ported (un-ported actions hit the loud runtime default).
+cargo test --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker --exclude workflow-tests ${@:-}
+''']
+>>>>>>> Stashed changes
 
 [tasks.test-qc]
 script = ['''

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -19,45 +19,24 @@ cargo fmt --all ${@:-}
 # since un-ported actions hit the loud runtime default and so their tests fail by
 # design until ported). CI builds both.
 [tasks.check]
-script = [
-  '''
+script = ['''
 #!/usr/bin/env bash -eux
-<<<<<<< Updated upstream
-cargo check --workspace --all-targets --all-features --exclude plateau-gis-quality-checker
-''',
-]
-=======
 cargo check --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker
 cargo check -p reearth-flow-cli -p reearth-flow-worker --features new-geometry
 ''']
->>>>>>> Stashed changes
 
 [tasks.clippy]
-script = [
-  '''
+script = ['''
 #!/usr/bin/env bash -eux
-<<<<<<< Updated upstream
-cargo clippy --workspace --all-targets --all-features --exclude plateau-gis-quality-checker -- -D warnings
-''',
-]
-=======
 cargo clippy --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker -- -D warnings
 cargo clippy -p reearth-flow-cli -p reearth-flow-worker --features new-geometry -- -D warnings
 ''']
->>>>>>> Stashed changes
 
 [tasks.clippy-fix]
-script = [
-  '''
+script = ['''
 #!/usr/bin/env bash -eux
-<<<<<<< Updated upstream
-cargo clippy --workspace --all-targets --all-features --exclude plateau-gis-quality-checker --fix ${@:-}
-''',
-]
-=======
 cargo clippy --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker --fix ${@:-}
 ''']
->>>>>>> Stashed changes
 
 [tasks.test]
 script = ['''
@@ -68,19 +47,12 @@ cargo make test-conv ${@:-}
 ''']
 
 [tasks.test-rs]
-script = [
-  '''
+script = ['''
 #!/usr/bin/env bash -eux
-<<<<<<< Updated upstream
-cargo test --workspace --all-targets --all-features --exclude plateau-gis-quality-checker --exclude workflow-tests ${@:-}
-''',
-]
-=======
 # Default geometry world only. The `new-geometry` world cannot be tested until
 # actions are ported (un-ported actions hit the loud runtime default).
 cargo test --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker --exclude workflow-tests ${@:-}
 ''']
->>>>>>> Stashed changes
 
 [tasks.test-qc]
 script = ['''

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -11,31 +11,29 @@ script = ['''
 cargo fmt --all ${@:-}
 ''']
 
-# NOTE: `--all-features` is intentionally avoided. The `new-geometry` migration
-# flag switches `Feature.geometry` to the new
-# type and is mutually exclusive with the default geometry world, so it cannot be
-# co-enabled with the default world's tests. The default world is gated with
-# `memory-stats` here; the `new-geometry` world is built separately (lib/bin only,
-# since un-ported actions hit the loud runtime default and so their tests fail by
-# design until ported). CI builds both.
+# NOTE: `--all-features` is intentionally avoided. It would enable the `new-geometry`
+# migration flag, which switches `Feature.geometry` to the new type and is mutually
+# exclusive with the default geometry world. So the default world is checked plainly,
+# and `new-geometry` is built separately (lib/bin only, since un-ported actions hit
+# the loud runtime default and their tests fail by design until ported). CI builds both.
 [tasks.check]
 script = ['''
 #!/usr/bin/env bash -eux
-cargo check --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker
+cargo check --workspace --all-targets --exclude plateau-gis-quality-checker
 cargo check -p reearth-flow-cli -p reearth-flow-worker --features new-geometry
 ''']
 
 [tasks.clippy]
 script = ['''
 #!/usr/bin/env bash -eux
-cargo clippy --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker -- -D warnings
+cargo clippy --workspace --all-targets --exclude plateau-gis-quality-checker -- -D warnings
 cargo clippy -p reearth-flow-cli -p reearth-flow-worker --features new-geometry -- -D warnings
 ''']
 
 [tasks.clippy-fix]
 script = ['''
 #!/usr/bin/env bash -eux
-cargo clippy --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker --fix ${@:-}
+cargo clippy --workspace --all-targets --exclude plateau-gis-quality-checker --fix ${@:-}
 ''']
 
 [tasks.test]
@@ -51,7 +49,7 @@ script = ['''
 #!/usr/bin/env bash -eux
 # Default geometry world only. The `new-geometry` world cannot be tested until
 # actions are ported (un-ported actions hit the loud runtime default).
-cargo test --workspace --all-targets --features memory-stats --exclude plateau-gis-quality-checker --exclude workflow-tests ${@:-}
+cargo test --workspace --all-targets --exclude plateau-gis-quality-checker --exclude workflow-tests ${@:-}
 ''']
 
 [tasks.test-qc]

--- a/engine/cli/Cargo.toml
+++ b/engine/cli/Cargo.toml
@@ -20,6 +20,15 @@ memory-stats = [
   "reearth-flow-action-plateau-processor/memory-stats",
   "reearth-flow-action-processor/memory-stats",
 ]
+# Temporary migration flag for the new-geometry migration.
+new-geometry = [
+  "reearth-flow-action-plateau-processor/new-geometry",
+  "reearth-flow-action-processor/new-geometry",
+  "reearth-flow-action-python-processor/new-geometry",
+  "reearth-flow-action-sink/new-geometry",
+  "reearth-flow-action-source/new-geometry",
+  "reearth-flow-types/new-geometry",
+]
 
 [dependencies]
 reearth-flow-action-log.workspace = true

--- a/engine/cli/Cargo.toml
+++ b/engine/cli/Cargo.toml
@@ -21,6 +21,7 @@ memory-stats = [
   "reearth-flow-action-processor/memory-stats",
 ]
 # Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
 new-geometry = [
   "reearth-flow-action-plateau-processor/new-geometry",
   "reearth-flow-action-processor/new-geometry",

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.340"
+version = "0.0.341"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/runtime/action-plateau-processor/Cargo.toml
+++ b/engine/runtime/action-plateau-processor/Cargo.toml
@@ -13,6 +13,11 @@ version.workspace = true
 [features]
 default = []
 memory-stats = ["reearth-flow-common/memory-stats"]
+# Temporary migration flag for the new-geometry migration.
+new-geometry = [
+  "reearth-flow-geometry/new-geometry",
+  "reearth-flow-types/new-geometry",
+]
 
 [dependencies]
 reearth-flow-action-log.workspace = true

--- a/engine/runtime/action-plateau-processor/Cargo.toml
+++ b/engine/runtime/action-plateau-processor/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 default = []
 memory-stats = ["reearth-flow-common/memory-stats"]
 # Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
 new-geometry = [
   "reearth-flow-geometry/new-geometry",
   "reearth-flow-types/new-geometry",

--- a/engine/runtime/action-plateau-processor/src/lib.rs
+++ b/engine/runtime/action-plateau-processor/src/lib.rs
@@ -1,4 +1,9 @@
 #![recursion_limit = "256"]
+// TODO(new-geometry): remove after migration. Gating each ported action's
+// `process`/`finish`/`start` leaves geometry-only imports and helpers unused
+// under the flag; silence that noise (feature-scoped, so the default build keeps
+// full lint coverage).
+#![cfg_attr(feature = "new-geometry", allow(unused_imports, dead_code))]
 
 pub(crate) mod citygml;
 pub(crate) mod common;

--- a/engine/runtime/action-plateau-processor/src/plateau4/building_part_connectivity_checker.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/building_part_connectivity_checker.rs
@@ -224,6 +224,7 @@ impl Processor for BuildingPartConnectivityChecker {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -297,6 +298,7 @@ impl Processor for BuildingPartConnectivityChecker {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-plateau-processor/src/plateau4/citygml_mesh_builder.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/citygml_mesh_builder.rs
@@ -139,6 +139,7 @@ impl Processor for CityGmlMeshBuilder {
         16
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -248,6 +249,7 @@ impl Processor for CityGmlMeshBuilder {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-plateau-processor/src/plateau4/composite_surface_continuity_filter.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/composite_surface_continuity_filter.rs
@@ -63,6 +63,7 @@ impl ProcessorFactory for CompositeSurfaceContinuityFilterFactory {
 pub struct CompositeSurfaceContinuityFilter;
 
 impl Processor for CompositeSurfaceContinuityFilter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -122,6 +123,7 @@ impl Processor for CompositeSurfaceContinuityFilter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-plateau-processor/src/plateau4/destination_mesh_code_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/destination_mesh_code_extractor.rs
@@ -189,6 +189,7 @@ fn ensure_proj_cached(epsg_code: &str) -> Result<(), BoxedError> {
 }
 
 impl Processor for DestinationMeshCodeExtractor {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -255,6 +256,7 @@ impl Processor for DestinationMeshCodeExtractor {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-plateau-processor/src/plateau4/face_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/face_extractor.rs
@@ -301,6 +301,7 @@ impl FaceExtractor {
         Ok(coords)
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process_xml(
         &mut self,
         ctx: &ExecutorContext,
@@ -525,6 +526,7 @@ impl FaceExtractor {
 }
 
 impl Processor for FaceExtractor {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -569,6 +571,7 @@ impl Processor for FaceExtractor {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-plateau-processor/src/plateau4/flooding_area_surface_generator.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/flooding_area_surface_generator.rs
@@ -180,6 +180,7 @@ impl Clone for FloodingAreaSurfaceGenerator {
 }
 
 impl Processor for FloodingAreaSurfaceGenerator {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -254,6 +255,7 @@ impl Processor for FloodingAreaSurfaceGenerator {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-plateau-processor/src/plateau4/unshared_edge_detector.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/unshared_edge_detector.rs
@@ -281,6 +281,7 @@ impl Processor for UnsharedEdgeDetector {
         true
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -349,6 +350,7 @@ impl Processor for UnsharedEdgeDetector {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -450,6 +452,7 @@ fn engine_cache_dir(executor_id: uuid::Uuid) -> PathBuf {
 }
 
 /// Process all chunks for a single group: multi-pass merge + sliding-window scan.
+#[cfg(not(feature = "new-geometry"))]
 fn process_group_chunks(
     dir: &Path,
     chunk_count: usize,
@@ -550,6 +553,7 @@ fn process_group_chunks(
 /// A group is a micro-gap when it has more than one member and the members do
 /// not all share identical coordinates (i.e., they are within tolerance but not
 /// exactly the same — indicating a tiny gap between mesh triangles).
+#[cfg(not(feature = "new-geometry"))]
 fn emit_microgaps(
     group: (Edge, Vec<Edge>),
     attrs_store: &[IndexMap<Attribute, AttributeValue>],
@@ -661,6 +665,7 @@ fn merge_edge_chunks_to_file(
 }
 
 /// Extract all edges from a feature's geometry (used eagerly in `process()`).
+#[cfg(not(feature = "new-geometry"))]
 fn extract_edges_from_feature(feature: &Feature, attr_idx: u32) -> Vec<Edge> {
     let mut edges = Vec::new();
     if let Some(geom_2d) = extract_geometry_2d(&feature.geometry) {

--- a/engine/runtime/action-plateau-processor/src/solar/sun_position_calculator/mod.rs
+++ b/engine/runtime/action-plateau-processor/src/solar/sun_position_calculator/mod.rs
@@ -298,6 +298,7 @@ pub struct SolarPositionCalculator {
 }
 
 impl Processor for SolarPositionCalculator {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -415,6 +416,7 @@ impl Processor for SolarPositionCalculator {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -501,6 +503,7 @@ impl SolarPositionCalculator {
     }
 
     /// Extract 3D centroid from feature geometry (in source CRS coordinates).
+    #[cfg(not(feature = "new-geometry"))]
     fn extract_centroid_3d(feature: &Feature) -> Result<Centroid3D, SolarPositionError> {
         let geometry = &feature.geometry;
 

--- a/engine/runtime/action-processor/Cargo.toml
+++ b/engine/runtime/action-processor/Cargo.toml
@@ -14,6 +14,7 @@ version.workspace = true
 default = []
 memory-stats = ["reearth-flow-common/memory-stats"]
 # Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
 new-geometry = [
   "reearth-flow-action-sink/new-geometry",
   "reearth-flow-geometry/new-geometry",

--- a/engine/runtime/action-processor/Cargo.toml
+++ b/engine/runtime/action-processor/Cargo.toml
@@ -13,6 +13,12 @@ version.workspace = true
 [features]
 default = []
 memory-stats = ["reearth-flow-common/memory-stats"]
+# Temporary migration flag for the new-geometry migration.
+new-geometry = [
+  "reearth-flow-action-sink/new-geometry",
+  "reearth-flow-geometry/new-geometry",
+  "reearth-flow-types/new-geometry",
+]
 
 [dependencies]
 reearth-flow-action-log.workspace = true

--- a/engine/runtime/action-processor/src/feature/json_fragmenter.rs
+++ b/engine/runtime/action-processor/src/feature/json_fragmenter.rs
@@ -552,6 +552,7 @@ mod tests {
         assert_eq!(ports[0], DEFAULT_PORT.clone());
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_preserves_input_attributes() {
         let mut feature = make_feature_with_json(r#"[{"x": 1}]"#);

--- a/engine/runtime/action-processor/src/feature/lod_filter.rs
+++ b/engine/runtime/action-processor/src/feature/lod_filter.rs
@@ -116,6 +116,7 @@ struct FeatureLodFilter {
 }
 
 impl Processor for FeatureLodFilter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -147,6 +148,7 @@ impl Processor for FeatureLodFilter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -162,6 +164,7 @@ impl Processor for FeatureLodFilter {
 }
 
 impl FeatureLodFilter {
+    #[cfg(not(feature = "new-geometry"))]
     fn flush_buffer(&self, ctx: Context, fw: &ProcessorChannelForwarder) {
         for (key, features) in self.buffer_features.iter() {
             let lod_count = LodCount {
@@ -173,6 +176,7 @@ impl FeatureLodFilter {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn routing_feature_by_lod(
         ctx: Context,
         fw: &ProcessorChannelForwarder,
@@ -218,6 +222,7 @@ impl FeatureLodFilter {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn feature_with_single_lod(feature: &Feature, max_lod: u8) -> Feature {
         let mut filtered_feature = feature.clone();
 

--- a/engine/runtime/action-processor/src/feature/reader/citygml/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml/processor.rs
@@ -19,7 +19,9 @@ use url::Url;
 
 use crate::feature::errors::FeatureProcessorError;
 
-use super::reader::{emit_buffered, parse_and_register};
+#[cfg(not(feature = "new-geometry"))]
+use super::reader::emit_buffered;
+use super::reader::parse_and_register;
 
 type StorePool = Vec<(Arc<RwLock<GeometryStore>>, Arc<RwLock<AppearanceStore>>)>;
 
@@ -178,6 +180,7 @@ impl Processor for FeatureCityGmlReader {
         1
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -222,6 +225,7 @@ impl Processor for FeatureCityGmlReader {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-processor/src/feature/reader/citygml/reader.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml/reader.rs
@@ -100,6 +100,7 @@ fn load_flat_map(
 /// Both the main emit loop and the cross-file feature-ref path call this so attribute keys
 /// only need to be maintained in one place.
 #[allow(clippy::too_many_arguments)]
+#[cfg(not(feature = "new-geometry"))]
 fn emit_flat_entity(
     ctx: &Context,
     fw: &ProcessorChannelForwarder,
@@ -428,6 +429,7 @@ fn collect_entities<R: BufRead>(
 /// Pass 2: stream entities from per-file JSONL caches and emit features.
 /// Cross-file xlink:href refs are resolved by lazily loading the referenced file's cache.
 #[allow(clippy::uninlined_format_args)]
+#[cfg(not(feature = "new-geometry"))]
 pub(super) fn emit_buffered(
     ctx: Context,
     fw: &ProcessorChannelForwarder,

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
@@ -225,6 +225,7 @@ impl Processor for FeatureCityGml3Reader {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn build_feature(node: &Arc<XmlNode>) -> Feature {
     let (stripped, raw_geoms) = geometry::extract_geometries(node);
     let mut feature = parser::to_feature(&stripped);

--- a/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3/processor.rs
@@ -177,6 +177,7 @@ impl Processor for FeatureCityGml3Reader {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-processor/src/feature/writer.rs
+++ b/engine/runtime/action-processor/src/feature/writer.rs
@@ -246,6 +246,7 @@ impl Processor for FeatureWriter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-processor/src/feature/writer/citygml.rs
+++ b/engine/runtime/action-processor/src/feature/writer/citygml.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+#[cfg(not(feature = "new-geometry"))]
 use reearth_flow_action_sink::file::citygml::write_citygml_to_storage;
 use reearth_flow_common::uri::Uri;
 use reearth_flow_storage::resolve::StorageResolver;
@@ -43,6 +44,7 @@ pub(super) fn build_lod_mask(lod_filter: &Option<Vec<u8>>) -> LodMask {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 pub(super) fn write_citygml(
     output: &Uri,
     sandbox_root: &Uri,

--- a/engine/runtime/action-processor/src/geometry/appearance_remover.rs
+++ b/engine/runtime/action-processor/src/geometry/appearance_remover.rs
@@ -58,6 +58,7 @@ impl ProcessorFactory for AppearanceRemoverFactory {
 pub struct AppearanceRemover;
 
 impl Processor for AppearanceRemover {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -90,6 +91,7 @@ impl Processor for AppearanceRemover {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/area_calculator.rs
+++ b/engine/runtime/action-processor/src/geometry/area_calculator.rs
@@ -124,6 +124,7 @@ fn default_multiplier() -> f64 {
 }
 
 impl Processor for AreaCalculator {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -192,6 +193,7 @@ impl Processor for AreaCalculator {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
@@ -282,6 +282,7 @@ impl Processor for AreaOnAreaOverlayer {
         true
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -341,6 +342,7 @@ impl Processor for AreaOnAreaOverlayer {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -481,6 +483,7 @@ impl DiskBackedFeatures {
     }
 
     /// Read and extract only the geometry from a feature at the given index.
+    #[cfg(not(feature = "new-geometry"))]
     fn read_geometry(&self, i: usize) -> Arc<Geometry> {
         let feature = self.read_feature(i);
         feature.geometry
@@ -613,6 +616,7 @@ impl AabbIndex {
 
 /// Disk-backed version of overlay_2d that reads geometries from disk on demand
 /// and writes MiddlePolygons to a JSONL file instead of collecting in memory.
+#[cfg(not(feature = "new-geometry"))]
 fn overlay_2d_disk(
     aabbs: &[[f64; 4]],
     disk_feats: &DiskBackedFeatures,
@@ -715,6 +719,7 @@ fn overlay_2d_disk(
 /// Stream MiddlePolygons from a JSONL file, convert to Features, and write
 /// directly to area/remnants output files without collecting in memory.
 /// Returns (area_count, remnants_count).
+#[cfg(not(feature = "new-geometry"))]
 fn from_midpolygons_disk<W: Write>(
     midpolygons_path: &Path,
     disk_feats: &DiskBackedFeatures,

--- a/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/area_on_area_overlayer.rs
@@ -864,6 +864,7 @@ mod tests {
         )))
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn make_feature(coords: Vec<(f64, f64)>) -> Feature {
         let geom = make_geom(coords);
         let mut f = Feature::new_with_attributes(IndexMap::new());
@@ -871,6 +872,7 @@ mod tests {
         f
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_overlay_two_squares_disk() {
         // Create temp dir and write features to disk
@@ -922,6 +924,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_overlay_triangles_sharing_an_edge_disk() {
         let dir =

--- a/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/boundary_extractor.rs
@@ -94,6 +94,7 @@ struct BoundaryExtractor {
 }
 
 impl Processor for BoundaryExtractor {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -151,6 +152,7 @@ impl Processor for BoundaryExtractor {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/bounds_extractor.rs
@@ -142,6 +142,7 @@ pub struct BoundsExtractor {
 }
 
 impl Processor for BoundsExtractor {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -195,6 +196,7 @@ impl Processor for BoundsExtractor {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/bufferer.rs
+++ b/engine/runtime/action-processor/src/geometry/bufferer.rs
@@ -105,6 +105,7 @@ struct Bufferer {
 }
 
 impl Processor for Bufferer {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -131,6 +132,7 @@ impl Processor for Bufferer {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -145,6 +147,7 @@ impl Processor for Bufferer {
 }
 
 impl Bufferer {
+    #[cfg(not(feature = "new-geometry"))]
     fn handle_2d_geometry(
         &self,
         geos: &Geometry2D,
@@ -216,6 +219,7 @@ impl Bufferer {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn handle_3d_geometry(
         &self,
         geos: &Geometry3D,

--- a/engine/runtime/action-processor/src/geometry/center_point_replacer.rs
+++ b/engine/runtime/action-processor/src/geometry/center_point_replacer.rs
@@ -457,6 +457,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn make_citygml_feature(gml_geometries: Vec<GmlGeometry>) -> Feature {
         let city_gml = CityGmlGeometry {
             gml_geometries,
@@ -495,6 +496,7 @@ mod tests {
         run_processor_with_mode(feature, CenterPointMode::CenterOfGravity)
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn make_2d_polygon_feature(coords: &[(f64, f64)]) -> Feature {
         let line_coords: Vec<Coordinate<f64, _>> =
             coords.iter().map(|&(x, y)| (x, y).into()).collect();
@@ -510,6 +512,7 @@ mod tests {
     // Center of Gravity tests (existing behavior)
     // =========================================================================
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_2d_polygon_centroid() {
         let feature =
@@ -527,6 +530,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_3d_polygon_centroid() {
         let polygon = make_polygon_3d(&[
@@ -555,6 +559,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_citygml_single_polygon_centroid() {
         let polygon = make_polygon_3d(&[
@@ -584,6 +589,7 @@ mod tests {
     // CityGML multi-polygon now succeeds for centroid & bbox modes
     // =========================================================================
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_citygml_multiple_polygons_centroid() {
         let poly1 = make_polygon_3d(&[
@@ -621,6 +627,7 @@ mod tests {
     // Bounding Box Center tests
     // =========================================================================
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_2d_polygon_bbox_center() {
         let feature =
@@ -639,6 +646,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_3d_polygon_bbox_center() {
         let polygon = make_polygon_3d(&[
@@ -668,6 +676,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_citygml_bbox_center() {
         let poly1 = make_polygon_3d(&[
@@ -706,6 +715,7 @@ mod tests {
     // Any Inside Point tests
     // =========================================================================
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_any_inside_point_convex() {
         let feature =
@@ -724,6 +734,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_any_inside_point_concave() {
         // C-shaped polygon where centroid would be outside
@@ -756,6 +767,7 @@ mod tests {
     // Rejection tests
     // =========================================================================
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_any_inside_point_rejects_line() {
         use reearth_flow_geometry::types::line_string::LineString2D;
@@ -777,6 +789,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_any_inside_point_rejects_point() {
         let point = reearth_flow_geometry::types::point::Point2D::from((1.0, 2.0));
@@ -791,6 +804,7 @@ mod tests {
         assert_eq!(ports[0], REJECTED_PORT.clone());
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_any_inside_point_rejects_citygml() {
         let polygon = make_polygon_3d(&[
@@ -813,6 +827,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_rejected_feature_has_rejection_code() {
         let geometry = Geometry {

--- a/engine/runtime/action-processor/src/geometry/center_point_replacer.rs
+++ b/engine/runtime/action-processor/src/geometry/center_point_replacer.rs
@@ -98,6 +98,7 @@ struct CenterPointReplacer {
 }
 
 impl Processor for CenterPointReplacer {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -174,6 +175,7 @@ impl CenterPointReplacer {
         )
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn handle_2d_geometry(
         &self,
         geos: &Geometry2D,
@@ -249,6 +251,7 @@ impl CenterPointReplacer {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn handle_3d_geometry(
         &self,
         geos: &Geometry3D,
@@ -322,6 +325,7 @@ impl CenterPointReplacer {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn handle_citygml_geometry(
         &self,
         city_gml: &CityGmlGeometry,

--- a/engine/runtime/action-processor/src/geometry/clipper.rs
+++ b/engine/runtime/action-processor/src/geometry/clipper.rs
@@ -81,6 +81,7 @@ struct Clipper {
 }
 
 impl Processor for Clipper {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -118,6 +119,7 @@ impl Processor for Clipper {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -243,6 +245,7 @@ impl Processor for Clipper {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn handle_2d_geometry(
     geos: &Geometry2D,
     clip_regions: &[Polygon2D<f64>],
@@ -275,6 +278,7 @@ fn handle_2d_geometry(
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn forward_polygon2d(
     insides: &[Polygon2D<f64>],
     outsides: &[Polygon2D<f64>],
@@ -307,6 +311,7 @@ fn forward_polygon2d(
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn handle_3d_geometry(
     geos: &Geometry3D,
     clip_regions: &[Polygon3D<f64>],
@@ -339,6 +344,7 @@ fn handle_3d_geometry(
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn forward_polygon3d(
     insides: &[Polygon3D<f64>],
     outsides: &[Polygon3D<f64>],
@@ -533,6 +539,7 @@ fn process_gml_geometry(
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn handle_citygml_geometry(
     citygml: &CityGmlGeometry,
     clip_regions: &[Polygon3D<f64>],

--- a/engine/runtime/action-processor/src/geometry/clipper.rs
+++ b/engine/runtime/action-processor/src/geometry/clipper.rs
@@ -618,6 +618,7 @@ mod tests {
 
     use crate::tests::utils::create_default_execute_context;
 
+    #[cfg(not(feature = "new-geometry"))]
     fn make_feature(geometry: Geometry) -> Feature {
         Feature::new_with_attributes_and_geometry(Attributes::new(), geometry)
     }
@@ -666,6 +667,7 @@ mod tests {
         Polygon3D::new(exterior, vec![])
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_clipper_with_empty_geometry() {
         let mut clipper = Clipper {
@@ -689,6 +691,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_clipper_adds_features_to_correct_lists() {
         let mut clipper = Clipper {
@@ -730,6 +733,7 @@ mod tests {
         assert_eq!(clipper.candidates.len(), 1);
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_clipper_finish_with_no_clippers() {
         let mut clipper = Clipper {
@@ -916,6 +920,7 @@ mod tests {
         assert!(!outsides.is_empty(), "Should have outside polygons");
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_clipper_finish_with_2d_geometries() {
         let polygon = create_test_polygon_2d();
@@ -947,6 +952,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_clipper_finish_with_3d_geometries() {
         let polygon = create_test_polygon_3d();
@@ -1002,6 +1008,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_clipper_with_non_polygon_geometry() {
         let mut clipper = Clipper {
@@ -1028,6 +1035,7 @@ mod tests {
         assert_eq!(clipper.candidates.len(), 1);
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_clipper_finish_with_non_polygon_candidate() {
         let clip_polygon = create_clipper_polygon_2d();
@@ -1059,6 +1067,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_clipper_with_citygml_geometry() {
         use reearth_flow_types::{GeometryType, GmlGeometry};
@@ -1111,6 +1120,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_clipper_with_citygml_as_clipper() {
         use reearth_flow_types::{GeometryType, GmlGeometry};
@@ -1163,6 +1173,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_clipper_with_citygml_curve_geometry() {
         use reearth_flow_geometry::types::line_string::LineString3D;
@@ -1222,6 +1233,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_clipper_with_geometry_collection() {
         let polygon1 = create_test_polygon_2d();

--- a/engine/runtime/action-processor/src/geometry/closed_curve_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/closed_curve_filter.rs
@@ -65,6 +65,7 @@ impl ProcessorFactory for ClosedCurveFilterFactory {
 struct ClosedCurveFilter;
 
 impl Processor for ClosedCurveFilter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -93,6 +94,7 @@ impl Processor for ClosedCurveFilter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/coercer.rs
+++ b/engine/runtime/action-processor/src/geometry/coercer.rs
@@ -94,6 +94,7 @@ struct GeometryCoercer {
 }
 
 impl Processor for GeometryCoercer {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -122,6 +123,7 @@ impl Processor for GeometryCoercer {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -136,6 +138,7 @@ impl Processor for GeometryCoercer {
 }
 
 impl GeometryCoercer {
+    #[cfg(not(feature = "new-geometry"))]
     fn handle_2d_geometry(
         &self,
         geos: &Geometry2D,
@@ -242,6 +245,7 @@ impl GeometryCoercer {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn handle_3d_geometry(
         &self,
         geos: &Geometry3D,
@@ -365,6 +369,7 @@ impl GeometryCoercer {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn handle_city_gml_geometry(
         &self,
         geos: &CityGmlGeometry,

--- a/engine/runtime/action-processor/src/geometry/convex_hull_accumulator.rs
+++ b/engine/runtime/action-processor/src/geometry/convex_hull_accumulator.rs
@@ -118,6 +118,7 @@ impl Processor for ConvexHullAccumulator {
         true
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -174,6 +175,7 @@ impl Processor for ConvexHullAccumulator {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -196,6 +198,7 @@ impl Processor for ConvexHullAccumulator {
 }
 
 impl ConvexHullAccumulator {
+    #[cfg(not(feature = "new-geometry"))]
     fn create_hull(&mut self) -> Vec<Feature> {
         let mut hulls = Vec::new();
         for buffer in std::mem::take(&mut self.buffer).into_values() {
@@ -204,6 +207,7 @@ impl ConvexHullAccumulator {
         hulls
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn create_hull_2d(buffer: GroupBuffer) -> Feature {
         let mut collection = buffer
             .geometries

--- a/engine/runtime/action-processor/src/geometry/coordinate_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_extractor.rs
@@ -343,6 +343,7 @@ mod tests {
     use reearth_flow_runtime::forwarder::NoopChannelForwarder;
     use reearth_flow_types::{feature::Attributes, Feature, Geometry};
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_all_coords_point_2d() {
         let noop = NoopChannelForwarder::default();
@@ -380,6 +381,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_all_coords_point_3d() {
         let noop = NoopChannelForwarder::default();
@@ -415,6 +417,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_all_coords_linestring_2d() {
         let noop = NoopChannelForwarder::default();
@@ -443,6 +446,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_all_coords_polygon_2d() {
         let noop = NoopChannelForwarder::default();
@@ -478,6 +482,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_specify_coord_positive_index() {
         let noop = NoopChannelForwarder::default();
@@ -507,6 +512,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_specify_coord_negative_index() {
         let noop = NoopChannelForwarder::default();
@@ -536,6 +542,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_specify_coord_out_of_range() {
         let noop = NoopChannelForwarder::default();
@@ -556,6 +563,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_no_geometry_rejected() {
         let noop = NoopChannelForwarder::default();
@@ -573,6 +581,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_default_z_value_2d() {
         let noop = NoopChannelForwarder::default();
@@ -596,6 +605,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_specify_coord_negative_out_of_range() {
         let noop = NoopChannelForwarder::default();
@@ -616,6 +626,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_all_coords_citygml() {
         let noop = NoopChannelForwarder::default();
@@ -675,6 +686,7 @@ mod tests {
     // helper functions
     //
 
+    #[cfg(not(feature = "new-geometry"))]
     fn make_feature(value: GeometryValue) -> Feature {
         Feature::new_with_attributes_and_geometry(
             Attributes::new(),

--- a/engine/runtime/action-processor/src/geometry/coordinate_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_extractor.rs
@@ -153,6 +153,7 @@ pub(super) struct CoordinateExtractor {
 }
 
 impl Processor for CoordinateExtractor {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -262,6 +263,7 @@ impl Processor for CoordinateExtractor {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/csg/csg_builder.rs
+++ b/engine/runtime/action-processor/src/geometry/csg/csg_builder.rs
@@ -151,6 +151,7 @@ impl Processor for CSGBuilder {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -211,6 +212,7 @@ impl Processor for CSGBuilder {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -244,6 +246,7 @@ impl Processor for CSGBuilder {
 }
 
 impl CSGBuilder {
+    #[cfg(not(feature = "new-geometry"))]
     fn create_and_send_csg(
         &self,
         left_feature: Feature,

--- a/engine/runtime/action-processor/src/geometry/csg/csg_evaluator.rs
+++ b/engine/runtime/action-processor/src/geometry/csg/csg_evaluator.rs
@@ -132,6 +132,7 @@ impl CSGEvaluator {
 }
 
 impl Processor for CSGEvaluator {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -182,6 +183,7 @@ impl Processor for CSGEvaluator {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/dimension_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/dimension_filter.rs
@@ -64,6 +64,7 @@ impl ProcessorFactory for DimensionFilterFactory {
 pub struct DimensionFilter;
 
 impl Processor for DimensionFilter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -114,6 +115,7 @@ impl Processor for DimensionFilter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/dissolver.rs
+++ b/engine/runtime/action-processor/src/geometry/dissolver.rs
@@ -249,6 +249,7 @@ impl Dissolver {
         Ok(features)
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn dissolve_all_groups(&mut self) -> Result<Vec<Feature>, BoxedError> {
         // Flush buffer before reading files
         self.flush_buffer()?;
@@ -290,6 +291,7 @@ impl Processor for Dissolver {
         true
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -341,6 +343,7 @@ impl Processor for Dissolver {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -362,6 +365,7 @@ impl Processor for Dissolver {
 }
 
 impl Dissolver {
+    #[cfg(not(feature = "new-geometry"))]
     fn dissolve_2d(&self, buffered_features_2d: Vec<Feature>) -> Option<Feature> {
         // Start with an empty multi-polygon
         let mut multi_polygon_2d = MultiPolygon2D::new(vec![]);

--- a/engine/runtime/action-processor/src/geometry/elevation_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/elevation_extractor.rs
@@ -95,6 +95,7 @@ impl Processor for ElevationExtractor {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -156,6 +157,7 @@ impl Processor for ElevationExtractor {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/extractor.rs
@@ -82,6 +82,7 @@ pub struct GeometryExtractor {
 }
 
 impl Processor for GeometryExtractor {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -104,6 +105,7 @@ impl Processor for GeometryExtractor {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/extruder.rs
+++ b/engine/runtime/action-processor/src/geometry/extruder.rs
@@ -106,6 +106,7 @@ impl Processor for Extruder {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -142,6 +143,7 @@ impl Processor for Extruder {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/filter.rs
+++ b/engine/runtime/action-processor/src/geometry/filter.rs
@@ -286,6 +286,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_filter_multiple_geometry_3d_multipolygon() {
         let noop = NoopChannelForwarder::default();
@@ -307,6 +308,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_filter_multiple_geometry_3d_geometry_collection() {
         let noop = NoopChannelForwarder::default();
@@ -330,6 +332,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_filter_multiple_geometry_3d_other_geometry() {
         let noop = NoopChannelForwarder::default();

--- a/engine/runtime/action-processor/src/geometry/filter.rs
+++ b/engine/runtime/action-processor/src/geometry/filter.rs
@@ -121,6 +121,7 @@ impl GeometryFilterParam {
 }
 
 impl Processor for GeometryFilter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -155,6 +156,7 @@ impl Processor for GeometryFilter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/footprint_replacer.rs
+++ b/engine/runtime/action-processor/src/geometry/footprint_replacer.rs
@@ -70,6 +70,7 @@ impl ProcessorFactory for FootprintReplacerFactory {
 pub struct FootprintReplacer;
 
 impl Processor for FootprintReplacer {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -106,6 +107,7 @@ impl Processor for FootprintReplacer {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(&mut self, _: NodeContext, _: &ProcessorChannelForwarder) -> Result<(), BoxedError> {
         Ok(())
     }
@@ -154,6 +156,7 @@ fn extract_polygons_from_geometry3d(geom: &Geometry3D<f64>) -> Vec<Polygon3D<f64
 }
 
 /// Create footprint from FlowGeometry3D
+#[cfg(not(feature = "new-geometry"))]
 fn create_footprint_from_geometry3d(feature: &Feature, geom: &Geometry3D<f64>) -> Option<Feature> {
     let polygons = extract_polygons_from_geometry3d(geom);
 
@@ -165,6 +168,7 @@ fn create_footprint_from_geometry3d(feature: &Feature, geom: &Geometry3D<f64>) -
 }
 
 /// Create footprint from CityGML geometry
+#[cfg(not(feature = "new-geometry"))]
 fn create_footprint_from_citygml(feature: &Feature, citygml: &CityGmlGeometry) -> Option<Feature> {
     // Collect all polygons from all GML geometries
     let polygons: Vec<Polygon3D<f64>> = citygml
@@ -209,6 +213,7 @@ fn project_polygon_to_2d(polygon: &Polygon3D<f64>) -> Polygon2D<f64> {
 const MIN_PROJECTED_AREA: f64 = 1e-6;
 
 /// Create footprint from a collection of 3D polygons
+#[cfg(not(feature = "new-geometry"))]
 fn create_footprint_from_polygons(
     feature: &Feature,
     polygons: &[Polygon3D<f64>],

--- a/engine/runtime/action-processor/src/geometry/geometry_part_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/geometry_part_extractor.rs
@@ -128,6 +128,7 @@ impl GeometryPartExtractor {
 }
 
 impl Processor for GeometryPartExtractor {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -155,6 +156,7 @@ impl Processor for GeometryPartExtractor {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -168,6 +170,7 @@ impl Processor for GeometryPartExtractor {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn extract_surfaces(
     feature: &Feature,
     ctx: &ExecutorContext,
@@ -227,6 +230,7 @@ fn extract_surfaces(
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn extract_surfaces_from_solid_2d(
     solid: &Solid2D<f64>,
     feature: &Feature,
@@ -245,6 +249,7 @@ fn extract_surfaces_from_solid_2d(
     true
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn extract_surfaces_from_solid_3d(
     solid: &Solid3D<f64>,
     feature: &Feature,
@@ -263,6 +268,7 @@ fn extract_surfaces_from_solid_3d(
     true
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn send_remaining_feature_with_empty_geometry(
     original_feature: &Feature,
     ctx: &ExecutorContext,
@@ -275,6 +281,7 @@ fn send_remaining_feature_with_empty_geometry(
     fw.send(ctx.new_with_feature_and_port(remaining_feature, REMAINING_PORT.clone()));
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn create_surface_feature_from_face_2d(
     face: &Face<f64, reearth_flow_geometry::types::no_value::NoValue>,
     original_feature: &Feature,
@@ -299,6 +306,7 @@ fn create_surface_feature_from_face_2d(
     fw.send(ctx.new_with_feature_and_port(surface_feature, EXTRACTED_PORT.clone()));
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn create_surface_feature_from_face_3d(
     face: &Face<f64, f64>,
     original_feature: &Feature,
@@ -323,6 +331,7 @@ fn create_surface_feature_from_face_3d(
     fw.send(ctx.new_with_feature_and_port(surface_feature, EXTRACTED_PORT.clone()));
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn create_surface_feature_from_citygml_polygon(
     polygon: &reearth_flow_geometry::types::polygon::Polygon3D<f64>,
     original_citygml: &reearth_flow_types::CityGmlGeometry,

--- a/engine/runtime/action-processor/src/geometry/grid_divider.rs
+++ b/engine/runtime/action-processor/src/geometry/grid_divider.rs
@@ -242,6 +242,7 @@ impl Processor for GridDivider {
         true
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -312,6 +313,7 @@ impl Processor for GridDivider {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -1079,6 +1081,7 @@ fn coords_equal_3d(a: &Coordinate3D<f64>, b: &Coordinate3D<f64>) -> bool {
 }
 
 /// Create output feature with all original attributes and grid metadata
+#[cfg(not(feature = "new-geometry"))]
 fn create_output_feature(
     original: &Feature,
     clipped_geometry: GeometryValue,

--- a/engine/runtime/action-processor/src/geometry/grid_divider.rs
+++ b/engine/runtime/action-processor/src/geometry/grid_divider.rs
@@ -1340,6 +1340,7 @@ mod tests {
         assert!((bounds.max().y - 10.0).abs() < f64::EPSILON);
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_create_output_feature() {
         let mut original = Feature::new_with_attributes(Attributes::default());

--- a/engine/runtime/action-processor/src/geometry/hole_counter.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_counter.rs
@@ -88,6 +88,7 @@ pub struct HoleCounter {
 }
 
 impl Processor for HoleCounter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -131,6 +132,7 @@ impl Processor for HoleCounter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/hole_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/hole_extractor.rs
@@ -64,6 +64,7 @@ impl ProcessorFactory for HoleExtractorFactory {
 pub struct HoleExtractor;
 
 impl Processor for HoleExtractor {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -116,6 +117,7 @@ impl Processor for HoleExtractor {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -129,6 +131,7 @@ impl Processor for HoleExtractor {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn handle_polygon2d(
     polygon: &Polygon2D<f64>,
     feature: &Feature,
@@ -155,6 +158,7 @@ fn handle_polygon2d(
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn handle_polygon3d(
     polygon: &Polygon3D<f64>,
     feature: &Feature,

--- a/engine/runtime/action-processor/src/geometry/horizontal_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/horizontal_reprojector.rs
@@ -421,6 +421,7 @@ where
 }
 
 impl Processor for HorizontalReprojector {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -505,6 +506,7 @@ impl Processor for HorizontalReprojector {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/image_rasterizer.rs
+++ b/engine/runtime/action-processor/src/geometry/image_rasterizer.rs
@@ -1284,6 +1284,7 @@ fn assign_texture_coordinates(
 mod tests {
     use super::*;
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn case01() {
         use std::fs::File;

--- a/engine/runtime/action-processor/src/geometry/image_rasterizer.rs
+++ b/engine/runtime/action-processor/src/geometry/image_rasterizer.rs
@@ -234,6 +234,7 @@ impl Default for ImageRasterizerParam {
 }
 
 impl Processor for ImageRasterizer {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -285,6 +286,7 @@ impl Processor for ImageRasterizer {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -1059,6 +1061,7 @@ impl GeometryPolygons {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn extract_geometry_polygon_from_feature(feature: &Feature) -> Option<GeometryPolygon> {
     // Extract color information from the feature attributes
     let r = feature
@@ -1131,6 +1134,7 @@ fn extract_geometry_polygon_from_feature(feature: &Feature) -> Option<GeometryPo
 }
 
 // Helper function to extract coordinates from the feature's geometry field
+#[cfg(not(feature = "new-geometry"))]
 fn extract_coordinates_from_feature_geometry(feature: &Feature) -> Option<Vec<Vec<(f64, f64)>>> {
     // Access the geometry field of the feature
     match &feature.geometry.value {
@@ -1187,6 +1191,7 @@ fn extract_coordinates_from_feature_geometry(feature: &Feature) -> Option<Vec<Ve
 
 /// Assigns texture coordinates to a feature's CityGmlGeometry based on the rasterized image boundary.
 /// Also sets the texture reference on each polygon to point to the generated image.
+#[cfg(not(feature = "new-geometry"))]
 fn assign_texture_coordinates(
     feature: &Feature,
     boundary: &CoordinatesBoundary,

--- a/engine/runtime/action-processor/src/geometry/jp_standard_grid_accumulator.rs
+++ b/engine/runtime/action-processor/src/geometry/jp_standard_grid_accumulator.rs
@@ -64,6 +64,7 @@ impl ProcessorFactory for JPStandardGridAccumulatorFactory {
 pub struct JPStandardGridAccumulator;
 
 impl Processor for JPStandardGridAccumulator {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -119,6 +120,7 @@ impl Processor for JPStandardGridAccumulator {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -1128,6 +1128,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_process_group_two_crossing_lines() {
         let dir =

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -247,6 +247,7 @@ impl Processor for LineOnLineOverlayer {
         true
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -301,6 +302,7 @@ impl Processor for LineOnLineOverlayer {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -455,6 +457,7 @@ impl RTreeObject for AabbEntry {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn process_group<W: Write>(
     group_dir: &Path,
     tolerance: f64,

--- a/engine/runtime/action-processor/src/geometry/neighbor_finder.rs
+++ b/engine/runtime/action-processor/src/geometry/neighbor_finder.rs
@@ -1374,6 +1374,7 @@ mod tests {
 
     use crate::tests::utils::create_default_execute_context;
 
+    #[cfg(not(feature = "new-geometry"))]
     fn create_point_feature(x: f64, y: f64) -> Feature {
         use reearth_flow_geometry::types::no_value::NoValue;
         Feature::new_with_attributes_and_geometry(
@@ -1389,6 +1390,7 @@ mod tests {
         )
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn create_point_feature_with_attr(
         x: f64,
         y: f64,
@@ -1411,6 +1413,7 @@ mod tests {
         )
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_single_closest_neighbor() {
         let mut finder = NeighborFinder {
@@ -1501,6 +1504,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_max_distance_filtering() {
         let mut finder = NeighborFinder {
@@ -1564,6 +1568,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_no_candidates_all_unmatched() {
         let mut finder = NeighborFinder {
@@ -1604,6 +1609,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_polygon_centroid() {
         use reearth_flow_geometry::types::geometry::Geometry2D;
@@ -1658,6 +1664,7 @@ mod tests {
 
     // v2 Tests
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_num_closest_3() {
         // Test that num_closest actually limits the number of neighbors returned.
@@ -1789,6 +1796,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_repeat_base_strategy() {
         let mut finder = NeighborFinder {
@@ -1898,6 +1906,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_array_attributes_strategy() {
         let mut finder = NeighborFinder {
@@ -1996,6 +2005,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_num_closest_less_than_available() {
         let mut finder = NeighborFinder {
@@ -2075,6 +2085,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_partial_matches_with_max_distance() {
         let mut finder = NeighborFinder {
@@ -2223,6 +2234,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_neighbor_index_attribute_suppressed() {
         let mut finder = NeighborFinder {
@@ -2319,6 +2331,7 @@ mod tests {
         assert!((dist_3d_with_z - 13.0).abs() < 0.001);
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     /// Test disk spilling behavior by manually setting up a temp directory.
     /// This verifies that the disk-based candidate storage and retrieval works correctly.
     #[test]
@@ -2434,6 +2447,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     /// Test that disk-based candidate reading works correctly.
     /// This tests the `read_candidates_from_disk` function directly.
     #[test]
@@ -2502,6 +2516,7 @@ mod tests {
         finder.cleanup_temp_dir();
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     /// Test that Haversine distance with ECEF spatial indexing correctly finds
     /// nearest neighbors near the North Pole, where simple Euclidean distance
     /// on lat/lon coordinates would fail.

--- a/engine/runtime/action-processor/src/geometry/neighbor_finder.rs
+++ b/engine/runtime/action-processor/src/geometry/neighbor_finder.rs
@@ -334,6 +334,7 @@ impl Processor for NeighborFinder {
         true
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -420,6 +421,7 @@ impl Processor for NeighborFinder {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -683,6 +685,7 @@ impl NeighborFinder {
     /// Process base features sequentially from disk without loading all into memory.
     /// This maintains memory efficiency - only one base feature is in memory at a time.
     /// Chunk files are deleted immediately after processing to free disk space.
+    #[cfg(not(feature = "new-geometry"))]
     fn process_base_features_from_disk(
         &self,
         ctx: &NodeContext,
@@ -745,6 +748,7 @@ impl NeighborFinder {
     }
 
     /// Process a single base feature
+    #[cfg(not(feature = "new-geometry"))]
     fn process_single_base(
         &self,
         ctx: &NodeContext,
@@ -834,6 +838,7 @@ impl NeighborFinder {
 
     /// Process base features in parallel using rayon.
     /// Performs neighbor matching in parallel, then sends results sequentially.
+    #[cfg(not(feature = "new-geometry"))]
     fn process_base_features_parallel(
         &self,
         ctx: &NodeContext,
@@ -883,6 +888,7 @@ impl NeighborFinder {
 
     /// Process a single base feature and return the result (for parallel execution).
     /// This is a pure computation function that doesn't interact with the forwarder.
+    #[cfg(not(feature = "new-geometry"))]
     fn process_base_feature_to_result(
         &self,
         rtree: &RTree<CandidateIndex>,
@@ -1291,6 +1297,7 @@ fn f64_to_attribute_value(value: f64) -> AttributeValue {
 
 /// Extract representative point from a feature's geometry.
 /// Returns (xy, z) where z is None for 2D geometries.
+#[cfg(not(feature = "new-geometry"))]
 fn extract_representative_point(feature: &Feature) -> Option<([f64; 2], Option<f64>)> {
     match &feature.geometry.value {
         GeometryValue::None => None,

--- a/engine/runtime/action-processor/src/geometry/offsetter.rs
+++ b/engine/runtime/action-processor/src/geometry/offsetter.rs
@@ -96,6 +96,7 @@ impl Processor for Offsetter {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -133,6 +134,7 @@ impl Processor for Offsetter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/orientation_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/orientation_extractor.rs
@@ -101,6 +101,7 @@ impl Processor for OrientationExtractor {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -228,6 +229,7 @@ impl Processor for OrientationExtractor {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/planarity_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/planarity_filter.rs
@@ -129,6 +129,7 @@ pub struct PlanarityFilter {
 }
 
 impl Processor for PlanarityFilter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -250,6 +251,7 @@ impl Processor for PlanarityFilter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/planarity_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/planarity_filter.rs
@@ -502,6 +502,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_process_null_geometry_covariance() {
         let mut processor = create_test_processor(PlanarityFilterType::Covariance, 1e-6);
@@ -522,6 +523,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_process_null_geometry_height() {
         let mut processor = create_test_processor(PlanarityFilterType::Height, 0.001);

--- a/engine/runtime/action-processor/src/geometry/polygon_normal_extractor.rs
+++ b/engine/runtime/action-processor/src/geometry/polygon_normal_extractor.rs
@@ -61,6 +61,7 @@ impl ProcessorFactory for PolygonNormalExtractorFactory {
 struct PolygonNormalExtractor {}
 
 impl Processor for PolygonNormalExtractor {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -127,6 +128,7 @@ impl Processor for PolygonNormalExtractor {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/ray_intersector.rs
+++ b/engine/runtime/action-processor/src/geometry/ray_intersector.rs
@@ -515,6 +515,7 @@ impl RayIntersector {
     }
 
     /// Creates an intersection feature (pure function — no fw.send()).
+    #[cfg(not(feature = "new-geometry"))]
     fn create_intersection_feature(
         &self,
         ray_feature: &Feature,
@@ -559,6 +560,7 @@ impl RayIntersector {
 
     /// Creates an output feature with ray geometry when lineSegmentToIntersection is set,
     /// or returns the original feature otherwise.
+    #[cfg(not(feature = "new-geometry"))]
     fn create_ray_output_feature(&self, ray_feature: &Feature, ray: &Ray3D) -> Feature {
         match self.output_geometry_type {
             OutputGeometryType::PointOfIntersection => ray_feature.clone(),
@@ -587,6 +589,7 @@ impl Processor for RayIntersector {
         true
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -724,6 +727,7 @@ impl Processor for RayIntersector {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/refiner.rs
+++ b/engine/runtime/action-processor/src/geometry/refiner.rs
@@ -71,6 +71,7 @@ impl ProcessorFactory for RefinerFactory {
 pub struct Refiner;
 
 impl Processor for Refiner {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -124,6 +125,7 @@ impl Processor for Refiner {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/remover.rs
+++ b/engine/runtime/action-processor/src/geometry/remover.rs
@@ -54,6 +54,7 @@ impl ProcessorFactory for GeometryRemoverFactory {
 pub struct GeometryRemover;
 
 impl Processor for GeometryRemover {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -65,6 +66,7 @@ impl Processor for GeometryRemover {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/replacer.rs
+++ b/engine/runtime/action-processor/src/geometry/replacer.rs
@@ -87,6 +87,7 @@ impl Processor for GeometryReplacer {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -110,6 +111,7 @@ impl Processor for GeometryReplacer {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/rotator_3d.rs
+++ b/engine/runtime/action-processor/src/geometry/rotator_3d.rs
@@ -180,6 +180,7 @@ pub struct Rotator3D {
 }
 
 impl Processor for Rotator3D {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -272,6 +273,7 @@ impl Processor for Rotator3D {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/solid_boundary_validator.rs
+++ b/engine/runtime/action-processor/src/geometry/solid_boundary_validator.rs
@@ -141,6 +141,7 @@ impl Processor for SolidBoundaryValidator {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -288,6 +289,7 @@ impl Processor for SolidBoundaryValidator {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/spatial_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/spatial_filter.rs
@@ -162,6 +162,7 @@ struct SpatialFilter {
 }
 
 impl Processor for SpatialFilter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -201,6 +202,7 @@ impl Processor for SpatialFilter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,
@@ -298,6 +300,7 @@ fn forward_result(
     ));
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn test_2d_geometry(
     candidate: &Geometry2D,
     filters: &[Feature],
@@ -366,6 +369,7 @@ fn test_2d_geometry(
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn test_3d_geometry(
     candidate: &Geometry3D,
     filters: &[Feature],
@@ -426,6 +430,7 @@ fn test_3d_geometry(
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn test_citygml_geometry(
     candidate: &CityGmlGeometry,
     filters: &[Feature],

--- a/engine/runtime/action-processor/src/geometry/spatial_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/spatial_filter.rs
@@ -636,6 +636,7 @@ mod tests {
         Polygon2D::new(exterior, vec![])
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_spatial_filter_accepts_features() {
         let mut filter = SpatialFilter {
@@ -687,6 +688,7 @@ mod tests {
         assert_eq!(filter.candidates.len(), 1);
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_spatial_filter_processes_multiple_ports() {
         let mut filter = SpatialFilter {
@@ -750,6 +752,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_spatial_filter_no_filters() {
         let mut filter = SpatialFilter {
@@ -773,6 +776,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_merge_filter_attributes_onto_passed_candidate() {
         let mut filter_attrs = Attributes::new();
@@ -830,6 +834,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_merge_filter_attributes_with_prefix() {
         let mut filter_attrs = Attributes::new();
@@ -890,6 +895,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_merge_filter_attributes_not_applied_to_failed_candidate() {
         let mut filter_attrs = Attributes::new();
@@ -948,6 +954,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_merge_filter_attributes_and_mode_multiple_filters() {
         // Filter 1: overlaps candidate from one side, has attribute "zone"

--- a/engine/runtime/action-processor/src/geometry/splitter.rs
+++ b/engine/runtime/action-processor/src/geometry/splitter.rs
@@ -132,6 +132,7 @@ fn engine_cache_dir(executor_id: uuid::Uuid) -> PathBuf {
 }
 
 impl Processor for GeometrySplitter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -163,6 +164,7 @@ impl Processor for GeometrySplitter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,
@@ -177,6 +179,7 @@ impl Processor for GeometrySplitter {
 }
 
 impl GeometrySplitter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process_flow_geometry_2d(
         &self,
         geometry: &Geometry2D,
@@ -222,6 +225,7 @@ impl GeometrySplitter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process_flow_geometry_3d(
         &mut self,
         geometry: &Geometry3D,
@@ -281,6 +285,7 @@ impl GeometrySplitter {
         Ok(self.temp_dir.as_ref().unwrap())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process_triangular_mesh(
         &mut self,
         mesh: &reearth_flow_geometry::types::triangular_mesh::TriangularMesh<f64>,
@@ -334,6 +339,7 @@ impl GeometrySplitter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process_citygml_geometry(
         &self,
         city_gml_geometry: &CityGmlGeometry,
@@ -380,6 +386,7 @@ impl GeometrySplitter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn emit_element_level_feature(
         &self,
         split_feature: CityGmlGeometry,
@@ -403,6 +410,7 @@ impl GeometrySplitter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn emit_polygon_level_features(
         &self,
         split_feature: &CityGmlGeometry,

--- a/engine/runtime/action-processor/src/geometry/three_dimension_box_replacer.rs
+++ b/engine/runtime/action-processor/src/geometry/three_dimension_box_replacer.rs
@@ -100,6 +100,7 @@ pub struct ThreeDimensionBoxReplacer {
 }
 
 impl Processor for ThreeDimensionBoxReplacer {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,

--- a/engine/runtime/action-processor/src/geometry/three_dimension_forcer.rs
+++ b/engine/runtime/action-processor/src/geometry/three_dimension_forcer.rs
@@ -117,6 +117,7 @@ pub struct ThreeDimensionForcer {
 }
 
 impl Processor for ThreeDimensionForcer {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -199,6 +200,7 @@ impl Processor for ThreeDimensionForcer {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/three_dimension_planarity_rotator.rs
+++ b/engine/runtime/action-processor/src/geometry/three_dimension_planarity_rotator.rs
@@ -63,6 +63,7 @@ impl ProcessorFactory for ThreeDimensionPlanarityRotatorFactory {
 pub struct ThreeDimensionPlanarityRotator;
 
 impl Processor for ThreeDimensionPlanarityRotator {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,

--- a/engine/runtime/action-processor/src/geometry/three_dimension_rotator.rs
+++ b/engine/runtime/action-processor/src/geometry/three_dimension_rotator.rs
@@ -146,6 +146,7 @@ pub struct ThreeDimensionRotator {
 }
 
 impl Processor for ThreeDimensionRotator {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,

--- a/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
+++ b/engine/runtime/action-processor/src/geometry/two_dimension_forcer.rs
@@ -59,6 +59,7 @@ impl ProcessorFactory for TwoDimensionForcerFactory {
 pub struct TwoDimensionForcer;
 
 impl Processor for TwoDimensionForcer {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -97,6 +98,7 @@ impl Processor for TwoDimensionForcer {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/validator.rs
+++ b/engine/runtime/action-processor/src/geometry/validator.rs
@@ -173,6 +173,7 @@ impl Processor for GeometryValidator {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -201,6 +202,7 @@ impl Processor for GeometryValidator {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/value_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/value_filter.rs
@@ -91,6 +91,7 @@ impl Processor for GeometryValueFilter {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,

--- a/engine/runtime/action-processor/src/geometry/value_filter.rs
+++ b/engine/runtime/action-processor/src/geometry/value_filter.rs
@@ -141,6 +141,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_filter_geometry_null() {
         let noop = NoopChannelForwarder::default();
@@ -157,6 +158,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_filter_geometry_none() {
         let noop = NoopChannelForwarder::default();
@@ -173,6 +175,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_filter_geometry_2d() {
         let noop = NoopChannelForwarder::default();
@@ -195,6 +198,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_filter_geometry_3d() {
         let noop = NoopChannelForwarder::default();
@@ -218,6 +222,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_filter_geometry_citygml() {
         let noop = NoopChannelForwarder::default();

--- a/engine/runtime/action-processor/src/geometry/vertex_counter.rs
+++ b/engine/runtime/action-processor/src/geometry/vertex_counter.rs
@@ -172,6 +172,7 @@ mod tests {
     use reearth_flow_runtime::forwarder::NoopChannelForwarder;
     use reearth_flow_types::{feature::Attributes, Attribute, Feature, Geometry, GeometryValue};
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_vertex_counter_point_2d() {
         let noop = NoopChannelForwarder::default();
@@ -203,6 +204,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_vertex_counter_linestring_2d() {
         let noop = NoopChannelForwarder::default();
@@ -235,6 +237,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_vertex_counter_polygon_2d() {
         let noop = NoopChannelForwarder::default();
@@ -275,6 +278,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_vertex_counter_polygon_with_hole() {
         let noop = NoopChannelForwarder::default();
@@ -323,6 +327,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_vertex_counter_empty_geometry() {
         let noop = NoopChannelForwarder::default();

--- a/engine/runtime/action-processor/src/geometry/vertex_counter.rs
+++ b/engine/runtime/action-processor/src/geometry/vertex_counter.rs
@@ -88,6 +88,7 @@ pub struct VertexCounter {
 }
 
 impl Processor for VertexCounter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -147,6 +148,7 @@ impl Processor for VertexCounter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/geometry/vertex_remover.rs
+++ b/engine/runtime/action-processor/src/geometry/vertex_remover.rs
@@ -66,6 +66,7 @@ impl Processor for VertexRemover {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -108,6 +109,7 @@ impl Processor for VertexRemover {
 }
 
 impl VertexRemover {
+    #[cfg(not(feature = "new-geometry"))]
     fn handle_2d_geometry(
         &self,
         geos: &Geometry2D,
@@ -146,6 +148,7 @@ impl VertexRemover {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn handle_3d_geometry(
         &self,
         geos: &Geometry3D,

--- a/engine/runtime/action-processor/src/geometry/vertical_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/vertical_reprojector.rs
@@ -105,6 +105,7 @@ impl Processor for VerticalReprojector {
         2
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -134,6 +135,7 @@ impl Processor for VerticalReprojector {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-processor/src/lib.rs
+++ b/engine/runtime/action-processor/src/lib.rs
@@ -1,3 +1,9 @@
+// TODO(new-geometry): remove after migration. Gating each ported action's
+// `process`/`finish`/`start` leaves geometry-only imports and helpers unused
+// under the flag; silence that noise (feature-scoped, so the default build keeps
+// full lint coverage).
+#![cfg_attr(feature = "new-geometry", allow(unused_imports, dead_code))]
+
 pub(crate) mod attribute;
 pub(crate) mod echo;
 pub(crate) mod feature;

--- a/engine/runtime/action-processor/src/xml/validator.rs
+++ b/engine/runtime/action-processor/src/xml/validator.rs
@@ -724,6 +724,7 @@ mod tests {
     use reearth_flow_runtime::forwarder::{NoopChannelForwarder, ProcessorChannelForwarder};
     use reearth_flow_types::{Attribute, AttributeValue, Feature, Geometry};
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_xml_validator_syntax_validation() {
         let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -735,6 +736,7 @@ mod tests {
         assert_eq!(port, *SUCCESS_PORT, "Should output to success port");
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_xml_validator_invalid_syntax() {
         let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -774,6 +776,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_xml_validator_malformed_xml() {
         let xml_content = r#"This is not XML at all!
@@ -819,6 +822,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_xml_validator_missing_local_schema() {
         let xml_content = r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -965,6 +969,7 @@ mod tests {
         });
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_xml_validator_schema_unreachable_url_should_not_error() {
         // xsi:schemaLocation URLs are hints per W3C spec.
@@ -1051,6 +1056,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     // Regression test for L02 false positive:
     // "element 'bldg:opening' is not declared in schema" is incorrectly reported
     // for valid PLATEAU CityGML files. The root cause is that check_schema_streaming
@@ -1232,6 +1238,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn create_feature_with_xml(xml_content: &str) -> Feature {
         let mut attributes = IndexMap::new();
         attributes.insert(
@@ -1242,6 +1249,7 @@ mod tests {
         Feature::new_with_attributes_and_geometry(attributes, Geometry::new())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn run_validator_test(
         xml_content: &str,
         validation_type: ValidationType,
@@ -1277,6 +1285,7 @@ mod tests {
         citymodel_name: &'static str,
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     /// Set up a temp directory mimicking the PLATEAU citymodel structure for
     /// file-based schema validation tests:
     ///   <tmp>/

--- a/engine/runtime/action-python-processor/Cargo.toml
+++ b/engine/runtime/action-python-processor/Cargo.toml
@@ -10,6 +10,13 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+# Temporary migration flag for the new-geometry migration.
+new-geometry = [
+  "reearth-flow-geometry/new-geometry",
+  "reearth-flow-types/new-geometry",
+]
+
 [dependencies]
 reearth-flow-common.workspace = true
 reearth-flow-eval-expr.workspace = true

--- a/engine/runtime/action-python-processor/Cargo.toml
+++ b/engine/runtime/action-python-processor/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 
 [features]
 # Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
 new-geometry = [
   "reearth-flow-geometry/new-geometry",
   "reearth-flow-types/new-geometry",

--- a/engine/runtime/action-python-processor/src/lib.rs
+++ b/engine/runtime/action-python-processor/src/lib.rs
@@ -1,3 +1,9 @@
+// TODO(new-geometry): remove after migration. Gating each ported action's
+// `process`/`finish`/`start` leaves geometry-only imports and helpers unused
+// under the flag; silence that noise (feature-scoped, so the default build keeps
+// full lint coverage).
+#![cfg_attr(feature = "new-geometry", allow(unused_imports, dead_code))]
+
 mod mapping;
 mod python_executor;
 

--- a/engine/runtime/action-python-processor/src/python_executor.rs
+++ b/engine/runtime/action-python-processor/src/python_executor.rs
@@ -898,6 +898,7 @@ mod tests {
     use serde_json::json;
     use std::collections::HashMap;
 
+    #[cfg(not(feature = "new-geometry"))]
     fn create_test_feature() -> Feature {
         let mut attributes = IndexMap::new();
         attributes.insert(
@@ -1021,6 +1022,7 @@ mod tests {
         assert!(geojson.is_null());
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_feature_to_geojson() {
         let feature = create_test_feature();

--- a/engine/runtime/action-python-processor/src/python_executor.rs
+++ b/engine/runtime/action-python-processor/src/python_executor.rs
@@ -273,6 +273,7 @@ fn flow_geometry_2d_to_geojson(geometry: &FlowGeometry2D<f64>) -> serde_json::Va
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn feature_to_geojson(feature: &Feature) -> serde_json::Value {
     let properties: serde_json::Map<String, serde_json::Value> = feature
         .attributes
@@ -610,6 +611,7 @@ fn geojson_to_geometry(geojson: &serde_json::Value) -> Result<Geometry, PythonPr
 }
 
 impl Processor for PythonScriptProcessor {
+    #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,
         ctx: ExecutorContext,
@@ -870,6 +872,7 @@ print(json.dumps(output))
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         _ctx: NodeContext,

--- a/engine/runtime/action-sink/Cargo.toml
+++ b/engine/runtime/action-sink/Cargo.toml
@@ -10,6 +10,13 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+# Temporary migration flag for the new-geometry migration.
+new-geometry = [
+  "reearth-flow-geometry/new-geometry",
+  "reearth-flow-types/new-geometry",
+]
+
 [dependencies]
 reearth-flow-action-log.workspace = true
 reearth-flow-atlas.workspace = true

--- a/engine/runtime/action-sink/Cargo.toml
+++ b/engine/runtime/action-sink/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 
 [features]
 # Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
 new-geometry = [
   "reearth-flow-geometry/new-geometry",
   "reearth-flow-types/new-geometry",

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/pipeline.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/pipeline.rs
@@ -21,13 +21,16 @@ use reearth_flow_runtime::executor_operation::NodeContext;
 use reearth_flow_types::Feature;
 use tempfile::tempdir;
 
+#[cfg(not(feature = "new-geometry"))]
+use super::slice::slice_to_tiles;
+use super::tiling;
 use super::tiling::{TileContent, TileTree};
-use super::{slice::slice_to_tiles, tiling};
 use crate::atlas::{build_atlas_geometry, GltfFeature};
 use crate::file::mvt::tileid::TileIdMethod;
 
 type FeatureBuffer<T> = (u64, Option<String>, Vec<T>);
 
+#[cfg(not(feature = "new-geometry"))]
 pub(super) fn geometry_slicing_stage(
     upstream: &[(Option<String>, Vec<Feature>)],
     tile_id_conv: TileIdMethod,

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/sink.rs
@@ -168,6 +168,7 @@ impl Sink for Cesium3DTilesWriter {
         "Cesium3DTilesWriter"
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         match &ctx.port {
             port if *port == *DEFAULT_PORT => self.process_default(&ctx)?,
@@ -181,6 +182,7 @@ impl Sink for Cesium3DTilesWriter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
         self.flush_buffer(ctx.as_context())?;
         Ok(())
@@ -188,6 +190,7 @@ impl Sink for Cesium3DTilesWriter {
 }
 
 impl Cesium3DTilesWriter {
+    #[cfg(not(feature = "new-geometry"))]
     fn process_default(&mut self, ctx: &ExecutorContext) -> crate::errors::Result<()> {
         let geometry = &ctx.feature.geometry;
         if geometry.is_empty() {
@@ -282,6 +285,7 @@ impl Cesium3DTilesWriter {
         self.schema.types.insert(schema_type, typedef);
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     pub(crate) fn flush_buffer(&self, ctx: Context) -> crate::errors::Result<()> {
         let mut features =
             HashMap::<(String, Option<String>), Vec<(Option<String>, Vec<Feature>)>>::new();
@@ -298,6 +302,7 @@ impl Cesium3DTilesWriter {
     }
 
     #[allow(clippy::type_complexity)]
+    #[cfg(not(feature = "new-geometry"))]
     pub(crate) fn write(
         &self,
         ctx: Context,

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/slice.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/slice.rs
@@ -16,6 +16,7 @@ use crate::zip_eq_logged::ZipEqLoggedExt;
 
 pub type TileZXYName = (u8, u32, u32);
 
+#[cfg(not(feature = "new-geometry"))]
 pub fn slice_to_tiles<E>(
     feature: &Feature,
     min_zoom: u8,

--- a/engine/runtime/action-sink/src/file/citygml.rs
+++ b/engine/runtime/action-sink/src/file/citygml.rs
@@ -30,6 +30,7 @@ use writer::CityGmlXmlWriter;
 ///
 /// This is the single canonical implementation shared by both the `CityGmlWriter` sink and
 /// the `FeatureWriter` processor.
+#[cfg(not(feature = "new-geometry"))]
 pub fn write_citygml_to_storage(
     output: &Uri,
     sandbox_root: &Uri,
@@ -353,6 +354,7 @@ impl Sink for CityGmlWriterSink {
         "CityGmlWriter"
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let feature = ctx.feature;
 
@@ -369,6 +371,7 @@ impl Sink for CityGmlWriterSink {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
         let path = self
             .params

--- a/engine/runtime/action-sink/src/file/csv.rs
+++ b/engine/runtime/action-sink/src/file/csv.rs
@@ -128,6 +128,7 @@ impl Sink for CsvWriter {
         "CsvWriter"
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let path = self
             .output
@@ -153,15 +154,31 @@ impl Sink for CsvWriter {
         Ok(())
     }
 
+<<<<<<< Updated upstream
     fn finish(&self, _ctx: NodeContext) -> Result<(), BoxedError> {
         let delimiter = self.format.delimiter();
         for (out, features) in self.buffer.values() {
             write_csv(out, features, delimiter.clone(), self.geometry.as_ref())?;
+=======
+    #[cfg(not(feature = "new-geometry"))]
+    fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
+        let storage_resolver = Arc::clone(&ctx.storage_resolver);
+        let delimiter = self.params.format.delimiter();
+        for (uri, features) in &self.buffer {
+            write_csv(
+                uri,
+                features,
+                delimiter.clone(),
+                &storage_resolver,
+                self.params.geometry.as_ref(),
+            )?;
+>>>>>>> Stashed changes
         }
         Ok(())
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn write_csv(
     out: &SinkOutput,
     features: &[Feature],

--- a/engine/runtime/action-sink/src/file/csv.rs
+++ b/engine/runtime/action-sink/src/file/csv.rs
@@ -154,25 +154,11 @@ impl Sink for CsvWriter {
         Ok(())
     }
 
-<<<<<<< Updated upstream
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(&self, _ctx: NodeContext) -> Result<(), BoxedError> {
         let delimiter = self.format.delimiter();
         for (out, features) in self.buffer.values() {
             write_csv(out, features, delimiter.clone(), self.geometry.as_ref())?;
-=======
-    #[cfg(not(feature = "new-geometry"))]
-    fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
-        let storage_resolver = Arc::clone(&ctx.storage_resolver);
-        let delimiter = self.params.format.delimiter();
-        for (uri, features) in &self.buffer {
-            write_csv(
-                uri,
-                features,
-                delimiter.clone(),
-                &storage_resolver,
-                self.params.geometry.as_ref(),
-            )?;
->>>>>>> Stashed changes
         }
         Ok(())
     }

--- a/engine/runtime/action-sink/src/file/czml.rs
+++ b/engine/runtime/action-sink/src/file/czml.rs
@@ -1150,15 +1150,11 @@ fn hex_to_rgba(hex: &str, alpha: u8) -> Option<[u8; 4]> {
 }
 
 /// Convert a Feature's polygon geometry to a styled CZML polygon JSON value.
-<<<<<<< Updated upstream
+#[cfg(not(feature = "new-geometry"))]
 fn feature_geometry_to_polygon_json(
     feature: &Feature,
     params: &CzmlWriterCompiledParam,
 ) -> Option<Value> {
-=======
-#[cfg(not(feature = "new-geometry"))]
-fn feature_geometry_to_polygon_json(feature: &Feature, params: &CzmlWriterParam) -> Option<Value> {
->>>>>>> Stashed changes
     let czml_polygon = match &feature.geometry.value {
         GeometryValue::FlowGeometry3D(Geometry3D::Polygon(poly)) => polygon_to_czml_polygon(poly),
         GeometryValue::FlowGeometry2D(Geometry2D::Polygon(poly)) => {

--- a/engine/runtime/action-sink/src/file/czml.rs
+++ b/engine/runtime/action-sink/src/file/czml.rs
@@ -1357,6 +1357,7 @@ mod tests {
     use reearth_flow_geometry::types::polygon::Polygon;
     use reearth_flow_types::{CodeType, Geometry};
 
+    #[cfg(not(feature = "new-geometry"))]
     fn make_feature_3d(lon: f64, lat: f64, height: f64) -> Feature {
         Feature::new_with_attributes_and_geometry(
             indexmap::IndexMap::new(),
@@ -1388,6 +1389,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_build_entity_packet_basic() {
         let params = make_timeseries_params();
@@ -1430,6 +1432,7 @@ mod tests {
         assert!(packet["availability"].as_str().is_some());
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn make_embedded_feature_with_timeseries() -> Feature {
         let mut f = make_feature_3d(139.6917, 35.6895, 50.0);
         f.insert(
@@ -1477,6 +1480,7 @@ mod tests {
         f
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn make_embedded_static_feature() -> Feature {
         let mut f = make_feature_3d(139.7454, 35.6586, 333.0);
         f.insert(
@@ -1513,6 +1517,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_build_embedded_packet_timeseries() {
         let f = make_embedded_feature_with_timeseries();
@@ -1538,6 +1543,7 @@ mod tests {
         assert!(packet["availability"].as_str().unwrap().contains('/'));
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_build_embedded_packet_static() {
         let f = make_embedded_static_feature();
@@ -1558,6 +1564,7 @@ mod tests {
         assert!(packet.get("availability").is_none());
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_build_embedded_czml_document() {
         let f1 = make_embedded_feature_with_timeseries();
@@ -1582,6 +1589,7 @@ mod tests {
         assert_eq!(czml[2]["id"], "static-poi");
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_build_entity_packet_numeric_times() {
         // Test with numeric time values and no explicit epoch
@@ -1653,6 +1661,7 @@ mod tests {
         assert_eq!(hex_to_rgba("#fff", 180), None); // too short
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn make_polygon_2d_feature() -> Feature {
         let coords: Vec<Coordinate<f64, NoValue>> = vec![
             (139.75, 35.68).into(),
@@ -1679,6 +1688,7 @@ mod tests {
         f
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_feature_geometry_to_polygon_2d() {
         let f = make_polygon_2d_feature();
@@ -1702,6 +1712,7 @@ mod tests {
         assert_eq!(pv["outline"], true);
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_polygon_with_styling() {
         let mut f = make_polygon_2d_feature();
@@ -1736,6 +1747,7 @@ mod tests {
         assert_eq!(polygon_val["closeTop"], true);
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_per_entity_availability() {
         let mut f1 = make_polygon_2d_feature();
@@ -1783,6 +1795,7 @@ mod tests {
         assert!(czml[1].get("point").is_none());
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_build_properties_bag() {
         let mut f = make_feature_3d(139.7, 35.7, 0.0);

--- a/engine/runtime/action-sink/src/file/czml.rs
+++ b/engine/runtime/action-sink/src/file/czml.rs
@@ -309,6 +309,7 @@ impl Sink for CzmlWriter {
         "CzmlWriter"
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let feature = &ctx.feature;
 
@@ -328,6 +329,7 @@ impl Sink for CzmlWriter {
         self.buffer.entry(key).or_default().push(feature.clone());
         Ok(())
     }
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
         let path = self
             .params
@@ -417,6 +419,7 @@ impl Sink for CzmlWriter {
 
 /// Build a CZML document from features with embedded `czml.*` attributes
 /// (produced by the reader's `PreserveRaw` strategy).
+#[cfg(not(feature = "new-geometry"))]
 fn build_embedded_czml(
     features: &[Feature],
     params: &CzmlWriterCompiledParam,
@@ -537,6 +540,7 @@ fn build_embedded_czml(
 /// When `params` provides `time_field` and `global_end` is set, per-entity availability
 /// is computed. Polygon geometry is auto-converted when no graphic property exists.
 /// `effective_epoch` is the epoch to use for numeric time conversion (may be auto-detected).
+#[cfg(not(feature = "new-geometry"))]
 fn build_embedded_packet(
     feature: &Feature,
     params: &CzmlWriterCompiledParam,
@@ -714,6 +718,7 @@ fn build_embedded_packet(
 }
 
 /// Build a CZML document with time-dynamic entities grouped by attribute.
+#[cfg(not(feature = "new-geometry"))]
 fn build_timeseries_czml(
     features: &[Feature],
     params: &CzmlWriterCompiledParam,
@@ -810,6 +815,7 @@ fn build_timeseries_czml(
 }
 
 /// Build a single CZML packet for a time-dynamic entity from grouped features.
+#[cfg(not(feature = "new-geometry"))]
 fn build_entity_packet(
     entity_id: &str,
     features: &[&Feature],
@@ -989,6 +995,7 @@ fn build_entity_packet(
     Ok(packet)
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn extract_point_coords(feature: &Feature) -> Option<(f64, f64, f64)> {
     match &feature.geometry.value {
         GeometryValue::FlowGeometry3D(Geometry3D::Point(p)) => Some((p.x(), p.y(), p.z())),
@@ -1143,10 +1150,15 @@ fn hex_to_rgba(hex: &str, alpha: u8) -> Option<[u8; 4]> {
 }
 
 /// Convert a Feature's polygon geometry to a styled CZML polygon JSON value.
+<<<<<<< Updated upstream
 fn feature_geometry_to_polygon_json(
     feature: &Feature,
     params: &CzmlWriterCompiledParam,
 ) -> Option<Value> {
+=======
+#[cfg(not(feature = "new-geometry"))]
+fn feature_geometry_to_polygon_json(feature: &Feature, params: &CzmlWriterParam) -> Option<Value> {
+>>>>>>> Stashed changes
     let czml_polygon = match &feature.geometry.value {
         GeometryValue::FlowGeometry3D(Geometry3D::Polygon(poly)) => polygon_to_czml_polygon(poly),
         GeometryValue::FlowGeometry2D(Geometry2D::Polygon(poly)) => {
@@ -1272,6 +1284,7 @@ fn build_properties_bag(feature: &Feature) -> Option<Value> {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn feature_to_packets(ctx: &Context, feature: &Feature) -> Vec<Packet> {
     let Some(parent_id) = feature.feature_id() else {
         ctx.event_hub

--- a/engine/runtime/action-sink/src/file/geojson.rs
+++ b/engine/runtime/action-sink/src/file/geojson.rs
@@ -107,6 +107,7 @@ impl Sink for GeoJsonWriter {
         "GeoJsonWriter"
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let feature = &ctx.feature;
 
@@ -126,6 +127,7 @@ impl Sink for GeoJsonWriter {
         self.buffer.entry(key).or_default().push(feature.clone());
         Ok(())
     }
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
         let path = self
             .output

--- a/engine/runtime/action-sink/src/file/geopackage.rs
+++ b/engine/runtime/action-sink/src/file/geopackage.rs
@@ -201,6 +201,7 @@ impl Sink for GeoPackageWriter {
         "GeoPackageWriter"
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let feature = &ctx.feature;
 
@@ -222,6 +223,7 @@ impl Sink for GeoPackageWriter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
         if self.buffer.is_empty() {
             return Ok(());
@@ -262,6 +264,7 @@ impl Sink for GeoPackageWriter {
 }
 
 impl GeoPackageWriter {
+    #[cfg(not(feature = "new-geometry"))]
     fn create_geopackage(&self) -> Result<Vec<u8>, BoxedError> {
         // Create in-memory SQLite database
         let temp_file = tempfile::NamedTempFile::new()
@@ -465,6 +468,7 @@ impl GeoPackageWriter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     async fn create_feature_table(&self, adapter: &SqlAdapter) -> Result<(), BoxedError> {
         // Build column definitions with proper SQL identifier quoting
         let mut columns = vec![
@@ -541,6 +545,7 @@ impl GeoPackageWriter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     async fn insert_features(&self, adapter: &SqlAdapter) -> Result<(), BoxedError> {
         for feature in &self.buffer {
             // Convert geometry to GeoPackage Binary
@@ -593,6 +598,7 @@ impl GeoPackageWriter {
         ))
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     async fn create_spatial_index(&self, adapter: &SqlAdapter) -> Result<(), BoxedError> {
         // Create safe rtree table name (sanitize to avoid SQL injection)
         let rtree_table = format!(
@@ -658,6 +664,7 @@ impl GeoPackageWriter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn calculate_bbox(&self) -> (f64, f64, f64, f64) {
         let mut min_x = f64::INFINITY;
         let mut min_y = f64::INFINITY;

--- a/engine/runtime/action-sink/src/file/gltf.rs
+++ b/engine/runtime/action-sink/src/file/gltf.rs
@@ -169,6 +169,7 @@ impl Sink for GltfWriter {
         "GltfWriter"
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let feature = &ctx.feature;
 
@@ -191,6 +192,7 @@ impl Sink for GltfWriter {
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
         let ellipsoid = nusamai_projection::ellipsoid::wgs84();
 

--- a/engine/runtime/action-sink/src/file/mvt/pipeline.rs
+++ b/engine/runtime/action-sink/src/file/mvt/pipeline.rs
@@ -23,6 +23,7 @@ use tinymvt::geometry::GeometryEncoder;
 use tinymvt::tag::TagsEncoder;
 use tinymvt::vector_tile;
 
+#[cfg(not(feature = "new-geometry"))]
 use super::slice::slice_cityobj_geoms;
 use super::tags::convert_properties;
 use super::tileid::TileIdMethod;
@@ -41,6 +42,7 @@ pub(super) struct SortKey {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(not(feature = "new-geometry"))]
 pub(super) fn geometry_slicing_stage(
     _ctx: Context,
     upstream: &[(Feature, String)],

--- a/engine/runtime/action-sink/src/file/mvt/sink.rs
+++ b/engine/runtime/action-sink/src/file/mvt/sink.rs
@@ -183,6 +183,7 @@ impl Sink for MVTWriter {
         "MVTWriter"
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         if ctx.port == *SCHEMA_PORT {
             let Some(ref schema_key) = self.params.schema_key else {
@@ -243,6 +244,7 @@ impl Sink for MVTWriter {
 
         Ok(())
     }
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
         let result = self.flush_buffer(ctx.as_context())?;
         let mut join_handles = self.join_handles.clone();
@@ -276,6 +278,7 @@ impl Sink for MVTWriter {
 
 impl MVTWriter {
     #[allow(clippy::type_complexity)]
+    #[cfg(not(feature = "new-geometry"))]
     pub(crate) fn flush_buffer(&self, ctx: Context) -> crate::errors::Result<Vec<JoinHandle>> {
         let mut result = Vec::new();
         let mut features = HashMap::<(String, Option<String>), BufferValue>::new();
@@ -315,6 +318,7 @@ impl MVTWriter {
         Ok(result)
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     pub fn write(
         &self,
         ctx: Context,

--- a/engine/runtime/action-sink/src/file/mvt/slice.rs
+++ b/engine/runtime/action-sink/src/file/mvt/slice.rs
@@ -20,6 +20,7 @@ pub(super) struct SlicedFeature<'a> {
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(not(feature = "new-geometry"))]
 pub(super) fn slice_cityobj_geoms<'a>(
     feature: &Feature,
     layer_name: &str,

--- a/engine/runtime/action-sink/src/file/obj.rs
+++ b/engine/runtime/action-sink/src/file/obj.rs
@@ -112,11 +112,13 @@ impl Sink for ObjWriter {
         "ObjWriter"
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         self.buffer.push(ctx.feature);
         Ok(())
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
         let path = self
             .output
@@ -145,6 +147,7 @@ impl Sink for ObjWriter {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn features_to_obj(
     features: &[Feature],
     writer: &ObjWriter,

--- a/engine/runtime/action-sink/src/file/obj.rs
+++ b/engine/runtime/action-sink/src/file/obj.rs
@@ -572,6 +572,7 @@ mod tests {
         Attribute, AttributeValue, Code, CodeType, Feature, Geometry, GeometryValue,
     };
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_generate_simple_obj() {
         let mut features = Vec::new();

--- a/engine/runtime/action-sink/src/file/shapefile/conversion.rs
+++ b/engine/runtime/action-sink/src/file/shapefile/conversion.rs
@@ -11,6 +11,7 @@ use shapefile::{
     NO_DATA,
 };
 
+#[cfg(not(feature = "new-geometry"))]
 pub(super) fn feature_to_shape(feature: &Feature) -> crate::errors::Result<shapefile::Shape> {
     match &feature.geometry.value {
         GeometryValue::CityGmlGeometry(geometry) => {

--- a/engine/runtime/action-sink/src/file/shapefile/pipeline.rs
+++ b/engine/runtime/action-sink/src/file/shapefile/pipeline.rs
@@ -8,12 +8,15 @@ use reearth_flow_runtime::executor_operation::Context;
 use reearth_flow_storage::resolve::StorageResolver;
 use reearth_flow_types::{AttributeValue, Feature};
 
+#[cfg(not(feature = "new-geometry"))]
+use super::conversion::feature_to_shape;
 use super::{
-    conversion::{attributes_to_record, feature_to_shape, make_table_builder},
+    conversion::{attributes_to_record, make_table_builder},
     crs::{self, ProjectionRepository},
     null_shape,
 };
 
+#[cfg(not(feature = "new-geometry"))]
 pub(super) fn pipeline(
     ctx: &Context,
     sandbox_root: &Uri,

--- a/engine/runtime/action-sink/src/file/shapefile/sink.rs
+++ b/engine/runtime/action-sink/src/file/shapefile/sink.rs
@@ -106,6 +106,7 @@ impl Sink for ShapefileWriter {
         "ShapefileWriter"
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError> {
         let feature = &ctx.feature;
 
@@ -125,6 +126,7 @@ impl Sink for ShapefileWriter {
         self.buffer.entry(key).or_default().push(feature.clone());
         Ok(())
     }
+    #[cfg(not(feature = "new-geometry"))]
     fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError> {
         let path = self
             .output

--- a/engine/runtime/action-sink/src/lib.rs
+++ b/engine/runtime/action-sink/src/lib.rs
@@ -1,3 +1,9 @@
+// TODO(new-geometry): remove after migration. Gating each ported action's
+// `process`/`finish`/`start` leaves geometry-only imports and helpers unused
+// under the flag; silence that noise (feature-scoped, so the default build keeps
+// full lint coverage).
+#![cfg_attr(feature = "new-geometry", allow(unused_imports, dead_code))]
+
 mod atlas;
 pub mod echo;
 pub mod errors;

--- a/engine/runtime/action-source/Cargo.toml
+++ b/engine/runtime/action-source/Cargo.toml
@@ -10,6 +10,13 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+# Temporary migration flag for the new-geometry migration.
+new-geometry = [
+  "reearth-flow-geometry/new-geometry",
+  "reearth-flow-types/new-geometry",
+]
+
 [dependencies]
 reearth-flow-action-log.workspace = true
 reearth-flow-common.workspace = true

--- a/engine/runtime/action-source/Cargo.toml
+++ b/engine/runtime/action-source/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 
 [features]
 # Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
 new-geometry = [
   "reearth-flow-geometry/new-geometry",
   "reearth-flow-types/new-geometry",

--- a/engine/runtime/action-source/src/file/citygml.rs
+++ b/engine/runtime/action-source/src/file/citygml.rs
@@ -117,6 +117,7 @@ impl Source for CityGmlReader {
         Ok(vec![])
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     async fn start(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-source/src/file/csv.rs
+++ b/engine/runtime/action-source/src/file/csv.rs
@@ -154,6 +154,7 @@ impl Source for CsvReader {
         Ok(vec![])
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     async fn start(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-source/src/file/czml.rs
+++ b/engine/runtime/action-source/src/file/czml.rs
@@ -995,6 +995,7 @@ mod tests {
         assert_eq!(ts.samples[1].lon, -76.0);
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_preserve_raw_strategy() {
         let ts = TimeTaggedPosition {
@@ -1044,6 +1045,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_packet_to_features_static() {
         let packet = serde_json::json!({
@@ -1066,6 +1068,7 @@ mod tests {
         assert_eq!(features.len(), 1);
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     #[test]
     fn test_packet_to_features_timeseries() {
         let packet = serde_json::json!({

--- a/engine/runtime/action-source/src/file/czml.rs
+++ b/engine/runtime/action-source/src/file/czml.rs
@@ -155,6 +155,7 @@ impl Source for CzmlReader {
         Ok(vec![])
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     async fn start(
         &mut self,
         ctx: NodeContext,
@@ -169,6 +170,7 @@ impl Source for CzmlReader {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 async fn read_czml(
     content: &Bytes,
     params: &CzmlReaderCompiledParam,
@@ -294,6 +296,7 @@ fn extract_extra_czml_properties(
 
 /// Convert a CZML packet into one or more features depending on the time
 /// sampling strategy.
+#[cfg(not(feature = "new-geometry"))]
 fn packet_to_features(
     packet: &Value,
     params: &CzmlReaderCompiledParam,
@@ -426,6 +429,7 @@ fn parse_time_value(value: &Value) -> Option<(f64, Option<String>)> {
 }
 
 /// Build features from time-tagged position data according to the sampling strategy.
+#[cfg(not(feature = "new-geometry"))]
 fn build_timeseries_features(
     ts: &TimeTaggedPosition,
     base_attributes: &indexmap::IndexMap<Attribute, AttributeValue>,

--- a/engine/runtime/action-source/src/file/geojson.rs
+++ b/engine/runtime/action-source/src/file/geojson.rs
@@ -102,6 +102,7 @@ impl Source for GeoJsonReader {
         Ok(vec![])
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     async fn start(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-source/src/file/geopackage.rs
+++ b/engine/runtime/action-source/src/file/geopackage.rs
@@ -172,6 +172,7 @@ impl Source for GeoPackageReader {
         Ok(vec![])
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     async fn start(
         &mut self,
         ctx: NodeContext,
@@ -198,6 +199,7 @@ impl Source for GeoPackageReader {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 async fn process_geopackage(
     content: Bytes,
     params: &GeoPackageReaderCompiledParam,
@@ -272,6 +274,7 @@ async fn verify_geopackage(adapter: &SqlAdapter) -> Result<(), SourceError> {
     Ok(())
 }
 
+#[cfg(not(feature = "new-geometry"))]
 async fn read_features(
     adapter: &SqlAdapter,
     params: &GeoPackageReaderCompiledParam,
@@ -305,6 +308,7 @@ async fn get_feature_layers(adapter: &SqlAdapter) -> Result<Vec<String>, SourceE
     Ok(layers)
 }
 
+#[cfg(not(feature = "new-geometry"))]
 async fn read_layer_features(
     adapter: &SqlAdapter,
     layer_name: &str,
@@ -377,6 +381,7 @@ async fn get_layer_srs_id(adapter: &SqlAdapter, table_name: &str) -> Result<i32,
     Ok(4326)
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn row_to_feature(
     row: &AnyRow,
     geom_col: &str,
@@ -1158,6 +1163,7 @@ fn read_coordinates(
 }
 
 #[allow(dead_code)]
+#[cfg(not(feature = "new-geometry"))]
 async fn read_tiles(
     adapter: &SqlAdapter,
     params: &GeoPackageReaderCompiledParam,
@@ -1194,6 +1200,7 @@ async fn get_tile_layers(adapter: &SqlAdapter) -> Result<Vec<String>, SourceErro
 }
 
 #[allow(dead_code)]
+#[cfg(not(feature = "new-geometry"))]
 async fn read_layer_tiles(
     adapter: &SqlAdapter,
     layer_name: &str,

--- a/engine/runtime/action-source/src/file/gltf.rs
+++ b/engine/runtime/action-source/src/file/gltf.rs
@@ -138,6 +138,7 @@ impl Source for GltfReader {
         Ok(vec![])
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     async fn start(
         &mut self,
         ctx: NodeContext,
@@ -152,6 +153,7 @@ impl Source for GltfReader {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 async fn read_gltf(
     ctx: &NodeContext,
     storage_resolver: Arc<reearth_flow_storage::resolve::StorageResolver>,
@@ -285,6 +287,7 @@ fn merge_geometries(geometries: Vec<&Geometry3D<f64>>) -> Geometry3D<f64> {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 async fn send_feature(
     sender: &Sender<(Port, IngestionMessage)>,
     flow_geometry: Geometry3D<f64>,

--- a/engine/runtime/action-source/src/file/obj.rs
+++ b/engine/runtime/action-source/src/file/obj.rs
@@ -175,6 +175,7 @@ impl Source for ObjReader {
         Ok(vec![])
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     async fn start(
         &mut self,
         ctx: NodeContext,
@@ -329,6 +330,7 @@ fn extract_material_properties(
     (materials_array, material_properties)
 }
 
+#[cfg(not(feature = "new-geometry"))]
 async fn read_obj(
     ctx: &NodeContext,
     storage_resolver: Arc<reearth_flow_storage::resolve::StorageResolver>,

--- a/engine/runtime/action-source/src/file/reader/citygml.rs
+++ b/engine/runtime/action-source/src/file/reader/citygml.rs
@@ -29,6 +29,7 @@ pub struct CityGmlReaderParam {
     pub(super) flatten: Option<bool>,
 }
 
+#[cfg(not(feature = "new-geometry"))]
 pub(crate) async fn read_citygml(
     content: &Bytes,
     input_path: Option<Uri>,
@@ -57,6 +58,7 @@ pub(crate) async fn read_citygml(
     Ok(())
 }
 
+#[cfg(not(feature = "new-geometry"))]
 async fn parse_tree_reader<R: BufRead>(
     st: &mut SubTreeReader<'_, '_, R>,
     base_url: Url,

--- a/engine/runtime/action-source/src/file/reader/csv.rs
+++ b/engine/runtime/action-source/src/file/reader/csv.rs
@@ -30,6 +30,7 @@ pub struct CsvReaderParam {
     pub(crate) geometry: Option<GeometryConfig>,
 }
 
+#[cfg(not(feature = "new-geometry"))]
 pub(crate) async fn read_csv(
     delimiter: Delimiter,
     content: &Bytes,

--- a/engine/runtime/action-source/src/file/reader/geojson.rs
+++ b/engine/runtime/action-source/src/file/reader/geojson.rs
@@ -4,6 +4,7 @@ use reearth_flow_runtime::node::{IngestionMessage, Port, DEFAULT_PORT};
 use reearth_flow_types::Feature;
 use tokio::sync::mpsc::Sender;
 
+#[cfg(not(feature = "new-geometry"))]
 pub(crate) async fn read_geojson(
     content: &Bytes,
     sender: Sender<(Port, IngestionMessage)>,

--- a/engine/runtime/action-source/src/file/shapefile.rs
+++ b/engine/runtime/action-source/src/file/shapefile.rs
@@ -230,6 +230,7 @@ impl Source for ShapefileReader {
         Ok(vec![])
     }
 
+    #[cfg(not(feature = "new-geometry"))]
     async fn start(
         &mut self,
         ctx: NodeContext,
@@ -256,6 +257,7 @@ impl Source for ShapefileReader {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 async fn read_shapefile(
     content: &Bytes,
     params: &ShapefileReaderCompiledParam,

--- a/engine/runtime/action-source/src/lib.rs
+++ b/engine/runtime/action-source/src/lib.rs
@@ -1,3 +1,9 @@
+// TODO(new-geometry): remove after migration. While actions are being ported,
+// gating each `process`/`finish`/`start` leaves their geometry-only imports and
+// helpers unused under the flag. Silence that noise here (scoped to the feature,
+// so the default build keeps full lint coverage).
+#![cfg_attr(feature = "new-geometry", allow(unused_imports, dead_code))]
+
 pub(crate) mod errors;
 pub(crate) mod feature_creator;
 pub(crate) mod file;

--- a/engine/runtime/action-wasm-processor/Cargo.toml
+++ b/engine/runtime/action-wasm-processor/Cargo.toml
@@ -10,6 +10,13 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+# Temporary migration flag for the new-geometry migration.
+new-geometry = [
+  "reearth-flow-geometry/new-geometry",
+  "reearth-flow-types/new-geometry",
+]
+
 [dependencies]
 reearth-flow-common.workspace = true
 reearth-flow-eval-expr.workspace = true

--- a/engine/runtime/action-wasm-processor/Cargo.toml
+++ b/engine/runtime/action-wasm-processor/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 
 [features]
 # Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
 new-geometry = [
   "reearth-flow-geometry/new-geometry",
   "reearth-flow-types/new-geometry",

--- a/engine/runtime/action-wasm-processor/src/lib.rs
+++ b/engine/runtime/action-wasm-processor/src/lib.rs
@@ -1,3 +1,9 @@
+// TODO(new-geometry): remove after migration. Gating each ported action's
+// `process`/`finish`/`start` leaves geometry-only imports and helpers unused
+// under the flag; silence that noise (feature-scoped, so the default build keeps
+// full lint coverage).
+#![cfg_attr(feature = "new-geometry", allow(unused_imports, dead_code))]
+
 pub(crate) mod errors;
 pub mod mapping;
 pub(crate) mod runtime_executor;

--- a/engine/runtime/geometry/Cargo.toml
+++ b/engine/runtime/geometry/Cargo.toml
@@ -10,6 +10,11 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+# Temporary migration flag: gates the placeholder new top-level geometry type.
+# Removed once the new-geometry migration completes.
+new-geometry = []
+
 [dependencies]
 reearth-flow-common.workspace = true
 

--- a/engine/runtime/geometry/Cargo.toml
+++ b/engine/runtime/geometry/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
-# Temporary migration flag: gates the placeholder new top-level geometry type.
-# Removed once the new-geometry migration completes.
+# Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
 new-geometry = []
 
 [dependencies]

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -13,3 +13,22 @@ pub mod macros;
 pub mod _alloc {
     pub use ::alloc::vec;
 }
+
+// TODO(new-geometry): replace this placeholder with the real geometry types.
+/// The top-level geometry type (work in progress).
+#[cfg(feature = "new-geometry")]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct Geometry {
+    // Intentionally empty for now.
+}
+
+#[cfg(feature = "new-geometry")]
+impl Geometry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        true
+    }
+}

--- a/engine/runtime/runtime/src/node.rs
+++ b/engine/runtime/runtime/src/node.rs
@@ -277,11 +277,15 @@ pub trait Source: Send + Sync + Debug + SourceClone {
     fn name(&self) -> &str;
     async fn serialize_state(&self) -> Result<Vec<u8>, BoxedError>;
 
+    // TODO(new-geometry): remove this temporary default after migration; restore
+    // `start` as a required method.
     async fn start(
         &mut self,
-        ctx: NodeContext,
-        sender: Sender<(Port, IngestionMessage)>,
-    ) -> Result<(), BoxedError>;
+        _ctx: NodeContext,
+        _sender: Sender<(Port, IngestionMessage)>,
+    ) -> Result<(), BoxedError> {
+        Err(format!("`{}` is not yet ported to new geometry", self.name()).into())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -360,16 +364,24 @@ pub trait Processor: Send + Sync + Debug + ProcessorClone {
     fn num_threads(&self) -> usize {
         1
     }
+    // TODO(new-geometry): remove these temporary defaults after migration; restore
+    // `process`/`finish` as required methods.
+    // The loud default fires for actions not yet ported to the new geometry; it must
+    // never be a silent `Ok(())`, which would pass features through unchanged.
     fn process(
         &mut self,
-        ctx: ExecutorContext,
-        fw: &ProcessorChannelForwarder,
-    ) -> Result<(), BoxedError>;
+        _ctx: ExecutorContext,
+        _fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Err(format!("`{}` is not yet ported to new geometry", self.name()).into())
+    }
     fn finish(
         &mut self,
-        ctx: NodeContext,
-        fw: &ProcessorChannelForwarder,
-    ) -> Result<(), BoxedError>;
+        _ctx: NodeContext,
+        _fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Err(format!("`{}` is not yet ported to new geometry", self.name()).into())
+    }
 
     fn name(&self) -> &str;
 }
@@ -435,8 +447,14 @@ pub trait Sink: Send + Debug + SinkClone {
     }
 
     fn name(&self) -> &str;
-    fn process(&mut self, ctx: ExecutorContext) -> Result<(), BoxedError>;
-    fn finish(&self, ctx: NodeContext) -> Result<(), BoxedError>;
+    // TODO(new-geometry): remove these temporary defaults after migration; restore
+    // `process`/`finish` as required methods.
+    fn process(&mut self, _ctx: ExecutorContext) -> Result<(), BoxedError> {
+        Err(format!("`{}` is not yet ported to new geometry", self.name()).into())
+    }
+    fn finish(&self, _ctx: NodeContext) -> Result<(), BoxedError> {
+        Err(format!("`{}` is not yet ported to new geometry", self.name()).into())
+    }
 
     fn set_source_state(&mut self, _source_state: &[u8]) -> Result<(), BoxedError> {
         Ok(())

--- a/engine/runtime/types/Cargo.toml
+++ b/engine/runtime/types/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
-# Temporary migration flag: switches `Feature.geometry` to the new geometry type.
-# Removed once the new-geometry migration completes.
+# Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
 new-geometry = ["reearth-flow-geometry/new-geometry"]
 
 [dependencies]

--- a/engine/runtime/types/Cargo.toml
+++ b/engine/runtime/types/Cargo.toml
@@ -10,6 +10,11 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+# Temporary migration flag: switches `Feature.geometry` to the new geometry type.
+# Removed once the new-geometry migration completes.
+new-geometry = ["reearth-flow-geometry/new-geometry"]
+
 [dependencies]
 reearth-flow-common.workspace = true
 reearth-flow-eval-expr.workspace = true

--- a/engine/runtime/types/src/conversion/geojson.rs
+++ b/engine/runtime/types/src/conversion/geojson.rs
@@ -1,3 +1,7 @@
+// Several imports here are only used by the `Feature`-geometry conversions that
+// are gated off under `new-geometry`.
+#![cfg_attr(feature = "new-geometry", allow(unused_imports))]
+
 use std::sync::Arc;
 
 use indexmap::IndexMap;
@@ -10,6 +14,8 @@ use crate::{
     Attribute, AttributeValue, Feature, GeometryValue, GmlGeometry,
 };
 
+// TODO(new-geometry): port to new geometry; gated off until then.
+#[cfg(not(feature = "new-geometry"))]
 impl TryFrom<Feature> for Vec<geojson::Feature> {
     type Error = Error;
 
@@ -69,6 +75,7 @@ impl TryFrom<Feature> for Vec<geojson::Feature> {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn from_attribute_value_map_to_geojson_object(
     map: &IndexMap<Attribute, AttributeValue>,
 ) -> geojson::JsonObject {
@@ -107,6 +114,8 @@ impl From<GmlGeometry> for Vec<geojson::Value> {
     }
 }
 
+// TODO(new-geometry): port to new geometry; gated off until then.
+#[cfg(not(feature = "new-geometry"))]
 impl TryFrom<geojson::Feature> for Feature {
     type Error = Error;
 
@@ -144,6 +153,7 @@ impl TryFrom<geojson::Feature> for Feature {
     }
 }
 
+#[cfg(not(feature = "new-geometry"))]
 fn from_geojson_object_to_attribute_value_map(
     obj: &geojson::JsonObject,
 ) -> IndexMap<Attribute, AttributeValue> {

--- a/engine/runtime/types/src/feature.rs
+++ b/engine/runtime/types/src/feature.rs
@@ -24,7 +24,7 @@ use crate::{all_attribute_keys, attribute::Attribute, lod::LodMask};
 #[cfg(not(feature = "new-geometry"))]
 use crate::geometry::Geometry;
 #[cfg(feature = "new-geometry")]
-use reearth_flow_geometry::next::Geometry;
+use reearth_flow_geometry::Geometry;
 
 pub(crate) const CITYGML_GML_ID_KEY: &str = "__citygml_gml_id";
 pub(crate) const CITYGML_FEATURE_TYPE_KEY: &str = "__citygml_feature_type";

--- a/engine/runtime/types/src/feature.rs
+++ b/engine/runtime/types/src/feature.rs
@@ -17,7 +17,14 @@ use serde_json::Number;
 use sqlx::{any::AnyTypeInfoKind, Column, Row, ValueRef};
 
 pub use crate::attribute::AttributeValue;
-use crate::{all_attribute_keys, attribute::Attribute, geometry::Geometry, lod::LodMask};
+use crate::{all_attribute_keys, attribute::Attribute, lod::LodMask};
+
+// `Feature.geometry` keeps the same field name in both worlds; only its type
+// switches with the `new-geometry` feature.
+#[cfg(not(feature = "new-geometry"))]
+use crate::geometry::Geometry;
+#[cfg(feature = "new-geometry")]
+use reearth_flow_geometry::next::Geometry;
 
 pub(crate) const CITYGML_GML_ID_KEY: &str = "__citygml_gml_id";
 pub(crate) const CITYGML_FEATURE_TYPE_KEY: &str = "__citygml_feature_type";

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.52"
+version = "0.2.53"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.242"
+version = "0.1.243"
 edition = "2021"
 
 [[bin]]

--- a/engine/worker/Cargo.toml
+++ b/engine/worker/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 
 [features]
 # Temporary migration flag for the new-geometry migration.
+# TODO: Remove after migration.
 new-geometry = [
   "reearth-flow-action-plateau-processor/new-geometry",
   "reearth-flow-action-processor/new-geometry",

--- a/engine/worker/Cargo.toml
+++ b/engine/worker/Cargo.toml
@@ -10,6 +10,17 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+# Temporary migration flag for the new-geometry migration.
+new-geometry = [
+  "reearth-flow-action-plateau-processor/new-geometry",
+  "reearth-flow-action-processor/new-geometry",
+  "reearth-flow-action-python-processor/new-geometry",
+  "reearth-flow-action-sink/new-geometry",
+  "reearth-flow-action-source/new-geometry",
+  "reearth-flow-types/new-geometry",
+]
+
 [[bin]]
 name = "reearth-flow-worker"
 path = "src/main.rs"


### PR DESCRIPTION
# Overview
This PR adds a library feature for geometry migration.
It is off by default, so no virtual change is introduced for the old geometry.
It is only for geometry migration, and it will be removed after the geometry migration gets completed.

## What I have done
- Introduced the feature.
- Mechanically added `#[cfg(not(feature = "new-geometry"))]` config to all functions / unit tests that relies on / test the old geometry. Those functions / tests will be removed after migration.
- Modified CI so that unit tests run with the `new-geometry` feature as well (though no unit tests for the new geometry are implemented in this PR). Note that geometry-agnotic tests run twice, but this is cargo's limitation, and unavoidable during the migration.

## What I haven't done
- The implementation of actual geometry types will be in a separate PR. This PR instead implements a placeholder geometry type.
- `workflow-tests` and `plateau-tiles-tests` never run with new geometry for this commit. How we handle these tests is postponed until later.

## How I tested
Both worlds compile clean.