### PR TITLE
ci(api): isolate OSS actions-schema upload so checkout doesn't clobber deploy creds

### DIFF
--- a/.github/workflows/build_deploy_api.yml
+++ b/.github/workflows/build_deploy_api.yml
@@ -163,14 +163,6 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
-      - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ inputs.sha }}
-
-      - name: Upload actions schema to GCS
-        run: gsutil -m cp engine/schema/actions*.json gs://${{ secrets.GCS_ASSETS_BUCKET }}/actions/
-
       - name: Configure Docker for GCP
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
@@ -187,3 +179,30 @@ jobs:
             --region ${{ secrets.GC_REGION }} \
             --platform managed \
             --quiet
+
+  upload-actions-schema:
+    name: Upload Actions Schema to GCS (Nightly)
+    needs: build-api
+    runs-on: ubuntu-latest
+    if: ${{ inputs.name == 'nightly' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+      - name: Checkout Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ inputs.sha }}
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          service_account: ${{ secrets.GC_SA_EMAIL }}
+          workload_identity_provider: ${{ secrets.GC_WORKLOAD_IDENTITY_PROVIDER }}
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
+      - name: Upload actions schema to GCS
+        run: gsutil -m cp engine/schema/actions*.json gs://${{ secrets.GCS_ASSETS_BUCKET }}/actions/


### PR DESCRIPTION
## Problem

After #2196 merged, the nightly OSS deploy (`deploy-to-cloud-run`) **fails** at *Push Docker Image to GCP Artifact Registry*:

```
ERROR: (gcloud.auth.docker-helper) Failed to load credential file: [.../gha-creds-….json]. File … was not found.
denied: Unauthenticated request …
```

**Cause:** #2196 added a `Checkout Repository` + schema-upload step *inside* `deploy-to-cloud-run`, **after** `Authenticate to Google Cloud`. `actions/checkout` cleans the workspace, deleting the `gha-creds-*.json` file the auth step wrote — so the docker credential helper can't authenticate. This breaks every nightly OSS API deploy.

(The schema upload itself succeeds — `gs://reearth-flow-oss-bucket/actions/` is populated — but it took down the deploy.)

## Fix

- Revert `deploy-to-cloud-run` to its original, known-good form (no checkout).
- Move the schema upload to a dedicated **`upload-actions-schema`** job (`checkout` → `auth` → `gsutil`, with checkout *before* auth). This decouples the two: a schema-upload issue can never block the API deploy, and the deploy's credentials are never clobbered.

Matches the separate-job pattern used in the reearth-cloud / PLATEAU-VIEW companion PRs.

## Verification

`actionlint` + YAML parse clean; `deploy-to-cloud-run` no longer contains a checkout step. Once merged, the next nightly will deploy the API correctly and (re)upload the schema.
