### PR TITLE
feat(api): per-environment, branch-matched actions schema from GCS bucket

### DIFF
--- a/.github/workflows/build_deploy_api.yml
+++ b/.github/workflows/build_deploy_api.yml
@@ -163,6 +163,14 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
+      - name: Checkout Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Upload actions schema to GCS
+        run: gsutil -m cp engine/schema/actions*.json gs://${{ secrets.GCS_ASSETS_BUCKET }}/actions/
+
       - name: Configure Docker for GCP
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 

--- a/server/api/internal/app/actions.go
+++ b/server/api/internal/app/actions.go
@@ -104,6 +104,20 @@ var (
 	}
 )
 
+// actionsReader reads a schema file (e.g. "actions_en.json") from the env bucket's
+// "actions/" prefix. gateway.File satisfies it via ReadActions.
+type actionsReader interface {
+	ReadActions(context.Context, string) (io.ReadCloser, error)
+}
+
+var (
+	// actionsRepo, when set, is the bucket-backed schema source. nil → GitHub.
+	actionsRepo actionsReader
+	// actionsFallbackBaseURL is used when actionsRepo is unset or a read fails
+	// (local dev / cold bucket). Overridable in tests.
+	actionsFallbackBaseURL = "https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/"
+)
+
 func loadActionsData(lang string) (ActionsData, error) {
 	if lang != "" && !supportedLangs[lang] {
 		return ActionsData{}, &loadError{err: fmt.Errorf("unsupported language: %s", lang), status: http.StatusBadRequest}
@@ -119,38 +133,14 @@ func loadActionsData(lang string) (ActionsData, error) {
 	}
 	mutex.RUnlock()
 
-	// Fetch from GitHub without holding any lock so other requests are not blocked.
-	baseURL := "https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/"
 	filename := "actions.json"
 	if lang != "" {
 		filename = fmt.Sprintf("actions_%s.json", lang)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+filename, nil)
+	body, err := fetchActionsFile(filename)
 	if err != nil {
-		return ActionsData{}, &loadError{err: err, status: http.StatusBadGateway}
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return ActionsData{}, &loadError{err: err, status: http.StatusBadGateway}
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			log.Warnf("actions: error closing response body: %v", err)
-		}
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		return ActionsData{}, &loadError{err: fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, baseURL+filename), status: http.StatusBadGateway}
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return ActionsData{}, &loadError{err: err, status: http.StatusInternalServerError}
+		return ActionsData{}, err
 	}
 
 	var newData ActionsData
@@ -171,6 +161,53 @@ func loadActionsData(lang string) (ActionsData, error) {
 	}
 	actionsDataMap[cacheKey] = newData
 	return newData, nil
+}
+
+// fetchActionsFile returns the bytes of a schema file, preferring the bucket-backed
+// actionsRepo and falling back to GitHub (actionsFallbackBaseURL).
+func fetchActionsFile(filename string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if actionsRepo != nil {
+		rc, err := actionsRepo.ReadActions(ctx, filename)
+		if err == nil {
+			defer func() {
+				if cerr := rc.Close(); cerr != nil {
+					log.Warnf("actions: error closing reader: %v", cerr)
+				}
+			}()
+			body, rerr := io.ReadAll(rc)
+			if rerr != nil {
+				return nil, &loadError{err: rerr, status: http.StatusInternalServerError}
+			}
+			return body, nil
+		}
+		log.Warnf("actions: bucket read failed for %s, falling back to GitHub: %v", filename, err)
+	}
+
+	url := actionsFallbackBaseURL + filename
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, &loadError{err: err, status: http.StatusBadGateway}
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, &loadError{err: err, status: http.StatusBadGateway}
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil {
+			log.Warnf("actions: error closing response body: %v", cerr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return nil, &loadError{err: fmt.Errorf("unexpected status %d fetching %s", resp.StatusCode, url), status: http.StatusBadGateway}
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, &loadError{err: err, status: http.StatusInternalServerError}
+	}
+	return body, nil
 }
 
 // listActions godoc

--- a/server/api/internal/app/actions_test.go
+++ b/server/api/internal/app/actions_test.go
@@ -1,17 +1,56 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 )
 
+const testActionsJSON = `{"actions":[{"name":"CsvReader","type":"source","description":"Reads features from a CSV file","inputPorts":[],"outputPorts":["output"],"categories":["File"],"tags":[],"parameter":{},"builtin":false}]}`
+
+// fakeActionsReader serves testActionsJSON, or err if set.
+type fakeActionsReader struct{ err error }
+
+func (r fakeActionsReader) ReadActions(context.Context, string) (io.ReadCloser, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return io.NopCloser(strings.NewReader(testActionsJSON)), nil
+}
+
 func resetTestData() {
 	actionsDataMap = make(map[string]ActionsData)
+	actionsRepo = fakeActionsReader{}
+	actionsFallbackBaseURL = "https://raw.githubusercontent.com/reearth/reearth-flow/main/engine/schema/"
+}
+
+func TestLoadActionsData_FromBucket(t *testing.T) {
+	resetTestData()
+	data, err := loadActionsData("")
+	assert.NoError(t, err)
+	assert.Equal(t, "CsvReader", data.Actions[0].Name)
+}
+
+func TestLoadActionsData_FallbackToHTTP(t *testing.T) {
+	resetTestData()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(testActionsJSON))
+	}))
+	defer srv.Close()
+	actionsRepo = fakeActionsReader{err: errors.New("bucket down")}
+	actionsFallbackBaseURL = srv.URL + "/"
+
+	data, err := loadActionsData("en")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, data.Actions)
 }
 
 func TestLoadActionsData(t *testing.T) {

--- a/server/api/internal/app/app.go
+++ b/server/api/internal/app/app.go
@@ -116,7 +116,7 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 		apiPrivate.POST("/signup/verify/:code", SignupVerify())
 		apiPrivate.POST("/password-reset", PasswordReset())
 	}
-	if err := initActionsData(ctx); err != nil {
+	if err := initActionsData(ctx, cfg.Gateways.File); err != nil {
 		log.Errorf("Failed to initialize actions data: %v", err)
 	}
 	SetupActionRoutes(e)
@@ -131,7 +131,8 @@ func initEcho(ctx context.Context, cfg *ServerConfig) *echo.Echo {
 	return e
 }
 
-func initActionsData(_ context.Context) error {
+func initActionsData(_ context.Context, repo actionsReader) error {
+	actionsRepo = repo
 	for lang := range supportedLangs {
 		if _, err := loadActionsData(lang); err != nil {
 			log.Errorf("Failed to load actions data for language %s: %v", lang, err)

--- a/server/api/internal/infrastructure/cloudrunworker/worker_test.go
+++ b/server/api/internal/infrastructure/cloudrunworker/worker_test.go
@@ -31,6 +31,7 @@ func (f *fakeFile) WriteCancelFlag(_ context.Context, jobID string) error {
 	return nil
 }
 func (f *fakeFile) ReadAsset(context.Context, string) (io.ReadCloser, error)         { panic("unused") }
+func (f *fakeFile) ReadActions(context.Context, string) (io.ReadCloser, error)       { panic("unused") }
 func (f *fakeFile) UploadAsset(context.Context, *file.File) (*url.URL, int64, error) { panic("unused") }
 func (f *fakeFile) DeleteAsset(context.Context, *url.URL) error                      { panic("unused") }
 func (f *fakeFile) ReadWorkflow(context.Context, string) (io.ReadCloser, error)      { panic("unused") }

--- a/server/api/internal/infrastructure/fs/common.go
+++ b/server/api/internal/infrastructure/fs/common.go
@@ -4,4 +4,5 @@ const (
 	assetDir     = "assets"
 	workflowsDir = "workflows"
 	metadataDir  = "metadata"
+	actionsDir   = "actions"
 )

--- a/server/api/internal/infrastructure/fs/file.go
+++ b/server/api/internal/infrastructure/fs/file.go
@@ -157,6 +157,10 @@ func (f *fileRepo) ReadAsset(ctx context.Context, filename string) (io.ReadClose
 	return f.read(ctx, filepath.Join(assetDir, sanitize.Path(filename)))
 }
 
+func (f *fileRepo) ReadActions(ctx context.Context, filename string) (io.ReadCloser, error) {
+	return f.read(ctx, filepath.Join(actionsDir, sanitize.Path(filename)))
+}
+
 func (f *fileRepo) UploadAsset(ctx context.Context, file *file.File) (*url.URL, int64, error) {
 	filename := sanitize.Path(newAssetID() + filepath.Ext(file.Path))
 	size, err := f.upload(ctx, filepath.Join(assetDir, filename), file.Content)

--- a/server/api/internal/infrastructure/fs/file_test.go
+++ b/server/api/internal/infrastructure/fs/file_test.go
@@ -41,6 +41,25 @@ func TestFile_ReadAsset(t *testing.T) {
 	assert.Nil(t, r)
 }
 
+func TestFile_ReadActions(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	af, _ := fs.Create(filepath.Join(actionsDir, "actions.json"))
+	_, _ = af.WriteString(`{"actions":[]}`)
+	_ = af.Close()
+
+	f, _ := NewFile(fs, "", "")
+	r, err := f.ReadActions(context.Background(), "actions.json")
+	assert.NoError(t, err)
+	c, err := io.ReadAll(r)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"actions":[]}`, string(c))
+	assert.NoError(t, r.Close())
+
+	r, err = f.ReadActions(context.Background(), "missing.json")
+	assert.ErrorIs(t, err, rerror.ErrNotFound)
+	assert.Nil(t, r)
+}
+
 func TestFile_UploadAsset(t *testing.T) {
 	fs := mockFs()
 	f, _ := NewFile(fs, "https://example.com/assets", "https://example.com/workflows")

--- a/server/api/internal/infrastructure/gcs/file.go
+++ b/server/api/internal/infrastructure/gcs/file.go
@@ -30,6 +30,7 @@ const (
 	gcsAssetBasePath    string = "assets"
 	gcsMetadataBasePath string = "metadata"
 	gcsWorkflowBasePath string = "workflows"
+	gcsActionsBasePath  string = "actions"
 	fileSizeLimit       int64  = 1024 * 1024 * 100 // about 100MB
 )
 
@@ -77,6 +78,14 @@ func (f *fileRepo) ReadAsset(ctx context.Context, name string) (io.ReadCloser, e
 		return nil, rerror.ErrNotFound
 	}
 	return f.read(ctx, path.Join(gcsAssetBasePath, sn))
+}
+
+func (f *fileRepo) ReadActions(ctx context.Context, name string) (io.ReadCloser, error) {
+	sn := sanitizePath(name)
+	if sn == "" {
+		return nil, rerror.ErrNotFound
+	}
+	return f.read(ctx, path.Join(gcsActionsBasePath, sn))
 }
 
 func (f *fileRepo) UploadAsset(ctx context.Context, file *file.File) (*url.URL, int64, error) {

--- a/server/api/internal/usecase/gateway/file.go
+++ b/server/api/internal/usecase/gateway/file.go
@@ -53,6 +53,7 @@ func (p IssueUploadAssetParam) GetOrGuessContentType() string {
 
 type File interface {
 	ReadAsset(context.Context, string) (io.ReadCloser, error)
+	ReadActions(context.Context, string) (io.ReadCloser, error)
 	UploadAsset(context.Context, *file.File) (*url.URL, int64, error)
 	DeleteAsset(context.Context, *url.URL) error
 	ReadWorkflow(context.Context, string) (io.ReadCloser, error)

--- a/server/api/internal/usecase/interactor/previewschema_test.go
+++ b/server/api/internal/usecase/interactor/previewschema_test.go
@@ -89,6 +89,9 @@ func (f *previewFakeFile) CheckJobPreviewSchemaExists(context.Context, string) (
 	return true, nil
 }
 func (f *previewFakeFile) ReadAsset(context.Context, string) (io.ReadCloser, error) { panic("unused") }
+func (f *previewFakeFile) ReadActions(context.Context, string) (io.ReadCloser, error) {
+	panic("unused")
+}
 func (f *previewFakeFile) UploadAsset(context.Context, *file.File) (*url.URL, int64, error) {
 	panic("unused")
 }


### PR DESCRIPTION
## Overview

Serve each environment's **actions schema** from its own GCS bucket (matching the engine branch that env runs) instead of a hardcoded GitHub `main` URL.

## What I've done

- **`gateway.File.ReadActions`** — new method (gcs + fs impls) reading `actions/<file>` from the env bucket, mirroring `ReadAsset`.
- **`loadActionsData`** now reads the schema through the File gateway (same bucket-backed path as assets/artifacts), falling back to GitHub `main` raw on a cold/missing bucket. `initActionsData` is wired with `cfg.Gateways.File`.
- **OSS deploy** (`build_deploy_api.yml`): uploads `engine/schema/actions*.json` → `gs://<oss-bucket>/actions/` (glob, future-proof for new languages).
- Tests are hermetic (fake reader) — no network calls.

## Why

The actions list powers the UI's node palette. Today every env shows `main`'s actions regardless of the deployed engine; plateau even runs a different branch (`plateau5`). This makes the schema per-env and branch-matched.

This **supersedes #2181** (reads via the File gateway instead of `AssetBaseURL`, which collides with the `/actions/:id` route; uploads via glob instead of a fixed 6-file list).

## Companion PRs (deploy side)

- **reearth-cloud**: `deploy_flow_{dev,prod}` publish/promote the schema for the `reearth-flow-{dev,prod}-bucket`.
- **PLATEAU-VIEW**: `deploy-flow-{dev,prod}` publish/promote for the plateau buckets (branch `plateau5`).

## Required config

- Secret `GCS_ASSETS_BUCKET` must resolve to `reearth-flow-oss-bucket` (OSS deploy job).

## How it degrades

If a bucket has no `actions/` yet (or read fails), the API falls back to GitHub `main` — no hard dependency at cold start beyond the existing behavior.
