### PR TITLE
fix(engine): normalize MVT winding instead of filtering

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "futures",
  "once_cell",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "approx",
  "async-trait",
@@ -6228,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "Inflector",
  "approx",
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6424,7 +6424,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6435,7 +6435,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "bytes",
  "clap",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6518,7 +6518,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "chrono",
  "futures",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6561,7 +6561,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -6574,7 +6574,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "approx",
  "bvh",
@@ -6604,7 +6604,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6638,7 +6638,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6647,7 +6647,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6677,7 +6677,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6714,7 +6714,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -6731,7 +6731,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -6743,7 +6743,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "bytes",
  "futures",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "bytes",
  "futures",
@@ -6779,7 +6779,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -6793,7 +6793,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6828,7 +6828,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -6866,7 +6866,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.412"
+version = "0.0.413"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.412"
+version = "0.0.413"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-sink/src/file/mvt/pipeline.rs
+++ b/engine/runtime/action-sink/src/file/mvt/pipeline.rs
@@ -56,7 +56,6 @@ pub(super) fn geometry_slicing_stage(
 ) -> crate::errors::Result<()> {
     let tile_contents = Arc::new(Mutex::new(Vec::new()));
     let layer_names = Arc::new(Mutex::new(std::collections::HashSet::new()));
-
     // Convert CityObjects to sliced features
     upstream
         .iter()

--- a/engine/runtime/action-sink/src/file/mvt/slice.rs
+++ b/engine/runtime/action-sink/src/file/mvt/slice.rs
@@ -67,9 +67,7 @@ pub(super) fn slice_cityobj_geoms<'a>(
                                 [mx, my]
                             });
 
-                            if !poly.exterior().is_cw() {
-                                continue;
-                            }
+                            let poly = normalize_winding(poly);
                             let area = poly.area();
 
                             for zoom in min_z..=max_z {
@@ -141,9 +139,7 @@ pub(super) fn slice_cityobj_geoms<'a>(
                         [mx, my]
                     });
 
-                    if !poly.exterior().is_cw() {
-                        return;
-                    }
+                    let poly = normalize_winding(poly);
                     let area = poly.area();
 
                     for zoom in min_z..=max_z {
@@ -281,6 +277,26 @@ pub(super) fn slice_cityobj_geoms<'a>(
     }
 
     Ok(tile_content)
+}
+
+fn normalize_winding(poly: Polygon2) -> Polygon2 {
+    let mut normalized = Polygon2::new();
+    let exterior = poly.exterior();
+    if exterior.signed_ring_area() > 0.0 {
+        let coords: Vec<_> = exterior.iter().collect();
+        normalized.add_ring(coords.into_iter().rev());
+    } else {
+        normalized.add_ring(exterior.iter());
+    }
+    for interior in poly.interiors() {
+        if interior.signed_ring_area() < 0.0 {
+            let coords: Vec<_> = interior.iter().collect();
+            normalized.add_ring(coords.into_iter().rev());
+        } else {
+            normalized.add_ring(interior.iter());
+        }
+    }
+    normalized
 }
 
 fn slice_polygon(

--- a/engine/runtime/action-sink/src/file/mvt/slice.rs
+++ b/engine/runtime/action-sink/src/file/mvt/slice.rs
@@ -283,15 +283,13 @@ fn normalize_winding(poly: Polygon2) -> Polygon2 {
     let mut normalized = Polygon2::new();
     let exterior = poly.exterior();
     if exterior.signed_ring_area() > 0.0 {
-        let coords: Vec<_> = exterior.iter().collect();
-        normalized.add_ring(coords.into_iter().rev());
+        normalized.add_ring(exterior.raw_coords().iter().rev().copied());
     } else {
         normalized.add_ring(exterior.iter());
     }
     for interior in poly.interiors() {
         if interior.signed_ring_area() < 0.0 {
-            let coords: Vec<_> = interior.iter().collect();
-            normalized.add_ring(coords.into_iter().rev());
+            normalized.add_ring(interior.raw_coords().iter().rev().copied());
         } else {
             normalized.add_ring(interior.iter());
         }


### PR DESCRIPTION
# Overview

Because Flow does not require ring winding in its internal geometry representation, it is not correct to drop some specific winding but to normalize them based on exterior/interior property.

## Notes

This fix applies to MVT currently because it is a severe problem dropping valid geometry components.
However, many other formats currently do not do winding normalization, even they do not filter geometry, their output is considered potentially invalid. Including:

- 2D: MVT(this PR), GeoJSON
- 3D: obj, glTF, Cesium3DTiles, CityGML

## How I tested it

Using a problematic GeoJSON test and simply created a workflow to connect it to an MVT writer. After the fix, the previously invisible geometry is now rendered.