### PR TITLE
chore(engine): further improvements on CI

### DIFF
--- a/.github/actions/setup-engine-ci/action.yml
+++ b/.github/actions/setup-engine-ci/action.yml
@@ -1,8 +1,9 @@
 name: Set up engine CI environment
 description: |
-  Shared post-checkout setup for engine CI jobs: frees disk space, installs the
-  pinned Rust toolchain, restores the cargo cache, and installs the small CLI
-  tools needed by every job (taplo-cli, cargo-make, cargo-edit).
+  Shared post-checkout setup for engine CI jobs: installs the pinned Rust
+  toolchain, restores the cargo cache, and installs the CLI tools needed by the
+  job. Defaults to cargo-make (used by every job); a job that needs extra tools
+  (e.g. lint needs taplo-cli) passes them via `tools`.
 
   The calling job MUST run `step-security/harden-runner` and `actions/checkout`
   before invoking this action — checkout is required for GitHub to locate this
@@ -23,20 +24,17 @@ inputs:
     description: Optional extra rustup components to install (comma-separated).
     required: false
     default: ""
+  tools:
+    description: |
+      Comma-separated CLI tools to install via taiki-e/install-action.
+      Defaults to cargo-make, which every job needs to run `cargo make`.
+      Jobs needing more (e.g. lint needs taplo-cli) override this.
+    required: false
+    default: cargo-make
 
 runs:
   using: composite
   steps:
-    - name: Maximize build space
-      uses: AdityaGarg8/remove-unwanted-software@8831c82abf29b34eb2caac48d5f999ecfc0d8eef # v4.1
-      with:
-        remove-dotnet: 'true'
-        remove-android: 'true'
-        remove-haskell: 'true'
-        remove-codeql: 'true'
-        remove-docker-images: 'true'
-        remove-swapfile: 'true'
-        remove-cached-tools: 'true'
     - uses: dtolnay/rust-toolchain@2ea1b3bdd0261867664fd125505456a7b9c3385c # 1.93.1
       with:
         components: ${{ inputs.rust-components }}
@@ -48,4 +46,4 @@ runs:
     - name: install required tools
       uses: taiki-e/install-action@74e87cbfa15a59692b158178d8905a61bf6fca95 # v2.75.20
       with:
-        tool: taplo-cli,cargo-make,cargo-edit
+        tool: ${{ inputs.tools }}

--- a/.github/workflows/ci_engine.yml
+++ b/.github/workflows/ci_engine.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: ./.github/actions/setup-engine-ci
         with:
           rust-components: clippy, rustfmt
+          tools: cargo-make,taplo-cli
       - name: Compare version with previous commit
         if: ${{ !(github.ref == 'refs/heads/main') }}
         run: |

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -78,7 +78,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
 dependencies = [
- "equator 0.4.2",
+ "equator",
 ]
 
 [[package]]
@@ -379,16 +379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
-]
-
-[[package]]
-name = "atomic-wait"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55b94919229f2c42292fd71ffa4b75e83193bffdd77b1e858cd55fd2d0b0ea8"
-dependencies = [
- "libc",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1525,12 +1515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "defer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
-
-[[package]]
 name = "deflate64"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,27 +1678,34 @@ dependencies = [
 
 [[package]]
 name = "draco-oxide"
-version = "0.1.0-alpha.5"
+version = "0.1.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a37bd567a310ee98389174647a70561d68c65e939a0df310ca5eb69bfcfeb09"
+checksum = "9811854bc6180df947656afa5131b40367ce49109dc60a508a657cd5bd4daa1c"
 dependencies = [
- "base64 0.21.7",
- "draco-nd-vector",
+ "draco-oxide-core",
  "enum_dispatch",
- "faer",
  "gltf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.25.10",
- "indexmap 2.13.0",
+ "remain",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tobj",
+]
+
+[[package]]
+name = "draco-oxide-core"
+version = "0.1.0-alpha.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918b965fe4b608267cc7a269af51cce6208b041829478cd35bd4fc12c26edb2a"
+dependencies = [
+ "draco-nd-vector",
  "kiddo",
- "lazy_static",
  "paste",
  "remain",
- "schemars 0.8.22",
  "seq-macro",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tobj",
 ]
 
 [[package]]
@@ -1743,22 +1734,6 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "dyn-stack"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
-dependencies = [
- "bytemuck",
- "dyn-stack-macros",
-]
-
-[[package]]
-name = "dyn-stack-macros"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "earcut"
@@ -1817,18 +1792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,31 +1805,11 @@ dependencies = [
 
 [[package]]
 name = "equator"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
-dependencies = [
- "equator-macro 0.2.1",
-]
-
-[[package]]
-name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
 dependencies = [
- "equator-macro 0.4.2",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "equator-macro",
 ]
 
 [[package]]
@@ -1948,61 +1891,6 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
-]
-
-[[package]]
-name = "faer"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fce40ad65c366fbc6cd70a99d09d1008f075280bf2455e558e163c82913a9f"
-dependencies = [
- "bytemuck",
- "dyn-stack",
- "equator 0.4.2",
- "faer-macros",
- "faer-traits",
- "gemm",
- "generativity",
- "libm",
- "nano-gemm",
- "npyz",
- "num-complex",
- "num-traits",
- "private-gemm-x86",
- "pulp",
- "rand 0.8.5",
- "rand_distr",
- "rayon",
- "reborrow",
-]
-
-[[package]]
-name = "faer-macros"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0a255d1442b5825c61812a7eafda9034ec53d969c98555251085e148428e6a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "faer-traits"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54febfcbb90edaab562d85447a94d500f1601f11db0b30d27da87ed6542c8f91"
-dependencies = [
- "bytemuck",
- "dyn-stack",
- "faer-macros",
- "generativity",
- "libm",
- "num-complex",
- "num-traits",
- "pulp",
- "qd",
- "reborrow",
 ]
 
 [[package]]
@@ -2442,131 +2330,6 @@ dependencies = [
  "system-deps 6.2.2",
  "x11",
 ]
-
-[[package]]
-name = "gemm"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
-dependencies = [
- "dyn-stack",
- "gemm-c32",
- "gemm-c64",
- "gemm-common",
- "gemm-f16",
- "gemm-f32",
- "gemm-f64",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "seq-macro",
-]
-
-[[package]]
-name = "gemm-c32"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
-dependencies = [
- "dyn-stack",
- "gemm-common",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "seq-macro",
-]
-
-[[package]]
-name = "gemm-c64"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
-dependencies = [
- "dyn-stack",
- "gemm-common",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "seq-macro",
-]
-
-[[package]]
-name = "gemm-common"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
-dependencies = [
- "bytemuck",
- "dyn-stack",
- "half",
- "libm",
- "num-complex",
- "num-traits",
- "once_cell",
- "paste",
- "pulp",
- "raw-cpuid",
- "rayon",
- "seq-macro",
- "sysctl",
-]
-
-[[package]]
-name = "gemm-f16"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
-dependencies = [
- "dyn-stack",
- "gemm-common",
- "gemm-f32",
- "half",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "rayon",
- "seq-macro",
-]
-
-[[package]]
-name = "gemm-f32"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
-dependencies = [
- "dyn-stack",
- "gemm-common",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "seq-macro",
-]
-
-[[package]]
-name = "gemm-f64"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
-dependencies = [
- "dyn-stack",
- "gemm-common",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid",
- "seq-macro",
-]
-
-[[package]]
-name = "generativity"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5881e4c3c2433fe4905bb19cfd2b5d49d4248274862b68c27c33d9ba4e13f9ec"
 
 [[package]]
 name = "generator"
@@ -3215,10 +2978,8 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
- "bytemuck",
  "cfg-if",
  "crunchy",
- "num-traits",
  "zerocopy",
 ]
 
@@ -3894,17 +3655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interpol"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb58032ba748f4010d15912a1855a8a0b1ba9eaad3395b0c171c09b3b356ae50"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4419,19 +4169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator 0.8.8",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "loop9"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4683,76 +4420,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nano-gemm"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb5ba2bea1c00e53de11f6ab5bd0761ba87dc0045d63b0c87ee471d2d3061376"
-dependencies = [
- "equator 0.2.2",
- "nano-gemm-c32",
- "nano-gemm-c64",
- "nano-gemm-codegen",
- "nano-gemm-core",
- "nano-gemm-f32",
- "nano-gemm-f64",
- "num-complex",
-]
-
-[[package]]
-name = "nano-gemm-c32"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40449e57a5713464c3a1208c4c3301c8d29ee1344711822cf022bc91373a91b"
-dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
- "num-complex",
-]
-
-[[package]]
-name = "nano-gemm-c64"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743a6e6211358fba85d1009616751e4107da86f4c95b24e684ce85f25c25b3bf"
-dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
- "num-complex",
-]
-
-[[package]]
-name = "nano-gemm-codegen"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963bf7c7110d55430169dc74c67096375491ed580cd2ef84842550ac72e781fa"
-
-[[package]]
-name = "nano-gemm-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3fc4f83ae8861bad79dc3c016bd6b0220da5f9de302e07d3112d16efc24aa6"
-
-[[package]]
-name = "nano-gemm-f32"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3681b7ce35658f79da94b7f62c60a005e29c373c7111ed070e3bf64546a8bb"
-dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
-]
-
-[[package]]
-name = "nano-gemm-f64"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1e619ed04d801809e1f63e61b669d380c4119e8b0cdd6ed184c6b111f046d8"
-dependencies = [
- "nano-gemm-codegen",
- "nano-gemm-core",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4834,17 +4501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
-name = "npyz"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0e759e014e630f90af745101b614f761306ddc541681e546649068e25ec1b9"
-dependencies = [
- "byteorder",
- "num-bigint",
- "py_literal",
-]
-
-[[package]]
 name = "nt-time"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4907,9 +4563,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "bytemuck",
  "num-traits",
- "rand 0.8.5",
  "serde",
 ]
 
@@ -5518,49 +5172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5983,22 +5594,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "private-gemm-x86"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af8c3e5087969c323f667ccb4b789fa0954f5aa650550e38e81cf9108be21b5"
-dependencies = [
- "crossbeam",
- "defer",
- "interpol",
- "num_cpus",
- "raw-cpuid",
- "rayon",
- "spindle",
- "sysctl",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6175,49 +5770,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulp"
-version = "0.21.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
-dependencies = [
- "bytemuck",
- "cfg-if",
- "libm",
- "num-complex",
- "reborrow",
- "version_check",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
-
-[[package]]
-name = "py_literal"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-traits",
- "pest",
- "pest_derive",
-]
-
-[[package]]
-name = "qd"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8bb755b6008c3b41bf8a0866c8dd4e1245a2f011ceaa22a13ee55c538493e2"
-dependencies = [
- "bytemuck",
- "libm",
- "num-traits",
- "pulp",
-]
 
 [[package]]
 name = "qoi"
@@ -6465,16 +6021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
-name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6543,15 +6089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6582,12 +6119,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "reborrow"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redox_syscall"
@@ -8604,19 +8135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spindle"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aaca3d8aa5387a6eba861fbf984af5348d9df5d940c25c6366b19556fdf64"
-dependencies = [
- "atomic-wait",
- "crossbeam",
- "equator 0.4.2",
- "loom 0.7.2",
- "rayon",
-]
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8832,7 +8350,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b"
 dependencies = [
- "loom 0.5.6",
+ "loom",
 ]
 
 [[package]]
@@ -8959,20 +8477,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sysctl"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
-dependencies = [
- "bitflags 2.11.0",
- "byteorder",
- "enum-as-inner",
- "libc",
- "thiserror 1.0.69",
- "walkdir",
 ]
 
 [[package]]
@@ -9970,12 +9474,6 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5417,7 +5417,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.341"
+version = "0.0.342"
 dependencies = [
  "directories",
  "log",
@@ -5446,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.53"
+version = "0.2.54"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "futures",
  "once_cell",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "approx",
  "async-trait",
@@ -6228,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "Inflector",
  "approx",
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6424,7 +6424,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6435,7 +6435,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "bytes",
  "clap",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6515,7 +6515,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "chrono",
  "futures",
@@ -6529,7 +6529,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6558,7 +6558,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -6571,7 +6571,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "approx",
  "bvh",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6635,7 +6635,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6644,7 +6644,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6674,7 +6674,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6711,7 +6711,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -6740,7 +6740,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "bytes",
  "futures",
@@ -6757,7 +6757,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "bytes",
  "futures",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -6790,7 +6790,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6825,7 +6825,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -6863,7 +6863,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.408"
+version = "0.0.409"
 dependencies = [
  "async-trait",
  "axum",
@@ -10723,7 +10723,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.243"
+version = "0.1.244"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -104,7 +104,6 @@ cesiumtiles = { git = "https://github.com/reearth/cesiumtiles-rs", tag = "v0.0.2
 chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.5.60", features = ["env", "string"] }
 clipper-sys = "0.8.0"
-color-eyre = "0.6.5"
 colored = "3.1.1"
 colorsys = "0.7.3"
 crossbeam = "0.8.4"
@@ -120,7 +119,6 @@ flatgeom = "0.0.2"
 float_next_after = "1.0.0"
 futures = "0.3.32"
 futures-util = "0.3.32"
-geo = "0.32.0"
 geo-buffer = "0.2.0"
 geo-types = "0.7.18"
 geojson = "0.24.2"
@@ -150,7 +148,6 @@ json-subscriber = "0.2.7"
 jsonpath_lib = "0.3.0"
 kiddo = "5.2.4"
 nalgebra = "0.34.1"
-nalgebra-glm = "0.19.0"
 num-traits = "0.2.19"
 num_cpus = "1.17.0"
 nutype = { version = "0.6.2", features = ["schemars08", "serde"] }
@@ -204,11 +201,9 @@ rhai = { version = "1.24.0", features = [
 rmp-serde = "1.3.1"
 robust = "1.2.0"
 rstar = "0.12.2"
-rstest = "0.26.1"
 rust_xlsxwriter = "0.93.0"
 schemars = { version = "0.8.22", features = ["chrono", "uuid1"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_derive = "1.0.228"
 serde_json = { version = "1.0.149", features = [
   "arbitrary_precision",
   "preserve_order",
@@ -233,7 +228,6 @@ sqlx = { version = "0.8.6", features = [
   "sqlite",
   "tls-rustls",
 ] }
-strum = "0.27.2"
 strum_macros = "0.27.2"
 sysinfo = "0.38.2"
 tempfile = "3.26.0"
@@ -241,8 +235,6 @@ thiserror = "2.0.18"
 time = { version = "0.3.47", features = ["formatting"] }
 tinymvt = { git = "https://github.com/reearth/tinymvt.git", tag = "v0.0.3" }
 tokio = { version = "1.49.0", features = ["full", "time"] }
-tokio-stream = { version = "0.1.18", features = ["sync"] }
-tokio-util = { version = "0.7.18", features = ["full"] }
 toml = "1.0.3"
 tracing = "0.1.44"
 tracing-appender = "0.2.4"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -112,7 +112,7 @@ crossbeam-channel = "0.5.15"
 crossbeam-utils = "0.8.21"
 csv = "1.4.0"
 directories = "6.0.0"
-draco-oxide = "0.1.0-alpha.5"
+draco-oxide = { version = "0.1.0-alpha.7", default-features = false }
 earcut = "0.4.5"
 encoding_rs = "0.8"
 flate2 = "1.1.9"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.408"
+version = "0.0.409"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -66,6 +66,7 @@ script = ['''
 #!/usr/bin/env bash -eux
 export RUST_LOG=warn,plateau_tiles_test=info # avoid engine info log flooding
 export PLATEAU_TILES_TEST_CLEANUP=1
+export PLATEAU_TILES_TEST_CONCURRENCY=4 # run 4 testcases concurrently
 cargo run -p plateau-tiles-test --bin plateau-tiles-test ${@:-}
 ''']
 

--- a/engine/Makefile.toml
+++ b/engine/Makefile.toml
@@ -66,7 +66,7 @@ script = ['''
 #!/usr/bin/env bash -eux
 export RUST_LOG=warn,plateau_tiles_test=info # avoid engine info log flooding
 export PLATEAU_TILES_TEST_CLEANUP=1
-export PLATEAU_TILES_TEST_CONCURRENCY=4 # run 4 testcases concurrently
+export PLATEAU_TILES_TEST_CONCURRENCY="${PLATEAU_TILES_TEST_CONCURRENCY:-4}" # default 4, caller can override
 cargo run -p plateau-tiles-test --bin plateau-tiles-test ${@:-}
 ''']
 

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.341"
+version = "0.0.342"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.53"
+version = "0.2.54"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/plateau-tiles-test/src/main.rs
+++ b/engine/testing/plateau-tiles-test/src/main.rs
@@ -479,14 +479,7 @@ fn main() {
         // Run testcases concurrently across the testcase set. Each testcase
         // writes to its own output directory and spawns its own Runner with
         // isolated state/storage/logger, so they are safe to interleave.
-        //
-        // Concurrency is bounded because each Runner internally spawns ~4
-        // worker threads for its DAG; running too many testcases at once
-        // oversubscribes the CPU and causes the runner agent to lose
-        // heartbeat (same failure mode we saw with --test-threads=16 in
-        // workflow-tests). On a 4-vCPU CI runner, 2 concurrent testcases is
-        // the safe ceiling. Override via PLATEAU_TILES_TEST_CONCURRENCY for
-        // larger machines.
+        // Override the default via PLATEAU_TILES_TEST_CONCURRENCY.
         let concurrency = env::var("PLATEAU_TILES_TEST_CONCURRENCY")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.243"
+version = "0.1.244"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR implements some CI improvements.
It can be seen as a follow up task of 72b7ada.

## What I've done
- `draco-oxide` version update (It now runs faster on the debug build), and changed the number of threads from 2 to 4 for tiles test, as it seems to be more IO bound rather than CPU bound due to the update. It is empirically tested multiple times that it runs without crash. The bottleneck `test-conv` became ~ 2m45s -> ~ 1m30s, excluding compilation time.
- Removed the unused software removal step, as we have more than 80GB of space without removing them. It was introduced back when we are using `ubuntu-latest`, but since we use `Blacksmith` today, this step became largely unnecessary. Minus ~10s on all 5 parallel jobs.
- Removed 7 unused dependencies, though this is mostly a hygiene improvement, rather than CI improvements.

## Further Improvements (Deferred)
- Executor's timer sleeps should be replaced with a proper condvar sleep, which will improve the new bottleneck `test-qc`.
- About 1/4 of 2.8 GB build cache (compressed) is the dependencies from github, which is adding ~10 seconds on all engine parallel jobs. Namely, these are `gltf`, `cesiumtiles`, `nusamai-*`, `tinymvt`. Consider publishing them to crates.io or some alternative method.