### PR TITLE
fix(ui): clamp to ground geojson [FLOW-DEV-198]

### DIFF
--- a/ui/src/components/visualizations/Cesium/GeoJson.tsx
+++ b/ui/src/components/visualizations/Cesium/GeoJson.tsx
@@ -291,6 +291,7 @@ const GeoJsonData: React.FC<Props> = ({
       key={dataSourceKey}
       data={sanitizedData}
       onLoad={handleLoad}
+      clampToGround={true}
     />
   );
 };


### PR DESCRIPTION
# Overview
This PR adjusts the UI’s Cesium GeoJSON visualization so that loaded GeoJSON entities are clamped to the ground, aligning the rendered geometry with the globe/terrain surface.
## What I've done
- Enable `clampToGround` on the `resium` `GeoJsonDataSource` used by the Cesium GeoJSON visualization.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
