### PR TITLE
feat(engine): new geometry constructors

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4092,7 +4092,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.56"
+version = "0.2.57"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "futures",
  "once_cell",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "approx",
  "async-trait",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "Inflector",
  "approx",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "bytes",
  "clap",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "approx",
  "bvh",
@@ -5053,7 +5053,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "bytes",
  "futures",
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "bytes",
  "futures",
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5239,7 +5239,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "ahash",
  "bytes",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.416"
+version = "0.0.417"
 dependencies = [
  "async-trait",
  "axum",
@@ -8041,7 +8041,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.246"
+version = "0.1.247"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.416"
+version = "0.0.417"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -10,6 +10,7 @@
 use reearth_flow_common::attribute::Attributes;
 use serde::{Deserialize, Serialize};
 
+use crate::error::Error;
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry};
 
 /// A `Multi*` collection of 2D geometries; members may differ in coordinate frame.
@@ -28,4 +29,82 @@ pub struct Collection3D {
     /// Per-member attributes, parallel to `members`; empty = no member carries
     /// any. Child-scoped.
     attrs: Vec<Attributes>,
+}
+
+/// Validate that `attrs` is either empty or exactly parallel to `members`.
+fn check_attrs<T>(members: &[T], attrs: &[Attributes]) -> Result<(), Error> {
+    if !attrs.is_empty() && attrs.len() != members.len() {
+        return Err(Error::invalid_geometry(format!(
+            "attribute count {} does not match member count {}",
+            attrs.len(),
+            members.len()
+        )));
+    }
+    Ok(())
+}
+
+impl Collection2D {
+    /// Collect members, with no per-child attributes.
+    pub fn new(members: impl IntoIterator<Item = Euclidean2DGeometry>) -> Self {
+        Self {
+            members: members.into_iter().collect(),
+            attrs: Vec::new(),
+        }
+    }
+
+    /// Build with per-child attributes parallel to `members`. `attrs` must be empty
+    /// or exactly one entry per member.
+    pub fn with_attributes(
+        members: Vec<Euclidean2DGeometry>,
+        attrs: Vec<Attributes>,
+    ) -> Result<Self, Error> {
+        check_attrs(&members, &attrs)?;
+        Ok(Self { members, attrs })
+    }
+}
+
+impl Collection3D {
+    /// Collect members, with no per-child attributes.
+    pub fn new(members: impl IntoIterator<Item = Euclidean3DGeometry>) -> Self {
+        Self {
+            members: members.into_iter().collect(),
+            attrs: Vec::new(),
+        }
+    }
+
+    /// Build with per-child attributes parallel to `members`. `attrs` must be empty
+    /// or exactly one entry per member.
+    pub fn with_attributes(
+        members: Vec<Euclidean3DGeometry>,
+        attrs: Vec<Attributes>,
+    ) -> Result<Self, Error> {
+        check_attrs(&members, &attrs)?;
+        Ok(Self { members, attrs })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinate::Coordinate;
+    use crate::point::{Point2D, Point3D};
+
+    #[test]
+    fn new_2d_collects_members_without_attrs() {
+        let c = Collection2D::new([
+            Euclidean2DGeometry::Point(Point2D::new(Coordinate::Euclidean, [0.0, 0.0])),
+            Euclidean2DGeometry::Point(Point2D::new(Coordinate::Euclidean, [1.0, 1.0])),
+        ]);
+        assert_eq!(c.members.len(), 2);
+        assert!(c.attrs.is_empty());
+    }
+
+    #[test]
+    fn with_attributes_rejects_length_mismatch() {
+        let members = vec![Euclidean3DGeometry::Point(Point3D::new(
+            Coordinate::Euclidean,
+            [0.0, 0.0, 0.0],
+        ))];
+        assert!(Collection3D::with_attributes(members, vec![Attributes::default(); 2]).is_err());
+    }
 }

--- a/engine/runtime/geometry/src/csg/constructor.rs
+++ b/engine/runtime/geometry/src/csg/constructor.rs
@@ -1,0 +1,81 @@
+//! Csg constructors.
+//!
+//! The operands — `Solid`s or nested `Csg`s — are already constructed; these
+//! constructors just box them into the boolean tree. The `From` impls let a
+//! `Solid` or `Csg` be passed where a [`ThreeDimensional`] operand is expected.
+
+use crate::solid::Solid;
+
+use super::{Csg, ThreeDimensional};
+
+impl From<Solid> for ThreeDimensional {
+    fn from(solid: Solid) -> Self {
+        ThreeDimensional::Solid(Box::new(solid))
+    }
+}
+
+impl From<Csg> for ThreeDimensional {
+    fn from(csg: Csg) -> Self {
+        ThreeDimensional::Csg(Box::new(csg))
+    }
+}
+
+impl Csg {
+    /// The union of two volumetric operands.
+    pub fn union(left: impl Into<ThreeDimensional>, right: impl Into<ThreeDimensional>) -> Self {
+        Csg::Union(Box::new(left.into()), Box::new(right.into()))
+    }
+
+    /// The intersection of two volumetric operands.
+    pub fn intersection(
+        left: impl Into<ThreeDimensional>,
+        right: impl Into<ThreeDimensional>,
+    ) -> Self {
+        Csg::Intersection(Box::new(left.into()), Box::new(right.into()))
+    }
+
+    /// The difference `left - right` of two volumetric operands.
+    pub fn difference(
+        left: impl Into<ThreeDimensional>,
+        right: impl Into<ThreeDimensional>,
+    ) -> Self {
+        Csg::Difference(Box::new(left.into()), Box::new(right.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinate::Coordinate;
+    use crate::triangular_mesh::TriangularMesh3DData;
+
+    fn solid() -> Solid {
+        let shell = TriangularMesh3DData::from_parts(
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap();
+        Solid::from_exterior(Coordinate::Euclidean, shell)
+    }
+
+    #[test]
+    fn union_of_two_solids() {
+        let csg = Csg::union(solid(), solid());
+        assert!(matches!(
+            csg,
+            Csg::Union(l, r)
+                if matches!(*l, ThreeDimensional::Solid(_))
+                && matches!(*r, ThreeDimensional::Solid(_))
+        ));
+    }
+
+    #[test]
+    fn nested_csg_is_an_operand() {
+        let inner = Csg::union(solid(), solid());
+        let outer = Csg::difference(solid(), inner);
+        assert!(matches!(
+            outer,
+            Csg::Difference(_, r) if matches!(*r, ThreeDimensional::Csg(_))
+        ));
+    }
+}

--- a/engine/runtime/geometry/src/csg/mod.rs
+++ b/engine/runtime/geometry/src/csg/mod.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use super::solid::Solid;
 
+mod constructor;
+
 /// Volumetric, closed 3D geometries that `Csg` boolean operations are defined
 /// over.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/engine/runtime/geometry/src/error.rs
+++ b/engine/runtime/geometry/src/error.rs
@@ -11,6 +11,9 @@ pub enum Error {
         expected_type: &'static str,
         found_type: &'static str,
     },
+
+    #[error("Invalid geometry construction: {0}")]
+    InvalidGeometry(String),
 }
 
 impl Error {
@@ -21,6 +24,10 @@ impl Error {
     pub fn projection<T: ToString>(message: T) -> Self {
         Self::Projection(message.to_string())
     }
+
+    pub fn invalid_geometry<T: ToString>(message: T) -> Self {
+        Self::InvalidGeometry(message.to_string())
+    }
 }
 
 // implement Eq and PartialEq for Error so that we can compare errors in tests
@@ -29,6 +36,7 @@ impl PartialEq for Error {
         match (self, other) {
             (Self::MismatchedGeometry(a), Self::MismatchedGeometry(b)) => a == b,
             (Self::Projection(a), Self::Projection(b)) => a == b,
+            (Self::InvalidGeometry(a), Self::InvalidGeometry(b)) => a == b,
             _ => false,
         }
     }

--- a/engine/runtime/geometry/src/index.rs
+++ b/engine/runtime/geometry/src/index.rs
@@ -97,7 +97,7 @@ pub(crate) enum IndexWidth {
 
 impl IndexWidth {
     /// Narrowest width that can store `value`.
-    fn for_value(value: u32) -> Self {
+    pub(crate) fn for_value(value: u32) -> Self {
         if value <= u8::MAX as u32 {
             IndexWidth::U8
         } else if value <= u16::MAX as u32 {

--- a/engine/runtime/geometry/src/index.rs
+++ b/engine/runtime/geometry/src/index.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
     serialize = "[u8; N]: Serialize, [u16; N]: Serialize, [u32; N]: Serialize",
     deserialize = "[u8; N]: Deserialize<'de>, [u16; N]: Deserialize<'de>, [u32; N]: Deserialize<'de>"
 ))]
-pub enum IndexBuffer<const N: usize> {
+pub(crate) enum IndexBuffer<const N: usize> {
     U8(Vec<[u8; N]>),
     U16(Vec<[u16; N]>),
     U32(Vec<[u32; N]>),
@@ -39,6 +39,14 @@ pub enum IndexBuffer<const N: usize> {
 ///
 /// Algorithms that read two arrays of independently-chosen width nest the
 /// macro, giving 3x3 = 9 monomorphizations of one generic impl.
+///
+/// The second form dispatches on an [`IndexWidth`] instead of an existing buffer:
+/// it binds `$Idx` to the chosen width and wraps the body's `Vec<[$Idx; N]>` in the
+/// matching variant, for constructors that pick a variant to *build*:
+///
+/// ```ignore
+/// dispatch_index!(width => |Idx| collect_indices::<Idx, N>(iter))
+/// ```
 #[macro_export]
 macro_rules! dispatch_index {
     ($buf:expr, |$Idx:ident, $slice:ident| $body:expr) => {
@@ -60,4 +68,315 @@ macro_rules! dispatch_index {
             }
         }
     };
+    ($width:expr => |$Idx:ident| $body:expr) => {
+        match $width {
+            $crate::index::IndexWidth::U8 => {
+                type $Idx = u8;
+                $crate::index::IndexBuffer::U8($body)
+            }
+            $crate::index::IndexWidth::U16 => {
+                type $Idx = u16;
+                $crate::index::IndexBuffer::U16($body)
+            }
+            $crate::index::IndexWidth::U32 => {
+                type $Idx = u32;
+                $crate::index::IndexBuffer::U32($body)
+            }
+        }
+    };
+}
+
+/// One of the three index widths an [`IndexBuffer`] can store, ordered narrowest
+/// to widest. Used to name a width when constructing a buffer.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum IndexWidth {
+    U8,
+    U16,
+    U32,
+}
+
+impl IndexWidth {
+    /// Narrowest width that can store `value`.
+    fn for_value(value: u32) -> Self {
+        if value <= u8::MAX as u32 {
+            IndexWidth::U8
+        } else if value <= u16::MAX as u32 {
+            IndexWidth::U16
+        } else {
+            IndexWidth::U32
+        }
+    }
+
+    /// Narrowest width that can store every component of `element`.
+    fn for_element<const N: usize>(element: &[u32; N]) -> Self {
+        Self::for_value(element.iter().copied().max().unwrap_or(0))
+    }
+
+    /// Position in the narrowest-to-widest order, for comparing widths.
+    fn rank(self) -> u8 {
+        match self {
+            IndexWidth::U8 => 0,
+            IndexWidth::U16 => 1,
+            IndexWidth::U32 => 2,
+        }
+    }
+}
+
+/// Reallocate `buf` into `target` when `target` is wider than the current width.
+/// Narrowing is a no-op: the constructors only ever promote.
+fn promote<const N: usize>(buf: &mut IndexBuffer<N>, target: IndexWidth) {
+    if target.rank() <= buf.width().rank() {
+        return;
+    }
+    let old = std::mem::replace(buf, IndexBuffer::U8(Vec::new()));
+    *buf = match (old, target) {
+        (IndexBuffer::U8(v), IndexWidth::U16) => {
+            IndexBuffer::U16(v.into_iter().map(|e| e.map(|x| x as u16)).collect())
+        }
+        (IndexBuffer::U8(v), IndexWidth::U32) => {
+            IndexBuffer::U32(v.into_iter().map(|e| e.map(|x| x as u32)).collect())
+        }
+        (IndexBuffer::U16(v), IndexWidth::U32) => {
+            IndexBuffer::U32(v.into_iter().map(|e| e.map(|x| x as u32)).collect())
+        }
+        (old, _) => old,
+    };
+}
+
+/// Allocate `len` elements without initializing them, write each item from `iter`
+/// (each component mapped through `f`) by raw pointer with no per-element bounds
+/// check, then set the length to the number actually written.
+///
+/// Private: the only public entry point to this is the single unsafe interface
+/// [`IndexBuffer::from_exact_unchecked`], which dispatches the concrete element
+/// type into this generic body.
+///
+/// # Safety
+/// The caller must ensure `iter` yields **at most** `len` items (yielding more
+/// writes out of bounds). Yielding fewer simply produces a shorter buffer.
+unsafe fn fill_uninit<const N: usize, T, F>(
+    len: usize,
+    iter: impl IntoIterator<Item = [u32; N]>,
+    f: F,
+) -> Vec<[T; N]>
+where
+    F: Fn(u32) -> T + Copy,
+{
+    let mut v: Vec<[T; N]> = Vec::with_capacity(len);
+    let ptr = v.as_mut_ptr();
+    let mut i = 0usize;
+    for element in iter {
+        ptr.add(i).write(element.map(f));
+        i += 1;
+    }
+    debug_assert_eq!(i, len, "iterator yielded {i} items, expected {len}");
+    v.set_len(i);
+    v
+}
+
+impl<const N: usize> IndexBuffer<N> {
+    /// The width this buffer currently stores its indices in.
+    pub(crate) fn width(&self) -> IndexWidth {
+        match self {
+            IndexBuffer::U8(_) => IndexWidth::U8,
+            IndexBuffer::U16(_) => IndexWidth::U16,
+            IndexBuffer::U32(_) => IndexWidth::U32,
+        }
+    }
+
+    /// Build from index elements, choosing the narrowest width that fits them all.
+    ///
+    /// Width-agnostic: storage starts at `u8` and fattens to `u16` then `u32` only
+    /// when an element exceeds the current width — so the common small-mesh case
+    /// stays `u8` and never pays for wider storage. A large mesh whose size is
+    /// unknown here reallocates on each promotion (at most twice), the same linear
+    /// cost its `Vec` growth pays anyway.
+    pub(crate) fn from_indices(iter: impl IntoIterator<Item = [u32; N]>) -> Self {
+        Self::with_min_width(IndexWidth::U8, None, iter)
+    }
+
+    /// Build starting at `width`, promoting to a wider one if an element needs it;
+    /// the result width is therefore `max(width, needed)`. Never panics: a `width`
+    /// too narrow for the data is widened, a `width` wider than necessary is kept
+    /// (costing storage but not correctness). `size_hint`, when given, presizes the
+    /// initial allocation.
+    pub(crate) fn with_min_width(
+        width: IndexWidth,
+        size_hint: Option<usize>,
+        iter: impl IntoIterator<Item = [u32; N]>,
+    ) -> Self {
+        let iter = iter.into_iter();
+        let cap = size_hint.unwrap_or_else(|| iter.size_hint().0);
+        let mut buf = match width {
+            IndexWidth::U8 => IndexBuffer::U8(Vec::with_capacity(cap)),
+            IndexWidth::U16 => IndexBuffer::U16(Vec::with_capacity(cap)),
+            IndexWidth::U32 => IndexBuffer::U32(Vec::with_capacity(cap)),
+        };
+        for element in iter {
+            promote(&mut buf, IndexWidth::for_element(&element));
+            match &mut buf {
+                IndexBuffer::U8(v) => v.push(element.map(|x| x as u8)),
+                IndexBuffer::U16(v) => v.push(element.map(|x| x as u16)),
+                IndexBuffer::U32(v) => v.push(element),
+            }
+        }
+        buf
+    }
+
+    /// Build at exactly `width`, panicking if an element does not fit. Unlike
+    /// [`with_min_width`](Self::with_min_width) this never promotes — use it when
+    /// the width is known and a mismatch is a bug worth surfacing. `size_hint`,
+    /// when given, presizes the allocation.
+    ///
+    /// # Panics
+    /// If any element has a component larger than `width` can store.
+    pub(crate) fn with_exact_width(
+        width: IndexWidth,
+        size_hint: Option<usize>,
+        iter: impl IntoIterator<Item = [u32; N]>,
+    ) -> Self {
+        let iter = iter.into_iter();
+        let cap = size_hint.unwrap_or_else(|| iter.size_hint().0);
+        match width {
+            IndexWidth::U8 => {
+                let mut v = Vec::with_capacity(cap);
+                for element in iter {
+                    v.push(element.map(|x| {
+                        assert!(x <= u8::MAX as u32, "index {x} does not fit in u8");
+                        x as u8
+                    }));
+                }
+                IndexBuffer::U8(v)
+            }
+            IndexWidth::U16 => {
+                let mut v = Vec::with_capacity(cap);
+                for element in iter {
+                    v.push(element.map(|x| {
+                        assert!(x <= u16::MAX as u32, "index {x} does not fit in u16");
+                        x as u16
+                    }));
+                }
+                IndexBuffer::U16(v)
+            }
+            IndexWidth::U32 => {
+                let mut v = Vec::with_capacity(cap);
+                v.extend(iter);
+                IndexBuffer::U32(v)
+            }
+        }
+    }
+
+    /// Build at exactly `width` and exactly `len` elements, allocating uninitialized
+    /// and filling from `iter` by raw pointer with no bounds checks — the fastest,
+    /// most dangerous path.
+    ///
+    /// # Safety
+    /// The caller must ensure both:
+    /// - every element fits in `width` (a component that does not is silently
+    ///   truncated), and
+    /// - `iter` yields **at most** `len` items (yielding more writes out of bounds,
+    ///   which is undefined behavior).
+    pub(crate) unsafe fn from_exact_unchecked(
+        width: IndexWidth,
+        len: usize,
+        iter: impl IntoIterator<Item = [u32; N]>,
+    ) -> Self {
+        dispatch_index!(width => |Idx| fill_uninit::<N, Idx, _>(len, iter, |x| x as Idx))
+    }
+}
+
+impl<const N: usize> FromIterator<[u32; N]> for IndexBuffer<N> {
+    /// Collects into the narrowest fitting width; see [`from_indices`](Self::from_indices).
+    fn from_iter<I: IntoIterator<Item = [u32; N]>>(iter: I) -> Self {
+        Self::from_indices(iter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn u8s<const N: usize>(buf: &IndexBuffer<N>) -> &[[u8; N]] {
+        match buf {
+            IndexBuffer::U8(v) => v,
+            _ => panic!("expected U8, got {:?}", buf.width()),
+        }
+    }
+
+    #[test]
+    fn from_indices_picks_u8_for_small_values() {
+        let buf = IndexBuffer::from_indices([[0u32], [5], [255]]);
+        assert_eq!(buf.width(), IndexWidth::U8);
+        assert_eq!(u8s(&buf), &[[0], [5], [255]]);
+    }
+
+    #[test]
+    fn from_indices_promotes_and_preserves_earlier_values() {
+        let buf = IndexBuffer::from_indices([[1u32], [2], [300]]);
+        assert_eq!(buf.width(), IndexWidth::U16);
+        match &buf {
+            IndexBuffer::U16(v) => assert_eq!(v, &[[1], [2], [300]]),
+            _ => panic!("expected U16"),
+        }
+    }
+
+    #[test]
+    fn from_indices_promotes_to_u32() {
+        let buf = IndexBuffer::from_indices([[1u32], [70_000]]);
+        assert_eq!(buf.width(), IndexWidth::U32);
+        match &buf {
+            IndexBuffer::U32(v) => assert_eq!(v, &[[1], [70_000]]),
+            _ => panic!("expected U32"),
+        }
+    }
+
+    #[test]
+    fn from_indices_promotes_once_for_triangles() {
+        let buf = IndexBuffer::from_indices([[0u32, 1, 2], [3, 4, 70_000]]);
+        assert_eq!(buf.width(), IndexWidth::U32);
+        match &buf {
+            IndexBuffer::U32(v) => assert_eq!(v, &[[0, 1, 2], [3, 4, 70_000]]),
+            _ => panic!("expected U32"),
+        }
+    }
+
+    #[test]
+    fn with_min_width_keeps_wider_floor() {
+        let buf = IndexBuffer::with_min_width(IndexWidth::U16, None, [[0u32], [5]]);
+        assert_eq!(buf.width(), IndexWidth::U16);
+    }
+
+    #[test]
+    fn with_min_width_promotes_above_floor() {
+        let buf = IndexBuffer::with_min_width(IndexWidth::U16, Some(2), [[5u32], [70_000]]);
+        assert_eq!(buf.width(), IndexWidth::U32);
+    }
+
+    #[test]
+    fn with_exact_width_keeps_stated_width() {
+        let buf = IndexBuffer::with_exact_width(IndexWidth::U32, None, [[0u32], [5]]);
+        assert_eq!(buf.width(), IndexWidth::U32);
+    }
+
+    #[test]
+    #[should_panic(expected = "does not fit in u8")]
+    fn with_exact_width_panics_on_overflow() {
+        let _ = IndexBuffer::with_exact_width(IndexWidth::U8, None, [[0u32], [256]]);
+    }
+
+    #[test]
+    fn from_exact_unchecked_fills_buffer() {
+        let buf =
+            unsafe { IndexBuffer::from_exact_unchecked(IndexWidth::U16, 3, [[0u32], [1], [400]]) };
+        match &buf {
+            IndexBuffer::U16(v) => assert_eq!(v, &[[0], [1], [400]]),
+            _ => panic!("expected U16"),
+        }
+    }
+
+    #[test]
+    fn collect_uses_minimal_width() {
+        let buf: IndexBuffer<3> = [[0u32, 1, 2], [2, 3, 4]].into_iter().collect();
+        assert_eq!(buf.width(), IndexWidth::U8);
+    }
 }

--- a/engine/runtime/geometry/src/index.rs
+++ b/engine/runtime/geometry/src/index.rs
@@ -39,14 +39,6 @@ pub(crate) enum IndexBuffer<const N: usize> {
 ///
 /// Algorithms that read two arrays of independently-chosen width nest the
 /// macro, giving 3x3 = 9 monomorphizations of one generic impl.
-///
-/// The second form dispatches on an [`IndexWidth`] instead of an existing buffer:
-/// it binds `$Idx` to the chosen width and wraps the body's `Vec<[$Idx; N]>` in the
-/// matching variant, for constructors that pick a variant to *build*:
-///
-/// ```ignore
-/// dispatch_index!(width => |Idx| collect_indices::<Idx, N>(iter))
-/// ```
 #[macro_export]
 macro_rules! dispatch_index {
     ($buf:expr, |$Idx:ident, $slice:ident| $body:expr) => {
@@ -65,22 +57,6 @@ macro_rules! dispatch_index {
                 type $Idx = u32;
                 let $slice = v;
                 $body
-            }
-        }
-    };
-    ($width:expr => |$Idx:ident| $body:expr) => {
-        match $width {
-            $crate::index::IndexWidth::U8 => {
-                type $Idx = u8;
-                $crate::index::IndexBuffer::U8($body)
-            }
-            $crate::index::IndexWidth::U16 => {
-                type $Idx = u16;
-                $crate::index::IndexBuffer::U16($body)
-            }
-            $crate::index::IndexWidth::U32 => {
-                type $Idx = u32;
-                $crate::index::IndexBuffer::U32($body)
             }
         }
     };
@@ -163,14 +139,18 @@ where
     F: Fn(u32) -> T + Copy,
 {
     let mut v: Vec<[T; N]> = Vec::with_capacity(len);
-    let ptr = v.as_mut_ptr();
-    let mut i = 0usize;
+    let start = v.as_mut_ptr();
+    let end = start.add(len);
+    let mut dst = start;
     for element in iter {
-        ptr.add(i).write(element.map(f));
-        i += 1;
+        debug_assert!(
+            dst < end,
+            "iterator yielded more than the {len} items reserved"
+        );
+        dst.write(element.map(f));
+        dst = dst.add(1);
     }
-    debug_assert_eq!(i, len, "iterator yielded {i} items, expected {len}");
-    v.set_len(i);
+    v.set_len(dst.offset_from(start) as usize);
     v
 }
 
@@ -281,7 +261,11 @@ impl<const N: usize> IndexBuffer<N> {
         len: usize,
         iter: impl IntoIterator<Item = [u32; N]>,
     ) -> Self {
-        dispatch_index!(width => |Idx| fill_uninit::<N, Idx, _>(len, iter, |x| x as Idx))
+        match width {
+            IndexWidth::U8 => IndexBuffer::U8(fill_uninit(len, iter, |x| x as u8)),
+            IndexWidth::U16 => IndexBuffer::U16(fill_uninit(len, iter, |x| x as u16)),
+            IndexWidth::U32 => IndexBuffer::U32(fill_uninit(len, iter, |x| x)),
+        }
     }
 }
 

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -75,6 +75,32 @@ pub struct GeometryCollection {
     attrs: Vec<Attributes>,
 }
 
+impl GeometryCollection {
+    /// Collect members, with no per-child attributes.
+    pub fn new(members: impl IntoIterator<Item = Geometry>) -> Self {
+        Self {
+            members: members.into_iter().collect(),
+            attrs: Vec::new(),
+        }
+    }
+
+    /// Build with per-child attributes parallel to `members`. `attrs` must be empty
+    /// or exactly one entry per member.
+    pub fn with_attributes(
+        members: Vec<Geometry>,
+        attrs: Vec<Attributes>,
+    ) -> Result<Self, error::Error> {
+        if !attrs.is_empty() && attrs.len() != members.len() {
+            return Err(error::Error::invalid_geometry(format!(
+                "attribute count {} does not match member count {}",
+                attrs.len(),
+                members.len()
+            )));
+        }
+        Ok(Self { members, attrs })
+    }
+}
+
 /// 2D-embedded geometry. All coordinates are 2D `(x, y)`; some leaves carry an
 /// optional per-vertex elevation (2.5D).
 ///

--- a/engine/runtime/geometry/src/line_string/constructor.rs
+++ b/engine/runtime/geometry/src/line_string/constructor.rs
@@ -1,0 +1,143 @@
+//! LineString constructors.
+//!
+//! A `LineString` is a flat coordinate chain: every reader (CityGML `gml:Curve`,
+//! shapefile polylines, GeoJSON, WKT, GeoPackage WKB) hands one over as a plain
+//! sequence of points — no shared pool, no indices, no rings. So construction is
+//! just wrapping that buffer; the 2D form optionally carries per-vertex elevation
+//! (2.5D), split out of `[x, y, z]` input. Lines are stored as given (not closed)
+//! and carry no appearance.
+
+use crate::coordinate::Coordinate;
+use crate::error::Error;
+
+use super::{LineString2D, LineString3D};
+
+impl LineString2D {
+    /// Build a 2D polyline from `[x, y]` coordinates. The result is pure 2D (no
+    /// elevation); for per-vertex elevation use
+    /// [`LineString2D::from_coords_with_elevation`].
+    pub fn from_coords(coordinate: Coordinate, coords: impl IntoIterator<Item = [f64; 2]>) -> Self {
+        Self {
+            coordinate,
+            coords: coords.into_iter().collect(),
+            z: None,
+        }
+    }
+
+    /// Build a 2.5D polyline from `[x, y, z]` coordinates: the `(x, y)` populate
+    /// `coords` and the `z` the parallel elevation buffer.
+    pub fn from_coords_with_elevation(
+        coordinate: Coordinate,
+        coords: impl IntoIterator<Item = [f64; 3]>,
+    ) -> Self {
+        let coords = coords.into_iter();
+        let cap = coords.size_hint().0;
+        let mut xy = Vec::with_capacity(cap);
+        let mut z = Vec::with_capacity(cap);
+        for [x, y, elevation] in coords {
+            xy.push([x, y]);
+            z.push(elevation);
+        }
+        Self {
+            coordinate,
+            coords: xy.into_boxed_slice(),
+            z: Some(z.into_boxed_slice()),
+        }
+    }
+
+    /// Build from an already-built coordinate buffer and optional parallel
+    /// elevation. Errors if `z` is present and not the same length as `coords`.
+    pub fn from_raw_parts(
+        coordinate: Coordinate,
+        coords: Box<[[f64; 2]]>,
+        z: Option<Box<[f64]>>,
+    ) -> Result<Self, Error> {
+        if let Some(z) = z.as_ref() {
+            if z.len() != coords.len() {
+                return Err(Error::invalid_geometry(format!(
+                    "elevation buffer length {} does not match coordinate count {}",
+                    z.len(),
+                    coords.len()
+                )));
+            }
+        }
+        Ok(Self {
+            coordinate,
+            coords,
+            z,
+        })
+    }
+}
+
+impl LineString3D {
+    /// Build a 3D polyline from `[x, y, z]` coordinates.
+    pub fn from_coords(coordinate: Coordinate, coords: impl IntoIterator<Item = [f64; 3]>) -> Self {
+        Self {
+            coordinate,
+            coords: coords.into_iter().collect(),
+        }
+    }
+
+    /// Build from an already-built coordinate buffer.
+    pub fn from_raw_parts(coordinate: Coordinate, coords: Box<[[f64; 3]]>) -> Self {
+        Self { coordinate, coords }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_coords_2d_is_open_and_pure() {
+        let l =
+            LineString2D::from_coords(Coordinate::Euclidean, [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]);
+        // Stored as given: no closing vertex appended.
+        assert_eq!(l.coords.len(), 3);
+        assert_eq!(l.coords[0], [0.0, 0.0]);
+        assert!(l.z.is_none());
+        assert_eq!(l.coordinate, Coordinate::Euclidean);
+    }
+
+    #[test]
+    fn from_coords_with_elevation_splits_z() {
+        let l = LineString2D::from_coords_with_elevation(
+            Coordinate::Euclidean,
+            [[0.0, 0.0, 10.0], [1.0, 0.0, 11.0]],
+        );
+        assert_eq!(l.coords, vec![[0.0, 0.0], [1.0, 0.0]].into_boxed_slice());
+        assert_eq!(l.z.as_deref(), Some(&[10.0, 11.0][..]));
+    }
+
+    #[test]
+    fn from_raw_parts_2d_rejects_unparallel_z() {
+        let coords: Box<[[f64; 2]]> = vec![[0.0, 0.0], [1.0, 0.0]].into_boxed_slice();
+        let err = LineString2D::from_raw_parts(
+            Coordinate::Euclidean,
+            coords,
+            Some(vec![0.0].into_boxed_slice()),
+        )
+        .unwrap_err();
+        assert!(matches!(err, Error::InvalidGeometry(_)));
+    }
+
+    #[test]
+    fn from_raw_parts_2d_accepts_parallel_z() {
+        let coords: Box<[[f64; 2]]> = vec![[0.0, 0.0], [1.0, 0.0]].into_boxed_slice();
+        let l = LineString2D::from_raw_parts(
+            Coordinate::Euclidean,
+            coords,
+            Some(vec![3.0, 4.0].into_boxed_slice()),
+        )
+        .unwrap();
+        assert_eq!(l.z.as_deref(), Some(&[3.0, 4.0][..]));
+    }
+
+    #[test]
+    fn from_coords_3d() {
+        let l =
+            LineString3D::from_coords(Coordinate::Euclidean, [[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]]);
+        assert_eq!(l.coords.len(), 2);
+        assert_eq!(l.coords[1], [1.0, 2.0, 3.0]);
+    }
+}

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::coordinate::Coordinate;
 
+mod constructor;
+
 /// A polyline in 2D space, with optional per-vertex elevation (2.5D).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct LineString2D {

--- a/engine/runtime/geometry/src/point/constructor.rs
+++ b/engine/runtime/geometry/src/point/constructor.rs
@@ -1,0 +1,45 @@
+//! Point constructors.
+//!
+//! A `Point` is a single position in a frame — readers (CityGML `gml:Point`, OBJ
+//! vertices, 2D/3D point features) hand over exactly that, so construction just
+//! pairs the position with its coordinate frame.
+
+use crate::coordinate::Coordinate;
+
+use super::{Point2D, Point3D};
+
+impl Point2D {
+    /// A 2D point at `position`, in `coordinate`.
+    pub fn new(coordinate: Coordinate, position: [f64; 2]) -> Self {
+        Self {
+            coordinate,
+            position,
+        }
+    }
+}
+
+impl Point3D {
+    /// A 3D point at `position`, in `coordinate`.
+    pub fn new(coordinate: Coordinate, position: [f64; 3]) -> Self {
+        Self {
+            coordinate,
+            position,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_stores_position_and_frame() {
+        let p = Point2D::new(Coordinate::Euclidean, [1.0, 2.0]);
+        assert_eq!(p.position, [1.0, 2.0]);
+        assert_eq!(p.coordinate, Coordinate::Euclidean);
+
+        let q = Point3D::new(Coordinate::Crs(4326), [1.0, 2.0, 3.0]);
+        assert_eq!(q.position, [1.0, 2.0, 3.0]);
+        assert_eq!(q.coordinate, Coordinate::Crs(4326));
+    }
+}

--- a/engine/runtime/geometry/src/point/mod.rs
+++ b/engine/runtime/geometry/src/point/mod.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use super::coordinate::Coordinate;
 
+mod constructor;
+
 /// A single position in 2D space.
 /// Used for CityGML `gml:Point` and 2D point features.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/engine/runtime/geometry/src/point_cloud/constructor.rs
+++ b/engine/runtime/geometry/src/point_cloud/constructor.rs
@@ -1,0 +1,78 @@
+//! PointCloud constructors.
+//!
+//! `from_positions` builds the basic case: a single acquisition segment of bare
+//! XYZ points in `f64` encoding — no optional fields, no user attributes — the
+//! shape a plain XYZ reader produces. The richer machinery (RGB / intensity /
+//! normals, `f32` or scaled-`i32` encodings, per-point attribute columns, multiple
+//! segments) is deferred until a reader needs it.
+
+use std::sync::OnceLock;
+
+use indexmap::IndexMap;
+use smallvec::SmallVec;
+
+use crate::coordinate::Coordinate;
+
+use super::{PointCloud, PositionEncoding, Segment};
+
+/// Bytes per point in `f64` XYZ encoding (`3 * size_of::<f64>()`).
+const F64_STRIDE: u16 = 24;
+
+impl PointCloud {
+    /// Build a point cloud from bare XYZ positions: one `f64`-encoded segment with
+    /// no optional fields or attributes.
+    pub fn from_positions(
+        coordinate: Coordinate,
+        positions: impl IntoIterator<Item = [f64; 3]>,
+    ) -> Self {
+        let positions = positions.into_iter();
+        let mut data = Vec::with_capacity(positions.size_hint().0 * F64_STRIDE as usize);
+        let mut count = 0usize;
+        for [x, y, z] in positions {
+            data.extend_from_slice(&x.to_le_bytes());
+            data.extend_from_slice(&y.to_le_bytes());
+            data.extend_from_slice(&z.to_le_bytes());
+            count += 1;
+        }
+        let mut segments = SmallVec::new();
+        segments.push(Segment {
+            source: None,
+            position: PositionEncoding::F64,
+            fields: 0,
+            stride: F64_STRIDE,
+            offsets: [0; 9],
+            data,
+            count,
+            attributes: IndexMap::new(),
+        });
+        Self {
+            coordinate,
+            segments,
+            kdtree: OnceLock::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_positions_packs_one_f64_segment() {
+        let pc = PointCloud::from_positions(
+            Coordinate::Euclidean,
+            [[0.0, 0.0, 0.0], [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+        );
+        assert_eq!(pc.segments.len(), 1);
+        let seg = &pc.segments[0];
+        assert_eq!(seg.count, 3);
+        assert_eq!(seg.stride, F64_STRIDE);
+        assert_eq!(seg.data.len(), 3 * F64_STRIDE as usize);
+        assert_eq!(seg.fields, 0);
+        assert!(matches!(seg.position, PositionEncoding::F64));
+        assert!(seg.attributes.is_empty());
+        // The third point's X decodes back from its little-endian bytes.
+        let x2 = f64::from_le_bytes(seg.data[48..56].try_into().unwrap());
+        assert_eq!(x2, 4.0);
+    }
+}

--- a/engine/runtime/geometry/src/point_cloud/mod.rs
+++ b/engine/runtime/geometry/src/point_cloud/mod.rs
@@ -20,6 +20,8 @@ use smallvec::SmallVec;
 
 use crate::coordinate::Coordinate;
 
+mod constructor;
+
 /// Bit positions of the optional primary fields within a [`Segment`]'s
 /// [`FieldMask`]. Private to this module: the full field-bit layout, not all of
 /// which are referenced until the per-field accessors land.

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -28,11 +28,10 @@
 //! Either way the rings are flattened into the leaf's CSR layout: exterior and
 //! interiors concatenated into one `coords` buffer, with `interior_offsets`
 //! recording each interior ring's start (the exterior is the prefix, so it carries
-//! no offset of its own). Each ring is closed on the way in — a closing vertex
-//! equal to the first is appended when the caller's ring is open — so the stored
-//! invariant (every ring closed, first == last) holds however the source delivered
-//! it; closing an already-closed ring is a no-op. Interior rings with no vertices
-//! carry no geometry and are dropped.
+//! no offset of its own). Rings are stored **verbatim** — a ring is *not* closed,
+//! so a malformed open ring (first != last) is preserved as-is for a later
+//! validation phase to flag, never silently repaired. Interior rings with no
+//! vertices carry no geometry and are dropped.
 //!
 //! [`Polygon2D::from_raw_parts`] / [`Polygon3D::from_raw_parts`] take pre-flattened
 //! CSR buffers directly and validate the layout invariants, returning [`Error`] on
@@ -78,8 +77,9 @@ impl Polygon2D {
     /// sequence of `[x, y]`. The result is pure 2D (no elevation, no allocation
     /// for `z`); for per-vertex elevation use [`Polygon2D::from_rings_with_elevation`].
     ///
-    /// Rings are concatenated exterior-first and each is closed; empty interior
-    /// rings are dropped.
+    /// Rings are concatenated exterior-first and stored verbatim — *not* closed, so
+    /// an open ring (first != last) is left as-is for later validation; empty
+    /// interior rings are dropped.
     pub fn from_rings<E, I, R>(coordinate: Coordinate, exterior: E, interiors: I) -> Self
     where
         E: IntoIterator<Item = [f64; 2]>,
@@ -166,8 +166,9 @@ impl Polygon3D {
     /// Build a 3D polygon from an exterior ring and interior holes, each a
     /// sequence of `[x, y, z]`.
     ///
-    /// Rings are concatenated exterior-first and each is closed; empty interior
-    /// rings are dropped.
+    /// Rings are concatenated exterior-first and stored verbatim — *not* closed, so
+    /// an open ring (first != last) is left as-is for later validation; empty
+    /// interior rings are dropped.
     pub fn from_rings<E, I, R>(coordinate: Coordinate, exterior: E, interiors: I) -> Self
     where
         E: IntoIterator<Item = [f64; 3]>,
@@ -251,18 +252,14 @@ impl PolygonBuilder2D<Empty> {
     }
 
     /// Set the exterior ring from a sequence of `[x, y]`, advancing the builder to
-    /// the `HasExterior` state. The ring is closed if open.
+    /// the `HasExterior` state. The ring is stored verbatim — not closed.
     pub fn set_exterior<R>(self, ring: R) -> PolygonBuilder2D<HasExterior>
     where
         R: IntoIterator<Item = [f64; 2]>,
     {
-        let mut coords: Vec<[f64; 2]> = ring.into_iter().collect();
-        if !coords.is_empty() {
-            close_ring(&mut coords, 0);
-        }
         PolygonBuilder2D {
             coordinate: self.coordinate,
-            coords,
+            coords: ring.into_iter().collect(),
             interior_offsets: Vec::new(),
             _state: PhantomData,
         }
@@ -281,7 +278,6 @@ impl PolygonBuilder2D<HasExterior> {
         if self.coords.len() == start {
             return self;
         }
-        close_ring(&mut self.coords, start);
         self.interior_offsets.push(start as u32);
         self
     }
@@ -321,18 +317,14 @@ impl PolygonBuilder3D<Empty> {
     }
 
     /// Set the exterior ring from a sequence of `[x, y, z]`, advancing the builder
-    /// to the `HasExterior` state. The ring is closed if open.
+    /// to the `HasExterior` state. The ring is stored verbatim — not closed.
     pub fn set_exterior<R>(self, ring: R) -> PolygonBuilder3D<HasExterior>
     where
         R: IntoIterator<Item = [f64; 3]>,
     {
-        let mut coords: Vec<[f64; 3]> = ring.into_iter().collect();
-        if !coords.is_empty() {
-            close_ring(&mut coords, 0);
-        }
         PolygonBuilder3D {
             coordinate: self.coordinate,
-            coords,
+            coords: ring.into_iter().collect(),
             interior_offsets: Vec::new(),
             _state: PhantomData,
         }
@@ -351,7 +343,6 @@ impl PolygonBuilder3D<HasExterior> {
         if self.coords.len() == start {
             return self;
         }
-        close_ring(&mut self.coords, start);
         self.interior_offsets.push(start as u32);
         self
     }
@@ -370,10 +361,11 @@ impl PolygonBuilder3D<HasExterior> {
 /// Flatten an exterior ring and interior holes into the CSR `(coords,
 /// interior_offsets)` pair shared by both polygon dimensions.
 ///
-/// The exterior fills the prefix of `coords` (and is closed); each non-empty
-/// interior ring is then appended, closed, and its start index recorded in
-/// `interior_offsets`. Empty interior rings are skipped so no offset ever points
-/// at a zero-length slice.
+/// The exterior fills the prefix of `coords`; each non-empty interior ring is then
+/// appended and its start index recorded in `interior_offsets`. Rings are stored
+/// verbatim — not closed — so a malformed open ring is preserved for later
+/// validation. Empty interior rings are skipped so no offset points at a
+/// zero-length slice.
 fn flatten_rings<const N: usize, E, I, R>(exterior: E, interiors: I) -> (Vec<[f64; N]>, Vec<u32>)
 where
     E: IntoIterator<Item = [f64; N]>,
@@ -387,7 +379,6 @@ where
         // the exterior) that `from_raw_parts`'s `1..coords.len()` check rejects.
         return (coords, Vec::new());
     }
-    close_ring(&mut coords, 0);
     let mut interior_offsets: Vec<u32> = Vec::new();
     for ring in interiors {
         let start = coords.len();
@@ -395,21 +386,9 @@ where
         if coords.len() == start {
             continue;
         }
-        close_ring(&mut coords, start);
         interior_offsets.push(start as u32);
     }
     (coords, interior_offsets)
-}
-
-/// Close the ring occupying `coords[start..]` by appending a copy of its first
-/// vertex when it does not already end where it began. `coords[start..]` must be
-/// non-empty.
-fn close_ring<const N: usize>(coords: &mut Vec<[f64; N]>, start: usize) {
-    let first = coords[start];
-    let last = coords[coords.len() - 1];
-    if first != last {
-        coords.push(first);
-    }
 }
 
 /// Validate `interior_offsets` against a `coords_len`-vertex buffer: strictly
@@ -432,15 +411,17 @@ fn check_offsets(offsets: &[u32], coords_len: usize) -> Result<(), Error> {
 mod tests {
     use super::*;
 
+    // The exterior is stored verbatim: an open ring is NOT auto-closed, so the
+    // first != last data bug survives for a later validation phase.
     #[test]
-    fn from_rings_closes_open_exterior() {
+    fn from_rings_stores_exterior_verbatim() {
         let p = Polygon2D::from_rings(
             Coordinate::Euclidean,
             [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
             Vec::<Vec<[f64; 2]>>::new(),
         );
-        assert_eq!(p.coords.len(), 4);
-        assert_eq!(p.coords[0], p.coords[3]);
+        assert_eq!(p.coords.len(), 3);
+        assert_ne!(p.coords[0], p.coords[p.coords.len() - 1]);
         assert!(p.interior_offsets.is_empty());
         assert!(p.z.is_none());
         assert_eq!(p.coordinate, Coordinate::Euclidean);
@@ -476,14 +457,13 @@ mod tests {
             [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]],
             vec![vec![[1.0, 1.0], [2.0, 1.0], [2.0, 2.0]]],
         );
-        // exterior: 4 open -> closed to 5; hole: 3 open -> closed to 4.
-        assert_eq!(p.interior_offsets.as_ref(), &[5]);
-        assert_eq!(p.coords.len(), 9);
+        // Stored verbatim: exterior 4, hole 3 — no closing vertices appended.
+        assert_eq!(p.interior_offsets.as_ref(), &[4]);
+        assert_eq!(p.coords.len(), 7);
         let ext = &p.coords[..p.interior_offsets[0] as usize];
         let hole = &p.coords[p.interior_offsets[0] as usize..];
-        assert_eq!(ext.len(), 5);
-        assert_eq!(hole.len(), 4);
-        assert_eq!(hole[0], hole[hole.len() - 1]);
+        assert_eq!(ext.len(), 4);
+        assert_eq!(hole.len(), 3);
     }
 
     #[test]
@@ -494,7 +474,7 @@ mod tests {
             vec![Vec::<[f64; 2]>::new()],
         );
         assert!(p.interior_offsets.is_empty());
-        assert_eq!(p.coords.len(), 4);
+        assert_eq!(p.coords.len(), 3);
     }
 
     #[test]
@@ -505,11 +485,10 @@ mod tests {
             Vec::<Vec<[f64; 3]>>::new(),
         );
         let z = p.z.as_ref().expect("elevation present");
+        assert_eq!(p.coords.len(), 3);
         assert_eq!(z.len(), p.coords.len());
         assert_eq!(p.coords[1], [1.0, 0.0]);
         assert_eq!(z[1], 11.0);
-        // The appended closing vertex carries the first vertex's elevation.
-        assert_eq!(z[3], 10.0);
     }
 
     #[test]
@@ -519,8 +498,8 @@ mod tests {
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 1.0]],
             Vec::<Vec<[f64; 3]>>::new(),
         );
-        assert_eq!(p.coords.len(), 4);
-        assert_eq!(p.coords[0], p.coords[3]);
+        assert_eq!(p.coords.len(), 3);
+        assert_ne!(p.coords[0], p.coords[p.coords.len() - 1]);
         assert!(p.interior_offsets.is_empty());
     }
 

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -381,9 +381,13 @@ where
     R: IntoIterator<Item = [f64; N]>,
 {
     let mut coords: Vec<[f64; N]> = exterior.into_iter().collect();
-    if !coords.is_empty() {
-        close_ring(&mut coords, 0);
+    if coords.is_empty() {
+        // No exterior ring: an empty polygon carries no holes, so we drop any and
+        // never record an interior offset of 0 — the invalid state (a hole posing as
+        // the exterior) that `from_raw_parts`'s `1..coords.len()` check rejects.
+        return (coords, Vec::new());
     }
+    close_ring(&mut coords, 0);
     let mut interior_offsets: Vec<u32> = Vec::new();
     for ring in interiors {
         let start = coords.len();
@@ -440,6 +444,19 @@ mod tests {
         assert!(p.interior_offsets.is_empty());
         assert!(p.z.is_none());
         assert_eq!(p.coordinate, Coordinate::Euclidean);
+    }
+
+    // An empty exterior yields an empty polygon with its holes dropped — never an
+    // interior offset of 0, which `from_raw_parts` rejects.
+    #[test]
+    fn from_rings_empty_exterior_drops_holes() {
+        let p = Polygon3D::from_rings(
+            Coordinate::Euclidean,
+            Vec::<[f64; 3]>::new(),
+            vec![vec![[1.0, 1.0, 0.0], [2.0, 1.0, 0.0], [2.0, 2.0, 0.0]]],
+        );
+        assert!(p.coords.is_empty());
+        assert!(p.interior_offsets.is_empty());
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -1,0 +1,594 @@
+//! Polygon constructors.
+//!
+//! A `Polygon` is built from *rings* — an exterior boundary and zero or more
+//! interior holes, each a sequence of coordinates. There are two ways in, chosen
+//! by how the *source format* delivers rings, not by how any current reader
+//! happens to be written:
+//!
+//! * [`PolygonBuilder2D`] / [`PolygonBuilder3D`] — for formats that deliver rings
+//!   one at a time, where a polygon's interiors are not all known up front. These
+//!   are the streaming-native formats:
+//!     - **CityGML / GML (XML)** — `quick_xml` is a pull parser and XML is
+//!       inherently sequential: a `<gml:exterior>` ring is parsed before its
+//!       `<gml:interior>` rings, so a streaming parse calls `set_exterior` then
+//!       `push_interior` as each ring's `posList` is read.
+//!     - **GeoPackage (WKB)** — ring data is read straight from a byte cursor, one
+//!       self-describing ring after another, so rings are produced incrementally.
+//!     - **Shapefile** — one shape record is a flat `Outer`/`Inner` ring list that
+//!       may hold several polygons (an `Outer` starts a new one); the builder turns
+//!       that walk into a polygon per exterior.
+//!
+//! * [`Polygon2D::from_rings`] / [`Polygon3D::from_rings`] — for formats whose
+//!   parser materializes the whole polygon before you ever see it, so the exterior
+//!   and all interiors are already in hand: **GeoJSON** (`Value::Polygon` is a
+//!   fully-built `Vec<Vec<Position>>`) and **WKT / CSV** (`wkt`/`geo_types` collect
+//!   every ring up front). A streaming builder would only re-feed an
+//!   already-materialized structure, so the all-at-once form is the honest fit.
+//!
+//! Either way the rings are flattened into the leaf's CSR layout: exterior and
+//! interiors concatenated into one `coords` buffer, with `interior_offsets`
+//! recording each interior ring's start (the exterior is the prefix, so it carries
+//! no offset of its own). Each ring is closed on the way in — a closing vertex
+//! equal to the first is appended when the caller's ring is open — so the stored
+//! invariant (every ring closed, first == last) holds however the source delivered
+//! it; closing an already-closed ring is a no-op. Interior rings with no vertices
+//! carry no geometry and are dropped.
+//!
+//! [`Polygon2D::from_raw_parts`] / [`Polygon3D::from_raw_parts`] take pre-flattened
+//! CSR buffers directly and validate the layout invariants, returning [`Error`] on
+//! violation rather than panicking.
+//!
+//! Constructed polygons are *bare*: no UV sets and no appearance. Attach an
+//! appearance afterwards via [`Polygon2D::appearance_mut`] /
+//! [`Polygon3D::appearance_mut`].
+
+use std::marker::PhantomData;
+
+use crate::coordinate::Coordinate;
+use crate::error::Error;
+
+use super::{Polygon2D, Polygon3D};
+
+mod sealed {
+    pub trait BuilderState {}
+}
+
+/// Type-level states for the polygon builders ([`PolygonBuilder2D`] /
+/// [`PolygonBuilder3D`]). The state is a phantom type parameter, so the ordering
+/// rules — exterior before any interior, set exactly once, present at `build` — are
+/// enforced by the type checker rather than at runtime. The trait is sealed: these
+/// are the only two states.
+pub mod state {
+    /// No exterior ring has been set yet. Only `set_exterior` is available.
+    #[derive(Debug, Clone, Copy)]
+    pub struct Empty;
+    /// The exterior ring is set; `push_interior` and `build` are available, and
+    /// `set_exterior` is not.
+    #[derive(Debug, Clone, Copy)]
+    pub struct HasExterior;
+    impl super::sealed::BuilderState for Empty {}
+    impl super::sealed::BuilderState for HasExterior {}
+}
+
+use sealed::BuilderState;
+use state::{Empty, HasExterior};
+
+impl Polygon2D {
+    /// Build a 2D polygon from an exterior ring and interior holes, each a
+    /// sequence of `[x, y]`. The result is pure 2D (no elevation, no allocation
+    /// for `z`); for per-vertex elevation use [`Polygon2D::from_rings_with_elevation`].
+    ///
+    /// Rings are concatenated exterior-first and each is closed; empty interior
+    /// rings are dropped.
+    pub fn from_rings<E, I, R>(coordinate: Coordinate, exterior: E, interiors: I) -> Self
+    where
+        E: IntoIterator<Item = [f64; 2]>,
+        I: IntoIterator<Item = R>,
+        R: IntoIterator<Item = [f64; 2]>,
+    {
+        let (coords, interior_offsets) = flatten_rings::<2, _, _, _>(exterior, interiors);
+        Self {
+            coordinate,
+            coords: coords.into_boxed_slice(),
+            interior_offsets: interior_offsets.into_boxed_slice(),
+            z: None,
+            uv_sets: Vec::new(),
+            appearance: None,
+        }
+    }
+
+    /// Build a 2.5D polygon from rings of `[x, y, z]`: the `(x, y)` populate
+    /// `coords` and the `z` the parallel elevation buffer. Use this for sources
+    /// that carry elevation on an otherwise 2D footprint (e.g. a height-tagged
+    /// shapefile or GeoPackage layer).
+    pub fn from_rings_with_elevation<E, I, R>(
+        coordinate: Coordinate,
+        exterior: E,
+        interiors: I,
+    ) -> Self
+    where
+        E: IntoIterator<Item = [f64; 3]>,
+        I: IntoIterator<Item = R>,
+        R: IntoIterator<Item = [f64; 3]>,
+    {
+        let (xyz, interior_offsets) = flatten_rings::<3, _, _, _>(exterior, interiors);
+        let mut coords = Vec::with_capacity(xyz.len());
+        let mut z = Vec::with_capacity(xyz.len());
+        for [x, y, zz] in xyz {
+            coords.push([x, y]);
+            z.push(zz);
+        }
+        Self {
+            coordinate,
+            coords: coords.into_boxed_slice(),
+            interior_offsets: interior_offsets.into_boxed_slice(),
+            z: Some(z.into_boxed_slice()),
+            uv_sets: Vec::new(),
+            appearance: None,
+        }
+    }
+
+    /// Build directly from already-flattened CSR buffers, for callers that hold
+    /// the leaf's exact layout (deserialization, slicing, geometry algorithms).
+    ///
+    /// The layout invariants are validated: `z`, when present, must be parallel to
+    /// `coords`, and `interior_offsets` must be strictly increasing with each
+    /// offset in `1..coords.len()` (every ring non-empty, exterior included).
+    /// Violations return [`Error::InvalidGeometry`].
+    pub fn from_raw_parts(
+        coordinate: Coordinate,
+        coords: Box<[[f64; 2]]>,
+        interior_offsets: Box<[u32]>,
+        z: Option<Box<[f64]>>,
+    ) -> Result<Self, Error> {
+        if let Some(z) = z.as_ref() {
+            if z.len() != coords.len() {
+                return Err(Error::invalid_geometry(format!(
+                    "elevation buffer length {} does not match coordinate count {}",
+                    z.len(),
+                    coords.len()
+                )));
+            }
+        }
+        check_offsets(&interior_offsets, coords.len())?;
+        Ok(Self {
+            coordinate,
+            coords,
+            interior_offsets,
+            z,
+            uv_sets: Vec::new(),
+            appearance: None,
+        })
+    }
+}
+
+impl Polygon3D {
+    /// Build a 3D polygon from an exterior ring and interior holes, each a
+    /// sequence of `[x, y, z]`.
+    ///
+    /// Rings are concatenated exterior-first and each is closed; empty interior
+    /// rings are dropped.
+    pub fn from_rings<E, I, R>(coordinate: Coordinate, exterior: E, interiors: I) -> Self
+    where
+        E: IntoIterator<Item = [f64; 3]>,
+        I: IntoIterator<Item = R>,
+        R: IntoIterator<Item = [f64; 3]>,
+    {
+        let (coords, interior_offsets) = flatten_rings::<3, _, _, _>(exterior, interiors);
+        Self {
+            coordinate,
+            coords: coords.into_boxed_slice(),
+            interior_offsets: interior_offsets.into_boxed_slice(),
+            uv_sets: Vec::new(),
+            appearance: None,
+        }
+    }
+
+    /// Build directly from already-flattened CSR buffers. `interior_offsets` must
+    /// be strictly increasing with each offset in `1..coords.len()`; violations
+    /// return [`Error::InvalidGeometry`].
+    pub fn from_raw_parts(
+        coordinate: Coordinate,
+        coords: Box<[[f64; 3]]>,
+        interior_offsets: Box<[u32]>,
+    ) -> Result<Self, Error> {
+        check_offsets(&interior_offsets, coords.len())?;
+        Ok(Self {
+            coordinate,
+            coords,
+            interior_offsets,
+            uv_sets: Vec::new(),
+            appearance: None,
+        })
+    }
+}
+
+/// Incremental builder for a [`Polygon2D`], for sources that discover an exterior
+/// ring first and its holes later (the streaming-native formats — CityGML/GML,
+/// GeoPackage WKB, shapefile).
+///
+/// Ordering is a *typestate* machine: the `S` parameter tracks whether the exterior
+/// is set, so the rules are enforced at compile time rather than checked at runtime.
+/// [`new`](Self::new) yields a `PolygonBuilder2D<`[`Empty`](state::Empty)`>` exposing
+/// only [`set_exterior`](Self::set_exterior); that consumes it and yields a
+/// `PolygonBuilder2D<`[`HasExterior`](state::HasExterior)`>` exposing
+/// [`push_interior`](Self::push_interior) and [`build`](Self::build). So an interior
+/// before the exterior, a second exterior, or a build with no exterior simply do not
+/// compile:
+///
+/// ```compile_fail
+/// use reearth_flow_geometry::coordinate::Coordinate;
+/// use reearth_flow_geometry::polygon::PolygonBuilder2D;
+/// // No `build` on the `Empty` state.
+/// let _ = PolygonBuilder2D::new(Coordinate::Euclidean).build();
+/// ```
+///
+/// ```compile_fail
+/// use reearth_flow_geometry::coordinate::Coordinate;
+/// use reearth_flow_geometry::polygon::PolygonBuilder2D;
+/// // No `push_interior` before `set_exterior`.
+/// let _ = PolygonBuilder2D::new(Coordinate::Euclidean).push_interior([[0.0, 0.0]]);
+/// ```
+///
+/// Produces a pure-2D polygon (no elevation).
+#[derive(Debug, Clone)]
+pub struct PolygonBuilder2D<S: BuilderState = Empty> {
+    coordinate: Coordinate,
+    coords: Vec<[f64; 2]>,
+    interior_offsets: Vec<u32>,
+    _state: PhantomData<S>,
+}
+
+impl PolygonBuilder2D<Empty> {
+    /// Start an empty builder in `coordinate`, awaiting an exterior ring.
+    pub fn new(coordinate: Coordinate) -> Self {
+        Self {
+            coordinate,
+            coords: Vec::new(),
+            interior_offsets: Vec::new(),
+            _state: PhantomData,
+        }
+    }
+
+    /// Set the exterior ring from a sequence of `[x, y]`, advancing the builder to
+    /// the `HasExterior` state. The ring is closed if open.
+    pub fn set_exterior<R>(self, ring: R) -> PolygonBuilder2D<HasExterior>
+    where
+        R: IntoIterator<Item = [f64; 2]>,
+    {
+        let mut coords: Vec<[f64; 2]> = ring.into_iter().collect();
+        if !coords.is_empty() {
+            close_ring(&mut coords, 0);
+        }
+        PolygonBuilder2D {
+            coordinate: self.coordinate,
+            coords,
+            interior_offsets: Vec::new(),
+            _state: PhantomData,
+        }
+    }
+}
+
+impl PolygonBuilder2D<HasExterior> {
+    /// Append an interior (hole) ring from a sequence of `[x, y]`. An empty ring is
+    /// dropped.
+    pub fn push_interior<R>(mut self, ring: R) -> Self
+    where
+        R: IntoIterator<Item = [f64; 2]>,
+    {
+        let start = self.coords.len();
+        self.coords.extend(ring);
+        if self.coords.len() == start {
+            return self;
+        }
+        close_ring(&mut self.coords, start);
+        self.interior_offsets.push(start as u32);
+        self
+    }
+
+    /// Finish the polygon. Returns [`Error::InvalidGeometry`] only on a data-level
+    /// problem the type system cannot rule out — e.g. interiors atop an empty
+    /// exterior ring (see [`Polygon2D::from_raw_parts`]).
+    pub fn build(self) -> Result<Polygon2D, Error> {
+        Polygon2D::from_raw_parts(
+            self.coordinate,
+            self.coords.into_boxed_slice(),
+            self.interior_offsets.into_boxed_slice(),
+            None,
+        )
+    }
+}
+
+/// Incremental builder for a [`Polygon3D`]; the 3D counterpart of
+/// [`PolygonBuilder2D`], with rings of `[x, y, z]` and the same typestate machine.
+#[derive(Debug, Clone)]
+pub struct PolygonBuilder3D<S: BuilderState = Empty> {
+    coordinate: Coordinate,
+    coords: Vec<[f64; 3]>,
+    interior_offsets: Vec<u32>,
+    _state: PhantomData<S>,
+}
+
+impl PolygonBuilder3D<Empty> {
+    /// Start an empty builder in `coordinate`, awaiting an exterior ring.
+    pub fn new(coordinate: Coordinate) -> Self {
+        Self {
+            coordinate,
+            coords: Vec::new(),
+            interior_offsets: Vec::new(),
+            _state: PhantomData,
+        }
+    }
+
+    /// Set the exterior ring from a sequence of `[x, y, z]`, advancing the builder
+    /// to the `HasExterior` state. The ring is closed if open.
+    pub fn set_exterior<R>(self, ring: R) -> PolygonBuilder3D<HasExterior>
+    where
+        R: IntoIterator<Item = [f64; 3]>,
+    {
+        let mut coords: Vec<[f64; 3]> = ring.into_iter().collect();
+        if !coords.is_empty() {
+            close_ring(&mut coords, 0);
+        }
+        PolygonBuilder3D {
+            coordinate: self.coordinate,
+            coords,
+            interior_offsets: Vec::new(),
+            _state: PhantomData,
+        }
+    }
+}
+
+impl PolygonBuilder3D<HasExterior> {
+    /// Append an interior (hole) ring from a sequence of `[x, y, z]`. An empty ring
+    /// is dropped.
+    pub fn push_interior<R>(mut self, ring: R) -> Self
+    where
+        R: IntoIterator<Item = [f64; 3]>,
+    {
+        let start = self.coords.len();
+        self.coords.extend(ring);
+        if self.coords.len() == start {
+            return self;
+        }
+        close_ring(&mut self.coords, start);
+        self.interior_offsets.push(start as u32);
+        self
+    }
+
+    /// Finish the polygon. Returns [`Error::InvalidGeometry`] only on a data-level
+    /// problem the type system cannot rule out (see [`Polygon3D::from_raw_parts`]).
+    pub fn build(self) -> Result<Polygon3D, Error> {
+        Polygon3D::from_raw_parts(
+            self.coordinate,
+            self.coords.into_boxed_slice(),
+            self.interior_offsets.into_boxed_slice(),
+        )
+    }
+}
+
+/// Flatten an exterior ring and interior holes into the CSR `(coords,
+/// interior_offsets)` pair shared by both polygon dimensions.
+///
+/// The exterior fills the prefix of `coords` (and is closed); each non-empty
+/// interior ring is then appended, closed, and its start index recorded in
+/// `interior_offsets`. Empty interior rings are skipped so no offset ever points
+/// at a zero-length slice.
+fn flatten_rings<const N: usize, E, I, R>(exterior: E, interiors: I) -> (Vec<[f64; N]>, Vec<u32>)
+where
+    E: IntoIterator<Item = [f64; N]>,
+    I: IntoIterator<Item = R>,
+    R: IntoIterator<Item = [f64; N]>,
+{
+    let mut coords: Vec<[f64; N]> = exterior.into_iter().collect();
+    if !coords.is_empty() {
+        close_ring(&mut coords, 0);
+    }
+    let mut interior_offsets: Vec<u32> = Vec::new();
+    for ring in interiors {
+        let start = coords.len();
+        coords.extend(ring);
+        if coords.len() == start {
+            continue;
+        }
+        close_ring(&mut coords, start);
+        interior_offsets.push(start as u32);
+    }
+    (coords, interior_offsets)
+}
+
+/// Close the ring occupying `coords[start..]` by appending a copy of its first
+/// vertex when it does not already end where it began. `coords[start..]` must be
+/// non-empty.
+fn close_ring<const N: usize>(coords: &mut Vec<[f64; N]>, start: usize) {
+    let first = coords[start];
+    let last = coords[coords.len() - 1];
+    if first != last {
+        coords.push(first);
+    }
+}
+
+/// Validate `interior_offsets` against a `coords_len`-vertex buffer: strictly
+/// increasing, with every offset in `1..coords_len` so the exterior prefix and
+/// each interior ring are non-empty.
+fn check_offsets(offsets: &[u32], coords_len: usize) -> Result<(), Error> {
+    let mut lo = 1u32;
+    for (i, &o) in offsets.iter().enumerate() {
+        if o < lo || o as usize >= coords_len {
+            return Err(Error::invalid_geometry(format!(
+                "interior_offsets[{i}] = {o} is out of range (expected {lo}..{coords_len})"
+            )));
+        }
+        lo = o + 1;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_rings_closes_open_exterior() {
+        let p = Polygon2D::from_rings(
+            Coordinate::Euclidean,
+            [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            Vec::<Vec<[f64; 2]>>::new(),
+        );
+        assert_eq!(p.coords.len(), 4);
+        assert_eq!(p.coords[0], p.coords[3]);
+        assert!(p.interior_offsets.is_empty());
+        assert!(p.z.is_none());
+        assert_eq!(p.coordinate, Coordinate::Euclidean);
+    }
+
+    #[test]
+    fn from_rings_keeps_closed_exterior() {
+        let p = Polygon2D::from_rings(
+            Coordinate::Euclidean,
+            [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
+            Vec::<Vec<[f64; 2]>>::new(),
+        );
+        assert_eq!(p.coords.len(), 4);
+    }
+
+    #[test]
+    fn from_rings_with_one_hole() {
+        let p = Polygon2D::from_rings(
+            Coordinate::Euclidean,
+            [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]],
+            vec![vec![[1.0, 1.0], [2.0, 1.0], [2.0, 2.0]]],
+        );
+        // exterior: 4 open -> closed to 5; hole: 3 open -> closed to 4.
+        assert_eq!(p.interior_offsets.as_ref(), &[5]);
+        assert_eq!(p.coords.len(), 9);
+        let ext = &p.coords[..p.interior_offsets[0] as usize];
+        let hole = &p.coords[p.interior_offsets[0] as usize..];
+        assert_eq!(ext.len(), 5);
+        assert_eq!(hole.len(), 4);
+        assert_eq!(hole[0], hole[hole.len() - 1]);
+    }
+
+    #[test]
+    fn from_rings_drops_empty_interior() {
+        let p = Polygon2D::from_rings(
+            Coordinate::Euclidean,
+            [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            vec![Vec::<[f64; 2]>::new()],
+        );
+        assert!(p.interior_offsets.is_empty());
+        assert_eq!(p.coords.len(), 4);
+    }
+
+    #[test]
+    fn from_rings_with_elevation_splits_z() {
+        let p = Polygon2D::from_rings_with_elevation(
+            Coordinate::Euclidean,
+            [[0.0, 0.0, 10.0], [1.0, 0.0, 11.0], [0.0, 1.0, 12.0]],
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
+        let z = p.z.as_ref().expect("elevation present");
+        assert_eq!(z.len(), p.coords.len());
+        assert_eq!(p.coords[1], [1.0, 0.0]);
+        assert_eq!(z[1], 11.0);
+        // The appended closing vertex carries the first vertex's elevation.
+        assert_eq!(z[3], 10.0);
+    }
+
+    #[test]
+    fn from_rings_3d() {
+        let p = Polygon3D::from_rings(
+            Coordinate::Euclidean,
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 1.0]],
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
+        assert_eq!(p.coords.len(), 4);
+        assert_eq!(p.coords[0], p.coords[3]);
+        assert!(p.interior_offsets.is_empty());
+    }
+
+    #[test]
+    fn from_raw_parts_stores_buffers() {
+        let coords: Box<[[f64; 2]]> =
+            vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 0.0]].into_boxed_slice();
+        let p =
+            Polygon2D::from_raw_parts(Coordinate::Euclidean, coords.clone(), Box::new([]), None)
+                .expect("valid layout");
+        assert_eq!(p.coords, coords);
+        assert!(p.interior_offsets.is_empty());
+        assert!(p.z.is_none());
+        assert!(p.uv_sets.is_empty());
+        assert!(p.appearance.is_none());
+    }
+
+    #[test]
+    fn from_raw_parts_rejects_unparallel_z() {
+        let coords: Box<[[f64; 2]]> = vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]].into_boxed_slice();
+        let err = Polygon2D::from_raw_parts(
+            Coordinate::Euclidean,
+            coords,
+            Box::new([]),
+            Some(vec![0.0, 0.0].into_boxed_slice()),
+        )
+        .unwrap_err();
+        assert!(matches!(err, Error::InvalidGeometry(_)));
+    }
+
+    #[test]
+    fn from_raw_parts_rejects_bad_offsets() {
+        let coords: Box<[[f64; 3]]> = vec![
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0],
+        ]
+        .into_boxed_slice();
+        // Offset 0 would leave the exterior empty.
+        assert!(
+            Polygon3D::from_raw_parts(Coordinate::Euclidean, coords.clone(), Box::new([0]))
+                .is_err()
+        );
+        // Offset == coords.len() leaves a zero-length interior.
+        assert!(
+            Polygon3D::from_raw_parts(Coordinate::Euclidean, coords.clone(), Box::new([4]))
+                .is_err()
+        );
+        // Non-increasing offsets.
+        assert!(
+            Polygon3D::from_raw_parts(Coordinate::Euclidean, coords, Box::new([2, 2])).is_err()
+        );
+    }
+
+    // Ordering rules are enforced at compile time by the typestate, so there are no
+    // runtime-rejection tests; see the `compile_fail` doctests on `PolygonBuilder2D`.
+    #[test]
+    fn builder_streams_rings() {
+        let built = PolygonBuilder2D::new(Coordinate::Euclidean)
+            .set_exterior([[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]])
+            .push_interior([[1.0, 1.0], [2.0, 1.0], [2.0, 2.0]])
+            .build()
+            .unwrap();
+
+        let batch = Polygon2D::from_rings(
+            Coordinate::Euclidean,
+            [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]],
+            vec![vec![[1.0, 1.0], [2.0, 1.0], [2.0, 2.0]]],
+        );
+        assert_eq!(built, batch);
+    }
+
+    #[test]
+    fn builder_streams_rings_3d() {
+        let built = PolygonBuilder3D::new(Coordinate::Euclidean)
+            .set_exterior([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
+            .build()
+            .unwrap();
+
+        let batch = Polygon3D::from_rings(
+            Coordinate::Euclidean,
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 1.0]],
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
+        assert_eq!(built, batch);
+    }
+}

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -64,7 +64,8 @@ impl Polygon2D {
         &self.coordinate
     }
 
-    /// The exterior ring, as stored (closed: first == last).
+    /// The exterior ring, as stored verbatim — a well-formed ring is closed
+    /// (first == last), but an open ring is preserved as-is for later validation.
     pub fn exterior(&self) -> &[[f64; 2]] {
         let end = self
             .interior_offsets
@@ -73,7 +74,8 @@ impl Polygon2D {
         &self.coords[..end]
     }
 
-    /// The interior (hole) rings, each as stored (closed), in order.
+    /// The interior (hole) rings, each as stored verbatim (not guaranteed closed),
+    /// in order.
     pub fn interiors(&self) -> impl Iterator<Item = &[[f64; 2]]> + '_ {
         let coords = &self.coords;
         let offsets = &self.interior_offsets;
@@ -104,7 +106,8 @@ impl Polygon3D {
         &self.coordinate
     }
 
-    /// The exterior ring, as stored (closed: first == last).
+    /// The exterior ring, as stored verbatim — a well-formed ring is closed
+    /// (first == last), but an open ring is preserved as-is for later validation.
     pub fn exterior(&self) -> &[[f64; 3]] {
         let end = self
             .interior_offsets
@@ -113,7 +116,8 @@ impl Polygon3D {
         &self.coords[..end]
     }
 
-    /// The interior (hole) rings, each as stored (closed), in order.
+    /// The interior (hole) rings, each as stored verbatim (not guaranteed closed),
+    /// in order.
     pub fn interiors(&self) -> impl Iterator<Item = &[[f64; 3]]> + '_ {
         let coords = &self.coords;
         let offsets = &self.interior_offsets;

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -14,6 +14,10 @@ use serde::{Deserialize, Serialize};
 use crate::appearance::{Appearance, UvSet};
 use crate::coordinate::Coordinate;
 
+mod constructor;
+
+pub use constructor::{state, PolygonBuilder2D, PolygonBuilder3D};
+
 /// A planar polygon face in 2D space, with optional per-vertex elevation.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Polygon2D {

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -58,6 +58,32 @@ pub struct Polygon3D {
 }
 
 impl Polygon2D {
+    /// The coordinate frame these coords are expressed in.
+    #[inline]
+    pub fn coordinate(&self) -> &Coordinate {
+        &self.coordinate
+    }
+
+    /// The exterior ring, as stored (closed: first == last).
+    pub fn exterior(&self) -> &[[f64; 2]] {
+        let end = self
+            .interior_offsets
+            .first()
+            .map_or(self.coords.len(), |&o| o as usize);
+        &self.coords[..end]
+    }
+
+    /// The interior (hole) rings, each as stored (closed), in order.
+    pub fn interiors(&self) -> impl Iterator<Item = &[[f64; 2]]> + '_ {
+        let coords = &self.coords;
+        let offsets = &self.interior_offsets;
+        (0..offsets.len()).map(move |j| {
+            let start = offsets[j] as usize;
+            let end = offsets.get(j + 1).map_or(coords.len(), |&o| o as usize);
+            &coords[start..end]
+        })
+    }
+
     /// Borrow the appearance, if any.
     #[inline]
     pub fn appearance(&self) -> &Option<Appearance> {
@@ -72,6 +98,32 @@ impl Polygon2D {
 }
 
 impl Polygon3D {
+    /// The coordinate frame these coords are expressed in.
+    #[inline]
+    pub fn coordinate(&self) -> &Coordinate {
+        &self.coordinate
+    }
+
+    /// The exterior ring, as stored (closed: first == last).
+    pub fn exterior(&self) -> &[[f64; 3]] {
+        let end = self
+            .interior_offsets
+            .first()
+            .map_or(self.coords.len(), |&o| o as usize);
+        &self.coords[..end]
+    }
+
+    /// The interior (hole) rings, each as stored (closed), in order.
+    pub fn interiors(&self) -> impl Iterator<Item = &[[f64; 3]]> + '_ {
+        let coords = &self.coords;
+        let offsets = &self.interior_offsets;
+        (0..offsets.len()).map(move |j| {
+            let start = offsets[j] as usize;
+            let end = offsets.get(j + 1).map_or(coords.len(), |&o| o as usize);
+            &coords[start..end]
+        })
+    }
+
     /// Borrow the appearance, if any.
     #[inline]
     pub fn appearance(&self) -> &Option<Appearance> {

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -1,0 +1,511 @@
+//! PolygonMesh constructors.
+//!
+//! Three entry points, matching how a polygon mesh's faces arrive:
+//!
+//! * `from_polygons` — a set of independent [`Polygon`](crate::polygon) faces, the
+//!   shape a CityGML surface parses into (a flat list of face polygons, each with
+//!   its own coords and holes, no shared pool). The shared vertex pool is
+//!   *discovered* by deduplicating face corners (exact `f64` bits), and each
+//!   polygon maps 1:1 to a mesh face — exterior then holes. Because the CityGML
+//!   reader also emits each face as its own `Polygon` feature, the mesh is built
+//!   from those same borrowed polygons with no extra geometry logic.
+//!
+//! * `from_parts` — a vertex pool already in hand plus faces given as vertex-index
+//!   lists (OBJ). Exterior-only (standard OBJ has no holes); indices are validated
+//!   `< vertices.len()`.
+//!
+//! * `from_raw_parts` — the flat CSR buffers in hand, validated for consistency.
+//!
+//! Rings are stored **open**: the closing vertex is implied by the face / hole
+//! boundary, so `from_polygons` drops the closing duplicate that a `Polygon`
+//! carries, and `from_parts` expects the open faces OBJ provides. The index widths
+//! follow the type's contract: `face_indices` from the (dedup-discovered) vertex
+//! count, `face_offsets` / `interior_offsets` from `face_indices.len()`.
+//!
+//! 3D constructors build the coordinate-free [`PolygonMesh3DData`] a
+//! [`Solid`](crate::solid::Solid) shell also stores, so the frame-carrying
+//! [`PolygonMesh3D`] is a thin wrapper. All meshes are built bare (no UV, no
+//! appearance); attach an appearance afterwards via `appearance_mut`.
+
+use std::collections::HashMap;
+
+use crate::coordinate::Coordinate;
+use crate::error::Error;
+use crate::index::{IndexBuffer, IndexWidth};
+use crate::polygon::Polygon3D;
+
+use super::{PolygonMesh2D, PolygonMesh3D, PolygonMesh3DData};
+
+impl PolygonMesh3DData {
+    /// Build coordinate-free mesh data from independent face polygons, deduplicating
+    /// their corners into a shared vertex pool. Each polygon becomes one face
+    /// (exterior then holes), stored open.
+    pub fn from_polygons<'a>(polygons: impl IntoIterator<Item = &'a Polygon3D>) -> Self {
+        let faces = polygons
+            .into_iter()
+            .map(|p| std::iter::once(p.exterior()).chain(p.interiors()));
+        let (vertices, face_indices, face_offsets, interior_offsets) = dedup_faces(faces);
+        let (face_indices, face_offsets, interior_offsets) =
+            pack_csr(vertices.len(), face_indices, face_offsets, interior_offsets);
+        Self {
+            vertices,
+            face_indices,
+            face_offsets,
+            interior_offsets,
+            uv_sets: Vec::new(),
+            appearance: None,
+        }
+    }
+
+    /// Build from a shared vertex pool and faces given as vertex-index lists
+    /// (exterior rings, no holes). Validates every index is `< vertices.len()`.
+    pub fn from_parts(
+        vertices: Vec<[f64; 3]>,
+        faces: impl IntoIterator<Item = impl IntoIterator<Item = u32>>,
+    ) -> Result<Self, Error> {
+        let (face_indices, face_offsets) = index_faces(vertices.len(), faces)?;
+        let (face_indices, face_offsets, interior_offsets) =
+            pack_csr(vertices.len(), face_indices, face_offsets, Vec::new());
+        Ok(Self {
+            vertices,
+            face_indices,
+            face_offsets,
+            interior_offsets,
+            uv_sets: Vec::new(),
+            appearance: None,
+        })
+    }
+
+    /// Build from flat CSR buffers, validating that the offsets are consistent and
+    /// every index is in range.
+    pub fn from_raw_parts(
+        vertices: Vec<[f64; 3]>,
+        face_indices: Vec<u32>,
+        face_offsets: Vec<u32>,
+        interior_offsets: Vec<u32>,
+    ) -> Result<Self, Error> {
+        validate_csr(
+            vertices.len(),
+            &face_indices,
+            &face_offsets,
+            &interior_offsets,
+        )?;
+        let (face_indices, face_offsets, interior_offsets) =
+            pack_csr(vertices.len(), face_indices, face_offsets, interior_offsets);
+        Ok(Self {
+            vertices,
+            face_indices,
+            face_offsets,
+            interior_offsets,
+            uv_sets: Vec::new(),
+            appearance: None,
+        })
+    }
+}
+
+impl PolygonMesh3D {
+    /// Pair coordinate-free mesh data with the frame it is expressed in.
+    pub fn new(coordinate: Coordinate, data: PolygonMesh3DData) -> Self {
+        Self { coordinate, data }
+    }
+
+    /// Build from independent face polygons; see [`PolygonMesh3DData::from_polygons`].
+    /// Errors if any polygon's frame differs from `coordinate`.
+    pub fn from_polygons<'a>(
+        coordinate: Coordinate,
+        polygons: impl IntoIterator<Item = &'a Polygon3D>,
+    ) -> Result<Self, Error> {
+        let polygons: Vec<&Polygon3D> = polygons.into_iter().collect();
+        for p in &polygons {
+            if p.coordinate() != &coordinate {
+                return Err(Error::invalid_geometry(
+                    "polygon coordinate frame differs from the mesh frame",
+                ));
+            }
+        }
+        Ok(Self::new(
+            coordinate,
+            PolygonMesh3DData::from_polygons(polygons),
+        ))
+    }
+
+    /// Build from a vertex pool and index-list faces; see
+    /// [`PolygonMesh3DData::from_parts`].
+    pub fn from_parts(
+        coordinate: Coordinate,
+        vertices: Vec<[f64; 3]>,
+        faces: impl IntoIterator<Item = impl IntoIterator<Item = u32>>,
+    ) -> Result<Self, Error> {
+        Ok(Self::new(
+            coordinate,
+            PolygonMesh3DData::from_parts(vertices, faces)?,
+        ))
+    }
+
+    /// Build from flat CSR buffers; see [`PolygonMesh3DData::from_raw_parts`].
+    pub fn from_raw_parts(
+        coordinate: Coordinate,
+        vertices: Vec<[f64; 3]>,
+        face_indices: Vec<u32>,
+        face_offsets: Vec<u32>,
+        interior_offsets: Vec<u32>,
+    ) -> Result<Self, Error> {
+        Ok(Self::new(
+            coordinate,
+            PolygonMesh3DData::from_raw_parts(
+                vertices,
+                face_indices,
+                face_offsets,
+                interior_offsets,
+            )?,
+        ))
+    }
+}
+
+impl PolygonMesh2D {
+    /// Build a pure-2D mesh from a vertex pool and index-list faces (no holes).
+    pub fn from_parts(
+        coordinate: Coordinate,
+        vertices: Vec<[f64; 2]>,
+        faces: impl IntoIterator<Item = impl IntoIterator<Item = u32>>,
+    ) -> Result<Self, Error> {
+        let (face_indices, face_offsets) = index_faces(vertices.len(), faces)?;
+        let (face_indices, face_offsets, interior_offsets) =
+            pack_csr(vertices.len(), face_indices, face_offsets, Vec::new());
+        Ok(Self {
+            coordinate,
+            vertices,
+            z: None,
+            face_indices,
+            face_offsets,
+            interior_offsets,
+            uv_sets: Vec::new(),
+            appearance: None,
+        })
+    }
+
+    /// Build a 2.5D mesh from `[x, y, z]` vertices (the `(x, y)` populate the pool,
+    /// the `z` a parallel elevation buffer) and index-list faces (no holes).
+    pub fn from_parts_with_elevation(
+        coordinate: Coordinate,
+        vertices: Vec<[f64; 3]>,
+        faces: impl IntoIterator<Item = impl IntoIterator<Item = u32>>,
+    ) -> Result<Self, Error> {
+        let (face_indices, face_offsets) = index_faces(vertices.len(), faces)?;
+        let (xy, z) = split_elevation(vertices);
+        let (face_indices, face_offsets, interior_offsets) =
+            pack_csr(xy.len(), face_indices, face_offsets, Vec::new());
+        Ok(Self {
+            coordinate,
+            vertices: xy,
+            z: Some(z),
+            face_indices,
+            face_offsets,
+            interior_offsets,
+            uv_sets: Vec::new(),
+            appearance: None,
+        })
+    }
+
+    /// Build a pure-2D mesh from flat CSR buffers.
+    pub fn from_raw_parts(
+        coordinate: Coordinate,
+        vertices: Vec<[f64; 2]>,
+        face_indices: Vec<u32>,
+        face_offsets: Vec<u32>,
+        interior_offsets: Vec<u32>,
+    ) -> Result<Self, Error> {
+        validate_csr(
+            vertices.len(),
+            &face_indices,
+            &face_offsets,
+            &interior_offsets,
+        )?;
+        let (face_indices, face_offsets, interior_offsets) =
+            pack_csr(vertices.len(), face_indices, face_offsets, interior_offsets);
+        Ok(Self {
+            coordinate,
+            vertices,
+            z: None,
+            face_indices,
+            face_offsets,
+            interior_offsets,
+            uv_sets: Vec::new(),
+            appearance: None,
+        })
+    }
+}
+
+/// Index of `coord` in `vertices`, inserting it (and assigning the next index) on
+/// first sight. Dedup is on exact `f64` bits.
+fn dedup_index<const N: usize>(
+    vertices: &mut Vec<[f64; N]>,
+    seen: &mut HashMap<[u64; N], u32>,
+    coord: [f64; N],
+) -> u32 {
+    *seen.entry(coord.map(f64::to_bits)).or_insert_with(|| {
+        let index = vertices.len() as u32;
+        vertices.push(coord);
+        index
+    })
+}
+
+/// Drop a ring's closing vertex when it duplicates the first, yielding the open
+/// ring (closure is implied by the face / hole boundary in the mesh).
+fn open_ring<const N: usize>(ring: &[[f64; N]]) -> &[[f64; N]] {
+    if ring.len() > 1 && ring.first() == ring.last() {
+        &ring[..ring.len() - 1]
+    } else {
+        ring
+    }
+}
+
+/// Deduplicate the corners of a sequence of faces (each a sequence of rings,
+/// exterior first) into a shared pool and the flat CSR buffers.
+fn dedup_faces<'a, const N: usize, Faces, Rings>(
+    faces: Faces,
+) -> (Vec<[f64; N]>, Vec<u32>, Vec<u32>, Vec<u32>)
+where
+    Faces: IntoIterator<Item = Rings>,
+    Rings: IntoIterator<Item = &'a [[f64; N]]>,
+{
+    let mut vertices: Vec<[f64; N]> = Vec::new();
+    let mut seen: HashMap<[u64; N], u32> = HashMap::new();
+    let mut face_indices: Vec<u32> = Vec::new();
+    let mut face_offsets: Vec<u32> = vec![0];
+    let mut interior_offsets: Vec<u32> = Vec::new();
+    for face in faces {
+        let mut is_exterior = true;
+        for ring in face {
+            if !is_exterior {
+                interior_offsets.push(face_indices.len() as u32);
+            }
+            is_exterior = false;
+            for &coord in open_ring(ring) {
+                face_indices.push(dedup_index(&mut vertices, &mut seen, coord));
+            }
+        }
+        face_offsets.push(face_indices.len() as u32);
+    }
+    (vertices, face_indices, face_offsets, interior_offsets)
+}
+
+/// Flatten index-list faces (exterior rings, no holes) into `face_indices` and
+/// `face_offsets`, validating every index is `< vertex_count`.
+fn index_faces(
+    vertex_count: usize,
+    faces: impl IntoIterator<Item = impl IntoIterator<Item = u32>>,
+) -> Result<(Vec<u32>, Vec<u32>), Error> {
+    let mut face_indices: Vec<u32> = Vec::new();
+    let mut face_offsets: Vec<u32> = vec![0];
+    for face in faces {
+        for index in face {
+            if index as usize >= vertex_count {
+                return Err(Error::invalid_geometry(format!(
+                    "face index {index} is out of range for {vertex_count} vertices"
+                )));
+            }
+            face_indices.push(index);
+        }
+        face_offsets.push(face_indices.len() as u32);
+    }
+    Ok((face_indices, face_offsets))
+}
+
+/// Validate flat CSR buffers: `face_offsets` starts at 0, is non-decreasing and
+/// ends at `face_indices.len()`; every index is `< vertex_count`; every interior
+/// offset is strictly increasing and within `face_indices`.
+fn validate_csr(
+    vertex_count: usize,
+    face_indices: &[u32],
+    face_offsets: &[u32],
+    interior_offsets: &[u32],
+) -> Result<(), Error> {
+    match face_offsets.first() {
+        None => return Err(Error::invalid_geometry("face_offsets must not be empty")),
+        Some(&first) if first != 0 => {
+            return Err(Error::invalid_geometry("face_offsets must start at 0"))
+        }
+        _ => {}
+    }
+    if face_offsets.windows(2).any(|w| w[0] > w[1]) {
+        return Err(Error::invalid_geometry(
+            "face_offsets must be non-decreasing",
+        ));
+    }
+    if *face_offsets.last().unwrap() as usize != face_indices.len() {
+        return Err(Error::invalid_geometry(
+            "the last face_offset must equal face_indices length",
+        ));
+    }
+    for &index in face_indices {
+        if index as usize >= vertex_count {
+            return Err(Error::invalid_geometry(format!(
+                "face index {index} is out of range for {vertex_count} vertices"
+            )));
+        }
+    }
+    let mut prev = 0u32;
+    for &offset in interior_offsets {
+        if offset <= prev || offset as usize >= face_indices.len() {
+            return Err(Error::invalid_geometry(format!(
+                "interior_offset {offset} is out of range or not strictly increasing"
+            )));
+        }
+        prev = offset;
+    }
+    Ok(())
+}
+
+/// Pack the flat CSR buffers into width-erased index buffers: `face_indices` at
+/// the vertex-count-derived width, the offsets at the `face_indices.len()` width.
+fn pack_csr(
+    vertex_count: usize,
+    face_indices: Vec<u32>,
+    face_offsets: Vec<u32>,
+    interior_offsets: Vec<u32>,
+) -> (IndexBuffer<1>, IndexBuffer<1>, IndexBuffer<1>) {
+    let index_width = IndexWidth::for_value(vertex_count.saturating_sub(1) as u32);
+    let offset_width = IndexWidth::for_value(face_indices.len() as u32);
+    (
+        IndexBuffer::with_exact_width(
+            index_width,
+            Some(face_indices.len()),
+            face_indices.into_iter().map(|i| [i]),
+        ),
+        IndexBuffer::with_exact_width(
+            offset_width,
+            Some(face_offsets.len()),
+            face_offsets.into_iter().map(|o| [o]),
+        ),
+        IndexBuffer::with_exact_width(
+            offset_width,
+            Some(interior_offsets.len()),
+            interior_offsets.into_iter().map(|o| [o]),
+        ),
+    )
+}
+
+/// Split a 3D vertex buffer into its 2D footprint and a parallel elevation buffer.
+fn split_elevation(vertices: Vec<[f64; 3]>) -> (Vec<[f64; 2]>, Box<[f64]>) {
+    let mut xy = Vec::with_capacity(vertices.len());
+    let mut z = Vec::with_capacity(vertices.len());
+    for [x, y, elevation] in vertices {
+        xy.push([x, y]);
+        z.push(elevation);
+    }
+    (xy, z.into_boxed_slice())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ones(buf: &IndexBuffer<1>) -> Vec<u32> {
+        match buf {
+            IndexBuffer::U8(v) => v.iter().map(|t| u32::from(t[0])).collect(),
+            IndexBuffer::U16(v) => v.iter().map(|t| u32::from(t[0])).collect(),
+            IndexBuffer::U32(v) => v.iter().map(|t| t[0]).collect(),
+        }
+    }
+
+    fn quad(corners: [[f64; 3]; 4]) -> Polygon3D {
+        Polygon3D::from_rings(Coordinate::Euclidean, corners, Vec::<Vec<[f64; 3]>>::new())
+    }
+
+    #[test]
+    fn from_polygons_dedups_shared_edge() {
+        // Two unit quads sharing the edge (1,0,0)-(1,1,0): 6 unique vertices.
+        let a = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
+        let b = quad([[1., 0., 0.], [2., 0., 0.], [2., 1., 0.], [1., 1., 0.]]);
+        let m = PolygonMesh3D::from_polygons(Coordinate::Euclidean, [&a, &b]).unwrap();
+        assert_eq!(
+            m.data.vertices,
+            vec![
+                [0., 0., 0.],
+                [1., 0., 0.],
+                [1., 1., 0.],
+                [0., 1., 0.],
+                [2., 0., 0.],
+                [2., 1., 0.],
+            ]
+        );
+        // Rings stored open (the closing duplicate is dropped).
+        assert_eq!(ones(&m.data.face_indices), vec![0, 1, 2, 3, 1, 4, 5, 2]);
+        assert_eq!(ones(&m.data.face_offsets), vec![0, 4, 8]);
+        assert!(ones(&m.data.interior_offsets).is_empty());
+    }
+
+    #[test]
+    fn from_polygons_preserves_a_hole() {
+        let outer = [[0., 0., 0.], [4., 0., 0.], [4., 4., 0.], [0., 4., 0.]];
+        let hole = vec![[1., 1., 0.], [2., 1., 0.], [2., 2., 0.], [1., 2., 0.]];
+        let p = Polygon3D::from_rings(Coordinate::Euclidean, outer, vec![hole]);
+        let m = PolygonMesh3DData::from_polygons([&p]);
+        assert_eq!(m.vertices.len(), 8);
+        assert_eq!(ones(&m.face_indices), vec![0, 1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(ones(&m.face_offsets), vec![0, 8]);
+        assert_eq!(ones(&m.interior_offsets), vec![4]);
+    }
+
+    #[test]
+    fn from_polygons_rejects_frame_mismatch() {
+        let a = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
+        let err = PolygonMesh3D::from_polygons(Coordinate::Crs(4326), [&a]).unwrap_err();
+        assert!(matches!(err, Error::InvalidGeometry(_)));
+    }
+
+    #[test]
+    fn from_parts_builds_faces() {
+        let verts = vec![[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]];
+        let faces = vec![vec![0u32, 1, 2], vec![0u32, 2, 3]];
+        let m = PolygonMesh3D::from_parts(Coordinate::Euclidean, verts, faces).unwrap();
+        assert_eq!(ones(&m.data.face_indices), vec![0, 1, 2, 0, 2, 3]);
+        assert_eq!(ones(&m.data.face_offsets), vec![0, 3, 6]);
+        assert!(ones(&m.data.interior_offsets).is_empty());
+    }
+
+    #[test]
+    fn from_parts_rejects_out_of_range_index() {
+        let verts = vec![[0., 0., 0.]];
+        assert!(PolygonMesh3DData::from_parts(verts, vec![vec![0u32, 1, 2]]).is_err());
+    }
+
+    #[test]
+    fn from_parts_with_elevation_splits_z() {
+        let verts = vec![[0., 0., 10.], [1., 0., 11.], [0., 1., 12.]];
+        let m = PolygonMesh2D::from_parts_with_elevation(
+            Coordinate::Euclidean,
+            verts,
+            vec![vec![0u32, 1, 2]],
+        )
+        .unwrap();
+        assert_eq!(m.vertices, vec![[0., 0.], [1., 0.], [0., 1.]]);
+        assert_eq!(m.z.as_deref(), Some(&[10., 11., 12.][..]));
+    }
+
+    #[test]
+    fn from_raw_parts_validates_offsets() {
+        let verts = vec![[0., 0., 0.], [1., 0., 0.], [1., 1., 0.]];
+        // Good: one triangular face.
+        assert!(PolygonMesh3DData::from_raw_parts(
+            verts.clone(),
+            vec![0, 1, 2],
+            vec![0, 3],
+            vec![]
+        )
+        .is_ok());
+        // Last offset must equal face_indices length.
+        assert!(PolygonMesh3DData::from_raw_parts(
+            verts.clone(),
+            vec![0, 1, 2],
+            vec![0, 2],
+            vec![]
+        )
+        .is_err());
+        // Index out of range.
+        assert!(
+            PolygonMesh3DData::from_raw_parts(verts, vec![0, 1, 9], vec![0, 3], vec![]).is_err()
+        );
+    }
+}

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -272,7 +272,7 @@ where
     let mut vertices: Vec<[f64; N]> = Vec::new();
     let mut seen: HashMap<[u64; N], u32> = HashMap::new();
     let mut face_indices: Vec<u32> = Vec::new();
-    let mut face_offsets: Vec<u32> = vec![0];
+    let mut face_offsets: Vec<u32> = Vec::new();
     let mut interior_offsets: Vec<u32> = Vec::new();
     for face in faces {
         let mut is_exterior = true;
@@ -287,6 +287,9 @@ where
         }
         face_offsets.push(face_indices.len() as u32);
     }
+    // `face_offsets` holds only the internal boundaries — no leading 0, no trailing
+    // total — so drop the last face's end (the implicit `face_indices.len()`).
+    face_offsets.pop();
     (vertices, face_indices, face_offsets, interior_offsets)
 }
 
@@ -297,7 +300,7 @@ fn index_faces(
     faces: impl IntoIterator<Item = impl IntoIterator<Item = u32>>,
 ) -> Result<(Vec<u32>, Vec<u32>), Error> {
     let mut face_indices: Vec<u32> = Vec::new();
-    let mut face_offsets: Vec<u32> = vec![0];
+    let mut face_offsets: Vec<u32> = Vec::new();
     for face in faces {
         for index in face {
             if index as usize >= vertex_count {
@@ -309,35 +312,22 @@ fn index_faces(
         }
         face_offsets.push(face_indices.len() as u32);
     }
+    // Keep only the internal boundaries (no leading 0, no trailing total).
+    face_offsets.pop();
     Ok((face_indices, face_offsets))
 }
 
-/// Validate flat CSR buffers: `face_offsets` starts at 0, is non-decreasing and
-/// ends at `face_indices.len()`; every index is `< vertex_count`; every interior
-/// offset is strictly increasing and within `face_indices`.
+/// Validate flat CSR buffers. `face_offsets` holds the `n_faces - 1` internal face
+/// boundaries (no leading 0): strictly increasing, each in `1..face_indices.len()`
+/// (every face non-empty). Every vertex index is `< vertex_count`. Each interior
+/// offset is strictly increasing, in `1..face_indices.len()`, and not a face
+/// boundary — so a hole starts strictly inside a face, after its exterior.
 fn validate_csr(
     vertex_count: usize,
     face_indices: &[u32],
     face_offsets: &[u32],
     interior_offsets: &[u32],
 ) -> Result<(), Error> {
-    match face_offsets.first() {
-        None => return Err(Error::invalid_geometry("face_offsets must not be empty")),
-        Some(&first) if first != 0 => {
-            return Err(Error::invalid_geometry("face_offsets must start at 0"))
-        }
-        _ => {}
-    }
-    if face_offsets.windows(2).any(|w| w[0] > w[1]) {
-        return Err(Error::invalid_geometry(
-            "face_offsets must be non-decreasing",
-        ));
-    }
-    if *face_offsets.last().unwrap() as usize != face_indices.len() {
-        return Err(Error::invalid_geometry(
-            "the last face_offset must equal face_indices length",
-        ));
-    }
     for &index in face_indices {
         if index as usize >= vertex_count {
             return Err(Error::invalid_geometry(format!(
@@ -346,10 +336,25 @@ fn validate_csr(
         }
     }
     let mut prev = 0u32;
-    for &offset in interior_offsets {
-        if offset <= prev || offset as usize >= face_indices.len() {
+    for (i, &boundary) in face_offsets.iter().enumerate() {
+        if boundary <= prev || boundary as usize >= face_indices.len() {
             return Err(Error::invalid_geometry(format!(
-                "interior_offset {offset} is out of range or not strictly increasing"
+                "face_offsets[{i}] = {boundary} must be strictly increasing and within 1..{}",
+                face_indices.len()
+            )));
+        }
+        prev = boundary;
+    }
+    let mut prev = 0u32;
+    for (i, &offset) in interior_offsets.iter().enumerate() {
+        if offset <= prev
+            || offset as usize >= face_indices.len()
+            || face_offsets.binary_search(&offset).is_ok()
+        {
+            return Err(Error::invalid_geometry(format!(
+                "interior_offsets[{i}] = {offset} must be strictly increasing, within \
+                 1..{}, and not coincide with a face boundary",
+                face_indices.len()
             )));
         }
         prev = offset;
@@ -432,7 +437,8 @@ mod tests {
         );
         // Rings stored open (the closing duplicate is dropped).
         assert_eq!(ones(&m.data.face_indices), vec![0, 1, 2, 3, 1, 4, 5, 2]);
-        assert_eq!(ones(&m.data.face_offsets), vec![0, 4, 8]);
+        // Internal boundary only: face 0 ends / face 1 begins at 4.
+        assert_eq!(ones(&m.data.face_offsets), vec![4]);
         assert!(ones(&m.data.interior_offsets).is_empty());
     }
 
@@ -444,7 +450,8 @@ mod tests {
         let m = PolygonMesh3DData::from_polygons([&p]);
         assert_eq!(m.vertices.len(), 8);
         assert_eq!(ones(&m.face_indices), vec![0, 1, 2, 3, 4, 5, 6, 7]);
-        assert_eq!(ones(&m.face_offsets), vec![0, 8]);
+        // Single face -> no internal boundaries; the hole starts at index 4.
+        assert!(ones(&m.face_offsets).is_empty());
         assert_eq!(ones(&m.interior_offsets), vec![4]);
     }
 
@@ -461,7 +468,8 @@ mod tests {
         let faces = vec![vec![0u32, 1, 2], vec![0u32, 2, 3]];
         let m = PolygonMesh3D::from_parts(Coordinate::Euclidean, verts, faces).unwrap();
         assert_eq!(ones(&m.data.face_indices), vec![0, 1, 2, 0, 2, 3]);
-        assert_eq!(ones(&m.data.face_offsets), vec![0, 3, 6]);
+        // Two faces -> a single internal boundary at 3.
+        assert_eq!(ones(&m.data.face_offsets), vec![3]);
         assert!(ones(&m.data.interior_offsets).is_empty());
     }
 
@@ -487,25 +495,42 @@ mod tests {
     #[test]
     fn from_raw_parts_validates_offsets() {
         let verts = vec![[0., 0., 0.], [1., 0., 0.], [1., 1., 0.]];
-        // Good: one triangular face.
+        // Good: a single triangular face has no internal boundaries.
+        assert!(
+            PolygonMesh3DData::from_raw_parts(verts.clone(), vec![0, 1, 2], vec![], vec![]).is_ok()
+        );
+        // Good: two faces with one internal boundary at 3.
         assert!(PolygonMesh3DData::from_raw_parts(
             verts.clone(),
-            vec![0, 1, 2],
-            vec![0, 3],
-            vec![]
+            vec![0, 1, 2, 0, 1, 2],
+            vec![3],
+            vec![],
         )
         .is_ok());
-        // Last offset must equal face_indices length.
+        // A leading 0 is no longer allowed (it would mean an empty first face).
+        assert!(
+            PolygonMesh3DData::from_raw_parts(verts.clone(), vec![0, 1, 2], vec![0], vec![])
+                .is_err()
+        );
+        // Equal boundaries (an empty face) are rejected.
         assert!(PolygonMesh3DData::from_raw_parts(
             verts.clone(),
-            vec![0, 1, 2],
-            vec![0, 2],
-            vec![]
+            vec![0, 1, 2, 0, 1, 2],
+            vec![3, 3],
+            vec![],
         )
         .is_err());
         // Index out of range.
+        assert!(PolygonMesh3DData::from_raw_parts(verts, vec![0, 1, 9], vec![], vec![]).is_err());
+    }
+
+    #[test]
+    fn from_raw_parts_rejects_interior_on_face_boundary() {
+        // Two faces, boundary at 3; an interior offset of 3 coincides with it.
+        let verts = vec![[0., 0., 0.], [1., 0., 0.], [1., 1., 0.]];
         assert!(
-            PolygonMesh3DData::from_raw_parts(verts, vec![0, 1, 9], vec![0, 3], vec![]).is_err()
+            PolygonMesh3DData::from_raw_parts(verts, vec![0, 1, 2, 0, 1, 2], vec![3], vec![3],)
+                .is_err()
         );
     }
 }

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -275,6 +275,8 @@ where
     let mut face_offsets: Vec<u32> = Vec::new();
     let mut interior_offsets: Vec<u32> = Vec::new();
     for face in faces {
+        let index_start = face_indices.len();
+        let interior_start = interior_offsets.len();
         let mut is_exterior = true;
         for ring in face {
             if !is_exterior {
@@ -284,6 +286,12 @@ where
             for &coord in open_ring(ring) {
                 face_indices.push(dedup_index(&mut vertices, &mut seen, coord));
             }
+        }
+        if face_indices.len() == index_start {
+            // Empty face contributes no geometry: drop it (and any hole offsets it
+            // recorded) so `face_offsets` stays strictly increasing with no leading 0.
+            interior_offsets.truncate(interior_start);
+            continue;
         }
         face_offsets.push(face_indices.len() as u32);
     }
@@ -302,6 +310,7 @@ fn index_faces(
     let mut face_indices: Vec<u32> = Vec::new();
     let mut face_offsets: Vec<u32> = Vec::new();
     for face in faces {
+        let index_start = face_indices.len();
         for index in face {
             if index as usize >= vertex_count {
                 return Err(Error::invalid_geometry(format!(
@@ -309,6 +318,11 @@ fn index_faces(
                 )));
             }
             face_indices.push(index);
+        }
+        if face_indices.len() == index_start {
+            // Empty face: contributes no ring, so record no boundary for it (keeps
+            // `face_offsets` strictly increasing with no leading 0).
+            continue;
         }
         face_offsets.push(face_indices.len() as u32);
     }
@@ -362,8 +376,10 @@ fn validate_csr(
     Ok(())
 }
 
-/// Pack the flat CSR buffers into width-erased index buffers: `face_indices` at
-/// the vertex-count-derived width, the offsets at the `face_indices.len()` width.
+/// Pack the flat CSR buffers into width-erased index buffers: `face_indices` at the
+/// vertex-count-derived width, the offsets at the `face_indices.len() - 1` width
+/// (the largest possible offset, since the internal boundaries carry no trailing
+/// total and every offset is `< face_indices.len()`).
 fn pack_csr(
     vertex_count: usize,
     face_indices: Vec<u32>,
@@ -371,7 +387,7 @@ fn pack_csr(
     interior_offsets: Vec<u32>,
 ) -> (IndexBuffer<1>, IndexBuffer<1>, IndexBuffer<1>) {
     let index_width = IndexWidth::for_value(vertex_count.saturating_sub(1) as u32);
-    let offset_width = IndexWidth::for_value(face_indices.len() as u32);
+    let offset_width = IndexWidth::for_value(face_indices.len().saturating_sub(1) as u32);
     (
         IndexBuffer::with_exact_width(
             index_width,
@@ -477,6 +493,32 @@ mod tests {
     fn from_parts_rejects_out_of_range_index() {
         let verts = vec![[0., 0., 0.]];
         assert!(PolygonMesh3DData::from_parts(verts, vec![vec![0u32, 1, 2]]).is_err());
+    }
+
+    // An empty face contributes no ring, so it is skipped rather than producing a
+    // duplicate (non-increasing) boundary.
+    #[test]
+    fn from_polygons_skips_empty_face() {
+        let a = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
+        let empty = Polygon3D::from_rings(
+            Coordinate::Euclidean,
+            Vec::<[f64; 3]>::new(),
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
+        let b = quad([[1., 0., 0.], [2., 0., 0.], [2., 1., 0.], [1., 1., 0.]]);
+        let m = PolygonMesh3DData::from_polygons([&a, &empty, &b]);
+        assert_eq!(m.vertices.len(), 6);
+        // Two real faces -> one internal boundary, no duplicate from the empty face.
+        assert_eq!(ones(&m.face_offsets), vec![4]);
+    }
+
+    #[test]
+    fn from_parts_skips_empty_face() {
+        let verts = vec![[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]];
+        let faces: Vec<Vec<u32>> = vec![vec![0, 1, 2], vec![], vec![0, 2, 3]];
+        let m = PolygonMesh3D::from_parts(Coordinate::Euclidean, verts, faces).unwrap();
+        assert_eq!(ones(&m.data.face_indices), vec![0, 1, 2, 0, 2, 3]);
+        assert_eq!(ones(&m.data.face_offsets), vec![3]);
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -16,6 +16,8 @@ use crate::appearance::{Appearance, UvSet};
 use crate::coordinate::Coordinate;
 use crate::index::IndexBuffer;
 
+mod constructor;
+
 /// A connected, vertex-sharing polygon mesh in 2D space, with optional
 /// per-vertex elevation.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -35,10 +35,10 @@ pub struct PolygonMesh2D {
     /// leading 0. `face_offsets[i]` is where face `i+1` begins; face `i` spans
     /// `face_indices[s..e]` with `s = if i == 0 { 0 } else { face_offsets[i-1] }`
     /// and `e = face_offsets.get(i).copied().unwrap_or(face_indices.len())`. Width
-    /// from `face_indices.len()`.
+    /// from `face_indices.len() - 1`.
     face_offsets: IndexBuffer<1>,
     /// Start in `face_indices` of each hole ring, across all faces; empty when
-    /// no face has holes. Width from `face_indices.len()`.
+    /// no face has holes. Width from `face_indices.len() - 1`.
     interior_offsets: IndexBuffer<1>,
     /// Geometric UV, parallel to the corner buffers; empty = no UV.
     uv_sets: Vec<UvSet>,
@@ -65,10 +65,10 @@ pub struct PolygonMesh3DData {
     /// leading 0. `face_offsets[i]` is where face `i+1` begins; face `i` spans
     /// `face_indices[s..e]` with `s = if i == 0 { 0 } else { face_offsets[i-1] }`
     /// and `e = face_offsets.get(i).copied().unwrap_or(face_indices.len())`. Width
-    /// from `face_indices.len()`.
+    /// from `face_indices.len() - 1`.
     face_offsets: IndexBuffer<1>,
     /// Start in `face_indices` of each hole ring, across all faces; empty when
-    /// no face has holes. Width from `face_indices.len()`.
+    /// no face has holes. Width from `face_indices.len() - 1`.
     interior_offsets: IndexBuffer<1>,
     /// Geometric UV, parallel to the corner buffers; empty = no UV.
     uv_sets: Vec<UvSet>,

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -31,9 +31,11 @@ pub struct PolygonMesh2D {
     /// All rings of all faces concatenated; each face is its exterior ring then
     /// its hole rings. Width from `vertices.len() - 1`.
     face_indices: IndexBuffer<1>,
-    /// `len() = n_faces + 1`; face i spans
-    /// `face_indices[face_offsets[i]..face_offsets[i+1]]`. Width from
-    /// `face_indices.len()`.
+    /// Internal face boundaries into `face_indices`: `len() = n_faces - 1`, no
+    /// leading 0. `face_offsets[i]` is where face `i+1` begins; face `i` spans
+    /// `face_indices[s..e]` with `s = if i == 0 { 0 } else { face_offsets[i-1] }`
+    /// and `e = face_offsets.get(i).copied().unwrap_or(face_indices.len())`. Width
+    /// from `face_indices.len()`.
     face_offsets: IndexBuffer<1>,
     /// Start in `face_indices` of each hole ring, across all faces; empty when
     /// no face has holes. Width from `face_indices.len()`.
@@ -59,9 +61,11 @@ pub struct PolygonMesh3DData {
     /// All rings of all faces concatenated; each face is its exterior ring then
     /// its hole rings. Width from `vertices.len() - 1`.
     face_indices: IndexBuffer<1>,
-    /// `len() = n_faces + 1`; face i spans
-    /// `face_indices[face_offsets[i]..face_offsets[i+1]]`. Width from
-    /// `face_indices.len()`.
+    /// Internal face boundaries into `face_indices`: `len() = n_faces - 1`, no
+    /// leading 0. `face_offsets[i]` is where face `i+1` begins; face `i` spans
+    /// `face_indices[s..e]` with `s = if i == 0 { 0 } else { face_offsets[i-1] }`
+    /// and `e = face_offsets.get(i).copied().unwrap_or(face_indices.len())`. Width
+    /// from `face_indices.len()`.
     face_offsets: IndexBuffer<1>,
     /// Start in `face_indices` of each hole ring, across all faces; empty when
     /// no face has holes. Width from `face_indices.len()`.

--- a/engine/runtime/geometry/src/solid/constructor.rs
+++ b/engine/runtime/geometry/src/solid/constructor.rs
@@ -1,0 +1,74 @@
+//! Solid constructors.
+//!
+//! A `Solid`'s shells are already-constructed coordinate-free meshes
+//! ([`PolygonMesh3DData`] / [`TriangularMesh3DData`]); these constructors just pair
+//! an exterior shell (and any interior void shells) with the frame they are
+//! expressed in. The `From` impls let a mesh be passed where a [`Shell`] is
+//! expected.
+
+use crate::coordinate::Coordinate;
+use crate::polygon_mesh::PolygonMesh3DData;
+use crate::triangular_mesh::TriangularMesh3DData;
+
+use super::{Shell, Solid};
+
+impl From<PolygonMesh3DData> for Shell {
+    fn from(mesh: PolygonMesh3DData) -> Self {
+        Shell::PolygonMesh(mesh)
+    }
+}
+
+impl From<TriangularMesh3DData> for Shell {
+    fn from(mesh: TriangularMesh3DData) -> Self {
+        Shell::TriangularMesh(mesh)
+    }
+}
+
+impl Solid {
+    /// A solid bounded by `exterior` with the given interior (void) shells, in
+    /// `coordinate`.
+    pub fn new(coordinate: Coordinate, exterior: impl Into<Shell>, interiors: Vec<Shell>) -> Self {
+        Self {
+            coordinate,
+            exterior: exterior.into(),
+            interiors,
+        }
+    }
+
+    /// A solid bounded by a single exterior shell, with no voids.
+    pub fn from_exterior(coordinate: Coordinate, exterior: impl Into<Shell>) -> Self {
+        Self::new(coordinate, exterior, Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cube_shell() -> TriangularMesh3DData {
+        // A degenerate stand-in is fine here: construction does not validate closure.
+        TriangularMesh3DData::from_parts(
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn from_exterior_has_no_voids() {
+        let s = Solid::from_exterior(Coordinate::Euclidean, cube_shell());
+        assert!(matches!(s.exterior, Shell::TriangularMesh(_)));
+        assert!(s.interiors.is_empty());
+        assert_eq!(s.coordinate, Coordinate::Euclidean);
+    }
+
+    #[test]
+    fn new_carries_void_shells() {
+        let s = Solid::new(
+            Coordinate::Euclidean,
+            cube_shell(),
+            vec![Shell::from(cube_shell())],
+        );
+        assert_eq!(s.interiors.len(), 1);
+    }
+}

--- a/engine/runtime/geometry/src/solid/mod.rs
+++ b/engine/runtime/geometry/src/solid/mod.rs
@@ -14,6 +14,8 @@ use crate::coordinate::Coordinate;
 use crate::polygon_mesh::PolygonMesh3DData;
 use crate::triangular_mesh::TriangularMesh3DData;
 
+mod constructor;
+
 /// One closed boundary of a [`Solid`]: a general polygon mesh or a triangle
 /// mesh, stored as coordinate-free mesh data so the boundary cannot carry a
 /// frame of its own — its frame is the `Solid`'s.

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -1,0 +1,397 @@
+//! TriangularMesh constructors.
+//!
+//! Two entry points, matching how a triangle mesh's buffers actually arrive:
+//!
+//! * `from_parts` — the vertex pool is already in hand (glTF / OBJ accessors,
+//!   earcut output over an input ring, any algorithm that tracks its own
+//!   indices). The index width is fixed by the vertex count — the largest index a
+//!   valid mesh can hold is `vertices.len() - 1` — so it is computed once, with no
+//!   scan of the index values, and the triangles are packed straight into that
+//!   exact width. Indices arrive as a flat `u32` stream (the glTF / earcut shape)
+//!   and are grouped into triples; the checked form validates that every index is
+//!   in range and the count is a multiple of three.
+//!
+//! * `from_soup` — a flat stream of triangle-corner coordinates with no sharing
+//!   (STL, marching-cubes-style emitters). The vertex pool is *discovered* by
+//!   deduplicating corners, so the final count — hence the index width — is not
+//!   known up front; the indices grow through [`IndexBuffer::from_indices`], which
+//!   starts at `u8` and widens only as the pool crosses a width boundary, keeping
+//!   the common small mesh narrow.
+//!
+//! 3D constructors build the coordinate-free [`TriangularMesh3DData`] that a
+//! [`Solid`](crate::solid::Solid) shell also stores, so the frame-carrying
+//! [`TriangularMesh3D`] is a thin wrapper. All meshes are built bare (no UV, no
+//! appearance); attach an appearance afterwards via `appearance_mut`.
+
+use std::collections::HashMap;
+
+use crate::coordinate::Coordinate;
+use crate::error::Error;
+use crate::index::{IndexBuffer, IndexWidth};
+
+use super::{TriangularMesh2D, TriangularMesh3D, TriangularMesh3DData};
+
+impl TriangularMesh3DData {
+    /// Build coordinate-free mesh data from a vertex pool and a flat `u32` index
+    /// stream. Validates that the index count is a multiple of three and every
+    /// index is `< vertices.len()`; the width is taken from the vertex count.
+    pub fn from_parts(
+        vertices: Vec<[f64; 3]>,
+        indices: impl IntoIterator<Item = u32>,
+    ) -> Result<Self, Error> {
+        let width = index_width_for(vertices.len());
+        let triangles = triangles_checked(indices, vertices.len())?;
+        Ok(Self {
+            vertices,
+            indices: pack_checked(width, triangles),
+            uv_sets: Vec::new(),
+            appearance: None,
+        })
+    }
+
+    /// Build mesh data without validating indices, filling the index buffer by the
+    /// fast uninitialized path.
+    ///
+    /// # Safety
+    /// The caller must ensure every index is `< vertices.len()` (an out-of-range
+    /// index is silently truncated into the vertex-count-derived width) and that
+    /// the flat `indices` stream yields exactly `3 * triangle_count` items.
+    #[allow(unused)] // TODO: remove this after the migration is complete at which point this will be used.
+    pub(crate) unsafe fn from_parts_unchecked(
+        vertices: Vec<[f64; 3]>,
+        triangle_count: usize,
+        indices: impl IntoIterator<Item = u32>,
+    ) -> Self {
+        let width = index_width_for(vertices.len());
+        Self {
+            indices: IndexBuffer::from_exact_unchecked(
+                width,
+                triangle_count,
+                group_triples(indices),
+            ),
+            vertices,
+            uv_sets: Vec::new(),
+            appearance: None,
+        }
+    }
+
+    /// Build mesh data from a triangle soup: a flat stream of corner coordinates,
+    /// three per triangle, deduplicated into a shared vertex pool.
+    pub fn from_soup(iter: impl IntoIterator<Item = [f64; 3]>) -> Self {
+        let (vertices, indices) = soup_buffers::<3>(iter);
+        Self {
+            vertices,
+            indices,
+            uv_sets: Vec::new(),
+            appearance: None,
+        }
+    }
+}
+
+impl TriangularMesh3D {
+    /// Pair coordinate-free mesh data with the frame it is expressed in.
+    pub fn new(coordinate: Coordinate, data: TriangularMesh3DData) -> Self {
+        Self { coordinate, data }
+    }
+
+    /// Build from a vertex pool and a flat `u32` index stream; see
+    /// [`TriangularMesh3DData::from_parts`].
+    pub fn from_parts(
+        coordinate: Coordinate,
+        vertices: Vec<[f64; 3]>,
+        indices: impl IntoIterator<Item = u32>,
+    ) -> Result<Self, Error> {
+        Ok(Self::new(
+            coordinate,
+            TriangularMesh3DData::from_parts(vertices, indices)?,
+        ))
+    }
+
+    /// Build without validating indices; see
+    /// [`TriangularMesh3DData::from_parts_unchecked`].
+    ///
+    /// # Safety
+    /// Same contract as [`TriangularMesh3DData::from_parts_unchecked`].
+    #[allow(unused)] // TODO: remove this after the migration is complete at which point this will be used.
+    pub unsafe fn from_parts_unchecked(
+        coordinate: Coordinate,
+        vertices: Vec<[f64; 3]>,
+        triangle_count: usize,
+        indices: impl IntoIterator<Item = u32>,
+    ) -> Self {
+        Self::new(
+            coordinate,
+            TriangularMesh3DData::from_parts_unchecked(vertices, triangle_count, indices),
+        )
+    }
+
+    /// Build from a triangle soup; see [`TriangularMesh3DData::from_soup`].
+    pub fn from_soup(coordinate: Coordinate, iter: impl IntoIterator<Item = [f64; 3]>) -> Self {
+        Self::new(coordinate, TriangularMesh3DData::from_soup(iter))
+    }
+}
+
+impl TriangularMesh2D {
+    /// Build a pure-2D mesh from a vertex pool and a flat `u32` index stream.
+    /// Validates the index count and range; the width is taken from the vertex
+    /// count.
+    pub fn from_parts(
+        coordinate: Coordinate,
+        vertices: Vec<[f64; 2]>,
+        indices: impl IntoIterator<Item = u32>,
+    ) -> Result<Self, Error> {
+        let width = index_width_for(vertices.len());
+        let triangles = triangles_checked(indices, vertices.len())?;
+        Ok(Self {
+            coordinate,
+            vertices,
+            z: None,
+            indices: pack_checked(width, triangles),
+            uv_sets: Vec::new(),
+            appearance: None,
+        })
+    }
+
+    /// Build a 2.5D mesh from `[x, y, z]` vertices: the `(x, y)` populate the
+    /// vertex pool and the `z` the parallel elevation buffer.
+    pub fn from_parts_with_elevation(
+        coordinate: Coordinate,
+        vertices: Vec<[f64; 3]>,
+        indices: impl IntoIterator<Item = u32>,
+    ) -> Result<Self, Error> {
+        let width = index_width_for(vertices.len());
+        let triangles = triangles_checked(indices, vertices.len())?;
+        let (xy, z) = split_elevation(vertices);
+        Ok(Self {
+            coordinate,
+            vertices: xy,
+            z: Some(z),
+            indices: pack_checked(width, triangles),
+            uv_sets: Vec::new(),
+            appearance: None,
+        })
+    }
+
+    /// Build a pure-2D mesh without validating indices.
+    ///
+    /// # Safety
+    /// Same contract as [`TriangularMesh3DData::from_parts_unchecked`].
+    pub unsafe fn from_parts_unchecked(
+        coordinate: Coordinate,
+        vertices: Vec<[f64; 2]>,
+        triangle_count: usize,
+        indices: impl IntoIterator<Item = u32>,
+    ) -> Self {
+        let width = index_width_for(vertices.len());
+        Self {
+            coordinate,
+            indices: IndexBuffer::from_exact_unchecked(
+                width,
+                triangle_count,
+                group_triples(indices),
+            ),
+            vertices,
+            z: None,
+            uv_sets: Vec::new(),
+            appearance: None,
+        }
+    }
+
+    /// Build a pure-2D mesh from a triangle soup of `[x, y]` corners.
+    pub fn from_soup(coordinate: Coordinate, iter: impl IntoIterator<Item = [f64; 2]>) -> Self {
+        let (vertices, indices) = soup_buffers::<2>(iter);
+        Self {
+            coordinate,
+            vertices,
+            z: None,
+            indices,
+            uv_sets: Vec::new(),
+            appearance: None,
+        }
+    }
+}
+
+/// Narrowest index width that can address `vertex_count` vertices (largest index
+/// `vertex_count - 1`); `IndexWidth::U8` for the empty mesh.
+fn index_width_for(vertex_count: usize) -> IndexWidth {
+    IndexWidth::for_value(vertex_count.saturating_sub(1) as u32)
+}
+
+/// Group a flat index stream into triangles, validating that the count is a
+/// multiple of three and every index addresses a vertex `< vertex_count`.
+fn triangles_checked(
+    indices: impl IntoIterator<Item = u32>,
+    vertex_count: usize,
+) -> Result<Vec<[u32; 3]>, Error> {
+    let mut it = indices.into_iter();
+    let mut triangles = Vec::with_capacity(it.size_hint().0 / 3);
+    while let Some(a) = it.next() {
+        let (Some(b), Some(c)) = (it.next(), it.next()) else {
+            return Err(Error::invalid_geometry(
+                "triangle index count is not a multiple of three",
+            ));
+        };
+        for index in [a, b, c] {
+            if index as usize >= vertex_count {
+                return Err(Error::invalid_geometry(format!(
+                    "triangle index {index} is out of range for {vertex_count} vertices"
+                )));
+            }
+        }
+        triangles.push([a, b, c]);
+    }
+    Ok(triangles)
+}
+
+/// Group a flat index stream into triangles, dropping a trailing partial triple.
+/// No validation — for the unchecked path only.
+fn group_triples(indices: impl IntoIterator<Item = u32>) -> impl Iterator<Item = [u32; 3]> {
+    let mut it = indices.into_iter();
+    std::iter::from_fn(move || Some([it.next()?, it.next()?, it.next()?]))
+}
+
+/// Pack already-range-checked triangles into the vertex-count-derived `width`.
+/// Every index was validated `< vertex_count`, so it fits `width` (derived from
+/// `vertex_count - 1`) and `with_exact_width` never panics here.
+fn pack_checked(width: IndexWidth, triangles: Vec<[u32; 3]>) -> IndexBuffer<3> {
+    IndexBuffer::with_exact_width(width, Some(triangles.len()), triangles)
+}
+
+/// Index of `coord` in `vertices`, inserting it (and assigning the next index) on
+/// first sight. Dedup is on exact `f64` bits.
+fn dedup_index<const N: usize>(
+    vertices: &mut Vec<[f64; N]>,
+    seen: &mut HashMap<[u64; N], u32>,
+    coord: [f64; N],
+) -> u32 {
+    *seen.entry(coord.map(f64::to_bits)).or_insert_with(|| {
+        let index = vertices.len() as u32;
+        vertices.push(coord);
+        index
+    })
+}
+
+/// Deduplicate a flat triangle-corner stream into a vertex pool and a grown index
+/// buffer, shared by the 2D and 3D soup constructors. A trailing partial triangle
+/// is dropped.
+fn soup_buffers<const N: usize>(
+    iter: impl IntoIterator<Item = [f64; N]>,
+) -> (Vec<[f64; N]>, IndexBuffer<3>) {
+    let mut vertices: Vec<[f64; N]> = Vec::new();
+    let mut seen: HashMap<[u64; N], u32> = HashMap::new();
+    let mut src = iter.into_iter();
+    let vertices_ref = &mut vertices;
+    let seen_ref = &mut seen;
+    let triangles = std::iter::from_fn(move || {
+        let a = src.next()?;
+        let b = src.next()?;
+        let c = src.next()?;
+        Some([
+            dedup_index(vertices_ref, seen_ref, a),
+            dedup_index(vertices_ref, seen_ref, b),
+            dedup_index(vertices_ref, seen_ref, c),
+        ])
+    });
+    let indices = IndexBuffer::from_indices(triangles);
+    (vertices, indices)
+}
+
+/// Split a 3D vertex buffer into its 2D footprint and a parallel elevation buffer.
+fn split_elevation(vertices: Vec<[f64; 3]>) -> (Vec<[f64; 2]>, Box<[f64]>) {
+    let mut xy = Vec::with_capacity(vertices.len());
+    let mut z = Vec::with_capacity(vertices.len());
+    for [x, y, elevation] in vertices {
+        xy.push([x, y]);
+        z.push(elevation);
+    }
+    (xy, z.into_boxed_slice())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn triples(buf: &IndexBuffer<3>) -> Vec<[u32; 3]> {
+        match buf {
+            IndexBuffer::U8(v) => v.iter().map(|t| (*t).map(u32::from)).collect(),
+            IndexBuffer::U16(v) => v.iter().map(|t| (*t).map(u32::from)).collect(),
+            IndexBuffer::U32(v) => v.iter().map(|t| (*t).map(u32::from)).collect(),
+        }
+    }
+
+    #[test]
+    fn from_parts_builds_validated_mesh() {
+        let verts = vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        let m = TriangularMesh3D::from_parts(Coordinate::Euclidean, verts, [0u32, 1, 2]).unwrap();
+        assert_eq!(m.data.vertices.len(), 3);
+        assert_eq!(m.data.indices.width(), IndexWidth::U8);
+        assert_eq!(triples(&m.data.indices), vec![[0, 1, 2]]);
+    }
+
+    #[test]
+    fn from_parts_width_follows_vertex_count_not_indices() {
+        // 300 vertices -> u16, even though the one triangle uses only small indices.
+        let verts: Vec<[f64; 3]> = (0..300).map(|i| [i as f64, 0.0, 0.0]).collect();
+        let m = TriangularMesh3DData::from_parts(verts, [0u32, 1, 2]).unwrap();
+        assert_eq!(m.indices.width(), IndexWidth::U16);
+    }
+
+    #[test]
+    fn from_parts_rejects_out_of_range_index() {
+        let verts = vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        let err = TriangularMesh3DData::from_parts(verts, [0u32, 1, 3]).unwrap_err();
+        assert!(matches!(err, Error::InvalidGeometry(_)));
+    }
+
+    #[test]
+    fn from_parts_rejects_non_multiple_of_three() {
+        let verts = vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        assert!(TriangularMesh3DData::from_parts(verts, [0u32, 1]).is_err());
+    }
+
+    #[test]
+    fn from_soup_dedups_shared_vertices() {
+        let a = [0.0, 0.0, 0.0];
+        let b = [1.0, 0.0, 0.0];
+        let c = [0.0, 1.0, 0.0];
+        let d = [1.0, 1.0, 0.0];
+        // Two triangles sharing edge b-c: a b c, b c d -> 4 unique vertices.
+        let m = TriangularMesh3DData::from_soup([a, b, c, b, c, d]);
+        assert_eq!(m.vertices, vec![a, b, c, d]);
+        assert_eq!(triples(&m.indices), vec![[0, 1, 2], [1, 2, 3]]);
+        assert_eq!(m.indices.width(), IndexWidth::U8);
+    }
+
+    #[test]
+    fn from_soup_drops_trailing_partial_triangle() {
+        let a = [0.0, 0.0, 0.0];
+        let b = [1.0, 0.0, 0.0];
+        let c = [0.0, 1.0, 0.0];
+        let d = [1.0, 1.0, 0.0];
+        let e = [2.0, 2.0, 0.0];
+        // One full triangle plus two leftover corners: d and e are never consumed
+        // into a triple, so they are not added to the pool.
+        let m = TriangularMesh3DData::from_soup([a, b, c, d, e]);
+        assert_eq!(triples(&m.indices), vec![[0, 1, 2]]);
+        assert_eq!(m.vertices, vec![a, b, c]);
+    }
+
+    #[test]
+    fn from_parts_with_elevation_splits_z() {
+        let verts = vec![[0.0, 0.0, 10.0], [1.0, 0.0, 11.0], [0.0, 1.0, 12.0]];
+        let m =
+            TriangularMesh2D::from_parts_with_elevation(Coordinate::Euclidean, verts, [0u32, 1, 2])
+                .unwrap();
+        assert_eq!(m.vertices, vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]);
+        assert_eq!(m.z.as_deref(), Some(&[10.0, 11.0, 12.0][..]));
+    }
+
+    #[test]
+    fn from_parts_unchecked_matches_checked() {
+        let verts = vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        let checked = TriangularMesh3DData::from_parts(verts.clone(), [0u32, 1, 2]).unwrap();
+        let unchecked =
+            unsafe { TriangularMesh3DData::from_parts_unchecked(verts, 1, [0u32, 1, 2]) };
+        assert_eq!(checked, unchecked);
+    }
+}

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -14,6 +14,8 @@ use crate::appearance::{Appearance, UvSet};
 use crate::coordinate::Coordinate;
 use crate::index::IndexBuffer;
 
+mod constructor;
+
 /// A triangle mesh in 2D space, with optional per-vertex elevation.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct TriangularMesh2D {

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.56"
+version = "0.2.57"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.246"
+version = "0.1.247"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR implements constructors for the new geometry types. They are optimized for the construction sites of Flow such as parsers and algorithms.  Appearance setting is out of scope for this PR. There are some unsafe functions, all of which are private to the `geometry` crate.

## What I've done
I have implemented constructors for the following:
**`IndexBuffer`** *(not a leaf type, but the meshes are built on it)*
Width-erased index storage (`u8`/`u16`/`u32`, chosen at construction).
- `from_indices`: growing one. It starts `u8` and promotes only when a value crosses a width boundary (i.e. first-class small-mesh support). 
- `with_exact_width`: pack at a known width with no scan, used when the width is derivable up front.
- `unsafe from_exact_unchecked`: unsafe unchecked variant of `with_exact_width`.

**Polygon**
Flattens an exterior ring + interior (hole) rings into one CSR `coords` buffer.
- `from_rings`: pure constructor.
- `from_rings_with_elevation`: `from_rings` for 2.5D.
- `from_raw_parts`: takes in pre-built buffers, and validates them. 
- typestate builder: (`PolygonBuilder{2,3}D<Empty|HasExterior>`) for streaming parsers that see the exterior strictly before its holes.

**TriangularMesh**
Index width comes from the vertex count, not from scanning the indices, so packing is exact-width and scan-free. 
- `from_parts`: takes the moved-in vertex `Vec` + a flat `u32` index stream (glTF/OBJ/earcut shape), groups it into triples, and validates `count % 3 == 0` and every index `< len`
- `unsafe from_parts_unchecked`: skips validation for trusted sources. 
- `from_soup`: handles triangle soup (STL/marching-cubes). It deduplicates corner coordinates (exact `f64` bits) into a pool and builds the indices through the growing `IndexBuffer::from_indices`.
- `from_parts_with_elevation`: for 2.5D.

**PolygonMesh**
`from_polygons`: the CityGML path: it deduplicates the corners of a set of independent `Polygon` faces into a shared pool, maps each polygon 1:1 to a face preserving its holes, stores rings open (drops the closing duplicate), and checks all faces share the mesh's coordinate frame. 
- `from_parts`: vertex pool + exterior-only index-list faces (validated). 
- `from_raw_parts`: accepts flat CSR buffers with full validation.

**PointCloud**
`from_positions` builds the basic case only: a single `f64`-encoded acquisition segment, packing XYZ as little-endian bytes (stride 24), with no optional fields or attribute columns. The richer machinery (RGB/intensity/normals, `f32`/scaled-`i32` encodings, per-point attribute columns, multiple segments) is deliberately deferred.

**LineString**
`from_coords`: for pure 2D/3D.
`from_coords_with_elevation`: for 2.5D.
`from_raw_parts`: from raw parts.

## What I haven't done
Appearance setting is out of scope for the PR. `PointCloud` constructors are from-positions only.

## Other minor changes
- There is a slight change to the `PolygonMesh` model; the first and last element of `face_offsets` are dropped.
- `IndexBuffer`, the dynamic width buffer for meshes, is now completely private to `geometry` crate.