### PR TITLE
fix(engine): iterative DAG traversal to prevent stack overflow on long workflows

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "futures",
  "once_cell",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "approx",
  "async-trait",
@@ -6228,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "Inflector",
  "approx",
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6424,7 +6424,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6435,7 +6435,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "bytes",
  "clap",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6515,7 +6515,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "chrono",
  "futures",
@@ -6529,7 +6529,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6558,7 +6558,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -6571,7 +6571,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "approx",
  "bvh",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6635,7 +6635,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6644,7 +6644,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6674,7 +6674,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6711,7 +6711,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -6740,7 +6740,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "bytes",
  "futures",
@@ -6757,7 +6757,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "bytes",
  "futures",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -6790,7 +6790,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6825,7 +6825,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -6863,7 +6863,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.409"
+version = "0.0.410"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/runtime/src/builder_dag.rs
+++ b/engine/runtime/runtime/src/builder_dag.rs
@@ -113,11 +113,7 @@ impl BuilderDag {
     pub async fn new(ctx: NodeContext, dag_schemas: DagSchemas) -> Result<Self, ExecutionError> {
         let graph_id = dag_schemas.id;
         // Collect sources that may affect a node.
-        let mut affecting_sources = dag_schemas
-            .graph()
-            .node_indices()
-            .map(|node_index| dag_schemas.collect_ancestor_sources(node_index))
-            .collect::<Vec<_>>();
+        let mut affecting_sources = dag_schemas.affecting_sources_per_node()?;
 
         // Prepare nodes and edges for consuming.
         let (nodes, edges) = dag_schemas.into_graph().into_nodes_edges();

--- a/engine/runtime/runtime/src/dag_schemas.rs
+++ b/engine/runtime/runtime/src/dag_schemas.rs
@@ -300,15 +300,6 @@ impl DagSchemas {
         &self.graph
     }
 
-    pub fn collect_ancestor_sources(
-        &self,
-        node_index: petgraph::graph::NodeIndex,
-    ) -> HashSet<NodeHandle> {
-        let mut sources = HashSet::new();
-        collect_ancestor_sources_recursive(self, node_index, &mut sources);
-        sources
-    }
-
     /// For every node, the set of `Source` nodes that are its strict ancestors,
     /// indexed by `NodeIndex::index()`.
     ///
@@ -583,24 +574,6 @@ impl DagSchemas {
                 }
             }
         }
-    }
-}
-
-fn collect_ancestor_sources_recursive(
-    dag: &DagSchemas,
-    node_index: NodeIndex,
-    sources: &mut HashSet<NodeHandle>,
-) {
-    for edge in dag.graph().edges_directed(node_index, Direction::Incoming) {
-        let source_node_index = edge.source();
-        let source_node = &dag.graph()[source_node_index];
-        let Some(ref kind) = source_node.kind else {
-            continue;
-        };
-        if matches!(kind, NodeKind::Source(_)) {
-            sources.insert(source_node.handle.clone());
-        }
-        collect_ancestor_sources_recursive(dag, source_node_index, sources);
     }
 }
 

--- a/engine/runtime/runtime/src/dag_schemas.rs
+++ b/engine/runtime/runtime/src/dag_schemas.rs
@@ -799,4 +799,23 @@ mod tests {
             Err(crate::errors::ExecutionError::SchemaInferenceCycle)
         ));
     }
+
+    #[test]
+    fn long_chain_does_not_overflow_stack() {
+        // A linear chain long enough that the OLD recursive walk overflowed the
+        // ~8 MB stack. The iterative pass must complete.
+        const N: usize = 100_000;
+        let mut dag = empty_dag();
+        let s = add(&mut dag, "s", K::Source);
+        let mut prev = s;
+        for _ in 0..N {
+            let p = add(&mut dag, "p", K::Proc);
+            link(&mut dag, prev, p);
+            prev = p;
+        }
+        let got = dag.affecting_sources_per_node().expect("no cycle");
+        let s_handle = dag.graph()[s].handle.clone();
+        assert_eq!(got[prev.index()], HashSet::from([s_handle]));
+        assert_eq!(got.len(), N + 1);
+    }
 }

--- a/engine/runtime/runtime/src/dag_schemas.rs
+++ b/engine/runtime/runtime/src/dag_schemas.rs
@@ -309,6 +309,41 @@ impl DagSchemas {
         sources
     }
 
+    /// For every node, the set of `Source` nodes that are its strict ancestors,
+    /// indexed by `NodeIndex::index()`.
+    ///
+    /// Single iterative pass in topological order (mirrors
+    /// `schema_infer::infer_and_validate`). Replaces the former per-node
+    /// recursive `collect_ancestor_sources`, which recursed to depth = ancestor
+    /// chain length (stack overflow on long workflows) and cost O(N^2). A
+    /// predecessor whose `kind` is `None` is a barrier: it and its ancestors are
+    /// excluded, exactly as the old recursive `continue`.
+    pub fn affecting_sources_per_node(
+        &self,
+    ) -> Result<Vec<HashSet<NodeHandle>>, crate::errors::ExecutionError> {
+        let graph = self.graph();
+        let order = petgraph::algo::toposort(graph, None)
+            .map_err(|_| crate::errors::ExecutionError::SchemaInferenceCycle)?;
+
+        let mut result: Vec<HashSet<NodeHandle>> = vec![HashSet::new(); graph.node_count()];
+        for node_index in order {
+            let mut acc: HashSet<NodeHandle> = HashSet::new();
+            for edge in graph.edges_directed(node_index, Direction::Incoming) {
+                let pred_index = edge.source();
+                let pred = &graph[pred_index];
+                let Some(ref kind) = pred.kind else {
+                    continue; // kind == None barrier
+                };
+                acc.extend(result[pred_index.index()].iter().cloned());
+                if matches!(kind, NodeKind::Source(_)) {
+                    acc.insert(pred.handle.clone());
+                }
+            }
+            result[node_index.index()] = acc;
+        }
+        Ok(result)
+    }
+
     pub fn remove_edge(&mut self, edge: petgraph::graph::EdgeIndex) {
         self.graph.remove_edge(edge);
     }
@@ -566,5 +601,229 @@ fn collect_ancestor_sources_recursive(
             sources.insert(source_node.handle.clone());
         }
         collect_ancestor_sources_recursive(dag, source_node_index, sources);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, HashSet};
+
+    use reearth_flow_types::workflow::{Node, NodeEntity};
+    use uuid::Uuid;
+
+    use crate::event::EventHub;
+    use crate::executor_operation::NodeContext;
+    use crate::node::{Processor, ProcessorFactory, Source, SourceFactory, DEFAULT_PORT};
+
+    #[derive(Debug, Clone)]
+    struct StubSource;
+    impl SourceFactory for StubSource {
+        fn name(&self) -> &str {
+            "StubSource"
+        }
+        fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+            None
+        }
+        fn get_output_ports(&self) -> Vec<Port> {
+            vec![DEFAULT_PORT.clone()]
+        }
+        fn build(
+            &self,
+            _ctx: NodeContext,
+            _event_hub: EventHub,
+            _action: String,
+            _with: Option<HashMap<String, serde_json::Value>>,
+            _state: Option<Vec<u8>>,
+        ) -> Result<Box<dyn Source>, crate::errors::BoxedError> {
+            Err("stub".into())
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct StubProc;
+    impl ProcessorFactory for StubProc {
+        fn name(&self) -> &str {
+            "StubProc"
+        }
+        fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+            None
+        }
+        fn get_input_ports(&self) -> Vec<Port> {
+            vec![DEFAULT_PORT.clone()]
+        }
+        fn get_output_ports(&self) -> Vec<Port> {
+            vec![DEFAULT_PORT.clone()]
+        }
+        fn build(
+            &self,
+            _ctx: NodeContext,
+            _event_hub: EventHub,
+            _action: String,
+            _with: Option<HashMap<String, serde_json::Value>>,
+        ) -> Result<Box<dyn Processor>, crate::errors::BoxedError> {
+            unreachable!()
+        }
+    }
+
+    fn dummy_node(name: &str) -> Node {
+        Node::Action {
+            entity: NodeEntity {
+                id: Uuid::new_v4(),
+                name: name.to_string(),
+                with: None,
+            },
+            action: name.to_string(),
+        }
+    }
+
+    fn empty_dag() -> DagSchemas {
+        let g = reearth_flow_types::workflow::Graph {
+            id: Uuid::new_v4(),
+            name: "t".to_string(),
+            nodes: vec![],
+            edges: vec![],
+        };
+        DagSchemas::from_graph(&g, &HashMap::new(), &None)
+    }
+
+    enum K {
+        Source,
+        Proc,
+        None_,
+    }
+
+    fn add(dag: &mut DagSchemas, name: &str, k: K) -> NodeIndex {
+        let kind = match k {
+            K::Source => Some(NodeKind::Source(Box::new(StubSource))),
+            K::Proc => Some(NodeKind::Processor(Box::new(StubProc))),
+            K::None_ => None,
+        };
+        dag.add_node(SchemaNodeType::new(
+            NodeId::new(Uuid::new_v4().to_string()),
+            name.to_string(),
+            dummy_node(name),
+            kind,
+            None,
+            None,
+        ))
+    }
+
+    fn link(dag: &mut DagSchemas, from: NodeIndex, to: NodeIndex) {
+        dag.connect_with_index(
+            EdgeId::new(Uuid::new_v4().to_string()),
+            from,
+            &DEFAULT_PORT,
+            to,
+            &DEFAULT_PORT,
+            None,
+        );
+    }
+
+    fn reference(dag: &DagSchemas, node: NodeIndex, out: &mut HashSet<NodeHandle>) {
+        for edge in dag.graph().edges_directed(node, Direction::Incoming) {
+            let src = edge.source();
+            let n = &dag.graph()[src];
+            let Some(ref kind) = n.kind else { continue };
+            if matches!(kind, NodeKind::Source(_)) {
+                out.insert(n.handle.clone());
+            }
+            reference(dag, src, out);
+        }
+    }
+
+    fn reference_all(dag: &DagSchemas) -> Vec<HashSet<NodeHandle>> {
+        (0..dag.graph().node_count())
+            .map(|i| {
+                let mut s = HashSet::new();
+                reference(dag, NodeIndex::new(i), &mut s);
+                s
+            })
+            .collect()
+    }
+
+    #[test]
+    fn chain_collects_single_source() {
+        let mut dag = empty_dag();
+        let s = add(&mut dag, "s", K::Source);
+        let a = add(&mut dag, "a", K::Proc);
+        let b = add(&mut dag, "b", K::Proc);
+        link(&mut dag, s, a);
+        link(&mut dag, a, b);
+        let got = dag.affecting_sources_per_node().unwrap();
+        let s_handle = dag.graph()[s].handle.clone();
+        assert!(got[s.index()].is_empty());
+        assert_eq!(got[a.index()], HashSet::from([s_handle.clone()]));
+        assert_eq!(got[b.index()], HashSet::from([s_handle]));
+    }
+
+    #[test]
+    fn diamond_unions_sources() {
+        let mut dag = empty_dag();
+        let s1 = add(&mut dag, "s1", K::Source);
+        let s2 = add(&mut dag, "s2", K::Source);
+        let a = add(&mut dag, "a", K::Proc);
+        let b = add(&mut dag, "b", K::Proc);
+        let c = add(&mut dag, "c", K::Proc);
+        link(&mut dag, s1, a);
+        link(&mut dag, a, c);
+        link(&mut dag, s2, b);
+        link(&mut dag, b, c);
+        let got = dag.affecting_sources_per_node().unwrap();
+        let h1 = dag.graph()[s1].handle.clone();
+        let h2 = dag.graph()[s2].handle.clone();
+        assert_eq!(got[c.index()], HashSet::from([h1, h2]));
+    }
+
+    #[test]
+    fn none_kind_predecessor_is_a_barrier() {
+        let mut dag = empty_dag();
+        let s = add(&mut dag, "s", K::Source);
+        let bar = add(&mut dag, "bar", K::None_);
+        let c = add(&mut dag, "c", K::Proc);
+        link(&mut dag, s, bar);
+        link(&mut dag, bar, c);
+        let got = dag.affecting_sources_per_node().unwrap();
+        assert!(got[c.index()].is_empty());
+    }
+
+    #[test]
+    fn differential_matches_reference_on_many_shapes() {
+        for shape in 0..4u8 {
+            let mut dag = empty_dag();
+            let s1 = add(&mut dag, "s1", K::Source);
+            let p1 = add(&mut dag, "p1", K::Proc);
+            link(&mut dag, s1, p1);
+            if shape >= 1 {
+                let s2 = add(&mut dag, "s2", K::Source);
+                link(&mut dag, s2, p1);
+            }
+            if shape >= 2 {
+                let p2 = add(&mut dag, "p2", K::Proc);
+                link(&mut dag, p1, p2);
+            }
+            if shape >= 3 {
+                let bar = add(&mut dag, "bar", K::None_);
+                let z = add(&mut dag, "z", K::Proc);
+                link(&mut dag, s1, bar);
+                link(&mut dag, bar, z);
+            }
+            let got = dag.affecting_sources_per_node().unwrap();
+            let want = reference_all(&dag);
+            assert_eq!(got, want, "iterative != reference for shape {shape}");
+        }
+    }
+
+    #[test]
+    fn cycle_returns_schema_inference_cycle() {
+        let mut dag = empty_dag();
+        let a = add(&mut dag, "a", K::Proc);
+        let b = add(&mut dag, "b", K::Proc);
+        link(&mut dag, a, b);
+        link(&mut dag, b, a);
+        assert!(matches!(
+            dag.affecting_sources_per_node(),
+            Err(crate::errors::ExecutionError::SchemaInferenceCycle)
+        ));
     }
 }

--- a/engine/runtime/runtime/src/incremental.rs
+++ b/engine/runtime/runtime/src/incremental.rs
@@ -178,7 +178,7 @@ fn collect_reusable_in_graph_and_upstream_subworkflows(
                 graph_id,
                 sub_graph_id
             );
-            collect_all_in_graph_recursive(
+            collect_all_in_graph(
                 graphs,
                 sub_graph_id,
                 edge_ids,
@@ -192,49 +192,43 @@ fn collect_reusable_in_graph_and_upstream_subworkflows(
     Ok(())
 }
 
-/// Recursively collects all edges and port file IDs in a graph and its nested subgraphs.
-fn collect_all_in_graph_recursive(
+/// Iteratively collect all edge ids and port file ids in a graph and its
+/// nested subgraphs (explicit-stack worklist; no recursion, so deep subgraph
+/// nesting cannot overflow the stack).
+fn collect_all_in_graph(
     graphs: &HashMap<uuid::Uuid, &reearth_flow_types::Graph>,
-    graph_id: uuid::Uuid,
+    entry_graph_id: uuid::Uuid,
     edge_ids: &mut HashSet<uuid::Uuid>,
     port_file_ids: &mut HashSet<String>,
     prefix_chains: &HashMap<uuid::Uuid, Vec<Vec<uuid::Uuid>>>,
     visited: &mut HashSet<uuid::Uuid>,
 ) -> Result<(), String> {
-    if !visited.insert(graph_id) {
-        tracing::info!(
-            "Skipping already-visited subgraph {} (cycle detected)",
-            graph_id
-        );
-        return Ok(());
-    }
-
-    let graph = graphs
-        .get(&graph_id)
-        .ok_or_else(|| format!("graph {} not found", graph_id))?;
-
-    for edge in &graph.edges {
-        edge_ids.insert(edge.id);
-    }
-
-    for node in &graph.nodes {
-        if let Some(chains) = prefix_chains.get(&graph_id) {
-            for chain in chains {
-                port_file_ids.extend(compute_port_file_ids(graph, node, chain));
+    let mut stack = vec![entry_graph_id];
+    while let Some(graph_id) = stack.pop() {
+        if !visited.insert(graph_id) {
+            tracing::info!(
+                "Skipping already-visited subgraph {} (cycle detected)",
+                graph_id
+            );
+            continue;
+        }
+        let graph = graphs
+            .get(&graph_id)
+            .ok_or_else(|| format!("graph {} not found", graph_id))?;
+        for edge in &graph.edges {
+            edge_ids.insert(edge.id);
+        }
+        for node in &graph.nodes {
+            if let Some(chains) = prefix_chains.get(&graph_id) {
+                for chain in chains {
+                    port_file_ids.extend(compute_port_file_ids(graph, node, chain));
+                }
+            }
+            if let Some(sub_graph_id) = extract_subgraph_id_if_subworkflow_node(node) {
+                stack.push(sub_graph_id);
             }
         }
-        if let Some(sub_graph_id) = extract_subgraph_id_if_subworkflow_node(node) {
-            collect_all_in_graph_recursive(
-                graphs,
-                sub_graph_id,
-                edge_ids,
-                port_file_ids,
-                prefix_chains,
-                visited,
-            )?;
-        }
     }
-
     Ok(())
 }
 
@@ -375,4 +369,154 @@ fn collect_output_ports(
 
 fn is_output_router(node: &reearth_flow_types::Node) -> bool {
     matches!(node, reearth_flow_types::Node::Action { action, .. } if action == OUTPUT_ROUTING_ACTION)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reearth_flow_types::{Edge, Graph, Node, NodeEntity};
+
+    /// Builds a `Node::SubGraph` referencing `sub_graph_id`. This is the exact
+    /// shape `extract_subgraph_id_if_subworkflow_node` matches.
+    fn subgraph_node(node_id: uuid::Uuid, sub_graph_id: uuid::Uuid) -> Node {
+        Node::SubGraph {
+            entity: NodeEntity {
+                id: node_id,
+                name: "sub".to_string(),
+                with: None,
+            },
+            sub_graph_id,
+        }
+    }
+
+    fn edge(id: uuid::Uuid, from: uuid::Uuid, to: uuid::Uuid) -> Edge {
+        Edge {
+            id,
+            from,
+            to,
+            from_port: "default".to_string(),
+            to_port: "default".to_string(),
+        }
+    }
+
+    #[test]
+    fn collect_all_in_graph_descends_nested_subgraphs() {
+        let g1_id = uuid::Uuid::new_v4();
+        let g2_id = uuid::Uuid::new_v4();
+        let g3_id = uuid::Uuid::new_v4();
+
+        let g1_edge = uuid::Uuid::new_v4();
+        let g2_edge = uuid::Uuid::new_v4();
+        let g3_edge = uuid::Uuid::new_v4();
+
+        // G1 contains a subworkflow node referencing G2.
+        let g1_sub_node = uuid::Uuid::new_v4();
+        let g1 = Graph {
+            id: g1_id,
+            name: "g1".to_string(),
+            nodes: vec![subgraph_node(g1_sub_node, g2_id)],
+            edges: vec![edge(g1_edge, uuid::Uuid::new_v4(), g1_sub_node)],
+        };
+
+        // G2 contains a subworkflow node referencing G3.
+        let g2_sub_node = uuid::Uuid::new_v4();
+        let g2 = Graph {
+            id: g2_id,
+            name: "g2".to_string(),
+            nodes: vec![subgraph_node(g2_sub_node, g3_id)],
+            edges: vec![edge(g2_edge, uuid::Uuid::new_v4(), g2_sub_node)],
+        };
+
+        // G3 is a leaf graph.
+        let g3 = Graph {
+            id: g3_id,
+            name: "g3".to_string(),
+            nodes: vec![],
+            edges: vec![edge(g3_edge, uuid::Uuid::new_v4(), uuid::Uuid::new_v4())],
+        };
+
+        let graphs: HashMap<uuid::Uuid, &Graph> = [(g1_id, &g1), (g2_id, &g2), (g3_id, &g3)]
+            .into_iter()
+            .collect();
+        let prefix_chains: HashMap<uuid::Uuid, Vec<Vec<uuid::Uuid>>> = HashMap::new();
+        let mut edge_ids: HashSet<uuid::Uuid> = HashSet::new();
+        let mut port_file_ids: HashSet<String> = HashSet::new();
+        let mut visited: HashSet<uuid::Uuid> = HashSet::new();
+
+        let result = collect_all_in_graph(
+            &graphs,
+            g1_id,
+            &mut edge_ids,
+            &mut port_file_ids,
+            &prefix_chains,
+            &mut visited,
+        );
+
+        assert_eq!(result, Ok(()));
+        // Edge ids from all three nested graphs must be present, proving the
+        // worklist descended through the full nesting chain.
+        assert!(edge_ids.contains(&g1_edge));
+        assert!(edge_ids.contains(&g2_edge));
+        assert!(edge_ids.contains(&g3_edge));
+        // All three graphs were visited.
+        assert!(visited.contains(&g1_id));
+        assert!(visited.contains(&g2_id));
+        assert!(visited.contains(&g3_id));
+        assert_eq!(visited.len(), 3);
+    }
+
+    #[test]
+    fn collect_all_in_graph_terminates_on_cycle() {
+        let g1_id = uuid::Uuid::new_v4();
+        let g2_id = uuid::Uuid::new_v4();
+        let g3_id = uuid::Uuid::new_v4();
+
+        let g1_edge = uuid::Uuid::new_v4();
+        let g2_edge = uuid::Uuid::new_v4();
+        let g3_edge = uuid::Uuid::new_v4();
+
+        // G1 -> G2 -> G3 -> G1 (cycle back to the entry graph).
+        let g1 = Graph {
+            id: g1_id,
+            name: "g1".to_string(),
+            nodes: vec![subgraph_node(uuid::Uuid::new_v4(), g2_id)],
+            edges: vec![edge(g1_edge, uuid::Uuid::new_v4(), uuid::Uuid::new_v4())],
+        };
+        let g2 = Graph {
+            id: g2_id,
+            name: "g2".to_string(),
+            nodes: vec![subgraph_node(uuid::Uuid::new_v4(), g3_id)],
+            edges: vec![edge(g2_edge, uuid::Uuid::new_v4(), uuid::Uuid::new_v4())],
+        };
+        let g3 = Graph {
+            id: g3_id,
+            name: "g3".to_string(),
+            nodes: vec![subgraph_node(uuid::Uuid::new_v4(), g1_id)],
+            edges: vec![edge(g3_edge, uuid::Uuid::new_v4(), uuid::Uuid::new_v4())],
+        };
+
+        let graphs: HashMap<uuid::Uuid, &Graph> = [(g1_id, &g1), (g2_id, &g2), (g3_id, &g3)]
+            .into_iter()
+            .collect();
+        let prefix_chains: HashMap<uuid::Uuid, Vec<Vec<uuid::Uuid>>> = HashMap::new();
+        let mut edge_ids: HashSet<uuid::Uuid> = HashSet::new();
+        let mut port_file_ids: HashSet<String> = HashSet::new();
+        let mut visited: HashSet<uuid::Uuid> = HashSet::new();
+
+        // Must terminate (not hang or overflow) thanks to the `visited` guard.
+        let result = collect_all_in_graph(
+            &graphs,
+            g1_id,
+            &mut edge_ids,
+            &mut port_file_ids,
+            &prefix_chains,
+            &mut visited,
+        );
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(visited.len(), 3);
+        assert!(edge_ids.contains(&g1_edge));
+        assert!(edge_ids.contains(&g2_edge));
+        assert!(edge_ids.contains(&g3_edge));
+    }
 }


### PR DESCRIPTION
## Summary

Long workflows could panic the engine with a **stack overflow** while *building* the executor. The cause was recursive traversal of the workflow/DAG whose recursion depth grows with workflow size. This converts the two such traversals to iterative algorithms — fixing the crash and, as a bonus, removing an O(N²) cost.

- **`DagSchemas::collect_ancestor_sources`** — a per-node recursive ancestor walk, called once per node by `BuilderDag::new`, so recursion depth = ancestor-chain length (overflow on long workflows) and total cost was O(N²). Replaced by a single **`affecting_sources_per_node()`** pass using `petgraph::algo::toposort` + forward propagation in topological order → constant stack depth, O(V+E). (Mirrors the existing `schema_infer::infer_and_validate` pattern.)
- **`collect_all_in_graph_recursive`** (downward subgraph-nesting walk in `incremental.rs`) → an explicit-stack worklist.

**Behavior is preserved exactly.** The new source-set pass is asserted identical to the old recursion via a differential test against a reference recursive oracle — including the subtle `kind == None` **barrier** semantics (a `None`-kind predecessor and its ancestors are excluded). A cyclic graph now returns a clean `ExecutionError::SchemaInferenceCycle` instead of recursing forever.

## Changes

- `engine/runtime/runtime/src/dag_schemas.rs` — add `affecting_sources_per_node`; remove `collect_ancestor_sources` + its recursive helper.
- `engine/runtime/runtime/src/builder_dag.rs` — call the batch method (one line).
- `engine/runtime/runtime/src/incremental.rs` — recursion → explicit-stack worklist.
- `engine/Cargo.toml` / `Cargo.lock` — workspace version bump.

## Tests

- **Differential** vs an independent recursive oracle across chain / diamond / multi-source / `None`-barrier shapes (guards behavior-equivalence).
- `kind == None` barrier, diamond union, and cycle-returns-`SchemaInferenceCycle`.
- **100k-node chain completes without stack overflow** — the core regression guard.
- Nested-subgraph descent + cycle termination for the incremental worklist.

## Test plan

- [ ] `cargo make clippy` clean
- [ ] `cargo test -p reearth-flow-runtime` green (incl. the new `dag_schemas::tests` and `incremental::tests`)
- [ ] CI engine workflow green
