### PR TITLE
fix(ui): remove isConnectable prop from Port component [FLOW-DEV-205]

### DIFF
--- a/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/CustomHandle/Port/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/CustomHandle/Port/index.tsx
@@ -34,7 +34,6 @@ const Port: React.FC<Props> = ({ nodeId, nodeData, portName, readonly }) => {
         type="source"
         className="right-1 z-10 w-[8px] rounded-none transition-colors"
         position={Position.Right}
-        isConnectable={hasIntermediateData ? 1 : 0}
       />
       <div className="group flex w-full min-w-0 -translate-x-0.5 items-center justify-end gap-1">
         <div


### PR DESCRIPTION
# Overview

## What I've done
- Removed `isConnectable={hasIntermediateData ? 1 : 0}` from the output `CustomHandle` in `Port`.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
