### PR TITLE
fix(worker): publish JobCompleteEvent from probe-schema so preview jobs finalize

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6162,7 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "futures",
  "once_cell",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "approx",
  "async-trait",
@@ -6228,7 +6228,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "Inflector",
  "approx",
@@ -6286,7 +6286,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6307,7 +6307,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6374,7 +6374,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6424,7 +6424,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "image 0.25.10",
  "rstar 0.12.2",
@@ -6435,7 +6435,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "bytes",
  "clap",
@@ -6475,7 +6475,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6518,7 +6518,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "chrono",
  "futures",
@@ -6532,7 +6532,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6561,7 +6561,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -6574,7 +6574,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "approx",
  "bvh",
@@ -6604,7 +6604,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6638,7 +6638,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6647,7 +6647,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6677,7 +6677,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6714,7 +6714,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -6731,7 +6731,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -6743,7 +6743,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "bytes",
  "futures",
@@ -6760,7 +6760,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "bytes",
  "futures",
@@ -6779,7 +6779,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -6793,7 +6793,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6828,7 +6828,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -6866,7 +6866,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.411"
+version = "0.0.412"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.411"
+version = "0.0.412"
 
 [profile.dev]
 opt-level = 0

--- a/engine/worker/src/probe_schema.rs
+++ b/engine/worker/src/probe_schema.rs
@@ -16,6 +16,9 @@ use tracing::debug;
 
 use crate::factory::ALL_ACTION_FACTORIES;
 use reearth_flow_worker::errors::{Error, Result};
+use reearth_flow_worker::pubsub::{PubSubBackend, Publisher};
+use reearth_flow_worker::types::job_complete_event::{JobCompleteEvent, JobResult};
+use uuid::Uuid;
 
 const DEFAULT_SAMPLE_SIZE: usize = 10;
 
@@ -36,6 +39,8 @@ pub fn build_probe_schema_command() -> Command {
         .arg(vars_arg())
         .arg(sample_size_arg())
         .arg(report_url_arg())
+        .arg(job_id_arg())
+        .arg(pubsub_backend_arg())
 }
 
 fn workflow_arg() -> Arg {
@@ -72,12 +77,32 @@ fn report_url_arg() -> Arg {
         .display_order(4)
 }
 
+fn job_id_arg() -> Arg {
+    Arg::new("job_id")
+        .long("job-id")
+        .help("Job id; published in the completion event so the server finalizes the job")
+        .required(true)
+        .display_order(5)
+}
+
+fn pubsub_backend_arg() -> Arg {
+    Arg::new("pubsub_backend")
+        .long("pubsub-backend")
+        .help("Pub/Sub backend for the job-complete event (google|noop)")
+        .env("FLOW_WORKER_PUBSUB_BACKEND")
+        .default_value("noop")
+        .required(false)
+        .display_order(6)
+}
+
 #[derive(Debug, Eq, PartialEq)]
 pub struct ProbeSchemaCommand {
     workflow: String,
     vars: HashMap<String, String>,
     sample_size: usize,
     report_url: String,
+    job_id: Uuid,
+    pubsub_backend: String,
 }
 
 impl ProbeSchemaCommand {
@@ -109,17 +134,27 @@ impl ProbeSchemaCommand {
         let report_url = matches
             .remove_one::<String>("report_url")
             .ok_or(Error::init("No report url provided"))?;
+        let job_id = matches
+            .remove_one::<String>("job_id")
+            .ok_or(Error::init("No job id provided"))?;
+        let job_id =
+            Uuid::from_str(&job_id).map_err(|e| Error::init(format!("Invalid job-id: {e}")))?;
+        let pubsub_backend = matches
+            .remove_one::<String>("pubsub_backend")
+            .unwrap_or_else(|| "noop".to_string());
         Ok(Self {
             workflow,
             vars,
             sample_size,
             report_url,
+            job_id,
+            pubsub_backend,
         })
     }
 
     /// Build the schema report. Mirrors `cli::probe_schema::build_report` but
     /// uses the worker's `ALL_ACTION_FACTORIES`.
-    fn build_report(&self, storage_resolver: &StorageResolver) -> Result<SchemaReport> {
+    fn build_report(&self, storage_resolver: &StorageResolver) -> Result<(Uuid, SchemaReport)> {
         let (yaml_content, base_dir) = if self.workflow == "-" {
             let content = io::read_to_string(io::stdin()).map_err(Error::init)?;
             (content, None)
@@ -150,6 +185,10 @@ impl ProbeSchemaCommand {
         workflow
             .merge_with(self.vars.clone())
             .map_err(Error::init)?;
+
+        // Captured before `workflow` is moved into `from_graphs`; needed for the
+        // completion event so the server can correlate the job.
+        let workflow_id = workflow.id;
 
         // Capture node id -> display name before `workflow` is moved into `from_graphs`.
         let mut names: HashMap<String, String> = HashMap::new();
@@ -195,31 +234,56 @@ impl ProbeSchemaCommand {
             );
         }
 
-        Ok(SchemaReport {
-            version: 1,
-            sample_size: self.sample_size,
-            nodes,
-        })
+        Ok((
+            workflow_id,
+            SchemaReport {
+                version: 1,
+                sample_size: self.sample_size,
+                nodes,
+            },
+        ))
     }
 
     pub fn execute(&self) -> Result<()> {
         debug!(args = ?self, "probe-schema");
         let storage_resolver = StorageResolver::new();
-        let report = self.build_report(&storage_resolver)?;
-        let json = serde_json::to_vec_pretty(&report).map_err(Error::run)?;
-
-        let report_uri = Uri::from_str(self.report_url.as_str()).map_err(Error::init)?;
-        let storage = storage_resolver.resolve(&report_uri).map_err(Error::init)?;
-        // Write via the async `put`, exactly as the run path's `upload_artifact`
-        // does: object-store backends like GCS do not implement OpenDAL's
-        // blocking layer, so `put_sync` fails with `Unsupported (persistent) at
-        // blocking_write`. `execute` runs in a sync context (worker `main` is
-        // not async), so drive the async write on a Tokio runtime, mirroring
-        // `RunWorkerCommand::execute`.
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .map_err(Error::FailedToCreateTokioRuntime)?;
+
+        let outcome = self.run_probe(&storage_resolver, &runtime);
+
+        // Publish a JobCompleteEvent so the server's monitoring loop finalizes
+        // the job, exactly as a debug run does. The probe path is otherwise
+        // silent, which would leave the job PENDING forever. Publishing must not
+        // mask the probe's own error: log a publish failure and propagate the
+        // original outcome.
+        let (workflow_id, result) = match &outcome {
+            Ok(id) => (*id, JobResult::Success),
+            Err(_) => (Uuid::nil(), JobResult::Failed),
+        };
+        if let Err(e) = runtime.block_on(self.publish_complete(workflow_id, result)) {
+            tracing::error!("probe-schema: failed to publish job-complete event: {e:?}");
+        }
+
+        outcome.map(|_| ())
+    }
+
+    /// Run the probe and write the report. Returns the workflow id on success.
+    fn run_probe(
+        &self,
+        storage_resolver: &StorageResolver,
+        runtime: &tokio::runtime::Runtime,
+    ) -> Result<Uuid> {
+        let (workflow_id, report) = self.build_report(storage_resolver)?;
+        let json = serde_json::to_vec_pretty(&report).map_err(Error::run)?;
+
+        let report_uri = Uri::from_str(self.report_url.as_str()).map_err(Error::init)?;
+        let storage = storage_resolver.resolve(&report_uri).map_err(Error::init)?;
+        // Write via the async `put`: object-store backends like GCS do not
+        // implement OpenDAL's blocking layer, so `put_sync` fails with
+        // `Unsupported (persistent) at blocking_write`.
         runtime.block_on(async {
             storage
                 .put(report_uri.path().as_path(), json.into())
@@ -227,7 +291,23 @@ impl ProbeSchemaCommand {
                 .map_err(Error::run)
         })?;
         tracing::info!("Wrote probe-schema report to {}", self.report_url);
-        Ok(())
+        Ok(workflow_id)
+    }
+
+    /// Publish the terminal JobCompleteEvent on the same Pub/Sub backend a run
+    /// uses, so the server's monitoring loop finalizes the preview job.
+    async fn publish_complete(&self, workflow_id: Uuid, result: JobResult) -> Result<()> {
+        let pubsub = PubSubBackend::try_from(self.pubsub_backend.as_str())
+            .await
+            .map_err(|e| Error::run(format!("{e:?}")))?;
+        let event = JobCompleteEvent::new(workflow_id, self.job_id, result);
+        match pubsub {
+            PubSubBackend::Google(p) => p.publish(event).await.map_err(Error::run),
+            PubSubBackend::Noop(p) => p
+                .publish(event)
+                .await
+                .map_err(|e| Error::run(format!("{e:?}"))),
+        }
     }
 }
 
@@ -339,6 +419,9 @@ graphs:
             vars: HashMap::new(),
             sample_size: 10,
             report_url,
+            job_id: Uuid::from_str(WORKFLOW_ID).expect("valid uuid"),
+            // noop backend: execute() publishes a (no-op) completion event.
+            pubsub_backend: "noop".to_string(),
         };
         cmd.execute().expect("probe-schema execute succeeds");
 

--- a/engine/worker/src/probe_schema.rs
+++ b/engine/worker/src/probe_schema.rs
@@ -90,7 +90,7 @@ fn pubsub_backend_arg() -> Arg {
         .long("pubsub-backend")
         .help("Pub/Sub backend for the job-complete event (google|noop)")
         .env("FLOW_WORKER_PUBSUB_BACKEND")
-        .default_value("noop")
+        .default_value("google")
         .required(false)
         .display_order(6)
 }
@@ -141,7 +141,7 @@ impl ProbeSchemaCommand {
             Uuid::from_str(&job_id).map_err(|e| Error::init(format!("Invalid job-id: {e}")))?;
         let pubsub_backend = matches
             .remove_one::<String>("pubsub_backend")
-            .unwrap_or_else(|| "noop".to_string());
+            .unwrap_or_else(|| "google".to_string());
         Ok(Self {
             workflow,
             vars,
@@ -186,8 +186,7 @@ impl ProbeSchemaCommand {
             .merge_with(self.vars.clone())
             .map_err(Error::init)?;
 
-        // Captured before `workflow` is moved into `from_graphs`; needed for the
-        // completion event so the server can correlate the job.
+        // Captured before `workflow` is moved into `from_graphs`; used in the event.
         let workflow_id = workflow.id;
 
         // Capture node id -> display name before `workflow` is moved into `from_graphs`.
@@ -253,21 +252,19 @@ impl ProbeSchemaCommand {
             .map_err(Error::FailedToCreateTokioRuntime)?;
 
         let outcome = self.run_probe(&storage_resolver, &runtime);
-
-        // Publish a JobCompleteEvent so the server's monitoring loop finalizes
-        // the job, exactly as a debug run does. The probe path is otherwise
-        // silent, which would leave the job PENDING forever. Publishing must not
-        // mask the probe's own error: log a publish failure and propagate the
-        // original outcome.
         let (workflow_id, result) = match &outcome {
             Ok(id) => (*id, JobResult::Success),
             Err(_) => (Uuid::nil(), JobResult::Failed),
         };
-        if let Err(e) = runtime.block_on(self.publish_complete(workflow_id, result)) {
-            tracing::error!("probe-schema: failed to publish job-complete event: {e:?}");
-        }
+        let published = runtime.block_on(self.publish_complete(workflow_id, result));
 
-        outcome.map(|_| ())
+        // This event is the only thing that finalizes the job, so on a
+        // successful probe a publish failure is fatal: swallowing it would
+        // report COMPLETED to the server while it never sees the event, leaving
+        // the job PENDING. A probe failure is the primary error; publishing its
+        // failed event is best effort.
+        outcome?;
+        published
     }
 
     /// Run the probe and write the report. Returns the workflow id on success.

--- a/engine/worker/src/wrapper.rs
+++ b/engine/worker/src/wrapper.rs
@@ -47,6 +47,8 @@ pub fn build_probe_args(req: &ProbeRequest) -> Vec<String> {
         req.workflow_url.clone(),
         "--report-url".to_string(),
         req.report_url.clone(),
+        "--job-id".to_string(),
+        req.job_id.clone(),
     ];
     for (k, v) in &req.variables {
         args.push("--var".to_string());
@@ -201,6 +203,8 @@ mod tests {
                 "gs://b/wf.yml",
                 "--report-url",
                 "gs://b/reports/j1.json",
+                "--job-id",
+                "j1",
             ]
         );
     }

--- a/engine/worker/src/wrapper.rs
+++ b/engine/worker/src/wrapper.rs
@@ -27,7 +27,8 @@ pub struct RunRequest {
 /// Probe is read-only and fast: no work-root, no cancel-flag, no metadata.
 #[derive(Debug, Deserialize, Clone)]
 pub struct ProbeRequest {
-    /// Validated for path safety but not passed to the worker CLI.
+    /// Validated for path safety and passed to the worker CLI as `--job-id`
+    /// (published in the completion event so the server can finalize the job).
     pub job_id: String,
     pub workflow_url: String,
     #[serde(default)]


### PR DESCRIPTION
## Summary

Makes `previewSchema` (preview-schema) jobs complete through the **same async path as a debug run**, fixing jobs hanging forever at `PENDING` (the `jobStatus` subscription never resolves).

## Root cause

The server already expects the worker to drive completion — `PreviewSchemaCloudRunWorker`'s own comment says *"the worker publishes its result and the standard monitoring loop finalizes the job; only an infra failure is finalized here."* But the `probe-schema` subcommand wrote its report and **published nothing**, unlike the run command (`command.rs` publishes a `JobCompleteEvent`). So `checkJobStatus` — which finalizes a Cloud Run job only on a Redis `JobCompleteEvent` (empty `GCPJobID` ⇒ no Batch polling) — never had an event to act on, and a successful probe sat at `PENDING` until the 24h monitor timeout.

## Fix (worker-only)

`probe-schema` now publishes a `JobCompleteEvent{workflow_id, job_id, success|failed}` on the same Pub/Sub backend a run uses, right after writing the report:
- new args: `--job-id` (passed by the worker server) and `--pubsub-backend` (env `FLOW_WORKER_PUBSUB_BACKEND`, **default `google`** to match the run command; tests/local override to `noop`);
- the publish is driven on the existing Tokio runtime. On a **successful** probe a publish failure is **fatal** (mirrors `command.rs`) — otherwise the wrapper would report `COMPLETED` while the server never sees the event. A probe failure is the primary error; publishing its failed event is best effort.

The existing subscriber → Redis → monitoring loop then finalizes the job (sets `outputURLs` to the report, notifies the subscription) — exactly as a debug run does. **No server change**: `main`'s `PreviewSchemaCloudRunWorker` already handles this.

## Why not the server-side finalize (#2189)

#2189 special-cased completion in the server (finalize from the synchronous HTTP response). That diverges from how every other Cloud Run job completes and from the "exactly like debug runs" intent. This is the consistent fix; **#2189 is closed in favor of it.**

## Tests

Worker build / clippy / fmt clean; the `execute` test publishes to the `noop` backend; `build_probe_args` test covers `--job-id`. Engine bumped to `0.0.412`.
