### PR TITLE
docs(engine): FlowExpr update and base language definition

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "futures",
  "once_cell",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "approx",
  "async-trait",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "Inflector",
  "approx",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "bytes",
  "clap",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "approx",
  "bvh",
@@ -5053,7 +5053,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "bytes",
  "futures",
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "bytes",
  "futures",
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5239,7 +5239,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "ahash",
  "bytes",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.417"
+version = "0.0.418"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-01-common.yml
@@ -699,7 +699,7 @@ nodes:
               total = 0;
               for key in attributes {
                 v = attributes[key];
-                if type(v) == "int" {
+                if type(v) == int {
                   total += v;
                 }
               }

--- a/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-02-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-02-common.yml
@@ -238,9 +238,9 @@ nodes:
               data = attributes.get("dataFileData");
               if data != null {
                 for item in data {
-                  if type(item) == "dict" {
+                  if type(item) == dict {
                     count = item.get("count");
-                    if count != null and type(count) == "int" {
+                    if count != null and type(count) == int {
                       total += count;
                     }
                   }

--- a/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-02-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau4/quality-check/01-02-common.yml
@@ -238,7 +238,7 @@ nodes:
               data = attributes.get("dataFileData");
               if data != null {
                 for item in data {
-                  if type(item) == "map" {
+                  if type(item) == "dict" {
                     count = item.get("count");
                     if count != null and type(count) == "int" {
                       total += count;

--- a/engine/runtime/examples/fixture/graphs/plateau6/quality-check/01-01-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau6/quality-check/01-01-common.yml
@@ -699,7 +699,7 @@ nodes:
               total = 0;
               for key in attributes {
                 v = attributes[key];
-                if type(v) == "int" {
+                if type(v) == int {
                   total += v;
                 }
               }

--- a/engine/runtime/examples/fixture/graphs/plateau6/quality-check/01-02-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau6/quality-check/01-02-common.yml
@@ -238,9 +238,9 @@ nodes:
               data = attributes.get("dataFileData");
               if data != null {
                 for item in data {
-                  if type(item) == "dict" {
+                  if type(item) == dict {
                     count = item.get("count");
-                    if count != null and type(count) == "int" {
+                    if count != null and type(count) == int {
                       total += count;
                     }
                   }

--- a/engine/runtime/examples/fixture/graphs/plateau6/quality-check/01-02-common.yml
+++ b/engine/runtime/examples/fixture/graphs/plateau6/quality-check/01-02-common.yml
@@ -238,7 +238,7 @@ nodes:
               data = attributes.get("dataFileData");
               if data != null {
                 for item in data {
-                  if type(item) == "map" {
+                  if type(item) == "dict" {
                     count = item.get("count");
                     if count != null and type(count) == "int" {
                       total += count;

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
@@ -174,7 +174,7 @@ graphs:
             cga = attributes["cityGmlAttributes"];
             uro_list = cga.get("uro:BuildingIDAttribute");
             gml_city_code = null;
-            if uro_list and type(uro_list) == "list" {
+            if uro_list and type(uro_list) == list {
               gml_city_code = uro_list[0].get("uro:city_code");
             }
             gml_city_code or attributes["cityCode"]
@@ -186,7 +186,7 @@ graphs:
             cga = attributes["cityGmlAttributes"];
             uro_list = cga.get("uro:BuildingIDAttribute");
             gml_city_name = null;
-            if uro_list and type(uro_list) == "list" {
+            if uro_list and type(uro_list) == list {
               gml_city_name = uro_list[0].get("uro:city")
             }
             gml_city_name or attributes.get("cityName")

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
@@ -75,7 +75,7 @@ graphs:
                   cga = attributes["cityGmlAttributes"];
                   uro_list = cga.get("uro:BuildingIDAttribute");
                   gml_city_code = null;
-                  if uro_list and type(uro_list) == "list" {
+                  if uro_list and type(uro_list) == list {
                     gml_city_code = uro_list[0].get("uro:city_code");
                   }
                   gml_city_code or attributes["cityCode"]
@@ -88,7 +88,7 @@ graphs:
                   cga = attributes["cityGmlAttributes"];
                   uro_list = cga.get("uro:BuildingIDAttribute");
                   gml_city_name = null;
-                  if uro_list and type(uro_list) == "list" {
+                  if uro_list and type(uro_list) == list {
                     gml_city_name = uro_list[0].get("uro:city")
                   }
                   gml_city_name or attributes.get("cityName")

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
@@ -971,7 +971,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -1493,9 +1493,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/01-common.yml
@@ -1493,7 +1493,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -974,7 +974,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -1496,9 +1496,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }
@@ -2838,11 +2838,11 @@ graphs:
             part_id = building_id_attr.get("uro:partID", "");
             gml_name = attributes.get("gmlName", "");
             building_id_valid = Regex(r"^\d{5}-bldg-\d+$").find(building_id) != null;
-            branch_id_valid = branch_id == "" or type(branch_id) == "int";
+            branch_id_valid = branch_id == "" or type(branch_id) == int;
             if gml_name == "bldg:Building" {
               part_id_valid = part_id == "";
             } else if gml_name == "bldg:BuildingPart" {
-              part_id_valid = type(part_id) == "int";
+              part_id_valid = type(part_id) == int;
             } else {
               part_id_valid = false;
             }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg.yml
@@ -1496,7 +1496,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/format_checks.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/02-bldg/format_checks.yml
@@ -258,11 +258,11 @@ nodes:
               part_id = building_id_attr.get("uro:partID", "");
               gml_name = attributes.get("gmlName", "");
               building_id_valid = Regex(r"^\d{5}-bldg-\d+$").find(building_id) != null;
-              branch_id_valid = branch_id == "" or type(branch_id) == "int";
+              branch_id_valid = branch_id == "" or type(branch_id) == int;
               if gml_name == "bldg:Building" {
                 part_id_valid = part_id == "";
               } else if gml_name == "bldg:BuildingPart" {
-                part_id_valid = type(part_id) == "int";
+                part_id_valid = type(part_id) == int;
               } else {
                 part_id_valid = false;
               }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -1654,7 +1654,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -2176,9 +2176,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -2176,7 +2176,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
@@ -1651,7 +1651,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -2173,9 +2173,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/04-frn-veg.yml
@@ -2173,7 +2173,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
@@ -1652,7 +1652,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -2174,9 +2174,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/05-luse-urf-area.yml
@@ -2174,7 +2174,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
@@ -1500,7 +1500,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
@@ -978,7 +978,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -1500,9 +1500,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
@@ -1650,7 +1650,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -2172,9 +2172,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/07-lsld.yml
@@ -2172,7 +2172,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
@@ -974,7 +974,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -1496,9 +1496,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/08-dem.yml
@@ -1496,7 +1496,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
@@ -3348,7 +3348,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/09-brid-tun-ubld.yml
@@ -2826,7 +2826,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -3348,9 +3348,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
@@ -974,7 +974,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -1496,9 +1496,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/10-cons.yml
@@ -1496,7 +1496,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
@@ -974,7 +974,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -1496,9 +1496,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/11-wtr.yml
@@ -1496,7 +1496,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
@@ -1494,7 +1494,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/12-unf.yml
@@ -972,7 +972,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -1494,9 +1494,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
@@ -974,7 +974,7 @@ graphs:
             total = 0;
             for key in attributes {
               v = attributes[key];
-              if type(v) == "int" {
+              if type(v) == int {
                 total += v;
               }
             }
@@ -1496,9 +1496,9 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "dict" {
+                if type(item) == dict {
                   count = item.get("count");
-                  if count != null and type(count) == "int" {
+                  if count != null and type(count) == int {
                     total += count;
                   }
                 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/13-gen.yml
@@ -1496,7 +1496,7 @@ graphs:
             data = attributes.get("dataFileData");
             if data != null {
               for item in data {
-                if type(item) == "map" {
+                if type(item) == "dict" {
                   count = item.get("count");
                   if count != null and type(count) == "int" {
                     total += count;

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/adequate_place_judgement.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/adequate_place_judgement.yml
@@ -400,7 +400,7 @@ nodes:
                 any_active = m.get("木造・土蔵造") or m.get("鉄骨鉄筋コンクリート造") or m.get("鉄筋コンクリート造") or m.get("鉄骨造") or m.get("軽量鉄骨造") or m.get("レンガ造等") or m.get("非木造") or m.get("不明");
                 if not any_active { "-" } else {
                   st_raw = attributes.get("structureType", "-1");
-                  if type(st_raw) == "string" { st = int(st_raw); } else { st = st_raw; }
+                  if type(st_raw) == "str" { st = int(st_raw); } else { st = st_raw; }
                   if st == 601 { excluded = m.get("木造・土蔵造"); }
                   else if st == 602 { excluded = m.get("鉄骨鉄筋コンクリート造"); }
                   else if st == 603 { excluded = m.get("鉄筋コンクリート造"); }

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/adequate_place_judgement.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/adequate_place_judgement.yml
@@ -400,7 +400,7 @@ nodes:
                 any_active = m.get("木造・土蔵造") or m.get("鉄骨鉄筋コンクリート造") or m.get("鉄筋コンクリート造") or m.get("鉄骨造") or m.get("軽量鉄骨造") or m.get("レンガ造等") or m.get("非木造") or m.get("不明");
                 if not any_active { "-" } else {
                   st_raw = attributes.get("structureType", "-1");
-                  if type(st_raw) == "str" { st = int(st_raw); } else { st = st_raw; }
+                  if type(st_raw) == str { st = int(st_raw); } else { st = st_raw; }
                   if st == 601 { excluded = m.get("木造・土蔵造"); }
                   else if st == 602 { excluded = m.get("鉄骨鉄筋コンクリート造"); }
                   else if st == 603 { excluded = m.get("鉄筋コンクリート造"); }

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
@@ -653,7 +653,7 @@ graphs:
               any_active = m.get("木造・土蔵造") or m.get("鉄骨鉄筋コンクリート造") or m.get("鉄筋コンクリート造") or m.get("鉄骨造") or m.get("軽量鉄骨造") or m.get("レンガ造等") or m.get("非木造") or m.get("不明");
               if not any_active { "-" } else {
                 st_raw = attributes.get("structureType", "-1");
-                if type(st_raw) == "str" { st = int(st_raw); } else { st = st_raw; }
+                if type(st_raw) == str { st = int(st_raw); } else { st = st_raw; }
                 if st == 601 { excluded = m.get("木造・土蔵造"); }
                 else if st == 602 { excluded = m.get("鉄骨鉄筋コンクリート造"); }
                 else if st == 603 { excluded = m.get("鉄筋コンクリート造"); }

--- a/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
+++ b/engine/runtime/examples/fixture/workflow/solar-radiation/solar-radiation.yml
@@ -653,7 +653,7 @@ graphs:
               any_active = m.get("木造・土蔵造") or m.get("鉄骨鉄筋コンクリート造") or m.get("鉄筋コンクリート造") or m.get("鉄骨造") or m.get("軽量鉄骨造") or m.get("レンガ造等") or m.get("非木造") or m.get("不明");
               if not any_active { "-" } else {
                 st_raw = attributes.get("structureType", "-1");
-                if type(st_raw) == "string" { st = int(st_raw); } else { st = st_raw; }
+                if type(st_raw) == "str" { st = int(st_raw); } else { st = st_raw; }
                 if st == 601 { excluded = m.get("木造・土蔵造"); }
                 else if st == 602 { excluded = m.get("鉄骨鉄筋コンクリート造"); }
                 else if st == 603 { excluded = m.get("鉄筋コンクリート造"); }

--- a/engine/runtime/expr/docs/design.md
+++ b/engine/runtime/expr/docs/design.md
@@ -2,6 +2,8 @@
 
 This document records non-obvious design decisions for cross-referencing from source comments.
 
+DEPRECATED: use comments directly if it is implementation specific; use spec if it is a language feature.
+
 ## No while-loop iteration limit {#no-while-iteration-limit}
 
 Reviewers sometimes suggest capping the number of `while` iterations as a safety measure. This is intentionally not done, for several reasons:
@@ -10,16 +12,6 @@ Reviewers sometimes suggest capping the number of `while` iterations as a safety
 2. **Wrong abstraction level**: workflow authors often cannot predict input scale, so any hard number will either be too small for legitimate workloads or too large to provide real protection.
 3. **Limited benefit**: an ill-formed expression that loops forever produces no useful output regardless — an early stop does not help the workflow recover. Action-level timeouts in the executor framework are the correct and consistent place to enforce wall-clock limits.
 4. **Turing-completeness expectation**: once a language has unbounded loops, adding a hidden iteration cap is surprising and breaks reasonable user expectations.
-
-## No cycle detection; cyclic references are unsupported {#no-cycle-detection}
-
-Reviewers sometimes flag the lack of cycle detection on `Rc`-backed `Array` and `Map` values. This is intentional.
-
-**Why not add runtime detection?** Sound cycle detection requires O(n) work on every assignment — a per-write path-stack traversal. That is unacceptable for an expression language where individual expressions are expected to be fast and short-lived.
-
-**Why not a GC?** A tracing GC would require arena-backing all values and replacing `Rc` entirely, adding significant implementation complexity and runtime overhead. Given that realistic workflow expressions have no use case for cyclic references, that complexity is not justified.
-
-**`Rc` is the right fit**: `Rc` covers all legitimate use cases. Cycle avoidance is the same contract users already accept in any `Rc`-based system without a tracing GC. Constructing cyclic values is an unsupported use case and the behavior is undefined.
 
 ## `find()` null-as-falsy is intentional; empty-string matches indicate a broken pattern {#regex-find-null-falsy}
 

--- a/engine/runtime/expr/docs/spec/1-base-language.md
+++ b/engine/runtime/expr/docs/spec/1-base-language.md
@@ -216,7 +216,7 @@ Without an `else` branch, the result is `null` when the condition is false.
 - `str`: `i` is an integer index into the Unicode codepoints, returning a single-character string. Negative indices count from the end.
 - `dict`: `i` is a key.
 
-Index failure (missing key, out of scope, wrong type) should trigger evaluation error.
+Index failure (missing key, out of bounds, wrong type) should trigger an evaluation error.
 
 ## scoping
 

--- a/engine/runtime/expr/docs/spec/1-base-language.md
+++ b/engine/runtime/expr/docs/spec/1-base-language.md
@@ -21,7 +21,7 @@ A 64-bit signed integer. Integer literals match one of:
 - octal: `0[oO][0-7]+`
 - hexadecimal: `0[xX][0-9a-fA-F]+`
 
-### Constructor
+### constructor
 
 `int` is a type object. Calling `int(value)` constructs an integer based on the type of `value`:
 
@@ -36,21 +36,93 @@ A 64-bit signed integer. Integer literals match one of:
 A 64-bit IEEE 754 double-precision floating-point number.
 Float literals must contain a decimal point or an exponent (e.g. `1.0`, `1e10`).
 
+### constructor
+
+`float` is a type object. Calling `float(value)` constructs a float based on the type of `value`:
+
+- `float`: same value
+- `int`: same numeric value
+- `bool`: `1.0` or `0.0`
+- `string`: decimal float parsed from the trimmed string; error if not parseable
+- no argument: `0.0`
+
 ## string type
 
 An immutable sequence of Unicode codepoints.
 String literals are enclosed in double quotes (e.g. `"hello"`).
+
+### constructor
+
+`str` is a type object. Calling `str(value)` constructs a string based on the type of `value`:
+
+- `string`: same value
+- `int`: decimal representation
+- `float`: a decimal representation; the exact format is unspecified
+- `bool`: `"true"` or `"false"`
+- `null`: `"null"`
+- no argument: `""`
 
 ## list type
 
 A mutable, ordered sequence of values.
 List literals use square brackets (e.g. `[1, "two", true]`). Elements may be of any type.
 
+### constructor
+
+`list` is a type object. Calling `list(value)` constructs a list based on the type of `value`:
+
+- `list`: shallow copy
+- `string`: list of single-character strings, one per Unicode codepoint
+- `dict`: list of keys
+- no argument: `[]`
+
 ## dictionary type
 
 A mutable, ordered map from string keys to values. Other key types are undefined.
 Dict literals use curly braces (e.g. `{"a": 1, "b": 2}`).
 Insertion order preservation is not stabilized by this spec.
+
+### constructor
+
+`dict` is a type object. Calling `dict(value)` constructs a dictionary based on the type of `value`:
+
+- `dict`: shallow copy
+- `list`: each element is a 2-element `[key, value]` list where `key` is a string
+- no argument: `{}`
+
+## operators
+
+Operators listed from lowest to highest precedence.
+`left` and `right` denote associativity; `prefix` denotes a unary operator with no left operand.
+
+- `or` (left)
+- `and` (left)
+- `not` (prefix)
+- `==` `!=` `in` `not in` (left)
+- `<` `<=` `>` `>=` (left)
+- `|` (left)
+- `^` (left)
+- `&` (left)
+- `<<` `>>` (left)
+- `+` `-` (left)
+- `*` `/` `//` `%` (left)
+- unary `-` (prefix)
+- `**` (right)
+
+## integer and float division
+
+`/` always returns a float, even when both operands are integers.
+`//` is floor division: the result is rounded toward negative infinity.
+`%` remainder has the same sign as the divisor.
+
+Division by zero is an error for `/`, `//`, and `%`.
+
+## bitwise operators
+
+`&`, `|`, `^`, `<<`, `>>` operate on integers. Both operands must be non-negative integers.
+
+Implementations must support left shift results across the full range of non-negative integers.
+Right shift (`>>`) with an amount >= 63 returns `0`.
 
 ## mutability
 

--- a/engine/runtime/expr/docs/spec/1-base-language.md
+++ b/engine/runtime/expr/docs/spec/1-base-language.md
@@ -1,6 +1,6 @@
-# Base Language
+# (DRAFT) Base Language
 
-**FlowExpr** is an expression language: every program is an expression that evaluates to a single value.
+**FlowExpr** is an expression language: every program evaluates to a single value.
 
 This document specifies the base language: basic types and operators, and the semantics.
 
@@ -11,6 +11,23 @@ This document specifies the base language: basic types and operators, and the se
 ## boolean type
 
 A boolean value, written `true` or `false`.
+
+### truthiness
+
+Truthiness by type:
+
+- `null`: always falsy
+- `bool`: its value
+- `int`: falsy if `0`, truthy otherwise
+- `float`: falsy if `0.0`, truthy otherwise
+- `str`: falsy if empty, truthy otherwise
+- `list`: falsy if empty, truthy otherwise
+- `dict`: falsy if empty, truthy otherwise
+
+### constructor
+
+`bool` is a type object. Calling `bool(value)` converts `value` to a boolean based on its truthiness.
+`bool()` with no argument returns `false`.
 
 ## integer type
 
@@ -51,6 +68,15 @@ Float literals must contain a decimal point or an exponent (e.g. `1.0`, `1e10`).
 An immutable sequence of Unicode codepoints.
 String literals are enclosed in double quotes (e.g. `"hello"`).
 
+### escape sequences
+
+Inside a double-quoted string, the following escape sequences are recognized:
+
+- `\n`: newline
+- `\t`: tab
+- `\\`: backslash
+- `\"`: double quote
+
 ### constructor
 
 `str` is a type object. Calling `str(value)` constructs a string based on the type of `value`:
@@ -90,6 +116,16 @@ Insertion order preservation is not stabilized by this spec.
 - `list`: each element is a 2-element `[key, value]` list where `key` is a string
 - no argument: `{}`
 
+## "type" type
+
+A type object represents a type. Type objects are first-class values and can be compared with `==`.
+
+### constructor
+
+`type` is a type object. Calling `type(value)` returns the type object of `value`.
+
+Built-in type objects: `null`, `bool`, `int`, `float`, `str`, `list`, `dict`, `type`.
+
 ## operators
 
 Operators listed from lowest to highest precedence.
@@ -109,7 +145,7 @@ Operators listed from lowest to highest precedence.
 - unary `-` (prefix)
 - `**` (right)
 
-## integer and float division
+### integer and float division
 
 `/` always returns a float, even when both operands are integers.
 `//` is floor division: the result is rounded toward negative infinity.
@@ -117,12 +153,48 @@ Operators listed from lowest to highest precedence.
 
 Division by zero is an error for `/`, `//`, and `%`.
 
-## bitwise operators
+### bitwise operators
 
 `&`, `|`, `^`, `<<`, `>>` operate on integers. Both operands must be non-negative integers.
 
-Implementations must support left shift results across the full range of non-negative integers.
-Right shift (`>>`) with an amount >= 63 returns `0`.
+Left shift results that exceed the positive range of the integer type are an error.
+Right shift with an amount at or beyond the positive range of the integer type returns `0`.
+
+## block
+
+A block is a sequence of expressions separated by `;`. It evaluates to its last expression.
+
+A trailing `;` appends an implicit `null`, making the block evaluate to `null`.
+
+## program
+
+A program is a block.
+
+## return
+
+`return v` exits early, producing `v` as the result of the program.
+
+## control flow
+
+### if
+
+`if cond { ... }` evaluates the block if `cond` is truthy and returns its value.
+Without an `else` branch, the result is `null` when the condition is false.
+`else if` chains are supported.
+
+### while
+
+`while cond { ... }` loops while `cond` is truthy.
+
+## assignment
+
+`=` is the assignment operator. It overwrites the existing binding of a name or creates a new one.
+
+`a[i] = v` assigns to an element: an integer index into a list, or a string key into a dict.
+
+## numeric coercion
+
+When one operand of an arithmetic or comparison operator is `int` and the other is `float`, the `int` is converted to `float` before the operation.
 
 ## mutability
 

--- a/engine/runtime/expr/docs/spec/1-base-language.md
+++ b/engine/runtime/expr/docs/spec/1-base-language.md
@@ -124,7 +124,7 @@ A type object represents a type. Type objects are first-class values and can be 
 
 `type` is a type object. Calling `type(value)` returns the type object of `value`.
 
-Built-in type objects: `null`, `bool`, `int`, `float`, `str`, `list`, `dict`, `type`.
+Built-in type objects: `bool`, `int`, `float`, `str`, `list`, `dict`, `type`.
 
 ## operators
 
@@ -160,6 +160,26 @@ Division by zero is an error for `/`, `//`, and `%`.
 Left shift results that exceed the positive range of the integer type are an error.
 Right shift with an amount at or beyond the positive range of the integer type returns `0`.
 
+### logical operators
+
+`and` and `or` return one of their operands, not a boolean:
+
+- `a and b`: returns `a` if falsy, otherwise `b`
+- `a or b`: returns `a` if truthy, otherwise `b`
+- `not a` returns the boolean negation of `a`'s truthiness.
+
+`and` and `or` are short-circuit.
+
+### membership operators
+
+`v in x` tests whether `v` is contained in `x`:
+
+- `list`: `v` equals any element
+- `str`: `v` is a substring (must be a `str`)
+- `dict`: `v` is a key
+
+`v not in x` is the negation of `v in x`.
+
 ## block
 
 A block is a sequence of expressions separated by `;`. It evaluates to its last expression.
@@ -185,6 +205,11 @@ Without an `else` branch, the result is `null` when the condition is false.
 ### while
 
 `while cond { ... }` loops while `cond` is truthy.
+
+## scoping
+
+Variables are scoped to the whole program.
+A variable bound by `=` is accessible from that point to the end of the program.
 
 ## assignment
 

--- a/engine/runtime/expr/docs/spec/1-base-language.md
+++ b/engine/runtime/expr/docs/spec/1-base-language.md
@@ -2,7 +2,7 @@
 
 **FlowExpr** is an expression language: every program is an expression that evaluates to a single value.
 
-This document specifies the built-in immutable types.
+This document specifies the built-in types.
 
 ## null
 

--- a/engine/runtime/expr/docs/spec/1-base-language.md
+++ b/engine/runtime/expr/docs/spec/1-base-language.md
@@ -1,0 +1,30 @@
+# Base Language
+
+**FlowExpr** is an expression language: every program is an expression that evaluates to a single value.
+
+This document specifies the built-in immutable types.
+
+## null
+
+`null` represents the absence of a value. There is exactly one null value, written `null`.
+
+## bool
+
+A boolean value, written `true` or `false`.
+
+## int
+
+A 64-bit signed integer. Integer literals match one of:
+
+- decimal: `[0-9]+`
+- binary: `0[bB][01]+`
+- octal: `0[oO][0-7]+`
+- hexadecimal: `0[xX][0-9a-fA-F]+`
+
+## float
+
+A 64-bit IEEE 754 double-precision floating-point number. Float literals must contain a decimal point or an exponent (e.g. `1.0`, `1e10`).
+
+## string
+
+An immutable sequence of Unicode codepoints. String literals are enclosed in double quotes (e.g. `"hello"`).

--- a/engine/runtime/expr/docs/spec/1-base-language.md
+++ b/engine/runtime/expr/docs/spec/1-base-language.md
@@ -129,7 +129,8 @@ Built-in type objects: `bool`, `int`, `float`, `str`, `list`, `dict`, `type`.
 ## operators
 
 Operators listed from lowest to highest precedence.
-`left` and `right` denote associativity; `prefix` denotes a unary operator with no left operand.
+`left` and `right` denote associativity of binary operators;
+`prefix` and `postfix` denote unary operators.
 
 - `or` (left)
 - `and` (left)
@@ -144,6 +145,7 @@ Operators listed from lowest to highest precedence.
 - `*` `/` `//` `%` (left)
 - unary `-` (prefix)
 - `**` (right)
+- index/slice `[...]`, attribute `.`, call `()` (postfix)
 
 ### integer and float division
 
@@ -205,6 +207,16 @@ Without an `else` branch, the result is `null` when the condition is false.
 ### while
 
 `while cond { ... }` loops while `cond` is truthy.
+
+## indexing
+
+`x[i]` accesses an element of `x`:
+
+- `list`: `i` is an integer index. Negative indices count from the end.
+- `str`: `i` is an integer index into the Unicode codepoints, returning a single-character string. Negative indices count from the end.
+- `dict`: `i` is a key.
+
+Index failure (missing key, out of scope, wrong type) should trigger evaluation error.
 
 ## scoping
 

--- a/engine/runtime/expr/docs/spec/1-base-language.md
+++ b/engine/runtime/expr/docs/spec/1-base-language.md
@@ -45,7 +45,7 @@ A 64-bit signed integer. Integer literals match one of:
 - `int`: same value
 - `float`: truncated toward zero; error if not finite or out of range
 - `bool`: `0` or `1`
-- `string`: decimal integer parsed from the trimmed string; error if not parseable
+- `str`: decimal integer parsed from the trimmed string; error if not parseable
 - no argument: `0`
 
 ## float type
@@ -60,7 +60,7 @@ Float literals must contain a decimal point or an exponent (e.g. `1.0`, `1e10`).
 - `float`: same value
 - `int`: same numeric value
 - `bool`: `1.0` or `0.0`
-- `string`: decimal float parsed from the trimmed string; error if not parseable
+- `str`: decimal float parsed from the trimmed string; error if not parseable
 - no argument: `0.0`
 
 ## string type
@@ -81,7 +81,7 @@ Inside a double-quoted string, the following escape sequences are recognized:
 
 `str` is a type object. Calling `str(value)` constructs a string based on the type of `value`:
 
-- `string`: same value
+- `str`: same value
 - `int`: decimal representation
 - `float`: a decimal representation; the exact format is unspecified
 - `bool`: `"true"` or `"false"`
@@ -98,13 +98,13 @@ List literals use square brackets (e.g. `[1, "two", true]`). Elements may be of 
 `list` is a type object. Calling `list(value)` constructs a list based on the type of `value`:
 
 - `list`: shallow copy
-- `string`: list of single-character strings, one per Unicode codepoint
+- `str`: list of single-character strings, one per Unicode codepoint
 - `dict`: list of keys
 - no argument: `[]`
 
 ## dictionary type
 
-A mutable, ordered map from string keys to values. Other key types are undefined.
+A mutable map from string keys to values. Other key types are undefined.
 Dict literals use curly braces (e.g. `{"a": 1, "b": 2}`).
 Insertion order preservation is not stabilized by this spec.
 
@@ -245,4 +245,4 @@ Whether a type is effectively mutable depends solely on whether it exposes any m
 Cyclic references (e.g. a list that contains itself) are undefined behavior.
 
 Notes: An implication is that FlowExpr may be implemented with reference counting memory management.
-However, silent memory leak is usually unwanted in most embeded evaluation environments that need to be handled or at least detected.
+However, silent memory leak is usually unwanted in most embedded evaluation environments that need to be handled or at least detected.

--- a/engine/runtime/expr/docs/spec/1-base-language.md
+++ b/engine/runtime/expr/docs/spec/1-base-language.md
@@ -2,17 +2,17 @@
 
 **FlowExpr** is an expression language: every program is an expression that evaluates to a single value.
 
-This document specifies the built-in types.
+This document specifies the base language: basic types and operators, and the semantics.
 
-## null
+## null type
 
 `null` represents the absence of a value. There is exactly one null value, written `null`.
 
-## bool
+## boolean type
 
 A boolean value, written `true` or `false`.
 
-## int
+## integer type
 
 A 64-bit signed integer. Integer literals match one of:
 
@@ -21,10 +21,47 @@ A 64-bit signed integer. Integer literals match one of:
 - octal: `0[oO][0-7]+`
 - hexadecimal: `0[xX][0-9a-fA-F]+`
 
-## float
+### Constructor
 
-A 64-bit IEEE 754 double-precision floating-point number. Float literals must contain a decimal point or an exponent (e.g. `1.0`, `1e10`).
+`int` is a type object. Calling `int(value)` constructs an integer based on the type of `value`:
 
-## string
+- `int`: same value
+- `float`: truncated toward zero; error if not finite or out of range
+- `bool`: `0` or `1`
+- `string`: decimal integer parsed from the trimmed string; error if not parseable
+- no argument: `0`
 
-An immutable sequence of Unicode codepoints. String literals are enclosed in double quotes (e.g. `"hello"`).
+## float type
+
+A 64-bit IEEE 754 double-precision floating-point number.
+Float literals must contain a decimal point or an exponent (e.g. `1.0`, `1e10`).
+
+## string type
+
+An immutable sequence of Unicode codepoints.
+String literals are enclosed in double quotes (e.g. `"hello"`).
+
+## list type
+
+A mutable, ordered sequence of values.
+List literals use square brackets (e.g. `[1, "two", true]`). Elements may be of any type.
+
+## dictionary type
+
+A mutable, ordered map from string keys to values. Other key types are undefined.
+Dict literals use curly braces (e.g. `{"a": 1, "b": 2}`).
+Insertion order preservation is not stabilized by this spec.
+
+## mutability
+
+All values have reference semantics: assigning a value to another variable does not copy it.
+Mutations through any alias are visible through all of them.
+
+Whether a type is effectively mutable depends solely on whether it exposes any mutating operations.
+
+## cyclic reference
+
+Cyclic references (e.g. a list that contains itself) are undefined behavior.
+
+Notes: An implication is that FlowExpr may be implemented with reference counting memory management.
+However, silent memory leak is usually unwanted in most embeded evaluation environments that need to be handled or at least detected.

--- a/engine/runtime/expr/docs/spec/README.md
+++ b/engine/runtime/expr/docs/spec/README.md
@@ -12,6 +12,8 @@ Writing the spec is the stabilization decision.
 The implementation must be fully compatible with this spec.
 The implementation may contain unstabilized features not yet documented here.
 
+Spec should describe the language design as an interface defined by behavior, not its implementation.
+
 ## Documentation Hierarchy
 
 Spec files follow the naming convention `<number>-<name>.md` (e.g. `1-base-language.md`).
@@ -21,3 +23,8 @@ Other documentation structured by topic can be generated from these files.
 
 Code should refer spec only, not user-facing documentation.
 Refer spec section from code with anchors following the GitHub convention: convert section title to lowercase, spaces replaced with `-`.
+
+## Writing Style Guideline
+
+- Sections should be atomic and describe one point, not a group of points - use child sections for that.
+- Avoid duplicating existing points. Use cross-reference, especially when new spec extends previous spec's some section.

--- a/engine/runtime/expr/docs/spec/README.md
+++ b/engine/runtime/expr/docs/spec/README.md
@@ -18,3 +18,6 @@ Spec files follow the naming convention `<number>-<name>.md` (e.g. `1-base-langu
 They are ordered by the time the decision was proposed, not by topic.
 
 Other documentation structured by topic can be generated from these files as the authoritative source.
+
+Code should refer spec only, not user-facing documentation.
+Refer spec section from code with anchors following the GitHub convention: convert section title to lowercase, spaces replaced with `-`.

--- a/engine/runtime/expr/docs/spec/README.md
+++ b/engine/runtime/expr/docs/spec/README.md
@@ -17,8 +17,8 @@ They are ordered by the time the decision was proposed, not by topic.
 
 Other documentation structured by topic can be generated from these files.
 
-Code should refer spec only, not user-facing documentation.
-Refer spec section from code with anchors following the GitHub convention: convert section title to lowercase, spaces replaced with `-`.
+Code should refer to the spec only, not user-facing documentation.
+Refer to spec sections from code with anchors following the GitHub convention: convert section title to lowercase, spaces replaced with `-`.
 
 ## Writing Style Guideline
 

--- a/engine/runtime/expr/docs/spec/README.md
+++ b/engine/runtime/expr/docs/spec/README.md
@@ -5,12 +5,14 @@ This directory is the authoritative definition of the FlowExpr language.
 ## Stabilization Process
 
 Everything documented here is stable for the current language type (`flowExpr`).
-Breaking changes require a migration tool.
-Semantic breaking changes introduce a new language type (`flowExpr2`, …) rather than modifying existing behavior.
 
 Writing the spec is the stabilization decision.
-The implementation must be fully compatible with this spec.
+The implementation should be compatible with this spec.
 The implementation may contain unstabilized features not yet documented here.
+
+When one spec subsume another, the more general one wins.
+For example, if one spec says foo() takes int, and another says foo() takes int and string, the second spec wins.
+If two specs are not compatible, it is considered a bug.
 
 Spec should describe the language design as an interface defined by behavior, not its implementation.
 

--- a/engine/runtime/expr/docs/spec/README.md
+++ b/engine/runtime/expr/docs/spec/README.md
@@ -4,15 +4,9 @@ This directory is the authoritative definition of the FlowExpr language.
 
 ## Stabilization Process
 
-Everything documented here is stable for the current language type (`flowExpr`).
-
 Writing the spec is the stabilization decision.
 The implementation should be compatible with this spec.
-The implementation may contain unstabilized features not yet documented here.
-
-When one spec subsume another, the more general one wins.
-For example, if one spec says foo() takes int, and another says foo() takes int and string, the second spec wins.
-If two specs are not compatible, it is considered a bug.
+The implementation may contain unstabilized features.
 
 Spec should describe the language design as an interface defined by behavior, not its implementation.
 
@@ -30,3 +24,4 @@ Refer spec section from code with anchors following the GitHub convention: conve
 
 - Sections should be atomic and describe one point, not a group of points - use child sections for that.
 - Avoid duplicating existing points. Use cross-reference, especially when new spec extends previous spec's some section.
+- Though generally should be avoided, "must" indicates forward compatibility break.

--- a/engine/runtime/expr/docs/spec/README.md
+++ b/engine/runtime/expr/docs/spec/README.md
@@ -17,7 +17,7 @@ The implementation may contain unstabilized features not yet documented here.
 Spec files follow the naming convention `<number>-<name>.md` (e.g. `1-base-language.md`).
 They are ordered by the time the decision was proposed, not by topic.
 
-Other documentation structured by topic can be generated from these files as the authoritative source.
+Other documentation structured by topic can be generated from these files.
 
 Code should refer spec only, not user-facing documentation.
 Refer spec section from code with anchors following the GitHub convention: convert section title to lowercase, spaces replaced with `-`.

--- a/engine/runtime/expr/docs/spec/README.md
+++ b/engine/runtime/expr/docs/spec/README.md
@@ -1,0 +1,20 @@
+# FlowExpr Language Specification
+
+This directory is the authoritative definition of the FlowExpr language.
+
+## Stabilization Process
+
+Everything documented here is stable for the current language type (`flowExpr`).
+Breaking changes require a migration tool.
+Semantic breaking changes introduce a new language type (`flowExpr2`, …) rather than modifying existing behavior.
+
+Writing the spec is the stabilization decision.
+The implementation must be fully compatible with this spec.
+The implementation may contain unstabilized features not yet documented here.
+
+## Documentation Hierarchy
+
+Spec files follow the naming convention `<number>-<name>.md` (e.g. `1-base-language.md`).
+They are ordered by the time the decision was proposed, not by topic.
+
+Other documentation structured by topic can be generated from these files as the authoritative source.

--- a/engine/runtime/expr/src/bin/repl.rs
+++ b/engine/runtime/expr/src/bin/repl.rs
@@ -1,6 +1,6 @@
 use std::io::{self, BufRead, Write};
 
-use reearth_flow_expr::{compile, default_env, eval_unsafe as eval};
+use reearth_flow_expr::{compile, default_env, eval_unsafe};
 
 fn main() {
     let env = default_env();
@@ -17,7 +17,7 @@ fn main() {
         };
         let line = line.trim();
         if !line.is_empty() {
-            match compile(line).and_then(|e| eval(&e, &env)) {
+            match compile(line).and_then(|e| eval_unsafe(&e, &env)) {
                 Ok(v) => println!("{v}"),
                 Err(e) => println!("error: {e}"),
             }

--- a/engine/runtime/expr/src/bin/repl.rs
+++ b/engine/runtime/expr/src/bin/repl.rs
@@ -1,6 +1,6 @@
 use std::io::{self, BufRead, Write};
 
-use reearth_flow_expr::{compile, default_env, eval};
+use reearth_flow_expr::{compile, default_env, eval_unsafe as eval};
 
 fn main() {
     let env = default_env();

--- a/engine/runtime/expr/src/core/builtins.rs
+++ b/engine/runtime/expr/src/core/builtins.rs
@@ -10,8 +10,8 @@ mod url;
 pub use itertools::builtin_itertools;
 pub use json::builtin_json;
 pub use math::builtin_math;
-pub use regex::builtin_regex;
-pub use url::builtin_url;
+pub use regex::regex_type_value;
+pub use url::url_type_value;
 
 use crate::core::error::Result;
 use crate::core::value::Value;

--- a/engine/runtime/expr/src/core/builtins.rs
+++ b/engine/runtime/expr/src/core/builtins.rs
@@ -1,7 +1,7 @@
 pub mod array;
+pub mod dict;
 mod itertools;
 mod json;
-pub mod map;
 pub mod math;
 mod regex;
 pub mod str;

--- a/engine/runtime/expr/src/core/builtins.rs
+++ b/engine/runtime/expr/src/core/builtins.rs
@@ -1,4 +1,4 @@
-pub mod array;
+pub mod list;
 pub mod dict;
 mod itertools;
 mod json;

--- a/engine/runtime/expr/src/core/builtins.rs
+++ b/engine/runtime/expr/src/core/builtins.rs
@@ -1,7 +1,7 @@
-pub mod list;
 pub mod dict;
 mod itertools;
 mod json;
+pub mod list;
 pub mod math;
 mod regex;
 pub mod str;

--- a/engine/runtime/expr/src/core/builtins/dict.rs
+++ b/engine/runtime/expr/src/core/builtins/dict.rs
@@ -1,13 +1,12 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::Rc;
 use std::sync::LazyLock;
 
 use indexmap::IndexMap;
 
 use crate::core::error::{eval_error, Result};
 use crate::core::eval::eval_eq;
-use crate::core::value::{NativeFn, Value};
+use crate::core::value::{NativeFn, TrackedRc, Value};
 use crate::expect_arity;
 
 use super::MethodFn;
@@ -82,10 +81,10 @@ fn get(args: &[Value]) -> Result<Value> {
 }
 
 pub fn eq_inner(
-    a: &Rc<RefCell<IndexMap<String, Value>>>,
-    b: &Rc<RefCell<IndexMap<String, Value>>>,
+    a: &TrackedRc<RefCell<IndexMap<String, Value>>>,
+    b: &TrackedRc<RefCell<IndexMap<String, Value>>>,
 ) -> Result<bool> {
-    if Rc::ptr_eq(a, b) {
+    if TrackedRc::ptr_eq(a, b) {
         return Ok(true);
     }
     let a = a.borrow();

--- a/engine/runtime/expr/src/core/builtins/dict.rs
+++ b/engine/runtime/expr/src/core/builtins/dict.rs
@@ -25,7 +25,7 @@ pub fn resolve_method(recv: Value, method: &str) -> Result<NativeFn> {
     let f = METHODS
         .get(method)
         .copied()
-        .ok_or_else(|| eval_error(format!("Map has no method '{method}'")))?;
+        .ok_or_else(|| eval_error(format!("dict has no method '{method}'")))?;
     Ok(NativeFn::new(move |args| {
         let mut a = vec![recv.clone()];
         a.extend_from_slice(args);
@@ -34,11 +34,11 @@ pub fn resolve_method(recv: Value, method: &str) -> Result<NativeFn> {
 }
 
 fn keys(args: &[Value]) -> Result<Value> {
-    expect_arity("map.keys", &args[1..], 0, 0)?;
+    expect_arity("dict.keys", &args[1..], 0, 0)?;
     let Value::Dict(rc) = &args[0] else {
-        return Err(eval_error("expected map receiver"));
+        return Err(eval_error("expected dict receiver"));
     };
-    Ok(Value::array(
+    Ok(Value::list(
         rc.borrow()
             .keys()
             .map(|k| Value::String(k.clone()))
@@ -47,30 +47,30 @@ fn keys(args: &[Value]) -> Result<Value> {
 }
 
 fn values(args: &[Value]) -> Result<Value> {
-    expect_arity("map.values", &args[1..], 0, 0)?;
+    expect_arity("dict.values", &args[1..], 0, 0)?;
     let Value::Dict(rc) = &args[0] else {
-        return Err(eval_error("expected map receiver"));
+        return Err(eval_error("expected dict receiver"));
     };
-    Ok(Value::array(rc.borrow().values().cloned().collect()))
+    Ok(Value::list(rc.borrow().values().cloned().collect()))
 }
 
 fn items(args: &[Value]) -> Result<Value> {
-    expect_arity("map.items", &args[1..], 0, 0)?;
+    expect_arity("dict.items", &args[1..], 0, 0)?;
     let Value::Dict(rc) = &args[0] else {
-        return Err(eval_error("expected map receiver"));
+        return Err(eval_error("expected dict receiver"));
     };
-    Ok(Value::array(
+    Ok(Value::list(
         rc.borrow()
             .iter()
-            .map(|(k, v)| Value::array(vec![Value::String(k.clone()), v.clone()]))
+            .map(|(k, v)| Value::list(vec![Value::String(k.clone()), v.clone()]))
             .collect(),
     ))
 }
 
 fn get(args: &[Value]) -> Result<Value> {
-    expect_arity("map.get", &args[1..], 1, 2)?;
+    expect_arity("dict.get", &args[1..], 1, 2)?;
     let Value::Dict(rc) = &args[0] else {
-        return Err(eval_error("expected map receiver"));
+        return Err(eval_error("expected dict receiver"));
     };
     let k = args[1].as_str()?;
     let fallback = args.get(2);

--- a/engine/runtime/expr/src/core/builtins/dict.rs
+++ b/engine/runtime/expr/src/core/builtins/dict.rs
@@ -35,7 +35,7 @@ pub fn resolve_method(recv: Value, method: &str) -> Result<NativeFn> {
 
 fn keys(args: &[Value]) -> Result<Value> {
     expect_arity("map.keys", &args[1..], 0, 0)?;
-    let Value::Map(rc) = &args[0] else {
+    let Value::Dict(rc) = &args[0] else {
         return Err(eval_error("expected map receiver"));
     };
     Ok(Value::array(
@@ -48,7 +48,7 @@ fn keys(args: &[Value]) -> Result<Value> {
 
 fn values(args: &[Value]) -> Result<Value> {
     expect_arity("map.values", &args[1..], 0, 0)?;
-    let Value::Map(rc) = &args[0] else {
+    let Value::Dict(rc) = &args[0] else {
         return Err(eval_error("expected map receiver"));
     };
     Ok(Value::array(rc.borrow().values().cloned().collect()))
@@ -56,7 +56,7 @@ fn values(args: &[Value]) -> Result<Value> {
 
 fn items(args: &[Value]) -> Result<Value> {
     expect_arity("map.items", &args[1..], 0, 0)?;
-    let Value::Map(rc) = &args[0] else {
+    let Value::Dict(rc) = &args[0] else {
         return Err(eval_error("expected map receiver"));
     };
     Ok(Value::array(
@@ -69,7 +69,7 @@ fn items(args: &[Value]) -> Result<Value> {
 
 fn get(args: &[Value]) -> Result<Value> {
     expect_arity("map.get", &args[1..], 1, 2)?;
-    let Value::Map(rc) = &args[0] else {
+    let Value::Dict(rc) = &args[0] else {
         return Err(eval_error("expected map receiver"));
     };
     let k = args[1].as_str()?;
@@ -113,7 +113,7 @@ mod tests {
 
     #[test]
     fn test_len() {
-        let m = Value::map(indexmap::indexmap! {
+        let m = Value::dict(indexmap::indexmap! {
             "x".into() => Value::from(1i64),
             "y".into() => Value::from(2i64),
         });
@@ -122,7 +122,7 @@ mod tests {
 
     #[test]
     fn test_keys() {
-        let m = Value::map(indexmap::indexmap! {
+        let m = Value::dict(indexmap::indexmap! {
             "x".into() => Value::from(1i64),
             "y".into() => Value::from(2i64),
         });
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn test_values() {
-        let m = Value::map(indexmap::indexmap! {
+        let m = Value::dict(indexmap::indexmap! {
             "x".into() => Value::from(1i64),
             "y".into() => Value::from(2i64),
         });
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn test_get() {
-        let m = Value::map(indexmap::indexmap! {
+        let m = Value::dict(indexmap::indexmap! {
             "x".into() => Value::from(1i64),
         });
         assert_eval("m.get(\"x\")", &[("m", m.clone())], Value::from(1i64));
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_items() {
-        let m = Value::map(indexmap::indexmap! {
+        let m = Value::dict(indexmap::indexmap! {
             "x".into() => Value::from(1i64),
             "y".into() => Value::from(2i64),
         });

--- a/engine/runtime/expr/src/core/builtins/itertools.rs
+++ b/engine/runtime/expr/src/core/builtins/itertools.rs
@@ -189,9 +189,9 @@ mod tests {
             r#"itertools.sorted([{"k": 3}, {"k": 1}, {"k": 2}], fn(x) { x["k"] })"#,
             &[],
             Value::from(vec![
-                Value::map(indexmap::indexmap! { "k".into() => Value::from(1i64) }),
-                Value::map(indexmap::indexmap! { "k".into() => Value::from(2i64) }),
-                Value::map(indexmap::indexmap! { "k".into() => Value::from(3i64) }),
+                Value::dict(indexmap::indexmap! { "k".into() => Value::from(1i64) }),
+                Value::dict(indexmap::indexmap! { "k".into() => Value::from(2i64) }),
+                Value::dict(indexmap::indexmap! { "k".into() => Value::from(3i64) }),
             ]),
         );
         assert_eval("itertools.sorted([])", &[], Value::from(vec![] as Vec<i64>));

--- a/engine/runtime/expr/src/core/builtins/itertools.rs
+++ b/engine/runtime/expr/src/core/builtins/itertools.rs
@@ -26,7 +26,7 @@ fn value_cmp(a: &Value, b: &Value) -> Result<Ordering> {
 fn sorted(args: &[Value]) -> Result<Value> {
     expect_arity("itertools.sorted", args, 1, 2)?;
     let items = match &args[0] {
-        Value::Array(rc) => rc.borrow().clone(),
+        Value::List(rc) => rc.borrow().clone(),
         other => {
             return Err(eval_error(format!(
                 "itertools.sorted() first argument must be a list, got {}",
@@ -50,7 +50,7 @@ fn sorted(args: &[Value]) -> Result<Value> {
             if let Some(e) = sort_err {
                 return Err(e);
             }
-            Ok(Value::array(out))
+            Ok(Value::list(out))
         }
         Some(key_fn) => {
             let keyed = items
@@ -74,7 +74,7 @@ fn sorted(args: &[Value]) -> Result<Value> {
             if let Some(e) = sort_err {
                 return Err(e);
             }
-            Ok(Value::array(
+            Ok(Value::list(
                 keyed.into_iter().map(|(item, _)| item).collect(),
             ))
         }
@@ -84,7 +84,7 @@ fn sorted(args: &[Value]) -> Result<Value> {
 fn filter(args: &[Value]) -> Result<Value> {
     expect_arity("itertools.filter", args, 2, 2)?;
     let items = match &args[0] {
-        Value::Array(rc) => rc.borrow().clone(),
+        Value::List(rc) => rc.borrow().clone(),
         other => {
             return Err(eval_error(format!(
                 "itertools.filter() first argument must be a list, got {}",
@@ -101,13 +101,13 @@ fn filter(args: &[Value]) -> Result<Value> {
             Err(e) => Some(Err(e)),
         })
         .collect::<Result<Vec<_>>>()?;
-    Ok(Value::array(result))
+    Ok(Value::list(result))
 }
 
 fn count(args: &[Value]) -> Result<Value> {
     expect_arity("itertools.count", args, 1, 1)?;
     match &args[0] {
-        Value::Array(rc) => Ok(Value::Int(rc.borrow().len() as i64)),
+        Value::List(rc) => Ok(Value::Int(rc.borrow().len() as i64)),
         other => Err(eval_error(format!(
             "itertools.count() argument must be a list, got {}",
             other.type_name()
@@ -118,7 +118,7 @@ fn count(args: &[Value]) -> Result<Value> {
 fn map(args: &[Value]) -> Result<Value> {
     expect_arity("itertools.map", args, 2, 2)?;
     let items = match &args[0] {
-        Value::Array(rc) => rc.borrow().clone(),
+        Value::List(rc) => rc.borrow().clone(),
         other => {
             return Err(eval_error(format!(
                 "itertools.map() first argument must be a list, got {}",
@@ -131,13 +131,13 @@ fn map(args: &[Value]) -> Result<Value> {
         .into_iter()
         .map(|item| call_value(f.clone(), vec![item]))
         .collect::<Result<Vec<_>>>()?;
-    Ok(Value::array(result))
+    Ok(Value::list(result))
 }
 
 fn sum(args: &[Value]) -> Result<Value> {
     expect_arity("itertools.sum", args, 1, 1)?;
     let items = match &args[0] {
-        Value::Array(rc) => rc.borrow().clone(),
+        Value::List(rc) => rc.borrow().clone(),
         other => {
             return Err(eval_error(format!(
                 "itertools.sum() argument must be a list, got {}",

--- a/engine/runtime/expr/src/core/builtins/json.rs
+++ b/engine/runtime/expr/src/core/builtins/json.rs
@@ -38,7 +38,7 @@ fn value_to_json(v: &Value) -> Result<JsonValue> {
             Some(serializable) => value_to_json(&serializable),
             None => Err(eval_error(format!(
                 "json.dumps: {} does not support serialization",
-                rc.type_name()
+                rc.type_object().name
             ))),
         },
         other => Err(eval_error(format!(

--- a/engine/runtime/expr/src/core/builtins/json.rs
+++ b/engine/runtime/expr/src/core/builtins/json.rs
@@ -18,7 +18,7 @@ fn value_to_json(v: &Value) -> Result<JsonValue> {
                 ))
             }),
         Value::String(s) => Ok(JsonValue::String(s.clone())),
-        Value::Array(rc) => {
+        Value::List(rc) => {
             let items = rc
                 .borrow()
                 .iter()
@@ -67,7 +67,7 @@ fn json_to_value(j: JsonValue) -> Result<Value> {
                 .into_iter()
                 .map(json_to_value)
                 .collect::<Result<Vec<_>>>()?;
-            Ok(Value::array(values))
+            Ok(Value::list(values))
         }
         JsonValue::Object(obj) => {
             let map = obj

--- a/engine/runtime/expr/src/core/builtins/json.rs
+++ b/engine/runtime/expr/src/core/builtins/json.rs
@@ -26,7 +26,7 @@ fn value_to_json(v: &Value) -> Result<JsonValue> {
                 .collect::<Result<Vec<_>>>()?;
             Ok(JsonValue::Array(items))
         }
-        Value::Map(rc) => {
+        Value::Dict(rc) => {
             let obj = rc
                 .borrow()
                 .iter()
@@ -74,7 +74,7 @@ fn json_to_value(j: JsonValue) -> Result<Value> {
                 .into_iter()
                 .map(|(k, v)| json_to_value(v).map(|val| (k, val)))
                 .collect::<Result<IndexMap<_, _>>>()?;
-            Ok(Value::map(map))
+            Ok(Value::dict(map))
         }
     }
 }

--- a/engine/runtime/expr/src/core/builtins/list.rs
+++ b/engine/runtime/expr/src/core/builtins/list.rs
@@ -18,7 +18,7 @@ pub fn resolve_method(recv: Value, method: &str) -> Result<NativeFn> {
     let f = METHODS
         .get(method)
         .copied()
-        .ok_or_else(|| eval_error(format!("Array has no method '{method}'")))?;
+        .ok_or_else(|| eval_error(format!("list has no method '{method}'")))?;
     Ok(NativeFn::new(move |args| {
         let mut a = vec![recv.clone()];
         a.extend_from_slice(args);
@@ -38,8 +38,8 @@ pub fn resolve_index(i: i64, len: usize) -> Option<usize> {
 
 fn get(args: &[Value]) -> Result<Value> {
     expect_arity("list.get", &args[1..], 1, 2)?;
-    let Value::Array(rc) = &args[0] else {
-        return Err(eval_error("expected array receiver"));
+    let Value::List(rc) = &args[0] else {
+        return Err(eval_error("expected list receiver"));
     };
     let i = args[1].as_int()?;
     let fallback = args.get(2);
@@ -50,8 +50,8 @@ fn get(args: &[Value]) -> Result<Value> {
 
 fn append(args: &[Value]) -> Result<Value> {
     expect_arity("list.append", &args[1..], 1, 1)?;
-    let Value::Array(rc) = &args[0] else {
-        return Err(eval_error("expected array receiver"));
+    let Value::List(rc) = &args[0] else {
+        return Err(eval_error("expected list receiver"));
     };
     rc.borrow_mut().push(args[1].clone());
     Ok(Value::Null)

--- a/engine/runtime/expr/src/core/builtins/list.rs
+++ b/engine/runtime/expr/src/core/builtins/list.rs
@@ -1,11 +1,10 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::Rc;
 use std::sync::LazyLock;
 
 use crate::core::error::{eval_error, Result};
 use crate::core::eval::eval_eq;
-use crate::core::value::{NativeFn, Value};
+use crate::core::value::{NativeFn, TrackedRc, Value};
 
 use crate::expect_arity;
 
@@ -57,8 +56,11 @@ fn append(args: &[Value]) -> Result<Value> {
     Ok(Value::Null)
 }
 
-pub fn eq_inner(a: &Rc<RefCell<Vec<Value>>>, b: &Rc<RefCell<Vec<Value>>>) -> Result<bool> {
-    if Rc::ptr_eq(a, b) {
+pub fn eq_inner(
+    a: &TrackedRc<RefCell<Vec<Value>>>,
+    b: &TrackedRc<RefCell<Vec<Value>>>,
+) -> Result<bool> {
+    if TrackedRc::ptr_eq(a, b) {
         return Ok(true);
     }
     let a = a.borrow();

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -1,8 +1,21 @@
+use std::rc::Rc;
+
 use crate::core::error::{eval_error, Result};
-use crate::core::value::{ImmutableObject, Value};
+use crate::core::value::{ImmutableObject, NativeFn, TypeValue, Value};
 
 use crate::expect_arity;
 use regex::Regex;
+
+thread_local! {
+    static REGEX_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new(
+        "Regex",
+        Some(NativeFn::new(construct)),
+    ));
+}
+
+pub fn regex_type_value() -> Rc<TypeValue> {
+    REGEX_TYPE.with(Rc::clone)
+}
 
 #[derive(Debug, Clone)]
 pub struct RegexObject {
@@ -11,8 +24,8 @@ pub struct RegexObject {
 }
 
 impl ImmutableObject for RegexObject {
-    fn type_name(&self) -> &'static str {
-        "Regex"
+    fn type_object(&self) -> Rc<TypeValue> {
+        regex_type_value()
     }
 
     fn call_method(&self, method: &str, args: &[Value]) -> Result<Value> {
@@ -88,7 +101,7 @@ fn regex_find_all(regex: &Regex, s: &str) -> Vec<Value> {
     }
 }
 
-pub fn builtin_regex(args: &[Value]) -> Result<Value> {
+pub fn construct(args: &[Value]) -> Result<Value> {
     if args.len() != 1 {
         return Err(eval_error(format!(
             "Regex() expected 1 argument, got {}",

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -36,7 +36,7 @@ impl ImmutableObject for RegexObject {
             }
             "find_all" => {
                 expect_arity("Regex.find_all", args, 1, 1)?;
-                Ok(Value::array(regex_find_all(&self.regex, args[0].as_str()?)))
+                Ok(Value::list(regex_find_all(&self.regex, args[0].as_str()?)))
             }
             m => Err(eval_error(format!("Regex has no method '{m}'"))),
         }
@@ -58,7 +58,7 @@ fn capture_to_value(cap: &regex::Captures, num_groups: usize) -> Value {
             .map(|m| Value::String(m.as_str().to_string()))
             .unwrap_or(Value::Null)
     } else {
-        Value::array(
+        Value::list(
             (1..=num_groups)
                 .map(|i| {
                     cap.get(i)
@@ -148,14 +148,14 @@ mod tests {
         // multi-group: second optional group absent → Null in that slot
         assert_val(
             &run(r#"Regex(r"(\d+)(x)?").find("123")"#, &[]),
-            &Value::array(vec![Value::from("123"), Value::Null]),
+            &Value::list(vec![Value::from("123"), Value::Null]),
         );
         // find_all: optional group absent → Null per match
         assert_val(
             &run(r#"Regex(r"(\d+)(x)?").find_all("123 456x")"#, &[]),
-            &Value::array(vec![
-                Value::array(vec![Value::from("123"), Value::Null]),
-                Value::array(vec![Value::from("456"), Value::from("x")]),
+            &Value::list(vec![
+                Value::list(vec![Value::from("123"), Value::Null]),
+                Value::list(vec![Value::from("456"), Value::from("x")]),
             ]),
         );
     }
@@ -164,22 +164,22 @@ mod tests {
     fn test_regex_find_all() {
         assert_val(
             &run(r#"Regex(r"\d+").find_all("abc 123 def 456")"#, &[]),
-            &Value::array(vec![Value::from("123"), Value::from("456")]),
+            &Value::list(vec![Value::from("123"), Value::from("456")]),
         );
         assert_val(
             &run(r#"Regex(r"(\d+)").find_all("abc 123 def 456")"#, &[]),
-            &Value::array(vec![Value::from("123"), Value::from("456")]),
+            &Value::list(vec![Value::from("123"), Value::from("456")]),
         );
         assert_val(
             &run(r#"Regex(r"(\w+)@(\w+)").find_all("a@b x@y")"#, &[]),
-            &Value::array(vec![
-                Value::array(vec![Value::from("a"), Value::from("b")]),
-                Value::array(vec![Value::from("x"), Value::from("y")]),
+            &Value::list(vec![
+                Value::list(vec![Value::from("a"), Value::from("b")]),
+                Value::list(vec![Value::from("x"), Value::from("y")]),
             ]),
         );
         assert_val(
             &run(r#"Regex(r"\d+").find_all("no digits here")"#, &[]),
-            &Value::array(vec![]),
+            &Value::list(vec![]),
         );
     }
 }

--- a/engine/runtime/expr/src/core/builtins/str.rs
+++ b/engine/runtime/expr/src/core/builtins/str.rs
@@ -548,14 +548,14 @@ mod tests {
         assert_eval(r#""{:5}".format("hi")"#, &[], Value::from("hi   "));
         assert_eval(r#""{:5}".format(7)"#, &[], Value::from("    7"));
 
-        let p = Value::Object(Rc::new(Point { x: 1.0, y: 2.0 }));
+        let p = Value::object(Point { x: 1.0, y: 2.0 });
         assert_eval(
             r#""{:compact}".format(p)"#,
             &[("p", p.clone())],
             Value::from("1,2"),
         );
         assert_eval(r#""{}".format(p)"#, &[("p", p)], Value::from("(1, 2)"));
-        let o = Value::Object(Rc::new(Opaque));
+        let o = Value::object(Opaque);
         assert_eval(r#""{}".format(o)"#, &[("o", o)], Value::from("opaque"));
     }
 

--- a/engine/runtime/expr/src/core/builtins/str.rs
+++ b/engine/runtime/expr/src/core/builtins/str.rs
@@ -59,7 +59,7 @@ fn split(args: &[Value]) -> Result<Value> {
             .collect(),
         None => s.split(sep).map(|p| Value::String(p.to_string())).collect(),
     };
-    Ok(Value::array(parts))
+    Ok(Value::list(parts))
 }
 
 fn rsplit(args: &[Value]) -> Result<Value> {
@@ -77,7 +77,7 @@ fn rsplit(args: &[Value]) -> Result<Value> {
     if n.is_some() {
         parts.reverse();
     }
-    Ok(Value::array(parts))
+    Ok(Value::list(parts))
 }
 
 fn starts_with(args: &[Value]) -> Result<Value> {
@@ -111,7 +111,7 @@ fn replace(args: &[Value]) -> Result<Value> {
 fn join(args: &[Value]) -> Result<Value> {
     expect_arity("str.join", &args[1..], 1, 1)?;
     let sep = args[0].as_str()?;
-    let Value::Array(list) = &args[1] else {
+    let Value::List(list) = &args[1] else {
         return Err(eval_error(format!(
             "join() argument must be an array, got {}",
             args[1].type_name()

--- a/engine/runtime/expr/src/core/builtins/str.rs
+++ b/engine/runtime/expr/src/core/builtins/str.rs
@@ -462,8 +462,12 @@ mod tests {
     }
 
     impl ImmutableObject for Point {
-        fn type_name(&self) -> &'static str {
-            "Point"
+        fn type_object(&self) -> Rc<crate::core::value::TypeValue> {
+            thread_local! {
+                static TY: Rc<crate::core::value::TypeValue> =
+                    Rc::new(crate::core::value::TypeValue::new("Point", None));
+            }
+            TY.with(Rc::clone)
         }
 
         fn call_method(&self, method: &str, args: &[Value]) -> EvalResult<Value> {
@@ -491,8 +495,12 @@ mod tests {
     struct Opaque;
 
     impl ImmutableObject for Opaque {
-        fn type_name(&self) -> &'static str {
-            "Opaque"
+        fn type_object(&self) -> Rc<crate::core::value::TypeValue> {
+            thread_local! {
+                static TY: Rc<crate::core::value::TypeValue> =
+                    Rc::new(crate::core::value::TypeValue::new("Opaque", None));
+            }
+            TY.with(Rc::clone)
         }
 
         fn call_method(&self, method: &str, _args: &[Value]) -> EvalResult<Value> {

--- a/engine/runtime/expr/src/core/builtins/str.rs
+++ b/engine/runtime/expr/src/core/builtins/str.rs
@@ -113,7 +113,7 @@ fn join(args: &[Value]) -> Result<Value> {
     let sep = args[0].as_str()?;
     let Value::List(list) = &args[1] else {
         return Err(eval_error(format!(
-            "join() argument must be an array, got {}",
+            "join() argument must be a list, got {}",
             args[1].type_name()
         )));
     };
@@ -123,7 +123,7 @@ fn join(args: &[Value]) -> Result<Value> {
         .map(|v| match v {
             Value::String(s) => Ok(s.clone()),
             other => Err(eval_error(format!(
-                "join() array elements must be strings, got {}",
+                "join() list elements must be strings, got {}",
                 other.type_name()
             ))),
         })

--- a/engine/runtime/expr/src/core/builtins/url.rs
+++ b/engine/runtime/expr/src/core/builtins/url.rs
@@ -1,10 +1,23 @@
+use std::rc::Rc;
+
 use crate::core::error::{eval_error, Result};
-use crate::core::value::{ImmutableObject, Value};
+use crate::core::value::{ImmutableObject, NativeFn, TypeValue, Value};
 
 use crate::expect_arity;
 use url::Url;
 
-fn parse_url(s: &str) -> Result<UrlObject> {
+thread_local! {
+    static URL_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new(
+        "Url",
+        Some(NativeFn::new(construct)),
+    ));
+}
+
+pub fn url_type_value() -> Rc<TypeValue> {
+    URL_TYPE.with(Rc::clone)
+}
+
+fn parse_url(s: &str) -> Result<Value> {
     let url = if s.contains("://") {
         Url::parse(s).map_err(|e| eval_error(format!("not a valid URI: {e}")))?
     } else if s.starts_with('/') {
@@ -13,7 +26,7 @@ fn parse_url(s: &str) -> Result<UrlObject> {
     } else {
         return Err(eval_error(format!("not a valid URI: {s}")));
     };
-    Ok(UrlObject { url })
+    Ok(Value::object(UrlObject { url }))
 }
 
 #[derive(Debug, Clone)]
@@ -52,8 +65,8 @@ impl UrlObject {
 }
 
 impl ImmutableObject for UrlObject {
-    fn type_name(&self) -> &'static str {
-        "Url"
+    fn type_object(&self) -> Rc<TypeValue> {
+        url_type_value()
     }
 
     fn get_property(&self, name: &str) -> Option<Result<Value>> {
@@ -76,7 +89,7 @@ impl ImmutableObject for UrlObject {
             "__eq__" => {
                 expect_arity("Url.__eq__", args, 1, 1)?;
                 match &args[0] {
-                    Value::Object(obj) if obj.type_name() == "Url" => {
+                    Value::Object(obj) if Rc::ptr_eq(&obj.type_object(), &url_type_value()) => {
                         Ok(Value::Bool(self.url.as_str() == obj.display()))
                     }
                     _ => Ok(Value::Bool(false)),
@@ -107,7 +120,7 @@ impl ImmutableObject for UrlObject {
     }
 }
 
-pub fn builtin_url(args: &[Value]) -> Result<Value> {
+pub fn construct(args: &[Value]) -> Result<Value> {
     if args.len() > 1 {
         return Err(eval_error(format!(
             "Url() expected at most 1 argument, got {}",
@@ -117,7 +130,9 @@ pub fn builtin_url(args: &[Value]) -> Result<Value> {
     let s = match args.first() {
         None => return Err(eval_error("Url() requires a string argument")),
         Some(Value::String(s)) => s.clone(),
-        Some(Value::Object(obj)) if obj.type_name() == "Url" => obj.display(),
+        Some(Value::Object(obj)) if Rc::ptr_eq(&obj.type_object(), &url_type_value()) => {
+            obj.display()
+        }
         Some(v) => {
             return Err(eval_error(format!(
                 "Url() expects a string, got {}",
@@ -125,7 +140,7 @@ pub fn builtin_url(args: &[Value]) -> Result<Value> {
             )))
         }
     };
-    parse_url(&s).map(Value::object)
+    parse_url(&s)
 }
 
 #[cfg(test)]

--- a/engine/runtime/expr/src/core/env.rs
+++ b/engine/runtime/expr/src/core/env.rs
@@ -8,7 +8,7 @@ use super::value::Value;
 /// A single scope frame in the environment chain.
 pub struct Frame {
     pub bindings: HashMap<String, Value>,
-    /// Parent frame — None for the root (default env) frame.
+    /// Parent frame. Root frames are immutable.
     pub parent: Option<Env>,
 }
 

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -2298,4 +2298,16 @@ mod tests {
         )
         .is_err());
     }
+
+    #[test]
+    fn test_cyclic_list_increases_live_alloc() {
+        let env = default_env();
+        let before = crate::core::value::LIVE_ALLOC.with(|c| c.get());
+        let expr = parse("let a = []; a.append(a); a").unwrap();
+        let v = eval(&expr, &env).unwrap();
+        let after = crate::core::value::LIVE_ALLOC.with(|c| c.get());
+        // Cyclic list keeps a TrackedRc alive; the guard in `crate::eval::<T>` detects this.
+        assert!(after > before, "expected live TrackedRc for cyclic list");
+        drop(v);
+    }
 }

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -1697,7 +1697,10 @@ mod tests {
         // dict(d) produces a shallow copy
         assert_eval(
             r#"let b = dict(a); b["x"] = 9; a"#,
-            &[("a", Value::dict(indexmap::indexmap! { "x".into() => Value::from(1i64) }))],
+            &[(
+                "a",
+                Value::dict(indexmap::indexmap! { "x".into() => Value::from(1i64) }),
+            )],
             Value::dict(indexmap::indexmap! { "x".into() => Value::from(1i64) }),
         );
     }

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -8,7 +8,7 @@ use super::builtins::{array as array_methods, map as map_methods, str as str_met
 use super::builtins::{builtin_itertools, builtin_json, builtin_math, builtin_regex, builtin_url};
 use super::env::{new_frame, Env};
 use super::error::{eval_error, Error, Result, POS_UNSET};
-use super::value::{format_float, ClosureValue, NativeFn, Value};
+use super::value::{format_float, ClosureValue, NativeFn, TypeTag, Value};
 use crate::expect_arity;
 
 struct DepthCounter {
@@ -112,12 +112,12 @@ pub fn env_bind(env: &Env, name: impl Into<String>, val: Value) {
 thread_local! {
     static BUILTIN_ENV: Env = {
         let env = new_frame(None);
-        env_bind(&env, "str", Value::Fn(NativeFn::new(builtin_str)));
-        env_bind(&env, "int", Value::Fn(NativeFn::new(builtin_int)));
-        env_bind(&env, "float", Value::Fn(NativeFn::new(builtin_float)));
-        env_bind(&env, "bool", Value::Fn(NativeFn::new(builtin_bool)));
-        env_bind(&env, "list", Value::Fn(NativeFn::new(builtin_list)));
-        env_bind(&env, "map", Value::Fn(NativeFn::new(builtin_map)));
+        env_bind(&env, "str", Value::Type(TypeTag::Str));
+        env_bind(&env, "int", Value::Type(TypeTag::Int));
+        env_bind(&env, "float", Value::Type(TypeTag::Float));
+        env_bind(&env, "bool", Value::Type(TypeTag::Bool));
+        env_bind(&env, "list", Value::Type(TypeTag::List));
+        env_bind(&env, "dict", Value::Type(TypeTag::Dict));
         env_bind(&env, "Url", Value::Fn(NativeFn::new(builtin_url)));
         env_bind(&env, "Regex", Value::Fn(NativeFn::new(builtin_regex)));
         env_bind(&env, "math", builtin_math());
@@ -142,11 +142,33 @@ pub fn eval(expr: &Expr, env: &Env) -> Result<Value> {
     }
 }
 
-/// Unified callable dispatch: invokes a NativeFn or Closure by value.
+fn call_type_constructor(tag: TypeTag, args: &[Value]) -> Result<Value> {
+    match tag {
+        TypeTag::Int => builtin_int(args),
+        TypeTag::Float => builtin_float(args),
+        TypeTag::Str => builtin_str(args),
+        TypeTag::Bool => builtin_bool(args),
+        TypeTag::List => builtin_list(args),
+        TypeTag::Dict => builtin_map(args),
+        TypeTag::Null => {
+            if !args.is_empty() {
+                return Err(eval_error(format!(
+                    "null() expects 0 arguments, got {}",
+                    args.len()
+                )));
+            }
+            Ok(Value::Null)
+        }
+        TypeTag::Fn => Err(eval_error("fn is not callable as a constructor")),
+    }
+}
+
+/// Unified callable dispatch: invokes a NativeFn, Type constructor, or Closure by value.
 pub(crate) fn call_value(f: Value, args: Vec<Value>) -> Result<Value> {
     let _guard = DepthGuard::enter(&CALL_DEPTH)?;
     match f {
         Value::Fn(native) => native.call(&args),
+        Value::Type(tag) => call_type_constructor(tag, &args),
         Value::Closure(cl) => {
             if args.len() != cl.params.len() {
                 return Err(eval_error(format!(
@@ -1615,7 +1637,7 @@ mod tests {
     #[test]
     fn test_map() {
         assert_eval(
-            r#"map([["a", 1], ["b", 2]])"#,
+            r#"dict([["a", 1], ["b", 2]])"#,
             &[],
             Value::map(indexmap::indexmap! {
                 "a".into() => Value::from(1i64),
@@ -1894,9 +1916,9 @@ mod tests {
         assert_eval("type(true)", &[], Value::from("bool"));
         assert_eval("type(42)", &[], Value::from("int"));
         assert_eval("type(3.14)", &[], Value::from("float"));
-        assert_eval(r#"type("hello")"#, &[], Value::from("string"));
+        assert_eval(r#"type("hello")"#, &[], Value::from("str"));
         assert_eval("type([1, 2])", &[], Value::from("list"));
-        assert_eval(r#"type({"a": 1})"#, &[], Value::from("map"));
+        assert_eval(r#"type({"a": 1})"#, &[], Value::from("dict"));
     }
 
     #[test]

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -1243,15 +1243,20 @@ fn builtin_list(args: &[Value]) -> Result<Value> {
 }
 
 fn builtin_dict(args: &[Value]) -> Result<Value> {
-    if args.len() != 1 {
+    if args.len() > 1 {
         return Err(eval_error(format!(
-            "dict() expects 1 argument, got {}",
+            "dict() expects at most 1 argument, got {}",
             args.len()
         )));
     }
+    match args.first() {
+        None => return Ok(Value::map(IndexMap::new())),
+        Some(Value::Map(m)) => return Ok(Value::map(m.borrow().clone())),
+        _ => {}
+    }
     let pairs = match args.first() {
         Some(Value::Array(a)) => a.borrow().clone(),
-        _ => return Err(eval_error("dict() expects an array of [key, value] pairs")),
+        _ => return Err(eval_error("dict() expects a dict, an array of [key, value] pairs, or no argument")),
     };
     let mut out = IndexMap::new();
     for (i, pair) in pairs.iter().enumerate() {

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -1258,7 +1258,7 @@ fn builtin_dict(args: &[Value]) -> Result<Value> {
         Some(Value::Array(a)) => a.borrow().clone(),
         _ => {
             return Err(eval_error(
-                "dict() expects a dict, an array of [key, value] pairs, or no argument",
+                "dict() expects a dict, a list of [key, value] pairs, or no argument",
             ))
         }
     };
@@ -1269,7 +1269,7 @@ fn builtin_dict(args: &[Value]) -> Result<Value> {
                 let kv = kv.borrow();
                 if kv.len() != 2 {
                     return Err(eval_error(format!(
-                        "dict() entry at index {i} must be a 2-element array"
+                        "dict() entry at index {i} must be a 2-element list"
                     )));
                 }
                 let key = match &kv[0] {
@@ -1285,7 +1285,7 @@ fn builtin_dict(args: &[Value]) -> Result<Value> {
             }
             _ => {
                 return Err(eval_error(format!(
-                    "dict() entry at index {i} must be a 2-element array"
+                    "dict() entry at index {i} must be a 2-element list"
                 )))
             }
         }

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -5,10 +5,12 @@ use indexmap::IndexMap;
 
 use super::ast::{BinOp, Expr, ExprKind, UnaryOp};
 use super::builtins::{array as array_methods, map as map_methods, str as str_methods};
-use super::builtins::{builtin_itertools, builtin_json, builtin_math, builtin_regex, builtin_url};
+use super::builtins::{
+    builtin_itertools, builtin_json, builtin_math, regex_type_value, url_type_value,
+};
 use super::env::{new_frame, Env};
 use super::error::{eval_error, Error, Result, POS_UNSET};
-use super::value::{format_float, ClosureValue, NativeFn, TypeTag, Value};
+use super::value::{format_float, ClosureValue, NativeFn, TypeValue, Value};
 use crate::expect_arity;
 
 struct DepthCounter {
@@ -110,16 +112,29 @@ pub fn env_bind(env: &Env, name: impl Into<String>, val: Value) {
 }
 
 thread_local! {
+    static NULL_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("null", None));
+    static BOOL_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("bool", Some(NativeFn::new(builtin_bool))));
+    static INT_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("int", Some(NativeFn::new(builtin_int))));
+    static FLOAT_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("float", Some(NativeFn::new(builtin_float))));
+    static STR_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("str", Some(NativeFn::new(builtin_str))));
+    static LIST_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("list", Some(NativeFn::new(builtin_list))));
+    static DICT_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("dict", Some(NativeFn::new(builtin_dict))));
+    static FN_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("function", None));
+    static MODULE_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("module", None));
+    static TYPE_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("type", None));
+}
+
+thread_local! {
     static BUILTIN_ENV: Env = {
         let env = new_frame(None);
-        env_bind(&env, "str", Value::Type(TypeTag::Str));
-        env_bind(&env, "int", Value::Type(TypeTag::Int));
-        env_bind(&env, "float", Value::Type(TypeTag::Float));
-        env_bind(&env, "bool", Value::Type(TypeTag::Bool));
-        env_bind(&env, "list", Value::Type(TypeTag::List));
-        env_bind(&env, "dict", Value::Type(TypeTag::Dict));
-        env_bind(&env, "Url", Value::Fn(NativeFn::new(builtin_url)));
-        env_bind(&env, "Regex", Value::Fn(NativeFn::new(builtin_regex)));
+        env_bind(&env, "str", Value::Type(STR_TYPE.with(Rc::clone)));
+        env_bind(&env, "int", Value::Type(INT_TYPE.with(Rc::clone)));
+        env_bind(&env, "float", Value::Type(FLOAT_TYPE.with(Rc::clone)));
+        env_bind(&env, "bool", Value::Type(BOOL_TYPE.with(Rc::clone)));
+        env_bind(&env, "list", Value::Type(LIST_TYPE.with(Rc::clone)));
+        env_bind(&env, "dict", Value::Type(DICT_TYPE.with(Rc::clone)));
+        env_bind(&env, "Url", Value::Type(url_type_value()));
+        env_bind(&env, "Regex", Value::Type(regex_type_value()));
         env_bind(&env, "math", builtin_math());
         env_bind(&env, "print", Value::Fn(NativeFn::new(builtin_print)));
         env_bind(&env, "type", Value::Fn(NativeFn::new(builtin_type)));
@@ -142,33 +157,12 @@ pub fn eval(expr: &Expr, env: &Env) -> Result<Value> {
     }
 }
 
-fn call_type_constructor(tag: TypeTag, args: &[Value]) -> Result<Value> {
-    match tag {
-        TypeTag::Int => builtin_int(args),
-        TypeTag::Float => builtin_float(args),
-        TypeTag::Str => builtin_str(args),
-        TypeTag::Bool => builtin_bool(args),
-        TypeTag::List => builtin_list(args),
-        TypeTag::Dict => builtin_map(args),
-        TypeTag::Null => {
-            if !args.is_empty() {
-                return Err(eval_error(format!(
-                    "null() expects 0 arguments, got {}",
-                    args.len()
-                )));
-            }
-            Ok(Value::Null)
-        }
-        TypeTag::Fn => Err(eval_error("fn is not callable as a constructor")),
-    }
-}
-
 /// Unified callable dispatch: invokes a NativeFn, Type constructor, or Closure by value.
 pub(crate) fn call_value(f: Value, args: Vec<Value>) -> Result<Value> {
     let _guard = DepthGuard::enter(&CALL_DEPTH)?;
     match f {
         Value::Fn(native) => native.call(&args),
-        Value::Type(tag) => call_type_constructor(tag, &args),
+        Value::Type(tv) => tv.call_ctor(&args),
         Value::Closure(cl) => {
             if args.len() != cl.params.len() {
                 return Err(eval_error(format!(
@@ -1131,6 +1125,7 @@ fn primitive_eq(a: &Value, b: &Value) -> bool {
         (Value::Int(x), Value::Float(y)) => (*x as f64) == *y,
         (Value::Float(x), Value::Int(y)) => *x == (*y as f64),
         (Value::Fn(a), Value::Fn(b)) => a.ptr_eq(b),
+        (Value::Type(a), Value::Type(b)) => Rc::ptr_eq(a, b),
         _ => false,
     }
 }
@@ -1247,16 +1242,16 @@ fn builtin_list(args: &[Value]) -> Result<Value> {
     }
 }
 
-fn builtin_map(args: &[Value]) -> Result<Value> {
+fn builtin_dict(args: &[Value]) -> Result<Value> {
     if args.len() != 1 {
         return Err(eval_error(format!(
-            "map() expects 1 argument, got {}",
+            "dict() expects 1 argument, got {}",
             args.len()
         )));
     }
     let pairs = match args.first() {
         Some(Value::Array(a)) => a.borrow().clone(),
-        _ => return Err(eval_error("map() expects an array of [key, value] pairs")),
+        _ => return Err(eval_error("dict() expects an array of [key, value] pairs")),
     };
     let mut out = IndexMap::new();
     for (i, pair) in pairs.iter().enumerate() {
@@ -1265,14 +1260,14 @@ fn builtin_map(args: &[Value]) -> Result<Value> {
                 let kv = kv.borrow();
                 if kv.len() != 2 {
                     return Err(eval_error(format!(
-                        "map() entry at index {i} must be a 2-element array"
+                        "dict() entry at index {i} must be a 2-element array"
                     )));
                 }
                 let key = match &kv[0] {
                     Value::String(s) => s.clone(),
                     v => {
                         return Err(eval_error(format!(
-                            "map() key at index {i} must be a string, got {}",
+                            "dict() key at index {i} must be a string, got {}",
                             v.type_name()
                         )))
                     }
@@ -1281,7 +1276,7 @@ fn builtin_map(args: &[Value]) -> Result<Value> {
             }
             _ => {
                 return Err(eval_error(format!(
-                    "map() entry at index {i} must be a 2-element array"
+                    "dict() entry at index {i} must be a 2-element array"
                 )))
             }
         }
@@ -1289,9 +1284,25 @@ fn builtin_map(args: &[Value]) -> Result<Value> {
     Ok(Value::map(out))
 }
 
+fn type_of(v: &Value) -> Rc<TypeValue> {
+    match v {
+        Value::Null => NULL_TYPE.with(Rc::clone),
+        Value::Bool(_) => BOOL_TYPE.with(Rc::clone),
+        Value::Int(_) => INT_TYPE.with(Rc::clone),
+        Value::Float(_) => FLOAT_TYPE.with(Rc::clone),
+        Value::String(_) => STR_TYPE.with(Rc::clone),
+        Value::Array(_) => LIST_TYPE.with(Rc::clone),
+        Value::Map(_) => DICT_TYPE.with(Rc::clone),
+        Value::Fn(_) | Value::Closure(_) => FN_TYPE.with(Rc::clone),
+        Value::Module(_) => MODULE_TYPE.with(Rc::clone),
+        Value::Type(_) => TYPE_TYPE.with(Rc::clone),
+        Value::Object(rc) => rc.type_object(),
+    }
+}
+
 fn builtin_type(args: &[Value]) -> Result<Value> {
     expect_arity("type", args, 1, 1)?;
-    Ok(Value::String(args[0].type_name().to_string()))
+    Ok(Value::Type(type_of(&args[0])))
 }
 
 fn builtin_len(args: &[Value]) -> Result<Value> {
@@ -1753,8 +1764,12 @@ mod tests {
         struct Counter(i64);
 
         impl super::super::value::ImmutableObject for Counter {
-            fn type_name(&self) -> &'static str {
-                "Counter"
+            fn type_object(&self) -> Rc<super::super::value::TypeValue> {
+                thread_local! {
+                    static TY: Rc<super::super::value::TypeValue> =
+                        Rc::new(super::super::value::TypeValue::new("Counter", None));
+                }
+                TY.with(Rc::clone)
             }
             fn call_method(&self, method: &str, args: &[Value]) -> Result<Value> {
                 match method {
@@ -1801,8 +1816,12 @@ mod tests {
         struct Bag(Vec<(String, i64)>);
 
         impl super::super::value::ImmutableObject for Bag {
-            fn type_name(&self) -> &'static str {
-                "Bag"
+            fn type_object(&self) -> Rc<super::super::value::TypeValue> {
+                thread_local! {
+                    static TY: Rc<super::super::value::TypeValue> =
+                        Rc::new(super::super::value::TypeValue::new("Bag", None));
+                }
+                TY.with(Rc::clone)
             }
             fn call_method(&self, method: &str, args: &[Value]) -> Result<Value> {
                 match method {
@@ -1912,13 +1931,15 @@ mod tests {
 
     #[test]
     fn test_type_builtin() {
-        assert_eval("type(null)", &[], Value::from("null"));
-        assert_eval("type(true)", &[], Value::from("bool"));
-        assert_eval("type(42)", &[], Value::from("int"));
-        assert_eval("type(3.14)", &[], Value::from("float"));
-        assert_eval(r#"type("hello")"#, &[], Value::from("str"));
-        assert_eval("type([1, 2])", &[], Value::from("list"));
-        assert_eval(r#"type({"a": 1})"#, &[], Value::from("dict"));
+        assert_eval("type(42) == int", &[], Value::Bool(true));
+        assert_eval("type(3.14) == float", &[], Value::Bool(true));
+        assert_eval(r#"type("hello") == str"#, &[], Value::Bool(true));
+        assert_eval("type([1, 2]) == list", &[], Value::Bool(true));
+        assert_eval(r#"type({"a": 1}) == dict"#, &[], Value::Bool(true));
+        assert_eval("type(true) == bool", &[], Value::Bool(true));
+        assert_eval("type(42) != float", &[], Value::Bool(true));
+        assert_eval("int == int", &[], Value::Bool(true));
+        assert_eval("int == str", &[], Value::Bool(false));
     }
 
     #[test]

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -4,10 +4,10 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::ast::{BinOp, Expr, ExprKind, UnaryOp};
-use super::builtins::{list as list_methods, dict as dict_methods, str as str_methods};
 use super::builtins::{
     builtin_itertools, builtin_json, builtin_math, regex_type_value, url_type_value,
 };
+use super::builtins::{dict as dict_methods, list as list_methods, str as str_methods};
 use super::env::{new_frame, Env};
 use super::error::{eval_error, Error, Result, POS_UNSET};
 use super::value::{format_float, ClosureValue, NativeFn, TypeValue, Value};
@@ -1691,6 +1691,14 @@ mod tests {
             r#"{"a": 1, "b": 2} == {"b": 2, "a": 1}"#,
             &[],
             Value::Bool(true),
+        );
+        // dict() with no args produces empty dict
+        assert_eval("dict()", &[], Value::dict(indexmap::indexmap! {}));
+        // dict(d) produces a shallow copy
+        assert_eval(
+            r#"let b = dict(a); b["x"] = 9; a"#,
+            &[("a", Value::dict(indexmap::indexmap! { "x".into() => Value::from(1i64) }))],
+            Value::dict(indexmap::indexmap! { "x".into() => Value::from(1i64) }),
         );
     }
 

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::ast::{BinOp, Expr, ExprKind, UnaryOp};
-use super::builtins::{array as array_methods, map as map_methods, str as str_methods};
+use super::builtins::{array as array_methods, dict as dict_methods, str as str_methods};
 use super::builtins::{
     builtin_itertools, builtin_json, builtin_math, regex_type_value, url_type_value,
 };
@@ -207,7 +207,7 @@ fn eq_op(args: &[Value]) -> Result<Value> {
     }
     match (a, b) {
         (Value::Array(a), Value::Array(b)) => array_methods::eq_inner(a, b).map(Value::Bool),
-        (Value::Map(a), Value::Map(b)) => map_methods::eq_inner(a, b).map(Value::Bool),
+        (Value::Dict(a), Value::Dict(b)) => dict_methods::eq_inner(a, b).map(Value::Bool),
         _ => Ok(Value::Bool(primitive_eq(a, b))),
     }
 }
@@ -232,7 +232,7 @@ fn resolve_attr(recv: Value, attr: &str) -> Result<Value> {
         },
         recv @ Value::String(_) => str_methods::resolve_method(recv, attr).map(Value::Fn),
         recv @ Value::Array(_) => array_methods::resolve_method(recv, attr).map(Value::Fn),
-        recv @ Value::Map(_) => map_methods::resolve_method(recv, attr).map(Value::Fn),
+        recv @ Value::Dict(_) => dict_methods::resolve_method(recv, attr).map(Value::Fn),
         Value::Object(rc) => {
             if let Some(result) = rc.get_property(attr) {
                 return result;
@@ -530,10 +530,10 @@ fn contains_inner(left: Value, right: Value) -> Result<bool> {
                 l.type_name()
             ))),
         },
-        Value::Map(map) => match left {
+        Value::Dict(map) => match left {
             Value::String(key) => Ok(map.borrow().contains_key(&key)),
             l => Err(eval_error(format!(
-                "'in' not supported between {} and map",
+                "'in' not supported between {} and dict",
                 l.type_name()
             ))),
         },
@@ -637,13 +637,13 @@ fn eval_node(expr: &Expr, env: &Env) -> Result<Value> {
                     other => {
                         return Err(Error::Eval {
                             pos,
-                            msg: format!("map key must be a string, got {}", other.type_name()),
+                            msg: format!("dict key must be a string, got {}", other.type_name()),
                         })
                     }
                 };
                 map.insert(key_str, eval_inner(v, env)?);
             }
-            Ok(Value::map(map))
+            Ok(Value::dict(map))
         }
         ExprKind::Var(name) => env_get(env, name.as_str()).ok_or_else(|| Error::Eval {
             pos,
@@ -778,7 +778,7 @@ fn collect_iterable(value: Value, pos: usize) -> Result<Vec<Value>> {
     match value {
         Value::Array(rc) => Ok(rc.borrow().clone()),
         Value::String(s) => Ok(s.chars().map(|c| Value::String(c.to_string())).collect()),
-        Value::Map(rc) => Ok(rc
+        Value::Dict(rc) => Ok(rc
             .borrow()
             .keys()
             .map(|k| Value::String(k.clone()))
@@ -823,7 +823,7 @@ fn eval_assign_lvalue(lvalue: &Expr, value: Value, env: &Env, local: bool) -> Re
                     })?;
                     rc.borrow_mut()[idx] = value;
                 }
-                (Value::Map(rc), Value::String(k)) => {
+                (Value::Dict(rc), Value::String(k)) => {
                     rc.borrow_mut().insert(k.clone(), value);
                 }
                 (c, k) => {
@@ -897,7 +897,7 @@ fn eval_compound_assign(
                     rc.borrow_mut()[idx] = new_val.clone();
                     Ok(new_val)
                 }
-                (Value::Map(rc), Value::String(k)) => {
+                (Value::Dict(rc), Value::String(k)) => {
                     let current = rc.borrow().get(k.as_str()).cloned().unwrap_or(Value::Null);
                     let new_val = call_value(Value::Fn(f.clone()), vec![current, rhs_val])?;
                     rc.borrow_mut().insert(k.clone(), new_val.clone());
@@ -922,11 +922,11 @@ fn eval_compound_assign(
 
 fn eval_index(target: Value, key: Value) -> Result<Value> {
     match (target, key) {
-        (Value::Map(map), Value::String(k)) => map
+        (Value::Dict(map), Value::String(k)) => map
             .borrow()
             .get(&k)
             .cloned()
-            .ok_or_else(|| eval_error(format!("map key '{k}' not found"))),
+            .ok_or_else(|| eval_error(format!("dict key '{k}' not found"))),
         (Value::Array(arr), Value::Int(i)) => {
             let arr = arr.borrow();
             let len = arr.len();
@@ -1228,7 +1228,7 @@ fn builtin_list(args: &[Value]) -> Result<Value> {
         Some(Value::String(s)) => Ok(Value::array(
             s.chars().map(|c| Value::String(c.to_string())).collect(),
         )),
-        Some(Value::Map(m)) => Ok(Value::array(
+        Some(Value::Dict(m)) => Ok(Value::array(
             m.borrow()
                 .keys()
                 .map(|k| Value::String(k.clone()))
@@ -1250,8 +1250,8 @@ fn builtin_dict(args: &[Value]) -> Result<Value> {
         )));
     }
     match args.first() {
-        None => return Ok(Value::map(IndexMap::new())),
-        Some(Value::Map(m)) => return Ok(Value::map(m.borrow().clone())),
+        None => return Ok(Value::dict(IndexMap::new())),
+        Some(Value::Dict(m)) => return Ok(Value::dict(m.borrow().clone())),
         _ => {}
     }
     let pairs = match args.first() {
@@ -1290,10 +1290,10 @@ fn builtin_dict(args: &[Value]) -> Result<Value> {
             }
         }
     }
-    Ok(Value::map(out))
+    Ok(Value::dict(out))
 }
 
-fn type_of(v: &Value) -> Rc<TypeValue> {
+pub(crate) fn type_of(v: &Value) -> Rc<TypeValue> {
     match v {
         Value::Null => NULL_TYPE.with(Rc::clone),
         Value::Bool(_) => BOOL_TYPE.with(Rc::clone),
@@ -1301,7 +1301,7 @@ fn type_of(v: &Value) -> Rc<TypeValue> {
         Value::Float(_) => FLOAT_TYPE.with(Rc::clone),
         Value::String(_) => STR_TYPE.with(Rc::clone),
         Value::Array(_) => LIST_TYPE.with(Rc::clone),
-        Value::Map(_) => DICT_TYPE.with(Rc::clone),
+        Value::Dict(_) => DICT_TYPE.with(Rc::clone),
         Value::Fn(_) | Value::Closure(_) => FN_TYPE.with(Rc::clone),
         Value::Module(_) => MODULE_TYPE.with(Rc::clone),
         Value::Type(_) => TYPE_TYPE.with(Rc::clone),
@@ -1319,7 +1319,7 @@ fn builtin_len(args: &[Value]) -> Result<Value> {
     match &args[0] {
         Value::String(s) => Ok(Value::Int(s.chars().count() as i64)),
         Value::Array(rc) => Ok(Value::Int(rc.borrow().len() as i64)),
-        Value::Map(rc) => Ok(Value::Int(rc.borrow().len() as i64)),
+        Value::Dict(rc) => Ok(Value::Int(rc.borrow().len() as i64)),
         other => Err(eval_error(format!(
             "len() not supported for {}",
             other.type_name()
@@ -1510,7 +1510,7 @@ mod tests {
 
     #[test]
     fn test_index() {
-        let m = Value::map(indexmap::indexmap! {
+        let m = Value::dict(indexmap::indexmap! {
             "name".into() => Value::from("alice"),
         });
         assert_eval(r#"m["name"]"#, &[("m", m.clone())], Value::from("alice"));
@@ -1577,7 +1577,7 @@ mod tests {
         assert_eval(r#""xyz" in "hello world""#, &[], Value::from(false));
         assert_eval(r#""xyz" not in "hello world""#, &[], Value::from(true));
         assert_eval(r#""" in "hello""#, &[], Value::from(true));
-        let m = Value::map(indexmap::indexmap! {
+        let m = Value::dict(indexmap::indexmap! {
             "a".into() => Value::from(1i64),
             "b".into() => Value::from(2i64),
         });
@@ -1655,11 +1655,11 @@ mod tests {
     }
 
     #[test]
-    fn test_map() {
+    fn test_dict() {
         assert_eval(
             r#"dict([["a", 1], ["b", 2]])"#,
             &[],
-            Value::map(indexmap::indexmap! {
+            Value::dict(indexmap::indexmap! {
                 "a".into() => Value::from(1i64),
                 "b".into() => Value::from(2i64),
             }),
@@ -1667,7 +1667,7 @@ mod tests {
         assert_eval(
             r#"{"a": 1, "b": 2}"#,
             &[],
-            Value::map(indexmap::indexmap! {
+            Value::dict(indexmap::indexmap! {
                 "a".into() => Value::from(1i64),
                 "b".into() => Value::from(2i64),
             }),
@@ -1675,15 +1675,15 @@ mod tests {
         assert_eval(
             r#"{"x": true,}"#,
             &[],
-            Value::map(indexmap::indexmap! { "x".into() => Value::Bool(true) }),
+            Value::dict(indexmap::indexmap! { "x".into() => Value::Bool(true) }),
         );
-        assert_eval("{}", &[], Value::map(indexmap::indexmap! {}));
+        assert_eval("{}", &[], Value::dict(indexmap::indexmap! {}));
         assert_eval(r#"{"pre" + "fix": 9}["prefix"]"#, &[], Value::from(9i64));
         assert_eval(
             r#"{"a": {"b": 2}}"#,
             &[],
-            Value::map(indexmap::indexmap! {
-                "a".into() => Value::map(indexmap::indexmap! { "b".into() => Value::from(2i64) }),
+            Value::dict(indexmap::indexmap! {
+                "a".into() => Value::dict(indexmap::indexmap! { "b".into() => Value::from(2i64) }),
             }),
         );
         // insertion order must not affect equality
@@ -1740,7 +1740,7 @@ mod tests {
         assert_eval(r#"list("abc")"#, &[], Value::from(vec!["a", "b", "c"]));
         let arr = Value::from(vec![1i64, 2i64]);
         assert_eval("list(arr)", &[("arr", arr.clone())], arr);
-        let m = Value::map(
+        let m = Value::dict(
             indexmap::indexmap! { "x".into() => Value::from(1i64), "y".into() => Value::from(2i64) },
         );
         assert_eval("list(m)", &[("m", m)], Value::from(vec!["x", "y"]));
@@ -1930,7 +1930,7 @@ mod tests {
         assert_eval(r#"len("")"#, &[], Value::from(0i64));
         let arr = Value::from(vec![1i64, 2i64, 3i64]);
         assert_eval("len(arr)", &[("arr", arr)], Value::from(3i64));
-        let m = Value::map(indexmap::indexmap! {
+        let m = Value::dict(indexmap::indexmap! {
             "x".into() => Value::from(1i64),
             "y".into() => Value::from(2i64),
         });
@@ -1956,7 +1956,7 @@ mod tests {
 
     #[test]
     fn test_complex_expr() {
-        let obj = Value::map(indexmap::indexmap! {
+        let obj = Value::dict(indexmap::indexmap! {
             "type".into() => Value::from("json"),
             "name".into() => Value::from("foo"),
         });
@@ -2037,7 +2037,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_index_assign() {
+    fn test_dict_index_assign() {
         assert_eval(
             r#"m = {"a": 1}; m["b"] = 2; m["b"]"#,
             &[],
@@ -2112,7 +2112,7 @@ mod tests {
 
     #[test]
     fn test_for_in_map_keys() {
-        let m = Value::map(indexmap::indexmap! {
+        let m = Value::dict(indexmap::indexmap! {
             "a".into() => Value::from(1i64),
             "b".into() => Value::from(2i64),
         });
@@ -2213,7 +2213,7 @@ mod tests {
 
     #[test]
     fn test_for_in_map_items() {
-        let m = Value::map(indexmap::indexmap! {
+        let m = Value::dict(indexmap::indexmap! {
             "a".into() => Value::from(10i64),
             "b".into() => Value::from(20i64),
         });

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -111,6 +111,11 @@ pub fn env_bind(env: &Env, name: impl Into<String>, val: Value) {
     env.borrow_mut().bindings.insert(name.into(), val);
 }
 
+/// Remove a binding from the innermost frame.
+pub fn env_remove(env: &Env, name: &str) {
+    env.borrow_mut().bindings.remove(name);
+}
+
 thread_local! {
     static NULL_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("nullType", None));
     static BOOL_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("bool", Some(NativeFn::new(builtin_bool))));
@@ -819,7 +824,7 @@ fn eval_assign_lvalue(lvalue: &Expr, value: Value, env: &Env, local: bool) -> Re
                     let len = rc.borrow().len();
                     let idx = list_methods::resolve_index(*i, len).ok_or_else(|| Error::Eval {
                         pos,
-                        msg: format!("array index {} out of range (len {})", i, len),
+                        msg: format!("list index {} out of range (len {})", i, len),
                     })?;
                     rc.borrow_mut()[idx] = value;
                 }
@@ -890,7 +895,7 @@ fn eval_compound_assign(
                     let len = rc.borrow().len();
                     let idx = list_methods::resolve_index(*i, len).ok_or_else(|| Error::Eval {
                         pos,
-                        msg: format!("array index {} out of range (len {})", i, len),
+                        msg: format!("list index {} out of range (len {})", i, len),
                     })?;
                     let current = rc.borrow()[idx].clone();
                     let new_val = call_value(Value::Fn(f.clone()), vec![current, rhs_val])?;
@@ -932,7 +937,7 @@ fn eval_index(target: Value, key: Value) -> Result<Value> {
             let len = arr.len();
             list_methods::resolve_index(i, len)
                 .map(|pos| arr[pos].clone())
-                .ok_or_else(|| eval_error(format!("array index {i} out of range (len {len})")))
+                .ok_or_else(|| eval_error(format!("list index {i} out of range (len {len})")))
         }
         (Value::String(s), Value::Int(i)) => {
             let chars: Vec<char> = s.chars().collect();

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -121,7 +121,7 @@ thread_local! {
     static DICT_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("dict", Some(NativeFn::new(builtin_dict))));
     static FN_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("function", None));
     static MODULE_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("module", None));
-    static TYPE_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("type", None));
+    static TYPE_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("type", Some(NativeFn::new(builtin_type))));
 }
 
 thread_local! {
@@ -137,7 +137,7 @@ thread_local! {
         env_bind(&env, "Regex", Value::Type(regex_type_value()));
         env_bind(&env, "math", builtin_math());
         env_bind(&env, "print", Value::Fn(NativeFn::new(builtin_print)));
-        env_bind(&env, "type", Value::Fn(NativeFn::new(builtin_type)));
+        env_bind(&env, "type", Value::Type(TYPE_TYPE.with(Rc::clone)));
         env_bind(&env, "len", Value::Fn(NativeFn::new(builtin_len)));
         env_bind(&env, "itertools", builtin_itertools());
         env_bind(&env, "json", builtin_json());
@@ -1940,6 +1940,9 @@ mod tests {
         assert_eval("type(42) != float", &[], Value::Bool(true));
         assert_eval("int == int", &[], Value::Bool(true));
         assert_eval("int == str", &[], Value::Bool(false));
+        assert_eval("type(type) == type", &[], Value::Bool(true));
+        assert_eval("type(int) == type", &[], Value::Bool(true));
+        assert_eval("type(42) == type", &[], Value::Bool(false));
     }
 
     #[test]

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::ast::{BinOp, Expr, ExprKind, UnaryOp};
-use super::builtins::{array as array_methods, dict as dict_methods, str as str_methods};
+use super::builtins::{list as list_methods, dict as dict_methods, str as str_methods};
 use super::builtins::{
     builtin_itertools, builtin_json, builtin_math, regex_type_value, url_type_value,
 };
@@ -206,7 +206,7 @@ fn eq_op(args: &[Value]) -> Result<Value> {
         return rc.call_method("__eq__", std::slice::from_ref(b));
     }
     match (a, b) {
-        (Value::Array(a), Value::Array(b)) => array_methods::eq_inner(a, b).map(Value::Bool),
+        (Value::List(a), Value::List(b)) => list_methods::eq_inner(a, b).map(Value::Bool),
         (Value::Dict(a), Value::Dict(b)) => dict_methods::eq_inner(a, b).map(Value::Bool),
         _ => Ok(Value::Bool(primitive_eq(a, b))),
     }
@@ -231,7 +231,7 @@ fn resolve_attr(recv: Value, attr: &str) -> Result<Value> {
             _ => Err(eval_error(format!("int has no attribute '{attr}'"))),
         },
         recv @ Value::String(_) => str_methods::resolve_method(recv, attr).map(Value::Fn),
-        recv @ Value::Array(_) => array_methods::resolve_method(recv, attr).map(Value::Fn),
+        recv @ Value::List(_) => list_methods::resolve_method(recv, attr).map(Value::Fn),
         recv @ Value::Dict(_) => dict_methods::resolve_method(recv, attr).map(Value::Fn),
         Value::Object(rc) => {
             if let Some(result) = rc.get_property(attr) {
@@ -255,10 +255,10 @@ pub(super) fn value_add(left: Value, right: Value) -> Result<Value> {
     }
     match (left, right) {
         (Value::String(a), Value::String(b)) => Ok(Value::String(a + b.as_str())),
-        (Value::Array(a), Value::Array(b)) => {
+        (Value::List(a), Value::List(b)) => {
             let mut new_vec = a.borrow().clone();
             new_vec.extend(b.borrow().iter().cloned());
-            Ok(Value::array(new_vec))
+            Ok(Value::list(new_vec))
         }
         (a, b) => match coerce_numeric(&a, &b) {
             Ok((Numeric::Int(a), Numeric::Int(b))) => {
@@ -514,7 +514,7 @@ fn resolve_op(op: &BinOp) -> NativeFn {
 
 fn contains_inner(left: Value, right: Value) -> Result<bool> {
     match right {
-        Value::Array(arr) => {
+        Value::List(arr) => {
             let arr = arr.borrow();
             for v in arr.iter() {
                 if eval_eq(v.clone(), left.clone())? {
@@ -626,7 +626,7 @@ fn eval_node(expr: &Expr, env: &Env) -> Result<Value> {
             for e in items {
                 values.push(eval_inner(e, env)?);
             }
-            Ok(Value::array(values))
+            Ok(Value::list(values))
         }
         ExprKind::Map(entries) => {
             let mut map = IndexMap::new();
@@ -776,7 +776,7 @@ fn eval_node(expr: &Expr, env: &Env) -> Result<Value> {
 
 fn collect_iterable(value: Value, pos: usize) -> Result<Vec<Value>> {
     match value {
-        Value::Array(rc) => Ok(rc.borrow().clone()),
+        Value::List(rc) => Ok(rc.borrow().clone()),
         Value::String(s) => Ok(s.chars().map(|c| Value::String(c.to_string())).collect()),
         Value::Dict(rc) => Ok(rc
             .borrow()
@@ -784,7 +784,7 @@ fn collect_iterable(value: Value, pos: usize) -> Result<Vec<Value>> {
             .map(|k| Value::String(k.clone()))
             .collect()),
         Value::Object(rc) => match rc.call_method("__iter__", &[])? {
-            Value::Array(arr) => Ok(arr.borrow().clone()),
+            Value::List(arr) => Ok(arr.borrow().clone()),
             v => Err(Error::Eval {
                 pos,
                 msg: format!("__iter__ must return a list, got {}", v.type_name()),
@@ -815,9 +815,9 @@ fn eval_assign_lvalue(lvalue: &Expr, value: Value, env: &Env, local: bool) -> Re
             let container = eval_inner(target, env)?;
             let key_val = eval_inner(key, env)?;
             match (container, &key_val) {
-                (Value::Array(rc), Value::Int(i)) => {
+                (Value::List(rc), Value::Int(i)) => {
                     let len = rc.borrow().len();
-                    let idx = array_methods::resolve_index(*i, len).ok_or_else(|| Error::Eval {
+                    let idx = list_methods::resolve_index(*i, len).ok_or_else(|| Error::Eval {
                         pos,
                         msg: format!("array index {} out of range (len {})", i, len),
                     })?;
@@ -886,9 +886,9 @@ fn eval_compound_assign(
             let container = eval_inner(target, env)?;
             let key_val = eval_inner(key, env)?;
             match (container, &key_val) {
-                (Value::Array(rc), Value::Int(i)) => {
+                (Value::List(rc), Value::Int(i)) => {
                     let len = rc.borrow().len();
-                    let idx = array_methods::resolve_index(*i, len).ok_or_else(|| Error::Eval {
+                    let idx = list_methods::resolve_index(*i, len).ok_or_else(|| Error::Eval {
                         pos,
                         msg: format!("array index {} out of range (len {})", i, len),
                     })?;
@@ -927,17 +927,17 @@ fn eval_index(target: Value, key: Value) -> Result<Value> {
             .get(&k)
             .cloned()
             .ok_or_else(|| eval_error(format!("dict key '{k}' not found"))),
-        (Value::Array(arr), Value::Int(i)) => {
+        (Value::List(arr), Value::Int(i)) => {
             let arr = arr.borrow();
             let len = arr.len();
-            array_methods::resolve_index(i, len)
+            list_methods::resolve_index(i, len)
                 .map(|pos| arr[pos].clone())
                 .ok_or_else(|| eval_error(format!("array index {i} out of range (len {len})")))
         }
         (Value::String(s), Value::Int(i)) => {
             let chars: Vec<char> = s.chars().collect();
             let len = chars.len();
-            array_methods::resolve_index(i, len)
+            list_methods::resolve_index(i, len)
                 .map(|pos| Value::String(chars[pos].to_string()))
                 .ok_or_else(|| eval_error(format!("string index {i} out of range (len {len})")))
         }
@@ -1008,10 +1008,10 @@ fn eval_slice(
     let stop = stop.map(|v| as_slice_index(v, "stop")).transpose()?;
 
     match target {
-        Value::Array(arr) => {
+        Value::List(arr) => {
             let arr = arr.borrow();
             let indices = slice_indices(arr.len(), start, stop, step);
-            Ok(Value::array(
+            Ok(Value::list(
                 indices.into_iter().map(|i| arr[i].clone()).collect(),
             ))
         }
@@ -1084,7 +1084,7 @@ fn compare_values(
         Ok(_) => unreachable!(),
         Err(_) => match (&left, &right) {
             (Value::String(a), Value::String(b)) => a.as_str().cmp(b.as_str()),
-            (Value::Array(a), Value::Array(b)) => compare_arrays(&a.borrow(), &b.borrow())?,
+            (Value::List(a), Value::List(b)) => compare_arrays(&a.borrow(), &b.borrow())?,
             _ => {
                 return Err(eval_error(format!(
                     "cannot compare {} and {}",
@@ -1224,11 +1224,11 @@ fn builtin_list(args: &[Value]) -> Result<Value> {
         )));
     }
     match args.first() {
-        Some(Value::Array(a)) => Ok(Value::array(a.borrow().clone())),
-        Some(Value::String(s)) => Ok(Value::array(
+        Some(Value::List(a)) => Ok(Value::list(a.borrow().clone())),
+        Some(Value::String(s)) => Ok(Value::list(
             s.chars().map(|c| Value::String(c.to_string())).collect(),
         )),
-        Some(Value::Dict(m)) => Ok(Value::array(
+        Some(Value::Dict(m)) => Ok(Value::list(
             m.borrow()
                 .keys()
                 .map(|k| Value::String(k.clone()))
@@ -1238,7 +1238,7 @@ fn builtin_list(args: &[Value]) -> Result<Value> {
             "list() not supported for {}",
             v.type_name()
         ))),
-        None => Ok(Value::array(vec![])),
+        None => Ok(Value::list(vec![])),
     }
 }
 
@@ -1255,7 +1255,7 @@ fn builtin_dict(args: &[Value]) -> Result<Value> {
         _ => {}
     }
     let pairs = match args.first() {
-        Some(Value::Array(a)) => a.borrow().clone(),
+        Some(Value::List(a)) => a.borrow().clone(),
         _ => {
             return Err(eval_error(
                 "dict() expects a dict, a list of [key, value] pairs, or no argument",
@@ -1265,7 +1265,7 @@ fn builtin_dict(args: &[Value]) -> Result<Value> {
     let mut out = IndexMap::new();
     for (i, pair) in pairs.iter().enumerate() {
         match pair {
-            Value::Array(kv) => {
+            Value::List(kv) => {
                 let kv = kv.borrow();
                 if kv.len() != 2 {
                     return Err(eval_error(format!(
@@ -1300,7 +1300,7 @@ pub(crate) fn type_of(v: &Value) -> Rc<TypeValue> {
         Value::Int(_) => INT_TYPE.with(Rc::clone),
         Value::Float(_) => FLOAT_TYPE.with(Rc::clone),
         Value::String(_) => STR_TYPE.with(Rc::clone),
-        Value::Array(_) => LIST_TYPE.with(Rc::clone),
+        Value::List(_) => LIST_TYPE.with(Rc::clone),
         Value::Dict(_) => DICT_TYPE.with(Rc::clone),
         Value::Fn(_) | Value::Closure(_) => FN_TYPE.with(Rc::clone),
         Value::Module(_) => MODULE_TYPE.with(Rc::clone),
@@ -1318,7 +1318,7 @@ fn builtin_len(args: &[Value]) -> Result<Value> {
     expect_arity("len", args, 1, 1)?;
     match &args[0] {
         Value::String(s) => Ok(Value::Int(s.chars().count() as i64)),
-        Value::Array(rc) => Ok(Value::Int(rc.borrow().len() as i64)),
+        Value::List(rc) => Ok(Value::Int(rc.borrow().len() as i64)),
         Value::Dict(rc) => Ok(Value::Int(rc.borrow().len() as i64)),
         other => Err(eval_error(format!(
             "len() not supported for {}",
@@ -1338,12 +1338,12 @@ fn builtin_range(args: &[Value]) -> Result<Value> {
     match args.len() {
         1 => {
             let end = to_int(&args[0], "end")?;
-            Ok(Value::array((0..end).map(Value::Int).collect()))
+            Ok(Value::list((0..end).map(Value::Int).collect()))
         }
         2 => {
             let start = to_int(&args[0], "start")?;
             let end = to_int(&args[1], "end")?;
-            Ok(Value::array((start..end).map(Value::Int).collect()))
+            Ok(Value::list((start..end).map(Value::Int).collect()))
         }
         3 => {
             let start = to_int(&args[0], "start")?;
@@ -1369,7 +1369,7 @@ fn builtin_range(args: &[Value]) -> Result<Value> {
                         .ok_or_else(|| eval_error("range() step caused integer overflow"))?;
                 }
             }
-            Ok(Value::array(result))
+            Ok(Value::list(result))
         }
         n => Err(eval_error(format!(
             "range() expects 1-3 arguments, got {n}"
@@ -1533,7 +1533,7 @@ mod tests {
         assert_eval(r#""abcde"[::-1]"#, &[], Value::from("edcba"));
         assert_eval(r#""abcde"[-1::-2]"#, &[], Value::from("eca"));
         assert_eval(r#""abcde"[::2]"#, &[], Value::from("ace"));
-        let arr = Value::array((0i64..5).map(Value::from).collect());
+        let arr = Value::list((0i64..5).map(Value::from).collect());
         assert_eval(
             "arr[1:3]",
             &[("arr", arr.clone())],
@@ -1547,7 +1547,7 @@ mod tests {
         assert_eval(
             "arr[::-1]",
             &[("arr", arr.clone())],
-            Value::array((0i64..5).rev().map(Value::from).collect()),
+            Value::list((0i64..5).rev().map(Value::from).collect()),
         );
         assert!(try_run("arr[s:]", &[("arr", arr.clone()), ("s", Value::Float(1.0))]).is_err());
         assert!(try_run("arr[:s]", &[("arr", arr.clone()), ("s", Value::Float(3.0))]).is_err());
@@ -1843,7 +1843,7 @@ mod tests {
                             .ok_or_else(|| eval_error(format!("key '{k}' not found"))),
                         _ => Err(eval_error("__getitem__ expects a string")),
                     },
-                    "__iter__" => Ok(Value::array(
+                    "__iter__" => Ok(Value::list(
                         self.0
                             .iter()
                             .map(|(k, _)| Value::String(k.clone()))
@@ -1987,11 +1987,11 @@ mod tests {
     #[test]
     // This tests if stack overflow is captured as error instead of crashing the engine
     fn test_deep_list_eq_depth_limit() {
-        let mut a = Value::array(vec![Value::Int(1)]);
-        let mut b = Value::array(vec![Value::Int(1)]);
+        let mut a = Value::list(vec![Value::Int(1)]);
+        let mut b = Value::list(vec![Value::Int(1)]);
         for _ in 0..CALL_DEPTH.with(|c| c.limit) {
-            a = Value::array(vec![a]);
-            b = Value::array(vec![b]);
+            a = Value::list(vec![a]);
+            b = Value::list(vec![b]);
         }
         assert!(try_run("a == b", &[("a", a), ("b", b)]).is_err());
     }

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -1256,7 +1256,11 @@ fn builtin_dict(args: &[Value]) -> Result<Value> {
     }
     let pairs = match args.first() {
         Some(Value::Array(a)) => a.borrow().clone(),
-        _ => return Err(eval_error("dict() expects a dict, an array of [key, value] pairs, or no argument")),
+        _ => {
+            return Err(eval_error(
+                "dict() expects a dict, an array of [key, value] pairs, or no argument",
+            ))
+        }
     };
     let mut out = IndexMap::new();
     for (i, pair) in pairs.iter().enumerate() {

--- a/engine/runtime/expr/src/core/eval.rs
+++ b/engine/runtime/expr/src/core/eval.rs
@@ -112,7 +112,7 @@ pub fn env_bind(env: &Env, name: impl Into<String>, val: Value) {
 }
 
 thread_local! {
-    static NULL_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("null", None));
+    static NULL_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("nullType", None));
     static BOOL_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("bool", Some(NativeFn::new(builtin_bool))));
     static INT_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("int", Some(NativeFn::new(builtin_int))));
     static FLOAT_TYPE: Rc<TypeValue> = Rc::new(TypeValue::new("float", Some(NativeFn::new(builtin_float))));

--- a/engine/runtime/expr/src/core/value.rs
+++ b/engine/runtime/expr/src/core/value.rs
@@ -102,7 +102,7 @@ impl std::fmt::Debug for NativeFn {
 
 /// Runtime value type for the expression evaluator.
 ///
-/// `Array` and `Dict` use `Rc<RefCell<...>>` for reference semantics: cloning a
+/// `List` and `Dict` use `Rc<RefCell<...>>` for reference semantics: cloning a
 /// value shares the same backing allocation, so mutations through one alias are
 /// visible through all others (Python-style). Circular references are the
 /// caller's responsibility and are not detected.
@@ -116,7 +116,7 @@ pub enum Value {
     Int(i64),
     Float(f64),
     String(String),
-    Array(Rc<RefCell<Vec<Value>>>),
+    List(Rc<RefCell<Vec<Value>>>),
     Dict(Rc<RefCell<IndexMap<String, Value>>>),
     /// A native Rust function seeded into the environment.
     Fn(NativeFn),
@@ -130,9 +130,8 @@ pub enum Value {
 }
 
 impl Value {
-    /// Construct an array value, wrapping `items` in a fresh shared allocation.
-    pub fn array(items: Vec<Value>) -> Self {
-        Value::Array(Rc::new(RefCell::new(items)))
+    pub fn list(items: Vec<Value>) -> Self {
+        Value::List(Rc::new(RefCell::new(items)))
     }
 
     pub fn dict(entries: IndexMap<String, Value>) -> Self {
@@ -191,7 +190,7 @@ impl Value {
             Value::Int(n) => *n != 0,
             Value::Float(f) => *f != 0.0,
             Value::String(s) => !s.is_empty(),
-            Value::Array(a) => !a.borrow().is_empty(),
+            Value::List(a) => !a.borrow().is_empty(),
             Value::Dict(o) => !o.borrow().is_empty(),
             Value::Fn(_)
             | Value::Closure(_)
@@ -237,7 +236,7 @@ impl std::fmt::Display for Value {
             Value::Int(n) => write!(f, "{n}"),
             Value::Float(n) => write!(f, "{}", format_float(*n)),
             Value::String(s) => write!(f, "{s:?}"),
-            Value::Array(arr) => {
+            Value::List(arr) => {
                 let arr = arr.borrow();
                 write!(f, "[")?;
                 for (i, v) in arr.iter().enumerate() {
@@ -300,6 +299,6 @@ impl From<String> for Value {
 
 impl<T: Into<Value>> From<Vec<T>> for Value {
     fn from(v: Vec<T>) -> Self {
-        Value::array(v.into_iter().map(Into::into).collect())
+        Value::list(v.into_iter().map(Into::into).collect())
     }
 }

--- a/engine/runtime/expr/src/core/value.rs
+++ b/engine/runtime/expr/src/core/value.rs
@@ -357,7 +357,7 @@ pub trait FromValue: Sized {
     fn from_string(s: String) -> std::result::Result<Self, Self::Error>;
     fn from_list(items: Vec<Self>) -> std::result::Result<Self, Self::Error>;
     fn from_dict(map: IndexMap<String, Self>) -> std::result::Result<Self, Self::Error>;
-    /// Called when a cycle is detected in List or Dict. Panic is the expected default.
+    /// Called when a cycle is detected in List or Dict.
     fn on_cycle() -> std::result::Result<Self, Self::Error>;
     /// Called for Value variants that cannot be represented (Fn, Closure, Module, Type,
     /// or a non-serializable Object).

--- a/engine/runtime/expr/src/core/value.rs
+++ b/engine/runtime/expr/src/core/value.rs
@@ -8,6 +8,7 @@ pub type Module = IndexMap<String, Value>;
 
 use super::ast::Expr;
 use super::env::Frame;
+use super::eval::type_of;
 use crate::core::error::{eval_error, Result};
 
 /// A user-defined closure: parameter names, body AST, and the lexical env captured at definition.
@@ -101,7 +102,7 @@ impl std::fmt::Debug for NativeFn {
 
 /// Runtime value type for the expression evaluator.
 ///
-/// `Array` and `Map` use `Rc<RefCell<...>>` for reference semantics: cloning a
+/// `Array` and `Dict` use `Rc<RefCell<...>>` for reference semantics: cloning a
 /// value shares the same backing allocation, so mutations through one alias are
 /// visible through all others (Python-style). Circular references are the
 /// caller's responsibility and are not detected.
@@ -116,7 +117,7 @@ pub enum Value {
     Float(f64),
     String(String),
     Array(Rc<RefCell<Vec<Value>>>),
-    Map(Rc<RefCell<IndexMap<String, Value>>>),
+    Dict(Rc<RefCell<IndexMap<String, Value>>>),
     /// A native Rust function seeded into the environment.
     Fn(NativeFn),
     /// A user-defined closure capturing a lexical env frame.
@@ -134,9 +135,8 @@ impl Value {
         Value::Array(Rc::new(RefCell::new(items)))
     }
 
-    /// Construct a map value, wrapping `entries` in a fresh shared allocation.
-    pub fn map(entries: IndexMap<String, Value>) -> Self {
-        Value::Map(Rc::new(RefCell::new(entries)))
+    pub fn dict(entries: IndexMap<String, Value>) -> Self {
+        Value::Dict(Rc::new(RefCell::new(entries)))
     }
 
     /// Construct an object value, wrapping `obj` in a fresh shared allocation.
@@ -146,19 +146,7 @@ impl Value {
 
     /// The kind of value this is, as a string. Used in error messages.
     pub fn type_name(&self) -> String {
-        match self {
-            Value::Null => "null".into(),
-            Value::Bool(_) => "bool".into(),
-            Value::Int(_) => "int".into(),
-            Value::Float(_) => "float".into(),
-            Value::String(_) => "str".into(),
-            Value::Array(_) => "list".into(),
-            Value::Map(_) => "dict".into(),
-            Value::Fn(_) | Value::Closure(_) => "function".into(),
-            Value::Object(rc) => rc.type_object().name.clone(),
-            Value::Module(_) => "module".into(),
-            Value::Type(_) => "type".into(),
-        }
+        type_of(self).name.clone()
     }
 
     pub fn module(m: Module) -> Self {
@@ -204,7 +192,7 @@ impl Value {
             Value::Float(f) => *f != 0.0,
             Value::String(s) => !s.is_empty(),
             Value::Array(a) => !a.borrow().is_empty(),
-            Value::Map(o) => !o.borrow().is_empty(),
+            Value::Dict(o) => !o.borrow().is_empty(),
             Value::Fn(_)
             | Value::Closure(_)
             | Value::Object(_)
@@ -260,7 +248,7 @@ impl std::fmt::Display for Value {
                 }
                 write!(f, "]")
             }
-            Value::Map(map) => {
+            Value::Dict(map) => {
                 let map = map.borrow();
                 write!(f, "{{")?;
                 for (i, (k, v)) in map.iter().enumerate() {

--- a/engine/runtime/expr/src/core/value.rs
+++ b/engine/runtime/expr/src/core/value.rs
@@ -153,14 +153,6 @@ impl std::fmt::Debug for NativeFn {
 }
 
 /// Runtime value type for the expression evaluator.
-///
-/// `List` and `Dict` use `Rc<RefCell<...>>` for reference semantics: cloning a
-/// value shares the same backing allocation, so mutations through one alias are
-/// visible through all others (Python-style). Circular references are the
-/// caller's responsibility and are not detected.
-///
-/// `Object` uses `Rc<dyn ImmutableObject>` without `RefCell` — objects are
-/// immutable from the expression language's perspective.
 #[derive(Debug, Clone)]
 pub enum Value {
     Null,
@@ -170,14 +162,10 @@ pub enum Value {
     String(String),
     List(TrackedRc<RefCell<Vec<Value>>>),
     Dict(TrackedRc<RefCell<IndexMap<String, Value>>>),
-    /// A native Rust function seeded into the environment.
     Fn(NativeFn),
-    /// A user-defined closure capturing a lexical env frame.
     Closure(ClosureValue),
-    /// A typed object that can respond to method calls via [`ImmutableObject`].
     Object(TrackedRc<dyn ImmutableObject>),
     Module(Rc<Module>),
-    /// A first-class type value: callable as a constructor, compared by pointer identity.
     Type(Rc<TypeValue>),
 }
 

--- a/engine/runtime/expr/src/core/value.rs
+++ b/engine/runtime/expr/src/core/value.rs
@@ -24,19 +24,49 @@ impl fmt::Debug for ClosureValue {
     }
 }
 
+/// A first-class type value: a comparable identity and an optional callable constructor.
+/// Identity is pointer-based (`Rc::ptr_eq`), not name-based, so two independently registered
+/// types with the same name remain distinct.
+#[derive(Debug, Clone)]
+pub struct TypeValue {
+    pub name: String,
+    pub constructor: Option<NativeFn>,
+}
+
+impl TypeValue {
+    pub fn new(name: impl Into<String>, constructor: Option<NativeFn>) -> Self {
+        Self {
+            name: name.into(),
+            constructor,
+        }
+    }
+
+    pub fn call_ctor(&self, args: &[Value]) -> Result<Value> {
+        match &self.constructor {
+            Some(f) => f.call(args),
+            None => Err(eval_error(format!(
+                "type '{}' is not constructible",
+                self.name
+            ))),
+        }
+    }
+}
+
 /// Trait for typed objects that can respond to method calls.
 ///
 /// All methods take `&self` — objects are immutable from the expression
 /// language's perspective. Implementations that need internal state must use
 /// their own `RefCell` internally.
 pub trait ImmutableObject: std::fmt::Debug {
-    fn type_name(&self) -> &'static str;
+    /// Return the canonical `Rc<TypeValue>` for this object's type.
+    /// Two objects of the same type must return `Rc`s that compare equal via `Rc::ptr_eq`.
+    fn type_object(&self) -> Rc<TypeValue>;
     fn call_method(&self, method: &str, args: &[Value]) -> Result<Value>;
     fn get_property(&self, _name: &str) -> Option<Result<Value>> {
         None
     }
     fn display(&self) -> String {
-        format!("<{}>", self.type_name())
+        format!("<{}>", self.type_object().name)
     }
     fn serialize(&self) -> Option<Value> {
         None
@@ -69,36 +99,6 @@ impl std::fmt::Debug for NativeFn {
     }
 }
 
-/// Built-in type tags, used by `type()` and as first-class type values.
-/// Binding `int` in the env to `Value::Type(TypeTag::Int)` makes `int` both a
-/// callable constructor and a comparable type identity.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TypeTag {
-    Null,
-    Bool,
-    Int,
-    Float,
-    Str,
-    List,
-    Dict,
-    Fn,
-}
-
-impl std::fmt::Display for TypeTag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TypeTag::Null => write!(f, "null"),
-            TypeTag::Bool => write!(f, "bool"),
-            TypeTag::Int => write!(f, "int"),
-            TypeTag::Float => write!(f, "float"),
-            TypeTag::Str => write!(f, "str"),
-            TypeTag::List => write!(f, "list"),
-            TypeTag::Dict => write!(f, "dict"),
-            TypeTag::Fn => write!(f, "function"),
-        }
-    }
-}
-
 /// Runtime value type for the expression evaluator.
 ///
 /// `Array` and `Map` use `Rc<RefCell<...>>` for reference semantics: cloning a
@@ -124,8 +124,8 @@ pub enum Value {
     /// A typed object that can respond to method calls via [`ImmutableObject`].
     Object(Rc<dyn ImmutableObject>),
     Module(Rc<Module>),
-    /// A first-class type value: both a callable constructor and a comparable identity.
-    Type(TypeTag),
+    /// A first-class type value: callable as a constructor, compared by pointer identity.
+    Type(Rc<TypeValue>),
 }
 
 impl Value {
@@ -144,19 +144,20 @@ impl Value {
         Value::Object(Rc::new(obj))
     }
 
-    pub fn type_name(&self) -> &str {
+    /// The kind of value this is, as a string. Used in error messages.
+    pub fn type_name(&self) -> String {
         match self {
-            Value::Null => "null",
-            Value::Bool(_) => "bool",
-            Value::Int(_) => "int",
-            Value::Float(_) => "float",
-            Value::String(_) => "str",
-            Value::Array(_) => "list",
-            Value::Map(_) => "dict",
-            Value::Fn(_) | Value::Closure(_) => "function",
-            Value::Object(rc) => rc.type_name(),
-            Value::Module(_) => "module",
-            Value::Type(_) => "type",
+            Value::Null => "null".into(),
+            Value::Bool(_) => "bool".into(),
+            Value::Int(_) => "int".into(),
+            Value::Float(_) => "float".into(),
+            Value::String(_) => "str".into(),
+            Value::Array(_) => "list".into(),
+            Value::Map(_) => "dict".into(),
+            Value::Fn(_) | Value::Closure(_) => "function".into(),
+            Value::Object(rc) => rc.type_object().name.clone(),
+            Value::Module(_) => "module".into(),
+            Value::Type(_) => "type".into(),
         }
     }
 
@@ -274,7 +275,7 @@ impl std::fmt::Display for Value {
             Value::Closure(c) => write!(f, "<fn({})>", c.params.join(", ")),
             Value::Object(rc) => write!(f, "{}", rc.display()),
             Value::Module(_) => write!(f, "<module>"),
-            Value::Type(t) => write!(f, "{t}"),
+            Value::Type(tv) => write!(f, "{}", tv.name),
         }
     }
 }

--- a/engine/runtime/expr/src/core/value.rs
+++ b/engine/runtime/expr/src/core/value.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::fmt;
 use std::rc::{Rc, Weak};
 
@@ -10,6 +10,87 @@ use super::ast::Expr;
 use super::env::Frame;
 use super::eval::type_of;
 use crate::core::error::{eval_error, Result};
+
+thread_local! {
+    pub(crate) static LIVE_ALLOC: Cell<usize> = const { Cell::new(0) };
+}
+
+pub struct TrackedRc<T: ?Sized>(Rc<T>);
+
+impl<T> TrackedRc<T> {
+    pub fn new(val: T) -> Self {
+        LIVE_ALLOC.with(|c| c.set(c.get() + 1));
+        TrackedRc(Rc::new(val))
+    }
+}
+
+impl<T: ?Sized> TrackedRc<T> {
+    pub fn from_rc(rc: Rc<T>) -> Self {
+        LIVE_ALLOC.with(|c| c.set(c.get() + 1));
+        TrackedRc(rc)
+    }
+
+    pub fn ptr_eq(a: &Self, b: &Self) -> bool {
+        Rc::ptr_eq(&a.0, &b.0)
+    }
+}
+
+impl<T: ?Sized> Clone for TrackedRc<T> {
+    fn clone(&self) -> Self {
+        TrackedRc(Rc::clone(&self.0))
+    }
+}
+
+impl<T: ?Sized> Drop for TrackedRc<T> {
+    fn drop(&mut self) {
+        if Rc::strong_count(&self.0) == 1 {
+            LIVE_ALLOC.with(|c| c.set(c.get() - 1));
+        }
+    }
+}
+
+impl<T: ?Sized> std::ops::Deref for TrackedRc<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for TrackedRc<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+pub struct LeakGuard;
+
+impl LeakGuard {
+    pub fn enter() -> Self {
+        let current = LIVE_ALLOC.with(|c| c.get());
+        if current != 0 {
+            panic!(
+                "expr LeakGuard::enter: {} allocation(s) already live on this thread; nested eval is not supported",
+                current
+            );
+        }
+        LeakGuard
+    }
+}
+
+impl Drop for LeakGuard {
+    fn drop(&mut self) {
+        if std::thread::panicking() {
+            return;
+        }
+        let current = LIVE_ALLOC.with(|c| c.get());
+        if current != 0 {
+            panic!(
+                "expr: {} Rc allocation(s) leaked; cyclic List, Dict, Object, or Module reference detected",
+                current
+            );
+        }
+    }
+}
 
 /// A user-defined closure: parameter names, body AST, and the lexical env captured at definition.
 #[derive(Clone)]
@@ -116,31 +197,31 @@ pub enum Value {
     Int(i64),
     Float(f64),
     String(String),
-    List(Rc<RefCell<Vec<Value>>>),
-    Dict(Rc<RefCell<IndexMap<String, Value>>>),
+    List(TrackedRc<RefCell<Vec<Value>>>),
+    Dict(TrackedRc<RefCell<IndexMap<String, Value>>>),
     /// A native Rust function seeded into the environment.
     Fn(NativeFn),
     /// A user-defined closure capturing a lexical env frame.
     Closure(ClosureValue),
     /// A typed object that can respond to method calls via [`ImmutableObject`].
-    Object(Rc<dyn ImmutableObject>),
-    Module(Rc<Module>),
+    Object(TrackedRc<dyn ImmutableObject>),
+    Module(TrackedRc<Module>),
     /// A first-class type value: callable as a constructor, compared by pointer identity.
     Type(Rc<TypeValue>),
 }
 
 impl Value {
     pub fn list(items: Vec<Value>) -> Self {
-        Value::List(Rc::new(RefCell::new(items)))
+        Value::List(TrackedRc::new(RefCell::new(items)))
     }
 
     pub fn dict(entries: IndexMap<String, Value>) -> Self {
-        Value::Dict(Rc::new(RefCell::new(entries)))
+        Value::Dict(TrackedRc::new(RefCell::new(entries)))
     }
 
     /// Construct an object value, wrapping `obj` in a fresh shared allocation.
     pub fn object(obj: impl ImmutableObject + 'static) -> Self {
-        Value::Object(Rc::new(obj))
+        Value::Object(TrackedRc::from_rc(Rc::new(obj)))
     }
 
     /// The kind of value this is, as a string. Used in error messages.
@@ -149,7 +230,7 @@ impl Value {
     }
 
     pub fn module(m: Module) -> Self {
-        Value::Module(Rc::new(m))
+        Value::Module(TrackedRc::new(m))
     }
 
     pub fn as_str(&self) -> Result<&str> {

--- a/engine/runtime/expr/src/core/value.rs
+++ b/engine/runtime/expr/src/core/value.rs
@@ -1,4 +1,5 @@
 use std::cell::{Cell, RefCell};
+use std::collections::HashSet;
 use std::fmt;
 use std::rc::{Rc, Weak};
 
@@ -59,36 +60,6 @@ impl<T: ?Sized> std::ops::Deref for TrackedRc<T> {
 impl<T: ?Sized + fmt::Debug> fmt::Debug for TrackedRc<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
-    }
-}
-
-pub struct LeakGuard;
-
-impl LeakGuard {
-    pub fn enter() -> Self {
-        let current = LIVE_ALLOC.with(|c| c.get());
-        if current != 0 {
-            panic!(
-                "expr LeakGuard::enter: {} allocation(s) already live on this thread; nested eval is not supported",
-                current
-            );
-        }
-        LeakGuard
-    }
-}
-
-impl Drop for LeakGuard {
-    fn drop(&mut self) {
-        if std::thread::panicking() {
-            return;
-        }
-        let current = LIVE_ALLOC.with(|c| c.get());
-        if current != 0 {
-            panic!(
-                "expr: {} Rc allocation(s) leaked; cyclic List, Dict, Object, or Module reference detected",
-                current
-            );
-        }
     }
 }
 
@@ -205,7 +176,7 @@ pub enum Value {
     Closure(ClosureValue),
     /// A typed object that can respond to method calls via [`ImmutableObject`].
     Object(TrackedRc<dyn ImmutableObject>),
-    Module(TrackedRc<Module>),
+    Module(Rc<Module>),
     /// A first-class type value: callable as a constructor, compared by pointer identity.
     Type(Rc<TypeValue>),
 }
@@ -230,7 +201,7 @@ impl Value {
     }
 
     pub fn module(m: Module) -> Self {
-        Value::Module(TrackedRc::new(m))
+        Value::Module(Rc::new(m))
     }
 
     pub fn as_str(&self) -> Result<&str> {
@@ -381,5 +352,77 @@ impl From<String> for Value {
 impl<T: Into<Value>> From<Vec<T>> for Value {
     fn from(v: Vec<T>) -> Self {
         Value::list(v.into_iter().map(Into::into).collect())
+    }
+}
+
+/// Convert a [`Value`] produced by the evaluator into a caller-defined type.
+///
+/// Implement this trait on your output type and pass it as `T` to [`crate::eval`].
+/// Cycle detection and the LIVE_ALLOC guard are handled by the evaluator — the
+/// trait only needs to describe how to fold each `Value` variant into `T`.
+pub trait FromValue: Sized {
+    type Error;
+    fn from_null() -> std::result::Result<Self, Self::Error>;
+    fn from_bool(b: bool) -> std::result::Result<Self, Self::Error>;
+    fn from_int(n: i64) -> std::result::Result<Self, Self::Error>;
+    fn from_float(f: f64) -> std::result::Result<Self, Self::Error>;
+    fn from_string(s: String) -> std::result::Result<Self, Self::Error>;
+    fn from_list(items: Vec<Self>) -> std::result::Result<Self, Self::Error>;
+    fn from_dict(map: IndexMap<String, Self>) -> std::result::Result<Self, Self::Error>;
+    /// Called when a cycle is detected in List or Dict. Panic is the expected default.
+    fn on_cycle() -> std::result::Result<Self, Self::Error>;
+    /// Called for Value variants that cannot be represented (Fn, Closure, Module, Type,
+    /// or a non-serializable Object).
+    fn on_unconvertible(msg: String) -> std::result::Result<Self, Self::Error>;
+}
+
+pub(crate) fn convert_value<T: FromValue>(v: Value) -> std::result::Result<T, T::Error> {
+    convert_inner(v, &mut HashSet::new())
+}
+
+fn convert_inner<T: FromValue>(
+    v: Value,
+    seen: &mut HashSet<usize>,
+) -> std::result::Result<T, T::Error> {
+    match v {
+        Value::Null => T::from_null(),
+        Value::Bool(b) => T::from_bool(b),
+        Value::Int(n) => T::from_int(n),
+        Value::Float(f) => T::from_float(f),
+        Value::String(s) => T::from_string(s),
+        Value::List(arr) => {
+            let ptr = &*arr as *const _ as usize;
+            if !seen.insert(ptr) {
+                return T::on_cycle();
+            }
+            let items = arr
+                .borrow()
+                .iter()
+                .map(|v| convert_inner(v.clone(), seen))
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            seen.remove(&ptr);
+            T::from_list(items)
+        }
+        Value::Dict(map) => {
+            let ptr = &*map as *const _ as usize;
+            if !seen.insert(ptr) {
+                return T::on_cycle();
+            }
+            let entries = map
+                .borrow()
+                .iter()
+                .map(|(k, v)| convert_inner(v.clone(), seen).map(|v| (k.clone(), v)))
+                .collect::<std::result::Result<IndexMap<_, _>, _>>()?;
+            seen.remove(&ptr);
+            T::from_dict(entries)
+        }
+        Value::Object(rc) => match rc.serialize() {
+            Some(v) => convert_inner(v, seen),
+            None => T::on_unconvertible(format!("{} cannot be converted", rc.type_object().name)),
+        },
+        Value::Fn(_) => T::on_unconvertible("function cannot be converted".into()),
+        Value::Closure(_) => T::on_unconvertible("closure cannot be converted".into()),
+        Value::Module(_) => T::on_unconvertible("module cannot be converted".into()),
+        Value::Type(tv) => T::on_unconvertible(format!("type '{}' cannot be converted", tv.name)),
     }
 }

--- a/engine/runtime/expr/src/core/value.rs
+++ b/engine/runtime/expr/src/core/value.rs
@@ -69,6 +69,36 @@ impl std::fmt::Debug for NativeFn {
     }
 }
 
+/// Built-in type tags, used by `type()` and as first-class type values.
+/// Binding `int` in the env to `Value::Type(TypeTag::Int)` makes `int` both a
+/// callable constructor and a comparable type identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeTag {
+    Null,
+    Bool,
+    Int,
+    Float,
+    Str,
+    List,
+    Dict,
+    Fn,
+}
+
+impl std::fmt::Display for TypeTag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TypeTag::Null => write!(f, "null"),
+            TypeTag::Bool => write!(f, "bool"),
+            TypeTag::Int => write!(f, "int"),
+            TypeTag::Float => write!(f, "float"),
+            TypeTag::Str => write!(f, "str"),
+            TypeTag::List => write!(f, "list"),
+            TypeTag::Dict => write!(f, "dict"),
+            TypeTag::Fn => write!(f, "function"),
+        }
+    }
+}
+
 /// Runtime value type for the expression evaluator.
 ///
 /// `Array` and `Map` use `Rc<RefCell<...>>` for reference semantics: cloning a
@@ -94,6 +124,8 @@ pub enum Value {
     /// A typed object that can respond to method calls via [`ImmutableObject`].
     Object(Rc<dyn ImmutableObject>),
     Module(Rc<Module>),
+    /// A first-class type value: both a callable constructor and a comparable identity.
+    Type(TypeTag),
 }
 
 impl Value {
@@ -118,12 +150,13 @@ impl Value {
             Value::Bool(_) => "bool",
             Value::Int(_) => "int",
             Value::Float(_) => "float",
-            Value::String(_) => "string",
+            Value::String(_) => "str",
             Value::Array(_) => "list",
-            Value::Map(_) => "map",
+            Value::Map(_) => "dict",
             Value::Fn(_) | Value::Closure(_) => "function",
             Value::Object(rc) => rc.type_name(),
             Value::Module(_) => "module",
+            Value::Type(_) => "type",
         }
     }
 
@@ -171,7 +204,11 @@ impl Value {
             Value::String(s) => !s.is_empty(),
             Value::Array(a) => !a.borrow().is_empty(),
             Value::Map(o) => !o.borrow().is_empty(),
-            Value::Fn(_) | Value::Closure(_) | Value::Object(_) | Value::Module(_) => true,
+            Value::Fn(_)
+            | Value::Closure(_)
+            | Value::Object(_)
+            | Value::Module(_)
+            | Value::Type(_) => true,
         }
     }
 }
@@ -237,6 +274,7 @@ impl std::fmt::Display for Value {
             Value::Closure(c) => write!(f, "<fn({})>", c.params.join(", ")),
             Value::Object(rc) => write!(f, "{}", rc.display()),
             Value::Module(_) => write!(f, "<module>"),
+            Value::Type(t) => write!(f, "{t}"),
         }
     }
 }

--- a/engine/runtime/expr/src/lib.rs
+++ b/engine/runtime/expr/src/lib.rs
@@ -3,7 +3,7 @@ mod core;
 pub use core::env::Env;
 pub use core::error::{eval_error, Error, Result};
 pub use core::eval::{default_env, env_bind};
-pub use core::value::{ClosureValue, ImmutableObject, NativeFn, Value};
+pub use core::value::{ClosureValue, ImmutableObject, NativeFn, TypeValue, Value};
 
 pub fn expect_arity(name: &str, args: &[Value], min: usize, max: usize) -> Result<()> {
     let n = args.len();

--- a/engine/runtime/expr/src/lib.rs
+++ b/engine/runtime/expr/src/lib.rs
@@ -24,10 +24,6 @@ pub fn compile(input: &str) -> Result<CompiledExpr> {
 }
 
 /// Evaluate a compiled expression, converting the result to `T` via [`FromValue`].
-///
-/// Cycle detection is fully encapsulated:
-/// - Cyclic values in the **return** tree are caught by [`FromValue::on_cycle`] during conversion.
-/// - Intermediate cyclic allocations that do not surface in the return value cause a panic.
 pub fn eval<T>(expr: &CompiledExpr, env: &Env) -> std::result::Result<T, T::Error>
 where
     T: FromValue,

--- a/engine/runtime/expr/src/lib.rs
+++ b/engine/runtime/expr/src/lib.rs
@@ -36,11 +36,11 @@ where
     drop(child);
     let after = core::value::LIVE_ALLOC.with(|c| c.get());
     if after != before {
-        panic!(
+        return Err(T::Error::from(core::error::eval_error(format!(
             "expr: {} TrackedRc allocation(s) still live after eval; \
              intermediate cyclic reference detected",
             after.wrapping_sub(before)
-        );
+        ))));
     }
     Ok(result)
 }

--- a/engine/runtime/expr/src/lib.rs
+++ b/engine/runtime/expr/src/lib.rs
@@ -2,7 +2,7 @@ mod core;
 
 pub use core::env::Env;
 pub use core::error::{eval_error, Error, Result};
-pub use core::eval::{default_env, env_bind};
+pub use core::eval::{default_env, env_bind, env_remove};
 pub use core::value::{ClosureValue, FromValue, ImmutableObject, NativeFn, TypeValue, Value};
 
 pub fn expect_arity(name: &str, args: &[Value], min: usize, max: usize) -> Result<()> {
@@ -33,9 +33,11 @@ where
     T: FromValue,
     T::Error: From<Error>,
 {
+    let child = core::env::new_frame(Some(env.clone()));
     let before = core::value::LIVE_ALLOC.with(|c| c.get());
-    let v = core::eval::eval(&expr.0, env).map_err(T::Error::from)?;
+    let v = core::eval::eval(&expr.0, &child).map_err(T::Error::from)?;
     let result = core::value::convert_value::<T>(v)?;
+    drop(child);
     let after = core::value::LIVE_ALLOC.with(|c| c.get());
     if after != before {
         panic!(

--- a/engine/runtime/expr/src/lib.rs
+++ b/engine/runtime/expr/src/lib.rs
@@ -3,7 +3,7 @@ mod core;
 pub use core::env::Env;
 pub use core::error::{eval_error, Error, Result};
 pub use core::eval::{default_env, env_bind};
-pub use core::value::{ClosureValue, ImmutableObject, LeakGuard, NativeFn, TypeValue, Value};
+pub use core::value::{ClosureValue, FromValue, ImmutableObject, NativeFn, TypeValue, Value};
 
 pub fn expect_arity(name: &str, args: &[Value], min: usize, max: usize) -> Result<()> {
     let n = args.len();
@@ -23,8 +23,32 @@ pub fn compile(input: &str) -> Result<CompiledExpr> {
     core::parser::parse(input).map(CompiledExpr)
 }
 
-/// Evaluate a compiled expression against an [`Env`].
-pub fn eval(expr: &CompiledExpr, env: &Env) -> Result<Value> {
+/// Evaluate a compiled expression, converting the result to `T` via [`FromValue`].
+///
+/// Cycle detection is fully encapsulated:
+/// - Cyclic values in the **return** tree are caught by [`FromValue::on_cycle`] during conversion.
+/// - Intermediate cyclic allocations that do not surface in the return value cause a panic.
+pub fn eval<T>(expr: &CompiledExpr, env: &Env) -> std::result::Result<T, T::Error>
+where
+    T: FromValue,
+    T::Error: From<Error>,
+{
+    let before = core::value::LIVE_ALLOC.with(|c| c.get());
+    let v = core::eval::eval(&expr.0, env).map_err(T::Error::from)?;
+    let result = core::value::convert_value::<T>(v)?;
+    let after = core::value::LIVE_ALLOC.with(|c| c.get());
+    if after != before {
+        panic!(
+            "expr: {} TrackedRc allocation(s) still live after eval; \
+             intermediate cyclic reference detected",
+            after.wrapping_sub(before)
+        );
+    }
+    Ok(result)
+}
+
+/// Evaluate a compiled expression, returning the raw [`Value`].
+pub fn eval_unsafe(expr: &CompiledExpr, env: &Env) -> Result<Value> {
     core::eval::eval(&expr.0, env)
 }
 

--- a/engine/runtime/expr/src/lib.rs
+++ b/engine/runtime/expr/src/lib.rs
@@ -3,7 +3,7 @@ mod core;
 pub use core::env::Env;
 pub use core::error::{eval_error, Error, Result};
 pub use core::eval::{default_env, env_bind};
-pub use core::value::{ClosureValue, ImmutableObject, NativeFn, TypeValue, Value};
+pub use core::value::{ClosureValue, ImmutableObject, LeakGuard, NativeFn, TypeValue, Value};
 
 pub fn expect_arity(name: &str, args: &[Value], min: usize, max: usize) -> Result<()> {
     let n = args.len();

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use std::rc::Rc;
 
 use reearth_flow_expr::{
-    compile, eval_error, expect_arity, Env as ExprEnv, FromValue, Result as ExprResult,
-    TypeValue as ExprTypeValue, Value as ExprValue,
+    compile, env_bind, env_remove, eval_error, expect_arity, Env as ExprEnv, FromValue,
+    Result as ExprResult, TypeValue as ExprTypeValue, Value as ExprValue,
 };
 
 use crate::error::{Error as TypesError, Result as TypesResult};
@@ -72,8 +72,43 @@ impl FromValue for FlowValue {
     }
 }
 
-fn eval_attr(expr: &reearth_flow_expr::CompiledExpr, env: &ExprEnv) -> TypesResult<AttributeValue> {
-    reearth_flow_expr::eval::<FlowValue>(expr, env).map(|FlowValue(v)| v)
+thread_local! {
+    static EVAL_ENV: ExprEnv = reearth_flow_expr::default_env();
+}
+
+fn eval_with_feature(
+    expr: &reearth_flow_expr::CompiledExpr,
+    feature: &Feature,
+    env_vars: &Arc<serde_json::Map<String, serde_json::Value>>,
+) -> TypesResult<AttributeValue> {
+    EVAL_ENV.with(|env| {
+        env_bind(
+            env,
+            "attributes",
+            ExprValue::object(AttributesObject(Arc::clone(&feature.attributes))),
+        );
+        env_bind(
+            env,
+            "env",
+            ExprValue::object(EnvObject(Arc::clone(env_vars))),
+        );
+        reearth_flow_expr::eval::<FlowValue>(expr, env).map(|FlowValue(v)| v)
+    })
+}
+
+fn eval_with_vars(
+    expr: &reearth_flow_expr::CompiledExpr,
+    env_vars: &Arc<serde_json::Map<String, serde_json::Value>>,
+) -> TypesResult<AttributeValue> {
+    EVAL_ENV.with(|env| {
+        env_remove(env, "attributes");
+        env_bind(
+            env,
+            "env",
+            ExprValue::object(EnvObject(Arc::clone(env_vars))),
+        );
+        reearth_flow_expr::eval::<FlowValue>(expr, env).map(|FlowValue(v)| v)
+    })
 }
 
 #[nutype(
@@ -243,7 +278,7 @@ impl CompiledCode {
     ) -> TypesResult<AttributeValue> {
         match self {
             CompiledCode::Literal(s) => Ok(AttributeValue::String(s.clone())),
-            CompiledCode::Expr(e) => eval_attr(e, &env_from_feature(feature, env_vars)),
+            CompiledCode::Expr(e) => eval_with_feature(e, feature, &env_vars),
         }
     }
 
@@ -254,7 +289,7 @@ impl CompiledCode {
     ) -> TypesResult<bool> {
         match self {
             CompiledCode::Literal(s) => Ok(!s.is_empty()),
-            CompiledCode::Expr(e) => eval_attr(e, &env_from_feature(feature, env_vars))?
+            CompiledCode::Expr(e) => eval_with_feature(e, feature, &env_vars)?
                 .as_bool()
                 .ok_or_else(|| TypesError::Conversion("eval result is not a bool".into())),
         }
@@ -270,7 +305,7 @@ impl CompiledCode {
                 .trim()
                 .parse::<f64>()
                 .map_err(|_| TypesError::Conversion(format!("literal {s:?} is not a number"))),
-            CompiledCode::Expr(e) => eval_attr(e, &env_from_feature(feature, env_vars))?
+            CompiledCode::Expr(e) => eval_with_feature(e, feature, &env_vars)?
                 .as_f64()
                 .ok_or_else(|| TypesError::Conversion("expected number".into())),
         }
@@ -286,7 +321,7 @@ impl CompiledCode {
                 .trim()
                 .parse::<i64>()
                 .map_err(|_| TypesError::Conversion(format!("literal {s:?} is not an integer"))),
-            CompiledCode::Expr(e) => eval_attr(e, &env_from_feature(feature, env_vars))?
+            CompiledCode::Expr(e) => eval_with_feature(e, feature, &env_vars)?
                 .as_i64()
                 .ok_or_else(|| TypesError::Conversion("expected integer".into())),
         }
@@ -299,7 +334,7 @@ impl CompiledCode {
     ) -> TypesResult<String> {
         match self {
             CompiledCode::Literal(s) => Ok(s.clone()),
-            CompiledCode::Expr(e) => eval_attr(e, &env_from_feature(feature, env_vars))?
+            CompiledCode::Expr(e) => eval_with_feature(e, feature, &env_vars)?
                 .as_string()
                 .ok_or_else(|| TypesError::Conversion("eval result is not a string".into())),
         }
@@ -312,7 +347,7 @@ impl CompiledCode {
     ) -> TypesResult<AttributeValue> {
         match self {
             CompiledCode::Literal(s) => Ok(AttributeValue::String(s.clone())),
-            CompiledCode::Expr(e) => eval_attr(e, &env_from_vars_only(env_vars)),
+            CompiledCode::Expr(e) => eval_with_vars(e, &env_vars),
         }
     }
 
@@ -324,7 +359,7 @@ impl CompiledCode {
     ) -> TypesResult<String> {
         match self {
             CompiledCode::Literal(s) => Ok(s.clone()),
-            CompiledCode::Expr(e) => eval_attr(e, &env_from_vars_only(env_vars))?
+            CompiledCode::Expr(e) => eval_with_vars(e, &env_vars)?
                 .as_string()
                 .ok_or_else(|| TypesError::Conversion("eval result is not a string".into())),
         }
@@ -492,26 +527,6 @@ impl reearth_flow_expr::ImmutableObject for EnvObject {
             m => Err(eval_error(format!("Env has no method '{m}'"))),
         }
     }
-}
-
-fn env_from_feature(
-    feature: &Feature,
-    env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
-) -> ExprEnv {
-    let env = reearth_flow_expr::default_env();
-    reearth_flow_expr::env_bind(
-        &env,
-        "attributes",
-        ExprValue::object(AttributesObject(Arc::clone(&feature.attributes))),
-    );
-    reearth_flow_expr::env_bind(&env, "env", ExprValue::object(EnvObject(env_vars)));
-    env
-}
-
-fn env_from_vars_only(env_vars: Arc<serde_json::Map<String, serde_json::Value>>) -> ExprEnv {
-    let env = reearth_flow_expr::default_env();
-    reearth_flow_expr::env_bind(&env, "env", ExprValue::object(EnvObject(env_vars)));
-    env
 }
 
 #[cfg(test)]

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -341,7 +341,7 @@ pub fn json_to_value(v: serde_json::Value) -> ExprValue {
         serde_json::Value::Array(arr) => {
             ExprValue::array(arr.into_iter().map(json_to_value).collect())
         }
-        serde_json::Value::Object(map) => ExprValue::map(
+        serde_json::Value::Object(map) => ExprValue::dict(
             map.into_iter()
                 .map(|(k, v)| (k, json_to_value(v)))
                 .collect(),
@@ -504,7 +504,7 @@ fn attribute_value_from_eval(v: ExprValue) -> TypesResult<AttributeValue> {
                 .map(|v| attribute_value_from_eval(v.clone()))
                 .collect::<TypesResult<Vec<_>>>()?,
         )),
-        ExprValue::Map(map) => Ok(AttributeValue::Map(
+        ExprValue::Dict(map) => Ok(AttributeValue::Map(
             map.borrow()
                 .iter()
                 .map(|(k, v)| attribute_value_from_eval(v.clone()).map(|v| (k.clone(), v)))

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use indexmap::IndexMap;
 use nutype::nutype;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -7,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::rc::Rc;
 
 use reearth_flow_expr::{
-    compile, eval, eval_error, expect_arity, Env as ExprEnv, Result as ExprResult,
+    compile, eval_error, expect_arity, Env as ExprEnv, FromValue, Result as ExprResult,
     TypeValue as ExprTypeValue, Value as ExprValue,
 };
 
@@ -15,6 +17,64 @@ use crate::error::{Error as TypesError, Result as TypesResult};
 
 use crate::attribute::{Attribute, AttributeValue};
 use crate::feature::Feature;
+
+impl From<reearth_flow_expr::Error> for TypesError {
+    fn from(e: reearth_flow_expr::Error) -> Self {
+        TypesError::InternalRuntime(e.to_string())
+    }
+}
+
+/// Newtype bridging `FromValue` (from `reearth_flow_expr`) and `AttributeValue`
+/// (from `reearth_flow_common`); required by the orphan rule since both are foreign to this crate.
+struct FlowValue(AttributeValue);
+
+impl FromValue for FlowValue {
+    type Error = TypesError;
+
+    fn from_null() -> TypesResult<Self> {
+        Ok(FlowValue(AttributeValue::Null))
+    }
+    fn from_bool(b: bool) -> TypesResult<Self> {
+        Ok(FlowValue(AttributeValue::Bool(b)))
+    }
+    fn from_int(n: i64) -> TypesResult<Self> {
+        Ok(FlowValue(AttributeValue::Number(n.into())))
+    }
+    fn from_float(f: f64) -> TypesResult<Self> {
+        serde_json::Number::from_f64(f)
+            .map(|n| FlowValue(AttributeValue::Number(n)))
+            .ok_or_else(|| {
+                TypesError::Conversion(format!(
+                    "float value {f} is not representable as an attribute (nan/inf)"
+                ))
+            })
+    }
+    fn from_string(s: String) -> TypesResult<Self> {
+        Ok(FlowValue(AttributeValue::String(s)))
+    }
+    fn from_list(items: Vec<Self>) -> TypesResult<Self> {
+        Ok(FlowValue(AttributeValue::Array(
+            items.into_iter().map(|FlowValue(v)| v).collect(),
+        )))
+    }
+    fn from_dict(map: IndexMap<String, Self>) -> TypesResult<Self> {
+        Ok(FlowValue(AttributeValue::Map(
+            map.into_iter()
+                .map(|(k, FlowValue(v))| (k, v))
+                .collect::<HashMap<_, _>>(),
+        )))
+    }
+    fn on_cycle() -> TypesResult<Self> {
+        panic!("expr: cyclic reference detected in eval return value")
+    }
+    fn on_unconvertible(msg: String) -> TypesResult<Self> {
+        Err(TypesError::Conversion(msg))
+    }
+}
+
+fn eval_attr(expr: &reearth_flow_expr::CompiledExpr, env: &ExprEnv) -> TypesResult<AttributeValue> {
+    reearth_flow_expr::eval::<FlowValue>(expr, env).map(|FlowValue(v)| v)
+}
 
 #[nutype(
     sanitize(trim),
@@ -181,12 +241,10 @@ impl CompiledCode {
         feature: &Feature,
         env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
     ) -> TypesResult<AttributeValue> {
-        let v = match self {
-            CompiledCode::Expr(e) => eval(e, &env_from_feature(feature, env_vars))
-                .map_err(|e| TypesError::InternalRuntime(e.to_string()))?,
-            CompiledCode::Literal(s) => ExprValue::String(s.clone()),
-        };
-        attribute_value_from_eval(v)
+        match self {
+            CompiledCode::Literal(s) => Ok(AttributeValue::String(s.clone())),
+            CompiledCode::Expr(e) => eval_attr(e, &env_from_feature(feature, env_vars)),
+        }
     }
 
     pub fn eval_bool(
@@ -195,14 +253,10 @@ impl CompiledCode {
         env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
     ) -> TypesResult<bool> {
         match self {
-            CompiledCode::Expr(e) => eval(e, &env_from_feature(feature, env_vars))
-                .map_err(|e| TypesError::InternalRuntime(e.to_string()))
-                .and_then(attribute_value_from_eval)
-                .and_then(|av| {
-                    av.as_bool()
-                        .ok_or_else(|| TypesError::Conversion("eval result is not a bool".into()))
-                }),
             CompiledCode::Literal(s) => Ok(!s.is_empty()),
+            CompiledCode::Expr(e) => eval_attr(e, &env_from_feature(feature, env_vars))?
+                .as_bool()
+                .ok_or_else(|| TypesError::Conversion("eval result is not a bool".into())),
         }
     }
 
@@ -212,20 +266,13 @@ impl CompiledCode {
         env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
     ) -> TypesResult<f64> {
         match self {
-            CompiledCode::Expr(e) => match eval(e, &env_from_feature(feature, env_vars))
-                .map_err(|e| TypesError::InternalRuntime(e.to_string()))?
-            {
-                ExprValue::Float(f) => Ok(f),
-                ExprValue::Int(n) => Ok(n as f64),
-                other => Err(TypesError::Conversion(format!(
-                    "expected number, got {}",
-                    other.type_name()
-                ))),
-            },
             CompiledCode::Literal(s) => s
                 .trim()
                 .parse::<f64>()
                 .map_err(|_| TypesError::Conversion(format!("literal {s:?} is not a number"))),
+            CompiledCode::Expr(e) => eval_attr(e, &env_from_feature(feature, env_vars))?
+                .as_f64()
+                .ok_or_else(|| TypesError::Conversion("expected number".into())),
         }
     }
 
@@ -235,19 +282,13 @@ impl CompiledCode {
         env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
     ) -> TypesResult<i64> {
         match self {
-            CompiledCode::Expr(e) => match eval(e, &env_from_feature(feature, env_vars))
-                .map_err(|e| TypesError::InternalRuntime(e.to_string()))?
-            {
-                ExprValue::Int(n) => Ok(n),
-                other => Err(TypesError::Conversion(format!(
-                    "expected integer, got {}",
-                    other.type_name()
-                ))),
-            },
             CompiledCode::Literal(s) => s
                 .trim()
                 .parse::<i64>()
                 .map_err(|_| TypesError::Conversion(format!("literal {s:?} is not an integer"))),
+            CompiledCode::Expr(e) => eval_attr(e, &env_from_feature(feature, env_vars))?
+                .as_i64()
+                .ok_or_else(|| TypesError::Conversion("expected integer".into())),
         }
     }
 
@@ -257,14 +298,10 @@ impl CompiledCode {
         env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
     ) -> TypesResult<String> {
         match self {
-            CompiledCode::Expr(e) => eval(e, &env_from_feature(feature, env_vars))
-                .map_err(|e| TypesError::InternalRuntime(e.to_string()))
-                .and_then(attribute_value_from_eval)
-                .and_then(|av| {
-                    av.as_string()
-                        .ok_or_else(|| TypesError::Conversion("eval result is not a string".into()))
-                }),
             CompiledCode::Literal(s) => Ok(s.clone()),
+            CompiledCode::Expr(e) => eval_attr(e, &env_from_feature(feature, env_vars))?
+                .as_string()
+                .ok_or_else(|| TypesError::Conversion("eval result is not a string".into())),
         }
     }
 
@@ -274,10 +311,8 @@ impl CompiledCode {
         env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
     ) -> TypesResult<AttributeValue> {
         match self {
-            CompiledCode::Expr(e) => eval(e, &env_from_vars_only(env_vars))
-                .map_err(|e| TypesError::InternalRuntime(e.to_string()))
-                .and_then(attribute_value_from_eval),
             CompiledCode::Literal(s) => Ok(AttributeValue::String(s.clone())),
+            CompiledCode::Expr(e) => eval_attr(e, &env_from_vars_only(env_vars)),
         }
     }
 
@@ -288,14 +323,10 @@ impl CompiledCode {
         env_vars: Arc<serde_json::Map<String, serde_json::Value>>,
     ) -> TypesResult<String> {
         match self {
-            CompiledCode::Expr(e) => eval(e, &env_from_vars_only(env_vars))
-                .map_err(|e| TypesError::InternalRuntime(e.to_string()))
-                .and_then(attribute_value_from_eval)
-                .and_then(|av| {
-                    av.as_string()
-                        .ok_or_else(|| TypesError::Conversion("eval result is not a string".into()))
-                }),
             CompiledCode::Literal(s) => Ok(s.clone()),
+            CompiledCode::Expr(e) => eval_attr(e, &env_from_vars_only(env_vars))?
+                .as_string()
+                .ok_or_else(|| TypesError::Conversion("eval result is not a string".into())),
         }
     }
 }
@@ -481,54 +512,6 @@ fn env_from_vars_only(env_vars: Arc<serde_json::Map<String, serde_json::Value>>)
     let env = reearth_flow_expr::default_env();
     reearth_flow_expr::env_bind(&env, "env", ExprValue::object(EnvObject(env_vars)));
     env
-}
-
-/// Cyclic values are unsupported — see expr/docs/design.md#no-cycle-detection
-fn attribute_value_from_eval(v: ExprValue) -> TypesResult<AttributeValue> {
-    let err = |msg: &str| TypesError::Conversion(msg.into());
-    match v {
-        ExprValue::Null => Ok(AttributeValue::Null),
-        ExprValue::Bool(b) => Ok(AttributeValue::Bool(b)),
-        ExprValue::Int(n) => Ok(AttributeValue::Number(n.into())),
-        ExprValue::Float(f) => serde_json::Number::from_f64(f)
-            .map(AttributeValue::Number)
-            .ok_or_else(|| {
-                err(&format!(
-                    "float value {f} is not representable as an attribute (nan/inf)"
-                ))
-            }),
-        ExprValue::String(s) => Ok(AttributeValue::String(s)),
-        ExprValue::List(arr) => Ok(AttributeValue::Array(
-            arr.borrow()
-                .iter()
-                .map(|v| attribute_value_from_eval(v.clone()))
-                .collect::<TypesResult<Vec<_>>>()?,
-        )),
-        ExprValue::Dict(map) => Ok(AttributeValue::Map(
-            map.borrow()
-                .iter()
-                .map(|(k, v)| attribute_value_from_eval(v.clone()).map(|v| (k.clone(), v)))
-                .collect::<TypesResult<_>>()?,
-        )),
-        ExprValue::Fn(_) | ExprValue::Closure(_) => {
-            Err(err("function value cannot be stored as an attribute"))
-        }
-        ExprValue::Module(_) => Err(err("module value cannot be stored as an attribute")),
-        ExprValue::Type(tv) => Err(err(&format!(
-            "type '{}' cannot be stored as an attribute",
-            tv.name
-        ))),
-        ExprValue::Object(rc) => {
-            if let Some(v) = rc.serialize() {
-                attribute_value_from_eval(v)
-            } else {
-                Err(err(&format!(
-                    "{} object cannot be stored as an attribute",
-                    rc.type_object().name
-                )))
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -339,7 +339,7 @@ pub fn json_to_value(v: serde_json::Value) -> ExprValue {
         }
         serde_json::Value::String(s) => ExprValue::String(s),
         serde_json::Value::Array(arr) => {
-            ExprValue::array(arr.into_iter().map(json_to_value).collect())
+            ExprValue::list(arr.into_iter().map(json_to_value).collect())
         }
         serde_json::Value::Object(map) => ExprValue::dict(
             map.into_iter()
@@ -394,7 +394,7 @@ impl reearth_flow_expr::ImmutableObject for AttributesObject {
                     .get_value(name)
                     .unwrap_or_else(|| fallback.cloned().unwrap_or(ExprValue::Null)))
             }
-            "__iter__" => Ok(ExprValue::array(
+            "__iter__" => Ok(ExprValue::list(
                 self.0
                     .keys()
                     .map(|k| ExprValue::String(k.as_ref().to_string()))
@@ -498,7 +498,7 @@ fn attribute_value_from_eval(v: ExprValue) -> TypesResult<AttributeValue> {
                 ))
             }),
         ExprValue::String(s) => Ok(AttributeValue::String(s)),
-        ExprValue::Array(arr) => Ok(AttributeValue::Array(
+        ExprValue::List(arr) => Ok(AttributeValue::Array(
             arr.borrow()
                 .iter()
                 .map(|v| attribute_value_from_eval(v.clone()))

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -4,9 +4,11 @@ use nutype::nutype;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use std::rc::Rc;
+
 use reearth_flow_expr::{
     compile, eval, eval_error, expect_arity, Env as ExprEnv, Result as ExprResult,
-    Value as ExprValue,
+    TypeValue as ExprTypeValue, Value as ExprValue,
 };
 
 use crate::error::{Error as TypesError, Result as TypesResult};
@@ -359,8 +361,11 @@ impl AttributesObject {
 }
 
 impl reearth_flow_expr::ImmutableObject for AttributesObject {
-    fn type_name(&self) -> &'static str {
-        "Attributes"
+    fn type_object(&self) -> Rc<ExprTypeValue> {
+        thread_local! {
+            static TY: Rc<ExprTypeValue> = Rc::new(ExprTypeValue::new("Attributes", None));
+        }
+        TY.with(Rc::clone)
     }
 
     fn call_method(&self, method: &str, args: &[ExprValue]) -> ExprResult<ExprValue> {
@@ -420,8 +425,11 @@ impl EnvObject {
 }
 
 impl reearth_flow_expr::ImmutableObject for EnvObject {
-    fn type_name(&self) -> &'static str {
-        "Env"
+    fn type_object(&self) -> Rc<ExprTypeValue> {
+        thread_local! {
+            static TY: Rc<ExprTypeValue> = Rc::new(ExprTypeValue::new("Env", None));
+        }
+        TY.with(Rc::clone)
     }
 
     fn call_method(&self, method: &str, args: &[ExprValue]) -> ExprResult<ExprValue> {
@@ -506,13 +514,17 @@ fn attribute_value_from_eval(v: ExprValue) -> TypesResult<AttributeValue> {
             Err(err("function value cannot be stored as an attribute"))
         }
         ExprValue::Module(_) => Err(err("module value cannot be stored as an attribute")),
+        ExprValue::Type(tv) => Err(err(&format!(
+            "type '{}' cannot be stored as an attribute",
+            tv.name
+        ))),
         ExprValue::Object(rc) => {
             if let Some(v) = rc.serialize() {
                 attribute_value_from_eval(v)
             } else {
                 Err(err(&format!(
                     "{} object cannot be stored as an attribute",
-                    rc.type_name()
+                    rc.type_object().name
                 )))
             }
         }

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -65,7 +65,9 @@ impl FromValue for FlowValue {
         )))
     }
     fn on_cycle() -> TypesResult<Self> {
-        panic!("expr: cyclic reference detected in eval return value")
+        Err(TypesError::Conversion(
+            "cyclic reference detected in eval return value".into(),
+        ))
     }
     fn on_unconvertible(msg: String) -> TypesResult<Self> {
         Err(TypesError::Conversion(msg))


### PR DESCRIPTION
# Overview

This PR initialized language feature stabilization policy, creates the first basic spec, and updated the implementation.

## Changes

- initialize `docs/spec/`. Add guideline of spec writing and draft of the first spec.
- implement cyclic reference memory leak detection. Though leak is still not recoverable, at least we know it happens.
- implement cyclic reference detection in returned value (in FlowExpr correctly via trait). Previously they exploded memory and went into dead loop.
- add type value `type` and let type() return the instantiated singleton type class, not string. `int()` etc. now are properly constructors, not registered functions.
- rename map->dict and string type name string->str to reduce unnecessary Python inconsistency.
- dict() now takes no argument (empty dict) or dict as argument (shallow copy).

## Note

- Note that flow language could still have major breaking changes to the doc before the release.
- Maybe we need safer (recoverable) cyclic reference solution. Go full GC, or scoped linked-list arena. Need considering because cyclic reference could be very rare in actual reearth-flow use cases so maybe current report-only mechanism is sufficient.
- We should NOT expose FlowExpr Value enum variants directly. A cleaner solution is to wrap it as a private field in a pu struct with getter/setter methods. List/Dict should expose handlers to provide borrow/borrow_mut methods, not exposing the `TrackedGc` instances directly.
- The test `test_cyclic_list_increases_live_alloc` for testing memory leak detection needs to leak memory, the leak is tiny so should be fine.