### PR TITLE
fix(api): action schema always fetched from main branch

### DIFF
--- a/server/api/internal/app/actions.go
+++ b/server/api/internal/app/actions.go
@@ -92,8 +92,6 @@ func (e *loadError) Error() string { return e.err.Error() }
 func (e *loadError) Unwrap() error { return e.err }
 
 var (
-	actionsDataMap = make(map[string]ActionsData)
-	mutex          sync.RWMutex
 	httpClient     = &http.Client{Timeout: 10 * time.Second}
 	supportedLangs = map[string]bool{
 		"en": true,
@@ -104,7 +102,29 @@ var (
 	}
 )
 
-func loadActionsData(lang string) (ActionsData, error) {
+type ActionsHandler struct {
+	baseURL        string
+	actionsDataMap map[string]ActionsData
+	mu             sync.RWMutex
+}
+
+func NewActionsHandler(baseURL string) *ActionsHandler {
+	return &ActionsHandler{
+		baseURL:        baseURL,
+		actionsDataMap: make(map[string]ActionsData),
+	}
+}
+
+func (h *ActionsHandler) init(ctx context.Context) error {
+	for lang := range supportedLangs {
+		if _, err := h.loadActionsData(lang); err != nil {
+			log.Errorf("Failed to load actions data for language %s: %v", lang, err)
+		}
+	}
+	return nil
+}
+
+func (h *ActionsHandler) loadActionsData(lang string) (ActionsData, error) {
 	if lang != "" && !supportedLangs[lang] {
 		return ActionsData{}, &loadError{err: fmt.Errorf("unsupported language: %s", lang), status: http.StatusBadRequest}
 	}
@@ -112,24 +132,24 @@ func loadActionsData(lang string) (ActionsData, error) {
 	cacheKey := lang
 
 	// Try to get from cache first using read lock
-	mutex.RLock()
-	if data, exists := actionsDataMap[cacheKey]; exists {
-		mutex.RUnlock()
+	h.mu.RLock()
+	if data, exists := h.actionsDataMap[cacheKey]; exists {
+		h.mu.RUnlock()
 		return data, nil
 	}
-	mutex.RUnlock()
+	h.mu.RUnlock()
 
 	// Fetch from GitHub without holding any lock so other requests are not blocked.
-	baseURL := "https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/"
 	filename := "actions.json"
 	if lang != "" {
 		filename = fmt.Sprintf("actions_%s.json", lang)
 	}
+	url := h.baseURL + filename
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	reqCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+filename, nil)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
 	if err != nil {
 		return ActionsData{}, &loadError{err: err, status: http.StatusBadGateway}
 	}
@@ -145,7 +165,7 @@ func loadActionsData(lang string) (ActionsData, error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return ActionsData{}, &loadError{err: fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, baseURL+filename), status: http.StatusBadGateway}
+		return ActionsData{}, &loadError{err: fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, url), status: http.StatusBadGateway}
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -164,12 +184,12 @@ func loadActionsData(lang string) (ActionsData, error) {
 
 	// Store in cache under write lock; double-check in case a concurrent
 	// goroutine already populated the same key while we were fetching.
-	mutex.Lock()
-	defer mutex.Unlock()
-	if data, exists := actionsDataMap[cacheKey]; exists {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if data, exists := h.actionsDataMap[cacheKey]; exists {
 		return data, nil
 	}
-	actionsDataMap[cacheKey] = newData
+	h.actionsDataMap[cacheKey] = newData
 	return newData, nil
 }
 
@@ -187,13 +207,13 @@ func loadActionsData(lang string) (ActionsData, error) {
 // @Failure      500       {object}  object         "Internal server error"
 // @Failure      502       {object}  object         "Upstream fetch error"
 // @Router       /actions [get]
-func listActions(c echo.Context) error {
+func (h *ActionsHandler) listActions(c echo.Context) error {
 	query := c.QueryParam("q")
 	category := c.QueryParam("category")
 	actionType := c.QueryParam("type")
 	lang := c.QueryParam("lang")
 
-	data, err := loadActionsData(lang)
+	data, err := h.loadActionsData(lang)
 	if err != nil {
 		status := http.StatusInternalServerError
 		var le *loadError
@@ -235,11 +255,11 @@ func listActions(c echo.Context) error {
 // @Failure      500   {object}  object             "Internal server error"
 // @Failure      502   {object}  object             "Upstream fetch error"
 // @Router       /actions/segregated [get]
-func getSegregatedActions(c echo.Context) error {
+func (h *ActionsHandler) getSegregatedActions(c echo.Context) error {
 	query := c.QueryParam("q")
 	lang := c.QueryParam("lang")
 
-	data, err := loadActionsData(lang)
+	data, err := h.loadActionsData(lang)
 	if err != nil {
 		status := http.StatusInternalServerError
 		var le *loadError
@@ -356,11 +376,11 @@ func containsCaseInsensitive(slice []string, s string) bool {
 // @Failure      500   {object}  object  "Internal server error"
 // @Failure      502   {object}  object  "Upstream fetch error"
 // @Router       /actions/{id} [get]
-func getActionDetails(c echo.Context) error {
+func (h *ActionsHandler) getActionDetails(c echo.Context) error {
 	id := c.Param("id")
 	lang := c.QueryParam("lang")
 
-	data, err := loadActionsData(lang)
+	data, err := h.loadActionsData(lang)
 	if err != nil {
 		status := http.StatusInternalServerError
 		var le *loadError
@@ -382,8 +402,8 @@ func getActionDetails(c echo.Context) error {
 	return c.JSON(http.StatusNotFound, map[string]string{"error": "Action not found"})
 }
 
-func SetupActionRoutes(e *echo.Echo) {
-	e.GET("/actions", listActions)
-	e.GET("/actions/segregated", getSegregatedActions)
-	e.GET("/actions/:id", getActionDetails)
+func (h *ActionsHandler) SetupRoutes(e *echo.Echo) {
+	e.GET("/actions", h.listActions)
+	e.GET("/actions/segregated", h.getSegregatedActions)
+	e.GET("/actions/:id", h.getActionDetails)
 }

--- a/server/api/internal/app/actions_test.go
+++ b/server/api/internal/app/actions_test.go
@@ -10,8 +10,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func resetTestData() {
-	actionsDataMap = make(map[string]ActionsData)
+const testSchemaBaseURL = "https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/"
+
+func newTestHandler() *ActionsHandler {
+	return NewActionsHandler(testSchemaBaseURL)
+}
+
+func newTestHandlerWithData(data map[string]ActionsData) *ActionsHandler {
+	h := NewActionsHandler("")
+	h.actionsDataMap = data
+	return h
 }
 
 func TestLoadActionsData(t *testing.T) {
@@ -28,8 +36,8 @@ func TestLoadActionsData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resetTestData()
-			data, err := loadActionsData(tt.lang)
+			h := newTestHandler()
+			data, err := h.loadActionsData(tt.lang)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -37,8 +45,11 @@ func TestLoadActionsData(t *testing.T) {
 				assert.NotEmpty(t, data.Actions)
 
 				// Verify cache
-				assert.NotNil(t, actionsDataMap[tt.lang])
-				assert.Equal(t, data, actionsDataMap[tt.lang])
+				h.mu.RLock()
+				cached, exists := h.actionsDataMap[tt.lang]
+				h.mu.RUnlock()
+				assert.True(t, exists)
+				assert.Equal(t, data, cached)
 			}
 		})
 	}
@@ -60,12 +71,12 @@ func TestListActions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resetTestData()
+			h := newTestHandler()
 			req := httptest.NewRequest(http.MethodGet, "/actions?lang="+tt.lang+tt.query, nil)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 
-			err := listActions(c)
+			err := h.listActions(c)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantCode, rec.Code)
 
@@ -86,15 +97,16 @@ func TestListActionsHiddenFilter(t *testing.T) {
 		{Name: "PLATEAU4.SolarPositionCalculator", Type: ActionTypeProcessor, Description: "not in allow-list", Categories: []string{"PLATEAU"}},
 	}
 
-	resetTestData()
-	actionsDataMap[""] = ActionsData{Actions: testActions}
+	h := newTestHandlerWithData(map[string]ActionsData{
+		"": {Actions: testActions},
+	})
 
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/actions", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 
-	err := listActions(c)
+	err := h.listActions(c)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
 
@@ -140,15 +152,16 @@ func TestGetSegregatedActions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resetTestData()
-			actionsDataMap[tt.lang] = ActionsData{Actions: testActions}
+			h := newTestHandlerWithData(map[string]ActionsData{
+				tt.lang: {Actions: testActions},
+			})
 
 			e := echo.New()
 			req := httptest.NewRequest(http.MethodGet, "/actions/segregated?lang="+tt.lang, nil)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 
-			err := getSegregatedActions(c)
+			err := h.getSegregatedActions(c)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantCode, rec.Code)
 
@@ -194,8 +207,9 @@ func TestGetActionDetails(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resetTestData()
-			actionsDataMap[tt.lang] = ActionsData{Actions: []Action{testAction, hiddenAction}}
+			h := newTestHandlerWithData(map[string]ActionsData{
+				tt.lang: {Actions: []Action{testAction, hiddenAction}},
+			})
 
 			e := echo.New()
 			req := httptest.NewRequest(http.MethodGet, "/?lang="+tt.lang, nil)
@@ -205,7 +219,7 @@ func TestGetActionDetails(t *testing.T) {
 			c.SetParamNames("id")
 			c.SetParamValues(tt.id)
 
-			err := getActionDetails(c)
+			err := h.getActionDetails(c)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantCode, rec.Code)
 
@@ -220,6 +234,10 @@ func TestGetActionDetails(t *testing.T) {
 }
 
 func TestGetActionDetailsNotFound(t *testing.T) {
+	h := newTestHandlerWithData(map[string]ActionsData{
+		"": {Actions: []Action{}},
+	})
+
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -228,7 +246,7 @@ func TestGetActionDetailsNotFound(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues("NonExistentAction")
 
-	err := getActionDetails(c)
+	err := h.getActionDetails(c)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 

--- a/server/api/internal/app/app.go
+++ b/server/api/internal/app/app.go
@@ -116,10 +116,11 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 		apiPrivate.POST("/signup/verify/:code", SignupVerify())
 		apiPrivate.POST("/password-reset", PasswordReset())
 	}
-	if err := initActionsData(ctx); err != nil {
+	actionsHandler := NewActionsHandler(cfg.Config.ActionsSchemaBaseURL)
+	if err := actionsHandler.init(ctx); err != nil {
 		log.Errorf("Failed to initialize actions data: %v", err)
 	}
-	SetupActionRoutes(e)
+	actionsHandler.SetupRoutes(e)
 
 	SetupTriggerRoutes(e)
 	SetupJobRoutes(e)
@@ -129,15 +130,6 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 	Web(e, cfg.Config.WebConfig(), cfg.Config.AuthForWeb(), cfg.Config.Web_Disabled, nil)
 
 	return e
-}
-
-func initActionsData(_ context.Context) error {
-	for lang := range supportedLangs {
-		if _, err := loadActionsData(lang); err != nil {
-			log.Errorf("Failed to load actions data for language %s: %v", lang, err)
-		}
-	}
-	return nil
 }
 
 func errorHandler(next func(error, echo.Context)) func(error, echo.Context) {

--- a/server/api/internal/app/config/config.go
+++ b/server/api/internal/app/config/config.go
@@ -39,22 +39,22 @@ type (
 		GCS GCSConfig `pp:",omitempty"`
 		S3  S3Config  `pp:",omitempty"`
 
-		AccountsApiHost string `envconfig:"REEARTH_ACCOUNTS_API_HOST" pp:",omitempty"`
-		AssetBaseURL    string `default:"http://localhost:8080/assets"`
-		DB              string `default:"mongodb://localhost"`
-		DB_Account      string `pp:",omitempty"`
-		GCPProject      string `envconfig:"GOOGLE_CLOUD_PROJECT" pp:",omitempty"`
-		GCPRegion       string `envconfig:"GOOGLE_CLOUD_REGION" pp:",omitempty"`
-		Host            string `default:"http://localhost:8080"`
-		Host_Web        string `pp:",omitempty"`
-		Port            string `default:"8080"`
-		Profiler        string `pp:",omitempty"`
-		ServerHost      string `pp:",omitempty"`
-		SharedPath      string `default:"shared"`
-		SignupSecret    string `pp:",omitempty"`
-		Tracer          string `pp:",omitempty"`
-		Web_FaviconURL  string `pp:",omitempty"`
-		Web_Title       string `pp:",omitempty"`
+		AccountsApiHost      string `envconfig:"REEARTH_ACCOUNTS_API_HOST" pp:",omitempty"`
+		AssetBaseURL         string `default:"http://localhost:8080/assets"`
+		DB                   string `default:"mongodb://localhost"`
+		DB_Account           string `pp:",omitempty"`
+		GCPProject           string `envconfig:"GOOGLE_CLOUD_PROJECT" pp:",omitempty"`
+		GCPRegion            string `envconfig:"GOOGLE_CLOUD_REGION" pp:",omitempty"`
+		Host                 string `default:"http://localhost:8080"`
+		Host_Web             string `pp:",omitempty"`
+		Port                 string `default:"8080"`
+		Profiler             string `pp:",omitempty"`
+		ServerHost           string `pp:",omitempty"`
+		SharedPath           string `default:"shared"`
+		SignupSecret         string `pp:",omitempty"`
+		Tracer               string `pp:",omitempty"`
+		Web_FaviconURL       string `pp:",omitempty"`
+		Web_Title            string `pp:",omitempty"`
 		WorkflowBaseURL      string `default:"http://localhost:8080/workflows"`
 		ActionsSchemaBaseURL string `envconfig:"ACTIONS_SCHEMA_BASE_URL" default:"https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/" pp:",omitempty"`
 

--- a/server/api/internal/app/config/config.go
+++ b/server/api/internal/app/config/config.go
@@ -55,7 +55,8 @@ type (
 		Tracer          string `pp:",omitempty"`
 		Web_FaviconURL  string `pp:",omitempty"`
 		Web_Title       string `pp:",omitempty"`
-		WorkflowBaseURL string `default:"http://localhost:8080/workflows"`
+		WorkflowBaseURL      string `default:"http://localhost:8080/workflows"`
+		ActionsSchemaBaseURL string `envconfig:"ACTIONS_SCHEMA_BASE_URL" default:"https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/" pp:",omitempty"`
 
 		// log
 		Redis_URL string `pp:",omitempty"`


### PR DESCRIPTION
# Overview
No matter the environment, the actions schemas available to the user were from the main branch, which meant in dev and prod environments the schemas and engine were sometimes incompatible.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
