### PR TITLE
fix(server): finalize preview-schema jobs from the sync probe response

### DIFF
--- a/server/api/internal/usecase/interactor/job.go
+++ b/server/api/internal/usecase/interactor/job.go
@@ -199,8 +199,13 @@ func (i *Job) PreviewSchemaCloudRunWorker(j *job.Job, p gateway.ProbeSchemaParam
 			log.Errorfc(ctx, "job: preview-schema cloud run worker %s run error: %v", j.ID(), err)
 		}
 
-		if err != nil || status == gateway.JobStatusFailed {
+		// The probe is synchronous and emits no Redis event, so finalize the job
+		// directly from the HTTP response instead of relying on the monitoring loop.
+		switch {
+		case err != nil || status == gateway.JobStatusFailed:
 			i.failCloudRunJob(ctx, j.ID())
+		case status == gateway.JobStatusCompleted:
+			i.completeCloudRunPreviewJob(ctx, j.ID())
 		}
 	}()
 }
@@ -241,6 +246,38 @@ func (i *Job) failCloudRunJob(ctx context.Context, jobID id.JobID) {
 
 	if err := i.handleJobCompletion(ctx, latest); err != nil {
 		log.Errorfc(ctx, "job: completion handling failed for cloud run job %s: %v", jobID, err)
+	}
+	i.subscriptions.Notify(jobID.String(), latest.Status())
+}
+
+// completeCloudRunPreviewJob marks a preview-schema job completed from the
+// synchronous /probe-schema response. Unlike a normal run, the read-only probe
+// emits no Redis completion event, so the monitoring loop would never finalize
+// it and the job would sit at PENDING forever. The HTTP response is the
+// authoritative, synchronous result, so no grace period or Redis check applies.
+func (i *Job) completeCloudRunPreviewJob(ctx context.Context, jobID id.JobID) {
+	lock := i.getJobLock(jobID.String())
+	lock.Lock()
+	defer lock.Unlock()
+
+	latest, err := i.jobRepo.FindByID(ctx, jobID)
+	if err != nil {
+		log.Errorfc(ctx, "job: failed to reload preview job %s: %v", jobID, err)
+		return
+	}
+	if s := latest.Status(); s == job.StatusCancelled || s == job.StatusCompleted || s == job.StatusFailed {
+		return
+	}
+
+	latest.SetStatus(job.StatusCompleted)
+
+	if err := i.jobRepo.Save(ctx, latest); err != nil {
+		log.Errorfc(ctx, "job: failed to save preview job %s: %v", jobID, err)
+		return
+	}
+
+	if err := i.handleJobCompletion(ctx, latest); err != nil {
+		log.Errorfc(ctx, "job: completion handling failed for preview job %s: %v", jobID, err)
 	}
 	i.subscriptions.Notify(jobID.String(), latest.Status())
 }

--- a/server/api/internal/usecase/interactor/previewschema_test.go
+++ b/server/api/internal/usecase/interactor/previewschema_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"io"
 	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	accountsid "github.com/reearth/reearth-accounts/server/pkg/id"
@@ -17,8 +19,10 @@ import (
 	"github.com/reearth/reearth-flow/api/pkg/file"
 	"github.com/reearth/reearth-flow/api/pkg/id"
 	"github.com/reearth/reearth-flow/api/pkg/job"
+	"github.com/reearth/reearth-flow/api/pkg/job/monitor"
 	"github.com/reearth/reearth-flow/api/pkg/parameter"
 	"github.com/reearth/reearth-flow/api/pkg/project"
+	"github.com/reearth/reearth-flow/api/pkg/subscription"
 	"github.com/reearth/reearth-flow/api/pkg/websocket"
 	"github.com/reearth/reearthx/appx"
 	"github.com/reearth/reearthx/usecasex"
@@ -105,15 +109,15 @@ func (f *previewFakeFile) ReadArtifact(context.Context, string) (io.ReadCloser, 
 	panic("unused")
 }
 func (f *previewFakeFile) ListJobArtifacts(context.Context, string) ([]string, error) {
-	panic("unused")
+	return nil, nil
 }
-func (f *previewFakeFile) GetJobLogURL(string) string                              { panic("unused") }
+func (f *previewFakeFile) GetJobLogURL(string) string                              { return "" }
 func (f *previewFakeFile) CheckJobLogExists(context.Context, string) (bool, error) { panic("unused") }
-func (f *previewFakeFile) GetJobWorkerLogURL(string) string                        { panic("unused") }
+func (f *previewFakeFile) GetJobWorkerLogURL(string) string                        { return "" }
 func (f *previewFakeFile) CheckJobWorkerLogExists(context.Context, string) (bool, error) {
 	panic("unused")
 }
-func (f *previewFakeFile) GetJobUserFacingLogURL(string) string { panic("unused") }
+func (f *previewFakeFile) GetJobUserFacingLogURL(string) string { return "" }
 func (f *previewFakeFile) CheckJobUserFacingLogExists(context.Context, string) (bool, error) {
 	panic("unused")
 }
@@ -365,4 +369,56 @@ func TestParametersToVariables(t *testing.T) {
 	assert.Equal(t, "file:///a.geojson", vars["dataset"])
 	_, ok := vars["noDefault"]
 	assert.False(t, ok, "parameter with nil default must be omitted, not set to \"<nil>\"")
+}
+
+// A successful preview probe is finalized from the synchronous /probe-schema
+// response, since the read-only probe emits no Redis completion event. The job
+// must reach COMPLETED, surface the report via outputURLs, and push COMPLETED to
+// the jobStatus subscription (the bug left it forever PENDING).
+func TestJob_completeCloudRunPreviewJob(t *testing.T) {
+	ctx := context.Background()
+	jobRepo := memory.NewJob()
+
+	debug := true
+	j, err := job.New().
+		NewID().
+		Debug(&debug).
+		Mode(job.ModePreviewSchema).
+		Workspace(project.NewWorkspaceID()).
+		Status(job.StatusPending).
+		StartedAt(time.Now()).
+		Build()
+	assert.NoError(t, err)
+	assert.NoError(t, jobRepo.Save(ctx, j))
+
+	uc := &Job{
+		jobRepo:       jobRepo,
+		transaction:   &usecasex.NopTransaction{},
+		file:          &previewFakeFile{},
+		monitor:       monitor.NewMonitor(),
+		subscriptions: subscription.NewJobManager(),
+		jobLocks:      map[string]*sync.Mutex{},
+	}
+
+	// Subscribe before finalizing: the fix must push COMPLETED here.
+	ch := uc.subscriptions.Subscribe(j.ID().String())
+
+	uc.completeCloudRunPreviewJob(ctx, j.ID())
+
+	select {
+	case s := <-ch:
+		assert.Equal(t, job.StatusCompleted, s)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a COMPLETED notification on the subscription, got none")
+	}
+
+	saved, err := jobRepo.FindByID(ctx, j.ID())
+	assert.NoError(t, err)
+	assert.Equal(t, job.StatusCompleted, saved.Status())
+	assert.NotNil(t, saved.CompletedAt())
+	// The SchemaReport is surfaced via outputURLs (no dedicated Job field).
+	assert.Equal(t,
+		[]string{"gs://bucket/artifacts/" + j.ID().String() + "/schema/schema-report.json"},
+		saved.OutputURLs(),
+	)
 }


### PR DESCRIPTION
## Summary

Fixes preview-schema jobs hanging forever at **`PENDING`** (the `jobStatus` subscription never resolves), the issue seen after #2180 fixed the report write.

## Root cause

A preview job is dispatched to the worker's `POST /probe-schema` route, which runs the **read-only** probe synchronously and returns the terminal status in the HTTP body — it does **not** publish a Redis `JobComplete` event like the `/run` path.

`PreviewSchemaCloudRunWorker` only acted on failure:
```go
status, err := i.cloudRunWorker.PreviewSchema(ctx, p)
if err != nil || status == gateway.JobStatusFailed { i.failCloudRunJob(...) }
// on COMPLETED: nothing — "trust the monitoring loop"
```
…but `checkJobStatus` finalizes a Cloud Run job only when a Redis worker event arrives (`statusChanged = batchStatusChanged || workerEvent != nil`; a preview job has an empty `GCPJobID`, so no Batch polling, and no event). So a **successful** probe never reached a terminal state — the job sat at `PENDING` until the 24h monitor timeout.

## Fix

Finalize preview jobs directly from the synchronous HTTP response (the authoritative result), instead of relying on the Redis/monitoring path:
- `status == COMPLETED` → new `completeCloudRunPreviewJob`: mark the job `COMPLETED`, run `handleJobCompletion` (surfaces the `SchemaReport` via `outputURLs`), and `subscriptions.Notify` so the `jobStatus` subscription resolves. Mirrors `failCloudRunJob` (no grace/Redis check — the probe is synchronous).
- failure → existing `failCloudRunJob`.

## Test

`TestJob_completeCloudRunPreviewJob` asserts a completed preview: job → `COMPLETED`, `completedAt` set, `outputURLs` = the report URL, **and** the subscription receives `COMPLETED` (directly guarding the forever-pending regression).

Build / `gofmt` / full `internal/usecase/interactor` suite green.
