### PR TITLE
fix(ui): add functionality to omit empty-valued params in convertNodes [FLOW-DEV-197]

### DIFF
--- a/ui/src/utils/toEngineWorkflow/convertNodes.test.ts
+++ b/ui/src/utils/toEngineWorkflow/convertNodes.test.ts
@@ -57,4 +57,31 @@ describe("convertNodes", () => {
 
     expect(convertNodes(input)).toEqual(expected);
   });
+
+  it("should omit empty-valued params from the `with` block", () => {
+    const input: Node[] = [
+      {
+        id: "1",
+        type: "reader",
+        position: { x: 22, y: 22 },
+        data: {
+          officialName: "GeoJsonReader",
+          params: {
+            dataset: { value: "https://example.com/a.geojson", type: "string" },
+            inline: { value: "", type: "string" },
+            format: "geojson",
+            prefix: "",
+            nullish: null,
+          },
+        },
+      },
+    ];
+
+    const result = convertNodes(input);
+
+    expect(result[0].with).toEqual({
+      dataset: { value: "https://example.com/a.geojson", type: "string" },
+      format: "geojson",
+    });
+  });
 });

--- a/ui/src/utils/toEngineWorkflow/convertNodes.ts
+++ b/ui/src/utils/toEngineWorkflow/convertNodes.ts
@@ -36,6 +36,27 @@ const convertEscapeSequences = (obj: any): any => {
   return obj;
 };
 
+const isEmptyParamValue = (value: unknown): boolean => {
+  if (value === undefined || value === null || value === "") return true;
+
+  if (
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    "value" in value &&
+    "type" in value
+  ) {
+    const inner = (value as { value: unknown }).value;
+    return inner === undefined || inner === null || inner === "";
+  }
+
+  return false;
+};
+
+const stripEmptyParams = (params: Record<string, any>): Record<string, any> =>
+  Object.fromEntries(
+    Object.entries(params).filter(([, value]) => !isEmptyParamValue(value)),
+  );
+
 export const convertNodes = (nodes?: Node[]) => {
   if (!nodes) return [];
 
@@ -52,7 +73,7 @@ export const convertNodes = (nodes?: Node[]) => {
       };
 
       if (data.params) {
-        n.with = convertEscapeSequences(data.params);
+        n.with = convertEscapeSequences(stripEmptyParams(data.params));
       }
 
       if (type === "subworkflow") {


### PR DESCRIPTION
# Overview
This PR updates the UI → Engine workflow node conversion so that node parameters with “empty” values (e.g., `""`, `null`, `undefined`, including `{ value, type }` wrappers with empty inner `value`) are omitted from the generated Engine-ready node `with` block.
## What I've done
- Added `isEmptyParamValue` + `stripEmptyParams` helpers to filter out empty-valued params before emitting `n.with`.
- Updated `convertNodes` to apply empty-param stripping prior to escape-sequence conversion.
- Added a unit test verifying empty-valued params are omitted from `with`.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
