### PR TITLE
fix(worker): write probe-schema report via async put (GCS has no blocking_write)

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5417,7 +5417,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.342"
+version = "0.0.343"
 dependencies = [
  "directories",
  "log",
@@ -5446,7 +5446,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.54"
+version = "0.2.55"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "futures",
  "once_cell",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "approx",
  "async-trait",
@@ -6228,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "Inflector",
  "approx",
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6424,7 +6424,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6435,7 +6435,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "bytes",
  "clap",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6515,7 +6515,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "chrono",
  "futures",
@@ -6529,7 +6529,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6558,7 +6558,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -6571,7 +6571,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "approx",
  "bvh",
@@ -6601,7 +6601,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6635,7 +6635,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6644,7 +6644,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6674,7 +6674,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6711,7 +6711,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -6740,7 +6740,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "bytes",
  "futures",
@@ -6757,7 +6757,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "bytes",
  "futures",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -6790,7 +6790,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6825,7 +6825,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -6863,7 +6863,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.409"
+version = "0.0.410"
 dependencies = [
  "async-trait",
  "axum",
@@ -10723,7 +10723,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.244"
+version = "0.1.245"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.409"
+version = "0.0.410"
 
 [profile.dev]
 opt-level = 0

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.342"
+version = "0.0.343"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.54"
+version = "0.2.55"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.244"
+version = "0.1.245"
 edition = "2021"
 
 [[bin]]

--- a/engine/worker/src/probe_schema.rs
+++ b/engine/worker/src/probe_schema.rs
@@ -210,9 +210,22 @@ impl ProbeSchemaCommand {
 
         let report_uri = Uri::from_str(self.report_url.as_str()).map_err(Error::init)?;
         let storage = storage_resolver.resolve(&report_uri).map_err(Error::init)?;
-        storage
-            .put_sync(report_uri.path().as_path(), json.into())
-            .map_err(Error::run)?;
+        // Write via the async `put`, exactly as the run path's `upload_artifact`
+        // does: object-store backends like GCS do not implement OpenDAL's
+        // blocking layer, so `put_sync` fails with `Unsupported (persistent) at
+        // blocking_write`. `execute` runs in a sync context (worker `main` is
+        // not async), so drive the async write on a Tokio runtime, mirroring
+        // `RunWorkerCommand::execute`.
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(Error::FailedToCreateTokioRuntime)?;
+        runtime.block_on(async {
+            storage
+                .put(report_uri.path().as_path(), json.into())
+                .await
+                .map_err(Error::run)
+        })?;
         tracing::info!("Wrote probe-schema report to {}", self.report_url);
         Ok(())
     }


### PR DESCRIPTION
# Overview

Fixes preview-schema (probe-schema) jobs failing on GCS with:

```
Operation not supported: Unsupported (persistent) at blocking_write,
context: { service: gcs, path: artifacts/<job>/schema/schema-report.json }
```

## Root cause

The worker's `probe-schema` `execute()` wrote the JSON report with `Storage::put_sync`, which calls OpenDAL's **blocking** layer (`self.inner.blocking().write(...)`). Object-store backends like **GCS do not implement blocking writes**, so the write fails. It only ever worked locally because the `fs` backend (and the `file://` unit test) *do* support `put_sync`, which masked the bug — `GetJobPreviewSchemaUploadURI` returns a `file://` path in local dev but a `gs://` URI in prod.

The workflow *read* path is unaffected: `UploadWorkflow` returns an `https://` URL, which `get_sync` handles via its reqwest path; only the `gs://` report **write** hit `blocking_write`.

## Fix

Write the report with the **async** `Storage::put` (the same call the run-path `upload_artifact` uses successfully on GCS), driven on a short-lived current-thread Tokio runtime since `execute()` runs in a sync context (worker `main` is not async). Mirrors `RunWorkerCommand::execute`'s runtime pattern.

## What I haven't done

- No new GCS integration test — that needs live credentials. The existing `file://` test still passes through the new async path, and `put` is the identical call already proven against GCS by the run-path artifact upload.

## How I tested

- `cargo test -p reearth-flow-worker probe_schema` — passes (report written + read back, AttributeManager removal still reflected).
- `cargo clippy -p reearth-flow-worker --all-targets` — clean.
- `cargo fmt -- --check` — clean.
- Engine version bumped to `0.0.410`.