### PR TITLE
feat(engine): appearance setters for the new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4092,7 +4092,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.57"
+version = "0.2.58"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "futures",
  "once_cell",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "approx",
  "async-trait",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "Inflector",
  "approx",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "bytes",
  "clap",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "approx",
  "bvh",
@@ -5053,7 +5053,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5124,7 +5124,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "bytes",
  "futures",
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "bytes",
  "futures",
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5239,7 +5239,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5273,7 +5273,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "ahash",
  "bytes",
@@ -5309,7 +5309,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.417"
+version = "0.0.418"
 dependencies = [
  "async-trait",
  "axum",
@@ -8041,7 +8041,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.247"
+version = "0.1.248"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.417"
+version = "0.0.418"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/geometry/src/appearance/material.rs
+++ b/engine/runtime/geometry/src/appearance/material.rs
@@ -49,6 +49,26 @@ pub struct PhongMaterial {
     pub normal_map: Option<Texture>,
 }
 
+impl Material {
+    /// Whether this material has any textured map slot, and therefore samples a
+    /// UV set. A material with no maps (colour / factors only) needs no UV; one
+    /// with at least one map requires a UV set to sample.
+    pub fn has_texture(&self) -> bool {
+        match self {
+            Material::Phong(m) => {
+                m.diffuse_map.is_some() || m.emissive_map.is_some() || m.normal_map.is_some()
+            }
+            Material::Pbr(m) => {
+                m.base_color_map.is_some()
+                    || m.metallic_roughness_map.is_some()
+                    || m.normal_map.is_some()
+                    || m.occlusion_map.is_some()
+                    || m.emissive_map.is_some()
+            }
+        }
+    }
+}
+
 /// glTF metallic-roughness PBR material.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct PbrMaterial {

--- a/engine/runtime/geometry/src/appearance/material.rs
+++ b/engine/runtime/geometry/src/appearance/material.rs
@@ -12,9 +12,12 @@
 //! here), and each map's `Texture` names the UV channel it samples, so a
 //! material may be reused under several themes.
 
+use std::collections::BTreeSet;
+
 use serde::{Deserialize, Serialize};
 
 use super::texture::Texture;
+use super::ChannelId;
 
 /// One self-contained shading description: exactly one of the two shading
 /// models.
@@ -66,6 +69,33 @@ impl Material {
                     || m.emissive_map.is_some()
             }
         }
+    }
+
+    /// The distinct UV channels this material's textured maps sample (empty if
+    /// colour-only). A UV set must be supplied for each when attaching appearance;
+    /// several maps sharing a channel collapse to one entry.
+    pub fn referenced_channels(&self) -> BTreeSet<ChannelId> {
+        let mut channels = BTreeSet::new();
+        let mut add = |map: &Option<Texture>| {
+            if let Some(texture) = map {
+                channels.insert(texture.uv_channel);
+            }
+        };
+        match self {
+            Material::Phong(m) => {
+                add(&m.diffuse_map);
+                add(&m.emissive_map);
+                add(&m.normal_map);
+            }
+            Material::Pbr(m) => {
+                add(&m.base_color_map);
+                add(&m.metallic_roughness_map);
+                add(&m.normal_map);
+                add(&m.occlusion_map);
+                add(&m.emissive_map);
+            }
+        }
+        channels
     }
 }
 

--- a/engine/runtime/geometry/src/appearance/mod.rs
+++ b/engine/runtime/geometry/src/appearance/mod.rs
@@ -24,6 +24,8 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::error::Error;
+
 /// A dataset-global, stable theme name. Switching to a theme selects the same
 /// theme across every feature, so this is an identity (a name), not a per-mesh
 /// index (contrast [`ChannelId`]).
@@ -134,6 +136,121 @@ pub enum FaceBinding {
     PerFace(Vec<Option<MaterialIndex>>),
 }
 
+impl FaceBinding {
+    /// Mark every palette index this binding references in `referenced`.
+    fn mark_referenced(&self, referenced: &mut [bool]) {
+        match self {
+            FaceBinding::Uniform(index) => referenced[index.get() as usize] = true,
+            FaceBinding::PerFace(faces) => {
+                for index in faces.iter().flatten() {
+                    referenced[index.get() as usize] = true;
+                }
+            }
+        }
+    }
+
+    /// Reindex every palette index through `remap` (old index → compacted index).
+    /// Only indices previously marked by [`mark_referenced`] are looked up.
+    fn reindex(&mut self, remap: &[Option<MaterialIndex>]) {
+        let map = |index: MaterialIndex| {
+            remap[index.get() as usize].expect("a referenced material survives compaction")
+        };
+        match self {
+            FaceBinding::Uniform(index) => *index = map(*index),
+            FaceBinding::PerFace(faces) => {
+                for slot in faces.iter_mut().flatten() {
+                    *slot = map(*slot);
+                }
+            }
+        }
+    }
+}
+
+impl Appearance {
+    /// Remove palette entries unreferenced by any binding and reindex the
+    /// survivors. Kept materials retain their relative order, so the compacted
+    /// palette is a stable subsequence of the original.
+    fn compact_materials(&mut self) {
+        let mut referenced = vec![false; self.materials.len()];
+        for binding in &self.themes {
+            binding.front.mark_referenced(&mut referenced);
+            if let Some(back) = &binding.back {
+                back.mark_referenced(&mut referenced);
+            }
+        }
+
+        let mut remap: Vec<Option<MaterialIndex>> = vec![None; self.materials.len()];
+        let mut kept: Vec<Material> = Vec::new();
+        for (old, material) in self.materials.iter().enumerate() {
+            if referenced[old] {
+                let new = MaterialIndex::new(kept.len() as u32)
+                    .expect("a compacted palette is no larger than the original");
+                remap[old] = Some(new);
+                kept.push(material.clone());
+            }
+        }
+        self.materials = kept;
+
+        for binding in &mut self.themes {
+            binding.front.reindex(&remap);
+            if let Some(back) = &mut binding.back {
+                back.reindex(&remap);
+            }
+        }
+    }
+}
+
+/// Validate the texture/UV coupling and, for an `Explicit` source, the UV length —
+/// the invariant every appearance setter shares. `references_texture` is whether
+/// any bound material samples a texture: a textured binding requires exactly one UV
+/// set, a colour-only one must not carry an orphan. `corner_count` is the number of
+/// corners an `Explicit` UV must match.
+pub(crate) fn validate_uv_coupling(
+    references_texture: bool,
+    uv: &Option<UvSource>,
+    corner_count: usize,
+) -> Result<(), Error> {
+    match (references_texture, uv) {
+        (true, None) => {
+            return Err(Error::invalid_appearance(
+                "a textured material requires a UV set, but none was supplied",
+            ));
+        }
+        (false, Some(_)) => {
+            return Err(Error::invalid_appearance(
+                "a UV set was supplied but no material is textured (orphan UV)",
+            ));
+        }
+        _ => {}
+    }
+    if let Some(UvSource::Explicit(coords)) = uv {
+        if coords.len() != corner_count {
+            return Err(Error::invalid_appearance(format!(
+                "UV length {} does not match the corner count {corner_count}",
+                coords.len()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Strip all back-side appearance from a mesh's `(appearance, uv_sets)`: drop each
+/// theme's back binding, remove every `Side::Back` UV set, and compact the palette
+/// so now-orphaned back-only materials are dropped. Shared by the polygon-mesh and
+/// triangular-mesh `make_front_only` shells — a [`Solid`](crate::solid::Solid)'s
+/// back face is its interior (or the inside of a void), which is never rendered, so
+/// back appearance is meaningless there; `Solid` construction calls this on every
+/// shell.
+pub(crate) fn make_front_only(appearance: &mut Option<Appearance>, uv_sets: &mut Vec<UvSet>) {
+    uv_sets.retain(|uv| uv.side != Side::Back);
+    if let Some(app) = appearance {
+        for binding in &mut app.themes {
+            binding.back = None;
+        }
+        app.compact_materials();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -171,5 +288,83 @@ mod tests {
 
         // the reserved sentinel is rejected on the wire, not silently accepted
         assert!(serde_json::from_str::<MaterialIndex>("4294967295").is_err());
+    }
+
+    fn phong(diffuse: f32) -> Material {
+        Material::Phong(PhongMaterial {
+            diffuse: [diffuse, diffuse, diffuse],
+            specular: [0.0; 3],
+            emissive: [0.0; 3],
+            ambient_intensity: 0.0,
+            shininess: 0.0,
+            transparency: 0.0,
+            diffuse_map: None,
+            emissive_map: None,
+            normal_map: None,
+        })
+    }
+
+    #[test]
+    fn make_front_only_drops_back_and_compacts_palette() {
+        let theme = ThemeId(Arc::from("rgb"));
+        // Material 0 is front-only, material 1 is back-only.
+        let mut appearance = Some(Appearance {
+            materials: vec![phong(1.0), phong(2.0)],
+            themes: vec![ThemeBinding {
+                theme: theme.clone(),
+                front: FaceBinding::Uniform(MaterialIndex::new(0).unwrap()),
+                back: Some(FaceBinding::Uniform(MaterialIndex::new(1).unwrap())),
+            }],
+            default_theme: theme.clone(),
+        });
+        let uv = |side| UvSet {
+            theme: Some(theme.clone()),
+            side,
+            channel: None,
+            uv: UvSource::Explicit(Box::new([])),
+        };
+        let mut uv_sets = vec![uv(Side::Front), uv(Side::Back)];
+
+        make_front_only(&mut appearance, &mut uv_sets);
+
+        let app = appearance.unwrap();
+        // The back binding is gone and its now-orphaned material dropped, leaving
+        // only the front material (still reachable at the compacted index 0).
+        assert_eq!(app.materials, vec![phong(1.0)]);
+        assert!(app.themes[0].back.is_none());
+        assert!(matches!(app.themes[0].front, FaceBinding::Uniform(i) if i.get() == 0));
+        // The back UV set is stripped; only the front survives.
+        assert_eq!(uv_sets.len(), 1);
+        assert_eq!(uv_sets[0].side, Side::Front);
+    }
+
+    #[test]
+    fn compact_materials_reindexes_perface_binding() {
+        let theme = ThemeId(Arc::from("rgb"));
+        // Palette entry 0 is unreferenced; faces bind 1 and 3, with a bare slot.
+        let mut app = Appearance {
+            materials: vec![phong(0.0), phong(1.0), phong(2.0), phong(3.0)],
+            themes: vec![ThemeBinding {
+                theme: theme.clone(),
+                front: FaceBinding::PerFace(vec![
+                    Some(MaterialIndex::new(1).unwrap()),
+                    None,
+                    Some(MaterialIndex::new(3).unwrap()),
+                ]),
+                back: None,
+            }],
+            default_theme: theme,
+        };
+
+        app.compact_materials();
+
+        // Only the referenced materials survive, in their original relative order.
+        assert_eq!(app.materials, vec![phong(1.0), phong(3.0)]);
+        let FaceBinding::PerFace(faces) = &app.themes[0].front else {
+            panic!("front binding should stay PerFace");
+        };
+        assert_eq!(faces[0].map(|i| i.get()), Some(0));
+        assert_eq!(faces[1], None);
+        assert_eq!(faces[2].map(|i| i.get()), Some(1));
     }
 }

--- a/engine/runtime/geometry/src/appearance/mod.rs
+++ b/engine/runtime/geometry/src/appearance/mod.rs
@@ -19,6 +19,7 @@ pub use material::{AlphaMode, Material, PbrMaterial, PhongMaterial};
 pub use texture::{Filter, Raster, RasterData, Sampler, Texture, TextureTransform, WrapMode};
 pub use uv::{TexMatrix, UvSet, UvSource};
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
@@ -34,7 +35,9 @@ pub struct ThemeId(pub Arc<str>);
 
 /// A material-local UV channel index. Carries no cross-theme meaning: channel 0
 /// under one theme and channel 0 under another are different UV sets.
-#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(
+    Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
 pub struct ChannelId(pub u32);
 
 /// An index into [`Appearance::materials`].
@@ -277,35 +280,49 @@ pub(crate) fn append_theme(
     Ok(())
 }
 
-/// Validate the texture/UV coupling and, for an `Explicit` source, the UV length —
-/// the invariant every appearance setter shares. `references_texture` is whether
-/// any bound material samples a texture: a textured binding requires exactly one UV
-/// set, a colour-only one must not carry an orphan. `corner_count` is the number of
-/// corners an `Explicit` UV must match.
+/// Wrap an optional single UV as the default-channel entry of a channel map — the
+/// single-`ParameterizedTexture` convenience the simple setters share. `None`
+/// yields an empty map (a colour-only material).
+pub(crate) fn single_channel_uv(uv: Option<UvSource>) -> BTreeMap<ChannelId, UvSource> {
+    uv.into_iter()
+        .map(|uv| (ChannelId::default(), uv))
+        .collect()
+}
+
+/// Validate the texture/UV channel coupling and, for `Explicit` sources, the UV
+/// length — the invariant every appearance setter shares. `referenced_channels`
+/// is the set of UV channels the bound materials' textured maps sample; `uvs` must
+/// supply exactly those channels — each textured channel needs a UV, and a channel
+/// no material samples must not carry an orphan UV — and each `Explicit` UV must
+/// have `corner_count` entries.
 pub(crate) fn validate_uv_coupling(
-    references_texture: bool,
-    uv: &Option<UvSource>,
+    referenced_channels: &BTreeSet<ChannelId>,
+    uvs: &BTreeMap<ChannelId, UvSource>,
     corner_count: usize,
 ) -> Result<(), Error> {
-    match (references_texture, uv) {
-        (true, None) => {
-            return Err(Error::invalid_appearance(
-                "a textured material requires a UV set, but none was supplied",
-            ));
-        }
-        (false, Some(_)) => {
-            return Err(Error::invalid_appearance(
-                "a UV set was supplied but no material is textured (orphan UV)",
-            ));
-        }
-        _ => {}
-    }
-    if let Some(UvSource::Explicit(coords)) = uv {
-        if coords.len() != corner_count {
+    for channel in referenced_channels {
+        if !uvs.contains_key(channel) {
             return Err(Error::invalid_appearance(format!(
-                "UV length {} does not match the corner count {corner_count}",
-                coords.len()
+                "a textured material samples UV channel {} but no UV set was supplied for it",
+                channel.0
             )));
+        }
+    }
+    for (channel, uv) in uvs {
+        if !referenced_channels.contains(channel) {
+            return Err(Error::invalid_appearance(format!(
+                "a UV set was supplied for channel {} but no material samples it (orphan UV)",
+                channel.0
+            )));
+        }
+        if let UvSource::Explicit(coords) = uv {
+            if coords.len() != corner_count {
+                return Err(Error::invalid_appearance(format!(
+                    "UV length {} for channel {} does not match the corner count {corner_count}",
+                    coords.len(),
+                    channel.0
+                )));
+            }
         }
     }
     Ok(())
@@ -397,7 +414,7 @@ mod tests {
         let uv = |side| UvSet {
             theme: Some(theme.clone()),
             side,
-            channel: None,
+            channel: ChannelId::default(),
             uv: UvSource::Explicit(Box::new([])),
         };
         let mut uv_sets = vec![uv(Side::Front), uv(Side::Back)];

--- a/engine/runtime/geometry/src/appearance/mod.rs
+++ b/engine/runtime/geometry/src/appearance/mod.rs
@@ -137,23 +137,55 @@ pub enum FaceBinding {
 }
 
 impl FaceBinding {
+    /// Shift every material index by `offset` into a merged palette, consuming the
+    /// binding. Errors (`"material palette too large"`) if any index overflows
+    /// `u32`. Handles both `Uniform` and `PerFace`, so it is the single offset
+    /// routine the polygon, triangular-mesh and weld paths share.
+    pub(crate) fn offset(self, offset: u32) -> Result<FaceBinding, Error> {
+        let shift = |index: MaterialIndex| {
+            index
+                .get()
+                .checked_add(offset)
+                .and_then(MaterialIndex::new)
+                .ok_or_else(|| Error::invalid_appearance("material palette too large"))
+        };
+        Ok(match self {
+            FaceBinding::Uniform(index) => FaceBinding::Uniform(shift(index)?),
+            FaceBinding::PerFace(faces) => FaceBinding::PerFace(
+                faces
+                    .into_iter()
+                    .map(|opt| opt.map(shift).transpose())
+                    .collect::<Result<_, _>>()?,
+            ),
+        })
+    }
+
     /// Mark every palette index this binding references in `referenced`.
+    ///
+    /// An index past the palette can only arrive from an appearance installed
+    /// through the unvalidated `appearance_mut` escape hatch; it references no
+    /// real material, so it is skipped rather than indexed (which would panic).
     fn mark_referenced(&self, referenced: &mut [bool]) {
-        match self {
-            FaceBinding::Uniform(index) => referenced[index.get() as usize] = true,
-            FaceBinding::PerFace(faces) => {
-                for index in faces.iter().flatten() {
-                    referenced[index.get() as usize] = true;
-                }
+        let mut mark = |index: &MaterialIndex| {
+            if let Some(slot) = referenced.get_mut(index.get() as usize) {
+                *slot = true;
             }
+        };
+        match self {
+            FaceBinding::Uniform(index) => mark(index),
+            FaceBinding::PerFace(faces) => faces.iter().flatten().for_each(mark),
         }
     }
 
     /// Reindex every palette index through `remap` (old index → compacted index).
     /// Only indices previously marked by [`mark_referenced`] are looked up.
     fn reindex(&mut self, remap: &[Option<MaterialIndex>]) {
-        let map = |index: MaterialIndex| {
-            remap[index.get() as usize].expect("a referenced material survives compaction")
+        let map = |index: MaterialIndex| match remap.get(index.get() as usize) {
+            // In range: it was marked referenced, so it has a compacted slot.
+            Some(slot) => slot.expect("a referenced material survives compaction"),
+            // Out of range (malformed appearance, see `mark_referenced`): nothing
+            // to remap to, so leave the dangling index untouched rather than panic.
+            None => index,
         };
         match self {
             FaceBinding::Uniform(index) => *index = map(*index),
@@ -198,6 +230,51 @@ impl Appearance {
             }
         }
     }
+}
+
+/// Append one theme's already-validated appearance to a geometry's accumulated
+/// `appearance` / `uv_sets`. `front` / `back` index `materials` locally; they are
+/// offset into the running palette here. Shared by the polygon and triangular-mesh
+/// setters so the palette bookkeeping lives in one place.
+///
+/// Additive and atomic: errors — leaving both `appearance` and `uv_sets` untouched
+/// — if `theme` is already set or a local index overflows the merged palette. The
+/// first theme appended becomes the default. The caller validates the bindings and
+/// UV before calling (the two setters validate in different ways).
+pub(crate) fn append_theme(
+    appearance: &mut Option<Appearance>,
+    uv_sets: &mut Vec<UvSet>,
+    theme: ThemeId,
+    materials: Vec<Material>,
+    front: FaceBinding,
+    back: Option<FaceBinding>,
+    new_uv_sets: Vec<UvSet>,
+) -> Result<(), Error> {
+    if let Some(app) = appearance.as_ref() {
+        if app.themes.iter().any(|b| b.theme == theme) {
+            return Err(Error::invalid_appearance(format!(
+                "theme `{}` is already set",
+                theme.0
+            )));
+        }
+    }
+
+    // Offset before mutating anything, so an overflow leaves the geometry unchanged.
+    let offset = appearance
+        .as_ref()
+        .map_or(0, |app| app.materials.len() as u32);
+    let front = front.offset(offset)?;
+    let back = back.map(|binding| binding.offset(offset)).transpose()?;
+
+    let app = appearance.get_or_insert_with(|| Appearance {
+        materials: Vec::new(),
+        themes: Vec::new(),
+        default_theme: theme.clone(),
+    });
+    app.materials.extend(materials);
+    app.themes.push(ThemeBinding { theme, front, back });
+    uv_sets.extend(new_uv_sets);
+    Ok(())
 }
 
 /// Validate the texture/UV coupling and, for an `Explicit` source, the UV length —
@@ -366,5 +443,39 @@ mod tests {
         assert_eq!(faces[0].map(|i| i.get()), Some(0));
         assert_eq!(faces[1], None);
         assert_eq!(faces[2].map(|i| i.get()), Some(1));
+    }
+
+    #[test]
+    fn offset_overflow_is_rejected_not_panicked() {
+        // A local index shifted by a near-`u32::MAX` palette offset overflows; the
+        // shift must surface "material palette too large", not wrap (release) or
+        // panic (debug) on a bare `index.get() + offset` add.
+        let binding = FaceBinding::Uniform(MaterialIndex::new(2).unwrap());
+        let err = binding.offset(u32::MAX - 1).unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+    }
+
+    #[test]
+    fn compact_materials_tolerates_out_of_range_binding() {
+        let theme = ThemeId(Arc::from("rgb"));
+        // A binding index past the palette can only arrive via the unvalidated
+        // `appearance_mut` escape hatch. Compaction (now run on every `Solid`
+        // shell) must not panic on it.
+        let mut app = Appearance {
+            materials: vec![phong(0.0)],
+            themes: vec![ThemeBinding {
+                theme: theme.clone(),
+                front: FaceBinding::Uniform(MaterialIndex::new(5).unwrap()),
+                back: None,
+            }],
+            default_theme: theme,
+        };
+
+        app.compact_materials();
+
+        // Nothing is referenced in range, so the palette empties; the dangling
+        // index is left untouched rather than remapped or panicked on.
+        assert!(app.materials.is_empty());
+        assert!(matches!(app.themes[0].front, FaceBinding::Uniform(i) if i.get() == 5));
     }
 }

--- a/engine/runtime/geometry/src/appearance/mod.rs
+++ b/engine/runtime/geometry/src/appearance/mod.rs
@@ -206,6 +206,11 @@ impl Appearance {
     /// survivors. Kept materials retain their relative order, so the compacted
     /// palette is a stable subsequence of the original.
     fn compact_materials(&mut self) {
+        // A palette this large (only via `appearance_mut`) can't be reindexed
+        // without truncating `kept.len() as u32`; leave the valid indices as-is.
+        if self.materials.len() > u32::MAX as usize {
+            return;
+        }
         let mut referenced = vec![false; self.materials.len()];
         for binding in &self.themes {
             binding.front.mark_referenced(&mut referenced);
@@ -263,9 +268,11 @@ pub(crate) fn append_theme(
     }
 
     // Offset before mutating anything, so an overflow leaves the geometry unchanged.
-    let offset = appearance
-        .as_ref()
-        .map_or(0, |app| app.materials.len() as u32);
+    let offset = match appearance.as_ref() {
+        Some(app) => u32::try_from(app.materials.len())
+            .map_err(|_| Error::invalid_appearance("material palette too large"))?,
+        None => 0,
+    };
     let front = front.offset(offset)?;
     let back = back.map(|binding| binding.offset(offset)).transpose()?;
 

--- a/engine/runtime/geometry/src/appearance/mod.rs
+++ b/engine/runtime/geometry/src/appearance/mod.rs
@@ -19,9 +19,10 @@ pub use material::{AlphaMode, Material, PbrMaterial, PhongMaterial};
 pub use texture::{Filter, Raster, RasterData, Sampler, Texture, TextureTransform, WrapMode};
 pub use uv::{TexMatrix, UvSet, UvSource};
 
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// A dataset-global, stable theme name. Switching to a theme selects the same
 /// theme across every feature, so this is an identity (a name), not a per-mesh
@@ -33,6 +34,59 @@ pub struct ThemeId(pub Arc<str>);
 /// under one theme and channel 0 under another are different UV sets.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub struct ChannelId(pub u32);
+
+/// An index into [`Appearance::materials`].
+///
+/// A "non-max" `u32`: every value except `u32::MAX` is representable. Reserving
+/// `u32::MAX` lets `Option<MaterialIndex>` reuse that slot as its niche, so
+/// `Option<MaterialIndex>` is **4 bytes**, not the 8 of `Option<u32>`. `None`
+/// is the bare / unbound face in [`FaceBinding::PerFace`]; a palette can never
+/// reach `u32::MAX` entries, so nothing usable is lost.
+///
+/// Stored as `!index` in a [`NonZeroU32`]: `index == u32::MAX` would map to the
+/// forbidden `0`, which is exactly what supplies the niche.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MaterialIndex(NonZeroU32);
+
+impl MaterialIndex {
+    /// Wraps a palette index. Returns `None` iff `index == u32::MAX` (reserved
+    /// as the niche, never a usable index).
+    #[inline]
+    pub const fn new(index: u32) -> Option<Self> {
+        match NonZeroU32::new(!index) {
+            Some(stored) => Some(Self(stored)),
+            None => None,
+        }
+    }
+
+    /// The palette index this refers to.
+    #[inline]
+    pub const fn get(self) -> u32 {
+        !self.0.get()
+    }
+}
+
+impl std::fmt::Debug for MaterialIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MaterialIndex({})", self.get())
+    }
+}
+
+// Serialize as the logical index (a plain number), so the wire form is readable
+// and `Option<MaterialIndex>` round-trips through `null` / number.
+impl Serialize for MaterialIndex {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.get().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for MaterialIndex {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let index = u32::deserialize(deserializer)?;
+        Self::new(index)
+            .ok_or_else(|| serde::de::Error::custom("material index u32::MAX is reserved"))
+    }
+}
 
 /// Materials, themes and per-face bindings for a surface geometry.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -72,10 +126,50 @@ pub enum Side {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum FaceBinding {
     /// One material for every face; the common case, and the only form a
-    /// single-material theme or a `Polygon` ever needs. The value indexes the
-    /// material palette.
-    Uniform(u32),
+    /// single-material theme or a `Polygon` ever needs. Indexes the material
+    /// palette.
+    Uniform(MaterialIndex),
     /// Per-face material index; length == face count; `None` = unbound (bare
-    /// face).
-    PerFace(Vec<Option<u32>>),
+    /// face). `Option<MaterialIndex>` is 4 bytes per face (see [`MaterialIndex`]).
+    PerFace(Vec<Option<MaterialIndex>>),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn material_index_round_trips() {
+        for index in [0, 1, 42, u32::MAX - 1] {
+            let mi = MaterialIndex::new(index).expect("non-max index is representable");
+            assert_eq!(mi.get(), index);
+        }
+        assert_eq!(MaterialIndex::new(u32::MAX), None);
+    }
+
+    #[test]
+    fn option_material_index_is_four_bytes() {
+        // The whole point of the non-max niche: `None` (bare face) costs no
+        // extra word, so `PerFace` is 4 bytes/face, not 8.
+        assert_eq!(std::mem::size_of::<Option<MaterialIndex>>(), 4);
+        assert_eq!(std::mem::size_of::<MaterialIndex>(), 4);
+    }
+
+    #[test]
+    fn material_index_serializes_as_plain_number() {
+        let mi = MaterialIndex::new(7).unwrap();
+        assert_eq!(serde_json::to_string(&mi).unwrap(), "7");
+        assert_eq!(serde_json::from_str::<MaterialIndex>("7").unwrap(), mi);
+
+        // bare face -> null, and back
+        let bare: Option<MaterialIndex> = None;
+        assert_eq!(serde_json::to_string(&bare).unwrap(), "null");
+        assert_eq!(
+            serde_json::from_str::<Option<MaterialIndex>>("null").unwrap(),
+            None
+        );
+
+        // the reserved sentinel is rejected on the wire, not silently accepted
+        assert!(serde_json::from_str::<MaterialIndex>("4294967295").is_err());
+    }
 }

--- a/engine/runtime/geometry/src/appearance/uv.rs
+++ b/engine/runtime/geometry/src/appearance/uv.rs
@@ -25,9 +25,10 @@ pub struct UvSet {
     /// Which surface side these coordinates parameterise. `Front` for the
     /// common single-sided case.
     pub side: Side,
-    /// Material-local UV channel; `None` when a theme makes no channel
-    /// distinction (then the theme/side holds exactly one UV set).
-    pub channel: Option<ChannelId>,
+    /// Material-local UV channel a textured map samples (the glTF `texCoord`
+    /// index); `ChannelId(0)` in the common single-map case. A `(theme, side)`
+    /// holds one UV set per distinct channel its materials reference.
+    pub channel: ChannelId,
     pub uv: UvSource,
 }
 

--- a/engine/runtime/geometry/src/appearance/uv.rs
+++ b/engine/runtime/geometry/src/appearance/uv.rs
@@ -37,6 +37,16 @@ pub struct UvSet {
 /// An affine georeferenced map is baked to `Explicit` on read; a projective
 /// world-to-texture matrix is retained, and collapsed to `Explicit` at any
 /// non-affine operation or per-vertex-only sink.
+///
+/// There is deliberately **no per-vertex variant**. A surface's UV is assumed
+/// *affine* in position (a photographic / orthophoto projection onto a planar
+/// face), so it reduces to one `WorldToTexture` matrix — and `Explicit` per-corner
+/// UV is an exact sampling of that matrix, recoverable from 3 `(position, UV)`
+/// pairs. So triangulating a face (earcut / spade) carries the single matrix
+/// instead of a per-vertex array: a Delaunay re-ordering is irrelevant (UV is
+/// positional) and inserted (Steiner) vertices get exact UV by evaluating it.
+/// `Explicit` ⊕ `WorldToTexture` therefore suffices; a *welded multi-face* mesh,
+/// whose faces carry different matrices, bakes them to per-corner `Explicit`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum UvSource {
     /// Flat UV array parallel to the host geometry's corner buffer.

--- a/engine/runtime/geometry/src/error.rs
+++ b/engine/runtime/geometry/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
 
     #[error("Invalid geometry construction: {0}")]
     InvalidGeometry(String),
+
+    #[error("Invalid appearance: {0}")]
+    InvalidAppearance(String),
 }
 
 impl Error {
@@ -28,6 +31,10 @@ impl Error {
     pub fn invalid_geometry<T: ToString>(message: T) -> Self {
         Self::InvalidGeometry(message.to_string())
     }
+
+    pub fn invalid_appearance<T: ToString>(message: T) -> Self {
+        Self::InvalidAppearance(message.to_string())
+    }
 }
 
 // implement Eq and PartialEq for Error so that we can compare errors in tests
@@ -37,6 +44,7 @@ impl PartialEq for Error {
             (Self::MismatchedGeometry(a), Self::MismatchedGeometry(b)) => a == b,
             (Self::Projection(a), Self::Projection(b)) => a == b,
             (Self::InvalidGeometry(a), Self::InvalidGeometry(b)) => a == b,
+            (Self::InvalidAppearance(a), Self::InvalidAppearance(b)) => a == b,
             _ => false,
         }
     }

--- a/engine/runtime/geometry/src/index.rs
+++ b/engine/runtime/geometry/src/index.rs
@@ -164,6 +164,16 @@ impl<const N: usize> IndexBuffer<N> {
         }
     }
 
+    /// The number of `N`-tuples stored (e.g. triangle count for `IndexBuffer<3>`,
+    /// corner count for `IndexBuffer<1>`).
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            IndexBuffer::U8(v) => v.len(),
+            IndexBuffer::U16(v) => v.len(),
+            IndexBuffer::U32(v) => v.len(),
+        }
+    }
+
     /// Build from index elements, choosing the narrowest width that fits them all.
     ///
     /// Width-agnostic: storage starts at `u8` and fattens to `u16` then `u32` only

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -39,6 +39,9 @@ pub mod polygon_mesh;
 pub mod solid;
 pub mod triangular_mesh;
 
+#[cfg(test)]
+mod test_support;
+
 use reearth_flow_common::attribute::Attributes;
 use serde::{Deserialize, Serialize};
 

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -602,7 +602,9 @@ fn push_face(
         });
     }
 
-    let index = MaterialIndex::new(materials.len() as u32)
+    let index = u32::try_from(materials.len())
+        .ok()
+        .and_then(MaterialIndex::new)
         .ok_or_else(|| Error::invalid_appearance("material palette too large"))?;
     materials.push(face.material);
     Ok(FaceBinding::Uniform(index))

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -37,12 +37,18 @@
 //! CSR buffers directly and validate the layout invariants, returning [`Error`] on
 //! violation rather than panicking.
 //!
-//! Constructed polygons are *bare*: no UV sets and no appearance. Attach an
-//! appearance afterwards via [`Polygon2D::appearance_mut`] /
-//! [`Polygon3D::appearance_mut`].
+//! Constructed polygons are *bare*: no UV sets and no appearance. Appearance is
+//! attached afterwards (CityGML binds it by `gml:id` in a later pass than the
+//! geometry) via the validated [`Polygon2D::set_appearance`] /
+//! [`Polygon2D::set_themed_appearance`] setters below — or the raw
+//! [`Polygon2D::appearance_mut`] escape hatch.
 
+use std::collections::HashSet;
 use std::marker::PhantomData;
 
+use crate::appearance::{
+    Appearance, FaceBinding, Material, MaterialIndex, Side, ThemeBinding, ThemeId, UvSet, UvSource,
+};
 use crate::coordinate::Coordinate;
 use crate::error::Error;
 
@@ -407,9 +413,228 @@ fn check_offsets(offsets: &[u32], coords_len: usize) -> Result<(), Error> {
     Ok(())
 }
 
+// ─── Appearance ──────────────────────────────────────────────────────────────
+//
+// Set after construction, not in the builder: CityGML binds appearance by
+// `gml:id` in a later pass than the geometry. The input types encode the
+// polygon's single-face nature — one material per (theme, side) — so the general
+// `FaceBinding` / `MaterialIndex` machinery never reaches the call site, and
+// illegal shapes (several materials on one face, a `PerFace` array) cannot be
+// expressed.
+
+/// One side's shading for a polygon: a single material and the UV its textured
+/// maps sample. `uv` is `None` for a colour-only material (no maps), `Some` for
+/// a textured one — either an `Explicit` array parallel to the polygon's
+/// `coords`, or a retained `WorldToTexture` matrix.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PolygonFace {
+    pub material: Material,
+    pub uv: Option<UvSource>,
+}
+
+/// One theme's appearance for a polygon: the front face and an optional distinct
+/// back face (CityGML `side="+"` / `side="-"`). Single-sided is `back: None`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PolygonTheme {
+    pub theme: ThemeId,
+    pub front: PolygonFace,
+    pub back: Option<PolygonFace>,
+}
+
+impl Polygon2D {
+    /// Attach a single-theme, single-material, front-only appearance — the
+    /// dominant CityGML case (one `ParameterizedTexture` / `X3DMaterial` per
+    /// surface). See [`PolygonFace`] for the `uv` contract. For multiple themes
+    /// or a distinct back side, use [`set_themed_appearance`](Self::set_themed_appearance).
+    ///
+    /// Returns `Err` and leaves the polygon unchanged on any invariant breach.
+    pub fn set_appearance(
+        &mut self,
+        theme: ThemeId,
+        material: Material,
+        uv: Option<UvSource>,
+    ) -> Result<(), Error> {
+        let themes = vec![PolygonTheme {
+            theme: theme.clone(),
+            front: PolygonFace { material, uv },
+            back: None,
+        }];
+        self.set_themed_appearance(themes, theme)
+    }
+
+    /// Attach a multi-theme / two-sided appearance. `default_theme` must name one
+    /// of `themes`. Each face is still a single material — no binding to get
+    /// wrong. Returns `Err` and leaves the polygon unchanged on any invariant
+    /// breach.
+    pub fn set_themed_appearance(
+        &mut self,
+        themes: Vec<PolygonTheme>,
+        default_theme: ThemeId,
+    ) -> Result<(), Error> {
+        let (appearance, uv_sets) = build_appearance(self.coords.len(), themes, default_theme)?;
+        self.appearance = Some(appearance);
+        self.uv_sets = uv_sets;
+        Ok(())
+    }
+}
+
+impl Polygon3D {
+    /// Attach a single-theme, single-material, front-only appearance. See
+    /// [`Polygon2D::set_appearance`].
+    pub fn set_appearance(
+        &mut self,
+        theme: ThemeId,
+        material: Material,
+        uv: Option<UvSource>,
+    ) -> Result<(), Error> {
+        let themes = vec![PolygonTheme {
+            theme: theme.clone(),
+            front: PolygonFace { material, uv },
+            back: None,
+        }];
+        self.set_themed_appearance(themes, theme)
+    }
+
+    /// Attach a multi-theme / two-sided appearance. See
+    /// [`Polygon2D::set_themed_appearance`].
+    pub fn set_themed_appearance(
+        &mut self,
+        themes: Vec<PolygonTheme>,
+        default_theme: ThemeId,
+    ) -> Result<(), Error> {
+        let (appearance, uv_sets) = build_appearance(self.coords.len(), themes, default_theme)?;
+        self.appearance = Some(appearance);
+        self.uv_sets = uv_sets;
+        Ok(())
+    }
+}
+
+/// Assemble and validate the leaf-level `(Appearance, uv_sets)` for a single-face
+/// polygon with `corner_count` coordinates. Shared by the 2D and 3D setters so
+/// the invariants live in one place.
+fn build_appearance(
+    corner_count: usize,
+    themes: Vec<PolygonTheme>,
+    default_theme: ThemeId,
+) -> Result<(Appearance, Vec<UvSet>), Error> {
+    if themes.is_empty() {
+        return Err(Error::invalid_appearance("appearance has no themes"));
+    }
+    if !themes.iter().any(|t| t.theme == default_theme) {
+        return Err(Error::invalid_appearance(format!(
+            "default_theme `{}` is not among the provided themes",
+            default_theme.0
+        )));
+    }
+
+    let mut materials: Vec<Material> = Vec::new();
+    let mut bindings: Vec<ThemeBinding> = Vec::with_capacity(themes.len());
+    let mut uv_sets: Vec<UvSet> = Vec::new();
+    let mut seen: HashSet<ThemeId> = HashSet::with_capacity(themes.len());
+
+    for theme in themes {
+        if !seen.insert(theme.theme.clone()) {
+            return Err(Error::invalid_appearance(format!(
+                "duplicate theme `{}`",
+                theme.theme.0
+            )));
+        }
+        let front = push_face(
+            &mut materials,
+            &mut uv_sets,
+            corner_count,
+            theme.theme.clone(),
+            Side::Front,
+            theme.front,
+        )?;
+        let back = match theme.back {
+            Some(face) => Some(push_face(
+                &mut materials,
+                &mut uv_sets,
+                corner_count,
+                theme.theme.clone(),
+                Side::Back,
+                face,
+            )?),
+            None => None,
+        };
+        bindings.push(ThemeBinding {
+            theme: theme.theme,
+            front,
+            back,
+        });
+    }
+
+    Ok((
+        Appearance {
+            materials,
+            themes: bindings,
+            default_theme,
+        },
+        uv_sets,
+    ))
+}
+
+/// Validate one face, push its material into the palette and (if any) its UV set,
+/// and return the `Uniform` binding pointing at the just-added material.
+fn push_face(
+    materials: &mut Vec<Material>,
+    uv_sets: &mut Vec<UvSet>,
+    corner_count: usize,
+    theme: ThemeId,
+    side: Side,
+    face: PolygonFace,
+) -> Result<FaceBinding, Error> {
+    // Texture/UV coupling: a textured material needs exactly one UV set; a
+    // colour-only material must not carry one (it would be an orphan).
+    match (face.material.has_texture(), &face.uv) {
+        (true, None) => {
+            return Err(Error::invalid_appearance(
+                "material has textured maps but no UV was supplied",
+            ));
+        }
+        (false, Some(_)) => {
+            return Err(Error::invalid_appearance(
+                "material has no textured maps but a UV was supplied (orphan UV)",
+            ));
+        }
+        _ => {}
+    }
+
+    if let Some(uv) = face.uv {
+        if let UvSource::Explicit(ref coords) = uv {
+            if coords.len() != corner_count {
+                return Err(Error::invalid_appearance(format!(
+                    "UV length {} does not match polygon corner count {corner_count}",
+                    coords.len()
+                )));
+            }
+        }
+        uv_sets.push(UvSet {
+            theme: Some(theme),
+            side,
+            channel: None,
+            uv,
+        });
+    }
+
+    let index = MaterialIndex::new(materials.len() as u32)
+        .ok_or_else(|| Error::invalid_appearance("material palette too large"))?;
+    materials.push(face.material);
+    Ok(FaceBinding::Uniform(index))
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use reearth_flow_common::image::MimeType;
+
     use super::*;
+    use crate::appearance::{
+        Filter, PhongMaterial, Raster, RasterData, Sampler, Texture, WrapMode,
+    };
 
     // The exterior is stored verbatim: an open ring is NOT auto-closed, so the
     // first != last data bug survives for a later validation phase.
@@ -586,5 +811,225 @@ mod tests {
             Vec::<Vec<[f64; 3]>>::new(),
         );
         assert_eq!(built, batch);
+    }
+
+    // ── Appearance setters ──
+
+    fn theme(name: &str) -> ThemeId {
+        ThemeId(Arc::from(name))
+    }
+
+    fn sampler() -> Sampler {
+        Sampler {
+            wrap_s: WrapMode::Repeat,
+            wrap_t: WrapMode::Repeat,
+            mag_filter: Filter::Linear,
+            min_filter: Filter::LinearMipmap,
+        }
+    }
+
+    fn texture() -> Texture {
+        Texture {
+            raster: Arc::new(Raster::InMemory(RasterData {
+                mime_type: MimeType::ImagePng,
+                bytes: Bytes::from_static(&[0u8]),
+            })),
+            sampler: sampler(),
+            transform: None,
+            uv_channel: Default::default(),
+        }
+    }
+
+    fn phong(map: Option<Texture>) -> Material {
+        Material::Phong(PhongMaterial {
+            diffuse: [1.0, 1.0, 1.0],
+            specular: [0.0, 0.0, 0.0],
+            emissive: [0.0, 0.0, 0.0],
+            ambient_intensity: 0.0,
+            shininess: 0.0,
+            transparency: 0.0,
+            diffuse_map: map,
+            emissive_map: None,
+            normal_map: None,
+        })
+    }
+
+    fn textured() -> Material {
+        phong(Some(texture()))
+    }
+
+    fn bare() -> Material {
+        phong(None)
+    }
+
+    /// A 3-corner triangle polygon (open ring), so `coords.len() == 3`.
+    fn triangle() -> Polygon3D {
+        Polygon3D::from_rings(
+            Coordinate::Euclidean,
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            Vec::<Vec<[f64; 3]>>::new(),
+        )
+    }
+
+    fn uv(n: usize) -> UvSource {
+        UvSource::Explicit(vec![[0.0, 0.0]; n].into_boxed_slice())
+    }
+
+    #[test]
+    fn textured_material_with_matching_uv_is_accepted() {
+        let mut p = triangle();
+        p.set_appearance(theme("rgb"), textured(), Some(uv(3)))
+            .unwrap();
+
+        let app = p.appearance().as_ref().unwrap();
+        assert_eq!(app.materials.len(), 1);
+        assert_eq!(app.themes.len(), 1);
+        assert_eq!(app.default_theme, theme("rgb"));
+        assert!(matches!(app.themes[0].front, FaceBinding::Uniform(_)));
+        assert!(app.themes[0].back.is_none());
+        assert_eq!(p.uv_sets.len(), 1);
+        assert_eq!(p.uv_sets[0].theme.as_ref(), Some(&theme("rgb")));
+        assert_eq!(p.uv_sets[0].side, Side::Front);
+    }
+
+    #[test]
+    fn bare_material_with_no_uv_is_accepted() {
+        let mut p = triangle();
+        p.set_appearance(theme("rgb"), bare(), None).unwrap();
+        assert_eq!(p.appearance().as_ref().unwrap().materials.len(), 1);
+        assert!(p.uv_sets.is_empty());
+    }
+
+    #[test]
+    fn textured_material_without_uv_is_rejected() {
+        let mut p = triangle();
+        let err = p
+            .set_appearance(theme("rgb"), textured(), None)
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+        assert!(p.appearance().is_none(), "left unchanged on error");
+    }
+
+    #[test]
+    fn bare_material_with_uv_is_rejected() {
+        let mut p = triangle();
+        let err = p
+            .set_appearance(theme("rgb"), bare(), Some(uv(3)))
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+    }
+
+    #[test]
+    fn uv_length_mismatch_is_rejected() {
+        let mut p = triangle();
+        // 4 UVs against a 3-corner polygon.
+        let err = p
+            .set_appearance(theme("rgb"), textured(), Some(uv(4)))
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+    }
+
+    #[test]
+    fn world_to_texture_uv_skips_length_check() {
+        use crate::appearance::TexMatrix;
+        let mut p = triangle();
+        let m = UvSource::WorldToTexture(TexMatrix([[0.0; 4]; 3]));
+        p.set_appearance(theme("rgb"), textured(), Some(m)).unwrap();
+        assert_eq!(p.uv_sets.len(), 1);
+    }
+
+    #[test]
+    fn default_theme_must_be_present() {
+        let mut p = triangle();
+        let themes = vec![PolygonTheme {
+            theme: theme("rgb"),
+            front: PolygonFace {
+                material: bare(),
+                uv: None,
+            },
+            back: None,
+        }];
+        let err = p
+            .set_themed_appearance(themes, theme("infrared"))
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+    }
+
+    #[test]
+    fn duplicate_theme_is_rejected() {
+        let mut p = triangle();
+        let face = || PolygonFace {
+            material: bare(),
+            uv: None,
+        };
+        let themes = vec![
+            PolygonTheme {
+                theme: theme("rgb"),
+                front: face(),
+                back: None,
+            },
+            PolygonTheme {
+                theme: theme("rgb"),
+                front: face(),
+                back: None,
+            },
+        ];
+        let err = p.set_themed_appearance(themes, theme("rgb")).unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+    }
+
+    #[test]
+    fn two_themes_build_a_two_entry_palette() {
+        let mut p = triangle();
+        let themes = vec![
+            PolygonTheme {
+                theme: theme("rgb"),
+                front: PolygonFace {
+                    material: textured(),
+                    uv: Some(uv(3)),
+                },
+                back: None,
+            },
+            PolygonTheme {
+                theme: theme("infrared"),
+                front: PolygonFace {
+                    material: bare(),
+                    uv: None,
+                },
+                back: None,
+            },
+        ];
+        p.set_themed_appearance(themes, theme("rgb")).unwrap();
+
+        let app = p.appearance().as_ref().unwrap();
+        assert_eq!(app.materials.len(), 2);
+        assert_eq!(app.themes.len(), 2);
+        // Only the textured theme contributes a UV set.
+        assert_eq!(p.uv_sets.len(), 1);
+        assert_eq!(p.uv_sets[0].theme.as_ref(), Some(&theme("rgb")));
+    }
+
+    #[test]
+    fn two_sided_theme_binds_both_faces() {
+        let mut p = triangle();
+        let themes = vec![PolygonTheme {
+            theme: theme("rgb"),
+            front: PolygonFace {
+                material: textured(),
+                uv: Some(uv(3)),
+            },
+            back: Some(PolygonFace {
+                material: textured(),
+                uv: Some(uv(3)),
+            }),
+        }];
+        p.set_themed_appearance(themes, theme("rgb")).unwrap();
+
+        let app = p.appearance().as_ref().unwrap();
+        assert_eq!(app.materials.len(), 2);
+        assert!(app.themes[0].back.is_some());
+        assert_eq!(p.uv_sets.len(), 2);
+        let sides: Vec<Side> = p.uv_sets.iter().map(|u| u.side).collect();
+        assert!(sides.contains(&Side::Front) && sides.contains(&Side::Back));
     }
 }

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -45,9 +45,11 @@
 
 use std::marker::PhantomData;
 
+use std::collections::BTreeMap;
+
 use crate::appearance::{
-    append_theme, validate_uv_coupling, Appearance, FaceBinding, Material, MaterialIndex, Side,
-    ThemeId, UvSet, UvSource,
+    append_theme, single_channel_uv, validate_uv_coupling, Appearance, ChannelId, FaceBinding,
+    Material, MaterialIndex, Side, ThemeId, UvSet, UvSource,
 };
 use crate::coordinate::Coordinate;
 use crate::error::Error;
@@ -423,13 +425,24 @@ fn check_offsets(offsets: &[u32], coords_len: usize) -> Result<(), Error> {
 // expressed.
 
 /// One side's shading for a polygon: a single material and the UV its textured
-/// maps sample. `uv` is `None` for a colour-only material (no maps), `Some` for
-/// a textured one — either an `Explicit` array parallel to the polygon's
-/// `coords`, or a retained `WorldToTexture` matrix.
+/// maps sample, one entry per UV channel the material references. `uv` is empty
+/// for a colour-only material (no maps); each entry is an `Explicit` array
+/// parallel to the polygon's `coords`, or a retained `WorldToTexture` matrix.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PolygonFace {
     pub material: Material,
-    pub uv: Option<UvSource>,
+    pub uv: BTreeMap<ChannelId, UvSource>,
+}
+
+impl PolygonFace {
+    /// A face whose textured map (if any) samples the default UV channel — the
+    /// dominant single-`ParameterizedTexture` case.
+    pub fn single(material: Material, uv: Option<UvSource>) -> Self {
+        Self {
+            material,
+            uv: single_channel_uv(uv),
+        }
+    }
 }
 
 impl Polygon2D {
@@ -454,7 +467,7 @@ impl Polygon2D {
             &mut self.appearance,
             &mut self.uv_sets,
             theme,
-            PolygonFace { material, uv },
+            PolygonFace::single(material, uv),
             None,
         )
     }
@@ -493,7 +506,7 @@ impl Polygon3D {
             &mut self.appearance,
             &mut self.uv_sets,
             theme,
-            PolygonFace { material, uv },
+            PolygonFace::single(material, uv),
             None,
         )
     }
@@ -578,13 +591,13 @@ fn push_face(
     side: Side,
     face: PolygonFace,
 ) -> Result<FaceBinding, Error> {
-    validate_uv_coupling(face.material.has_texture(), &face.uv, corner_count)?;
+    validate_uv_coupling(&face.material.referenced_channels(), &face.uv, corner_count)?;
 
-    if let Some(uv) = face.uv {
+    for (channel, uv) in face.uv {
         uv_sets.push(UvSet {
-            theme: Some(theme),
+            theme: Some(theme.clone()),
             side,
-            channel: None,
+            channel,
             uv,
         });
     }
@@ -888,10 +901,7 @@ mod tests {
     #[test]
     fn two_sided_theme_binds_both_faces() {
         let mut p = triangle();
-        let face = || PolygonFace {
-            material: textured(),
-            uv: Some(uv(3)),
-        };
+        let face = || PolygonFace::single(textured(), Some(uv(3)));
         p.set_two_sided_appearance(theme("rgb"), face(), face())
             .unwrap();
 

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -40,14 +40,14 @@
 //! Constructed polygons are *bare*: no UV sets and no appearance. Appearance is
 //! attached afterwards (CityGML binds it by `gml:id` in a later pass than the
 //! geometry) via the validated [`Polygon2D::set_appearance`] /
-//! [`Polygon2D::set_themed_appearance`] setters below — or the raw
+//! [`Polygon2D::set_two_sided_appearance`] setters below — or the raw
 //! [`Polygon2D::appearance_mut`] escape hatch.
 
-use std::collections::HashSet;
 use std::marker::PhantomData;
 
 use crate::appearance::{
-    Appearance, FaceBinding, Material, MaterialIndex, Side, ThemeBinding, ThemeId, UvSet, UvSource,
+    validate_uv_coupling, Appearance, FaceBinding, Material, MaterialIndex, Side, ThemeBinding,
+    ThemeId, UvSet, UvSource,
 };
 use crate::coordinate::Coordinate;
 use crate::error::Error;
@@ -432,49 +432,50 @@ pub struct PolygonFace {
     pub uv: Option<UvSource>,
 }
 
-/// One theme's appearance for a polygon: the front face and an optional distinct
-/// back face (CityGML `side="+"` / `side="-"`). Single-sided is `back: None`.
-#[derive(Clone, Debug, PartialEq)]
-pub struct PolygonTheme {
-    pub theme: ThemeId,
-    pub front: PolygonFace,
-    pub back: Option<PolygonFace>,
-}
-
 impl Polygon2D {
     /// Attach a single-theme, single-material, front-only appearance — the
     /// dominant CityGML case (one `ParameterizedTexture` / `X3DMaterial` per
-    /// surface). See [`PolygonFace`] for the `uv` contract. For multiple themes
-    /// or a distinct back side, use [`set_themed_appearance`](Self::set_themed_appearance).
+    /// surface). See [`PolygonFace`] for the `uv` contract.
     ///
-    /// Returns `Err` and leaves the polygon unchanged on any invariant breach.
+    /// Additive: call once per theme to build a multi-theme appearance; the first
+    /// theme added becomes the default. For a distinct back side use
+    /// [`set_two_sided_appearance`](Self::set_two_sided_appearance).
+    ///
+    /// Returns `Err` (leaving the polygon unchanged) if the theme is already set
+    /// or any invariant is breached.
     pub fn set_appearance(
         &mut self,
         theme: ThemeId,
         material: Material,
         uv: Option<UvSource>,
     ) -> Result<(), Error> {
-        let themes = vec![PolygonTheme {
-            theme: theme.clone(),
-            front: PolygonFace { material, uv },
-            back: None,
-        }];
-        self.set_themed_appearance(themes, theme)
+        add_polygon_theme(
+            self.coords.len(),
+            &mut self.appearance,
+            &mut self.uv_sets,
+            theme,
+            PolygonFace { material, uv },
+            None,
+        )
     }
 
-    /// Attach a multi-theme / two-sided appearance. `default_theme` must name one
-    /// of `themes`. Each face is still a single material — no binding to get
-    /// wrong. Returns `Err` and leaves the polygon unchanged on any invariant
-    /// breach.
-    pub fn set_themed_appearance(
+    /// Attach a two-sided appearance for one theme: a distinct `front` and `back`
+    /// face (CityGML `side="+"` / `side="-"`). Each face is still a single
+    /// material. Additive like [`set_appearance`](Self::set_appearance).
+    pub fn set_two_sided_appearance(
         &mut self,
-        themes: Vec<PolygonTheme>,
-        default_theme: ThemeId,
+        theme: ThemeId,
+        front: PolygonFace,
+        back: PolygonFace,
     ) -> Result<(), Error> {
-        let (appearance, uv_sets) = build_appearance(self.coords.len(), themes, default_theme)?;
-        self.appearance = Some(appearance);
-        self.uv_sets = uv_sets;
-        Ok(())
+        add_polygon_theme(
+            self.coords.len(),
+            &mut self.appearance,
+            &mut self.uv_sets,
+            theme,
+            front,
+            Some(back),
+        )
     }
 }
 
@@ -487,92 +488,114 @@ impl Polygon3D {
         material: Material,
         uv: Option<UvSource>,
     ) -> Result<(), Error> {
-        let themes = vec![PolygonTheme {
-            theme: theme.clone(),
-            front: PolygonFace { material, uv },
-            back: None,
-        }];
-        self.set_themed_appearance(themes, theme)
+        add_polygon_theme(
+            self.coords.len(),
+            &mut self.appearance,
+            &mut self.uv_sets,
+            theme,
+            PolygonFace { material, uv },
+            None,
+        )
     }
 
-    /// Attach a multi-theme / two-sided appearance. See
-    /// [`Polygon2D::set_themed_appearance`].
-    pub fn set_themed_appearance(
+    /// Attach a two-sided appearance for one theme. See
+    /// [`Polygon2D::set_two_sided_appearance`].
+    pub fn set_two_sided_appearance(
         &mut self,
-        themes: Vec<PolygonTheme>,
-        default_theme: ThemeId,
+        theme: ThemeId,
+        front: PolygonFace,
+        back: PolygonFace,
     ) -> Result<(), Error> {
-        let (appearance, uv_sets) = build_appearance(self.coords.len(), themes, default_theme)?;
-        self.appearance = Some(appearance);
-        self.uv_sets = uv_sets;
-        Ok(())
+        add_polygon_theme(
+            self.coords.len(),
+            &mut self.appearance,
+            &mut self.uv_sets,
+            theme,
+            front,
+            Some(back),
+        )
     }
 }
 
-/// Assemble and validate the leaf-level `(Appearance, uv_sets)` for a single-face
-/// polygon with `corner_count` coordinates. Shared by the 2D and 3D setters so
-/// the invariants live in one place.
-fn build_appearance(
+/// Add one theme's appearance to a single-face polygon's `appearance` / `uv_sets`.
+/// `corner_count` is the polygon's coordinate count. The `front` face is required;
+/// `back` adds a distinct back-side material/UV. Shared by the 2D and 3D setters
+/// so the invariants live in one place.
+///
+/// Additive: errors (leaving the polygon unchanged) if `theme` is already set or
+/// any face breaches the material/UV-coupling or UV-length invariants. The first
+/// theme added becomes the default.
+fn add_polygon_theme(
     corner_count: usize,
-    themes: Vec<PolygonTheme>,
-    default_theme: ThemeId,
-) -> Result<(Appearance, Vec<UvSet>), Error> {
-    if themes.is_empty() {
-        return Err(Error::invalid_appearance("appearance has no themes"));
-    }
-    if !themes.iter().any(|t| t.theme == default_theme) {
-        return Err(Error::invalid_appearance(format!(
-            "default_theme `{}` is not among the provided themes",
-            default_theme.0
-        )));
-    }
-
-    let mut materials: Vec<Material> = Vec::new();
-    let mut bindings: Vec<ThemeBinding> = Vec::with_capacity(themes.len());
-    let mut uv_sets: Vec<UvSet> = Vec::new();
-    let mut seen: HashSet<ThemeId> = HashSet::with_capacity(themes.len());
-
-    for theme in themes {
-        if !seen.insert(theme.theme.clone()) {
+    appearance: &mut Option<Appearance>,
+    uv_sets: &mut Vec<UvSet>,
+    theme: ThemeId,
+    front: PolygonFace,
+    back: Option<PolygonFace>,
+) -> Result<(), Error> {
+    if let Some(app) = appearance.as_ref() {
+        if app.themes.iter().any(|b| b.theme == theme) {
             return Err(Error::invalid_appearance(format!(
-                "duplicate theme `{}`",
-                theme.theme.0
+                "theme `{}` is already set",
+                theme.0
             )));
         }
-        let front = push_face(
-            &mut materials,
-            &mut uv_sets,
-            corner_count,
-            theme.theme.clone(),
-            Side::Front,
-            theme.front,
-        )?;
-        let back = match theme.back {
-            Some(face) => Some(push_face(
-                &mut materials,
-                &mut uv_sets,
-                corner_count,
-                theme.theme.clone(),
-                Side::Back,
-                face,
-            )?),
-            None => None,
-        };
-        bindings.push(ThemeBinding {
-            theme: theme.theme,
-            front,
-            back,
-        });
     }
 
-    Ok((
-        Appearance {
-            materials,
-            themes: bindings,
-            default_theme,
-        },
-        uv_sets,
-    ))
+    // Validate both faces into scratch buffers first, so an invalid back face
+    // leaves the polygon untouched (`push_face` mutates as it validates).
+    let mut materials: Vec<Material> = Vec::new();
+    let mut new_uv_sets: Vec<UvSet> = Vec::new();
+    let front_binding = push_face(
+        &mut materials,
+        &mut new_uv_sets,
+        corner_count,
+        theme.clone(),
+        Side::Front,
+        front,
+    )?;
+    let back_binding = match back {
+        Some(face) => Some(push_face(
+            &mut materials,
+            &mut new_uv_sets,
+            corner_count,
+            theme.clone(),
+            Side::Back,
+            face,
+        )?),
+        None => None,
+    };
+
+    // Commit: append into the accumulated palette, offsetting the scratch indices.
+    let app = appearance.get_or_insert_with(|| Appearance {
+        materials: Vec::new(),
+        themes: Vec::new(),
+        default_theme: theme.clone(),
+    });
+    let offset = app.materials.len() as u32;
+    app.materials.extend(materials);
+    let front = offset_uniform(front_binding, offset)?;
+    let back = back_binding
+        .map(|binding| offset_uniform(binding, offset))
+        .transpose()?;
+    app.themes.push(ThemeBinding { theme, front, back });
+    uv_sets.extend(new_uv_sets);
+    Ok(())
+}
+
+/// Shift a single-face polygon's `Uniform` binding by `offset` into the merged
+/// palette. `push_face` only ever yields `Uniform`, so other shapes are
+/// unreachable here.
+fn offset_uniform(binding: FaceBinding, offset: u32) -> Result<FaceBinding, Error> {
+    let FaceBinding::Uniform(index) = binding else {
+        unreachable!("push_face returns a Uniform binding for a single-face polygon");
+    };
+    index
+        .get()
+        .checked_add(offset)
+        .and_then(MaterialIndex::new)
+        .map(FaceBinding::Uniform)
+        .ok_or_else(|| Error::invalid_appearance("material palette too large"))
 }
 
 /// Validate one face, push its material into the palette and (if any) its UV set,
@@ -585,31 +608,9 @@ fn push_face(
     side: Side,
     face: PolygonFace,
 ) -> Result<FaceBinding, Error> {
-    // Texture/UV coupling: a textured material needs exactly one UV set; a
-    // colour-only material must not carry one (it would be an orphan).
-    match (face.material.has_texture(), &face.uv) {
-        (true, None) => {
-            return Err(Error::invalid_appearance(
-                "material has textured maps but no UV was supplied",
-            ));
-        }
-        (false, Some(_)) => {
-            return Err(Error::invalid_appearance(
-                "material has no textured maps but a UV was supplied (orphan UV)",
-            ));
-        }
-        _ => {}
-    }
+    validate_uv_coupling(face.material.has_texture(), &face.uv, corner_count)?;
 
     if let Some(uv) = face.uv {
-        if let UvSource::Explicit(ref coords) = uv {
-            if coords.len() != corner_count {
-                return Err(Error::invalid_appearance(format!(
-                    "UV length {} does not match polygon corner count {corner_count}",
-                    coords.len()
-                )));
-            }
-        }
         uv_sets.push(UvSet {
             theme: Some(theme),
             side,
@@ -626,15 +627,8 @@ fn push_face(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use bytes::Bytes;
-    use reearth_flow_common::image::MimeType;
-
     use super::*;
-    use crate::appearance::{
-        Filter, PhongMaterial, Raster, RasterData, Sampler, Texture, WrapMode,
-    };
+    use crate::test_support::*;
 
     // The exterior is stored verbatim: an open ring is NOT auto-closed, so the
     // first != last data bug survives for a later validation phase.
@@ -815,53 +809,6 @@ mod tests {
 
     // ── Appearance setters ──
 
-    fn theme(name: &str) -> ThemeId {
-        ThemeId(Arc::from(name))
-    }
-
-    fn sampler() -> Sampler {
-        Sampler {
-            wrap_s: WrapMode::Repeat,
-            wrap_t: WrapMode::Repeat,
-            mag_filter: Filter::Linear,
-            min_filter: Filter::LinearMipmap,
-        }
-    }
-
-    fn texture() -> Texture {
-        Texture {
-            raster: Arc::new(Raster::InMemory(RasterData {
-                mime_type: MimeType::ImagePng,
-                bytes: Bytes::from_static(&[0u8]),
-            })),
-            sampler: sampler(),
-            transform: None,
-            uv_channel: Default::default(),
-        }
-    }
-
-    fn phong(map: Option<Texture>) -> Material {
-        Material::Phong(PhongMaterial {
-            diffuse: [1.0, 1.0, 1.0],
-            specular: [0.0, 0.0, 0.0],
-            emissive: [0.0, 0.0, 0.0],
-            ambient_intensity: 0.0,
-            shininess: 0.0,
-            transparency: 0.0,
-            diffuse_map: map,
-            emissive_map: None,
-            normal_map: None,
-        })
-    }
-
-    fn textured() -> Material {
-        phong(Some(texture()))
-    }
-
-    fn bare() -> Material {
-        phong(None)
-    }
-
     /// A 3-corner triangle polygon (open ring), so `coords.len() == 3`.
     fn triangle() -> Polygon3D {
         Polygon3D::from_rings(
@@ -869,10 +816,6 @@ mod tests {
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
             Vec::<Vec<[f64; 3]>>::new(),
         )
-    }
-
-    fn uv(n: usize) -> UvSource {
-        UvSource::Explicit(vec![[0.0, 0.0]; n].into_boxed_slice())
     }
 
     #[test]
@@ -939,67 +882,30 @@ mod tests {
     }
 
     #[test]
-    fn default_theme_must_be_present() {
+    fn first_theme_added_becomes_default() {
         let mut p = triangle();
-        let themes = vec![PolygonTheme {
-            theme: theme("rgb"),
-            front: PolygonFace {
-                material: bare(),
-                uv: None,
-            },
-            back: None,
-        }];
-        let err = p
-            .set_themed_appearance(themes, theme("infrared"))
-            .unwrap_err();
-        assert!(matches!(err, Error::InvalidAppearance(_)));
+        p.set_appearance(theme("infrared"), bare(), None).unwrap();
+        p.set_appearance(theme("rgb"), bare(), None).unwrap();
+
+        let app = p.appearance().as_ref().unwrap();
+        assert_eq!(app.default_theme, theme("infrared"));
+        assert_eq!(app.themes.len(), 2);
     }
 
     #[test]
     fn duplicate_theme_is_rejected() {
         let mut p = triangle();
-        let face = || PolygonFace {
-            material: bare(),
-            uv: None,
-        };
-        let themes = vec![
-            PolygonTheme {
-                theme: theme("rgb"),
-                front: face(),
-                back: None,
-            },
-            PolygonTheme {
-                theme: theme("rgb"),
-                front: face(),
-                back: None,
-            },
-        ];
-        let err = p.set_themed_appearance(themes, theme("rgb")).unwrap_err();
+        p.set_appearance(theme("rgb"), bare(), None).unwrap();
+        let err = p.set_appearance(theme("rgb"), bare(), None).unwrap_err();
         assert!(matches!(err, Error::InvalidAppearance(_)));
     }
 
     #[test]
     fn two_themes_build_a_two_entry_palette() {
         let mut p = triangle();
-        let themes = vec![
-            PolygonTheme {
-                theme: theme("rgb"),
-                front: PolygonFace {
-                    material: textured(),
-                    uv: Some(uv(3)),
-                },
-                back: None,
-            },
-            PolygonTheme {
-                theme: theme("infrared"),
-                front: PolygonFace {
-                    material: bare(),
-                    uv: None,
-                },
-                back: None,
-            },
-        ];
-        p.set_themed_appearance(themes, theme("rgb")).unwrap();
+        p.set_appearance(theme("rgb"), textured(), Some(uv(3)))
+            .unwrap();
+        p.set_appearance(theme("infrared"), bare(), None).unwrap();
 
         let app = p.appearance().as_ref().unwrap();
         assert_eq!(app.materials.len(), 2);
@@ -1012,18 +918,12 @@ mod tests {
     #[test]
     fn two_sided_theme_binds_both_faces() {
         let mut p = triangle();
-        let themes = vec![PolygonTheme {
-            theme: theme("rgb"),
-            front: PolygonFace {
-                material: textured(),
-                uv: Some(uv(3)),
-            },
-            back: Some(PolygonFace {
-                material: textured(),
-                uv: Some(uv(3)),
-            }),
-        }];
-        p.set_themed_appearance(themes, theme("rgb")).unwrap();
+        let face = || PolygonFace {
+            material: textured(),
+            uv: Some(uv(3)),
+        };
+        p.set_two_sided_appearance(theme("rgb"), face(), face())
+            .unwrap();
 
         let app = p.appearance().as_ref().unwrap();
         assert_eq!(app.materials.len(), 2);

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -415,15 +415,6 @@ fn check_offsets(offsets: &[u32], coords_len: usize) -> Result<(), Error> {
     Ok(())
 }
 
-// ─── Appearance ──────────────────────────────────────────────────────────────
-//
-// Set after construction, not in the builder: CityGML binds appearance by
-// `gml:id` in a later pass than the geometry. The input types encode the
-// polygon's single-face nature — one material per (theme, side) — so the general
-// `FaceBinding` / `MaterialIndex` machinery never reaches the call site, and
-// illegal shapes (several materials on one face, a `PerFace` array) cannot be
-// expressed.
-
 /// One side's shading for a polygon: a single material and the UV its textured
 /// maps sample, one entry per UV channel the material references. `uv` is empty
 /// for a colour-only material (no maps); each entry is an `Explicit` array

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -46,7 +46,7 @@
 use std::marker::PhantomData;
 
 use crate::appearance::{
-    validate_uv_coupling, Appearance, FaceBinding, Material, MaterialIndex, Side, ThemeBinding,
+    append_theme, validate_uv_coupling, Appearance, FaceBinding, Material, MaterialIndex, Side,
     ThemeId, UvSet, UvSource,
 };
 use crate::coordinate::Coordinate;
@@ -533,15 +533,6 @@ fn add_polygon_theme(
     front: PolygonFace,
     back: Option<PolygonFace>,
 ) -> Result<(), Error> {
-    if let Some(app) = appearance.as_ref() {
-        if app.themes.iter().any(|b| b.theme == theme) {
-            return Err(Error::invalid_appearance(format!(
-                "theme `{}` is already set",
-                theme.0
-            )));
-        }
-    }
-
     // Validate both faces into scratch buffers first, so an invalid back face
     // leaves the polygon untouched (`push_face` mutates as it validates).
     let mut materials: Vec<Material> = Vec::new();
@@ -566,36 +557,15 @@ fn add_polygon_theme(
         None => None,
     };
 
-    // Commit: append into the accumulated palette, offsetting the scratch indices.
-    let app = appearance.get_or_insert_with(|| Appearance {
-        materials: Vec::new(),
-        themes: Vec::new(),
-        default_theme: theme.clone(),
-    });
-    let offset = app.materials.len() as u32;
-    app.materials.extend(materials);
-    let front = offset_uniform(front_binding, offset)?;
-    let back = back_binding
-        .map(|binding| offset_uniform(binding, offset))
-        .transpose()?;
-    app.themes.push(ThemeBinding { theme, front, back });
-    uv_sets.extend(new_uv_sets);
-    Ok(())
-}
-
-/// Shift a single-face polygon's `Uniform` binding by `offset` into the merged
-/// palette. `push_face` only ever yields `Uniform`, so other shapes are
-/// unreachable here.
-fn offset_uniform(binding: FaceBinding, offset: u32) -> Result<FaceBinding, Error> {
-    let FaceBinding::Uniform(index) = binding else {
-        unreachable!("push_face returns a Uniform binding for a single-face polygon");
-    };
-    index
-        .get()
-        .checked_add(offset)
-        .and_then(MaterialIndex::new)
-        .map(FaceBinding::Uniform)
-        .ok_or_else(|| Error::invalid_appearance("material palette too large"))
+    append_theme(
+        appearance,
+        uv_sets,
+        theme,
+        materials,
+        front_binding,
+        back_binding,
+        new_uv_sets,
+    )
 }
 
 /// Validate one face, push its material into the palette and (if any) its UV set,

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -16,7 +16,7 @@ use crate::coordinate::Coordinate;
 
 mod constructor;
 
-pub use constructor::{state, PolygonBuilder2D, PolygonBuilder3D, PolygonFace, PolygonTheme};
+pub use constructor::{state, PolygonBuilder2D, PolygonBuilder3D, PolygonFace};
 
 /// A planar polygon face in 2D space, with optional per-vertex elevation.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -16,7 +16,7 @@ use crate::coordinate::Coordinate;
 
 mod constructor;
 
-pub use constructor::{state, PolygonBuilder2D, PolygonBuilder3D};
+pub use constructor::{state, PolygonBuilder2D, PolygonBuilder3D, PolygonFace, PolygonTheme};
 
 /// A planar polygon face in 2D space, with optional per-vertex elevation.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -97,6 +97,13 @@ impl Polygon2D {
     pub fn appearance_mut(&mut self) -> &mut Option<Appearance> {
         &mut self.appearance
     }
+
+    /// The UV sets, one per (theme, side, channel); each `Explicit` array is
+    /// parallel to `coords` (exterior then interiors, closed).
+    #[inline]
+    pub fn uv_sets(&self) -> &[UvSet] {
+        &self.uv_sets
+    }
 }
 
 impl Polygon3D {
@@ -138,5 +145,12 @@ impl Polygon3D {
     #[inline]
     pub fn appearance_mut(&mut self) -> &mut Option<Appearance> {
         &mut self.appearance
+    }
+
+    /// The UV sets, one per (theme, side, channel); each `Explicit` array is
+    /// parallel to `coords` (exterior then interiors, closed).
+    #[inline]
+    pub fn uv_sets(&self) -> &[UvSet] {
+        &self.uv_sets
     }
 }

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -28,7 +28,7 @@
 //! bare (attach appearance later via `appearance_mut`); `from_polygons` welds
 //! the constituent polygons' appearance and UV across into the mesh.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::appearance::{
     Appearance, ChannelId, FaceBinding, Material, MaterialIndex, Side, TexMatrix, ThemeBinding,
@@ -477,12 +477,22 @@ fn polygon_uv_corners(polygon: &Polygon3D, source: &UvSource) -> Vec<[f64; 2]> {
 }
 
 /// Bake a `WorldToTexture` projective matrix at a vertex: `(s, t) = (s'/q', t'/q')`.
+///
+/// A vertex on the matrix's vanishing line makes `q` zero (or the products
+/// non-finite), which would otherwise bake `inf`/`NaN` UVs that corrupt texture
+/// sampling and break downstream tile encoders. Such degenerate corners have no
+/// meaningful UV, so they fall back to the texture origin.
 fn bake(matrix: &TexMatrix, [x, y, z]: [f64; 3]) -> [f64; 2] {
     let apply = |row: [f64; 4]| row[0] * x + row[1] * y + row[2] * z + row[3];
     let s = apply(matrix.0[0]);
     let t = apply(matrix.0[1]);
     let q = apply(matrix.0[2]);
-    [s / q, t / q]
+    let (u, v) = (s / q, t / q);
+    if u.is_finite() && v.is_finite() {
+        [u, v]
+    } else {
+        [0.0, 0.0]
+    }
 }
 
 /// The single material a polygon's (single-face) binding resolves to, if bound.
@@ -583,30 +593,48 @@ fn merge_appearance(polygons: &[&Polygon3D]) -> (Vec<UvSet>, Option<Appearance>)
         })
         .collect();
 
-    // UV-set key union (first-seen), then one mesh-wide array per key.
-    let mut keys: Vec<(Option<ThemeId>, Side, Option<ChannelId>)> = Vec::new();
+    // Index each face's UV sets by key once (so the per-key build is a map lookup,
+    // not a linear scan) and precompute each face's corner count (recomputing it
+    // per key would re-walk every ring).
+    type UvKey = (Option<ThemeId>, Side, Option<ChannelId>);
+    let corner_counts: Vec<usize> = kept.iter().map(|p| corner_count(p)).collect();
+    let total_corners: usize = corner_counts.iter().sum();
+    let per_face_uv: Vec<HashMap<UvKey, &UvSource>> = kept
+        .iter()
+        .map(|polygon| {
+            polygon
+                .uv_sets()
+                .iter()
+                .map(|set| ((set.theme.clone(), set.side, set.channel), &set.uv))
+                .collect()
+        })
+        .collect();
+
+    // UV-set key union, in first-seen order.
+    let mut keys: Vec<UvKey> = Vec::new();
+    let mut seen: HashSet<UvKey> = HashSet::new();
     for polygon in &kept {
         for set in polygon.uv_sets() {
             let key = (set.theme.clone(), set.side, set.channel);
-            if !keys.contains(&key) {
+            if seen.insert(key.clone()) {
                 keys.push(key);
             }
         }
     }
+
+    // One mesh-wide UV array per key: each face contributes its corners, or a
+    // zero-filled run where it lacks that key. Reserved to the total up front.
     let uv_sets = keys
         .into_iter()
-        .map(|(theme, side, channel)| {
-            let mut data: Vec<[f64; 2]> = Vec::new();
-            for polygon in &kept {
-                match polygon
-                    .uv_sets()
-                    .iter()
-                    .find(|s| s.theme == theme && s.side == side && s.channel == channel)
-                {
-                    Some(set) => data.extend(polygon_uv_corners(polygon, &set.uv)),
-                    None => data.resize(data.len() + corner_count(polygon), [0.0, 0.0]),
+        .map(|key| {
+            let mut data: Vec<[f64; 2]> = Vec::with_capacity(total_corners);
+            for (i, polygon) in kept.iter().enumerate() {
+                match per_face_uv[i].get(&key).copied() {
+                    Some(uv) => data.extend(polygon_uv_corners(polygon, uv)),
+                    None => data.resize(data.len() + corner_counts[i], [0.0, 0.0]),
                 }
             }
+            let (theme, side, channel) = key;
             UvSet {
                 theme,
                 side,
@@ -628,15 +656,8 @@ fn merge_appearance(polygons: &[&Polygon3D]) -> (Vec<UvSet>, Option<Appearance>)
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use bytes::Bytes;
-    use reearth_flow_common::image::MimeType;
-
     use super::*;
-    use crate::appearance::{
-        Filter, PhongMaterial, Raster, RasterData, Sampler, Texture, WrapMode,
-    };
+    use crate::test_support::*;
 
     fn ones(buf: &IndexBuffer<1>) -> Vec<u32> {
         match buf {
@@ -794,49 +815,6 @@ mod tests {
 
     // ── from_polygons appearance / UV merge ──
 
-    fn theme(name: &str) -> ThemeId {
-        ThemeId(Arc::from(name))
-    }
-
-    fn texture() -> Texture {
-        Texture {
-            raster: Arc::new(Raster::InMemory(RasterData {
-                mime_type: MimeType::ImagePng,
-                bytes: Bytes::from_static(&[0u8]),
-            })),
-            sampler: Sampler {
-                wrap_s: WrapMode::Repeat,
-                wrap_t: WrapMode::Repeat,
-                mag_filter: Filter::Linear,
-                min_filter: Filter::LinearMipmap,
-            },
-            transform: None,
-            uv_channel: Default::default(),
-        }
-    }
-
-    fn textured() -> Material {
-        Material::Phong(PhongMaterial {
-            diffuse: [1.0, 1.0, 1.0],
-            specular: [0.0; 3],
-            emissive: [0.0; 3],
-            ambient_intensity: 0.0,
-            shininess: 0.0,
-            transparency: 0.0,
-            diffuse_map: Some(texture()),
-            emissive_map: None,
-            normal_map: None,
-        })
-    }
-
-    fn explicit(uv: &[[f64; 2]]) -> UvSource {
-        UvSource::Explicit(uv.to_vec().into_boxed_slice())
-    }
-
-    fn unit_quad_uv() -> UvSource {
-        explicit(&[[0., 0.], [1., 0.], [1., 1.], [0., 1.]])
-    }
-
     #[test]
     fn from_polygons_welds_single_textured_face() {
         let mut p = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
@@ -886,7 +864,12 @@ mod tests {
         a.set_appearance(
             theme("rgb"),
             textured(),
-            Some(explicit(&[[0.2, 0.2], [0.4, 0.2], [0.4, 0.4], [0.2, 0.4]])),
+            Some(explicit_uv(&[
+                [0.2, 0.2],
+                [0.4, 0.2],
+                [0.4, 0.4],
+                [0.2, 0.4],
+            ])),
         )
         .unwrap();
         // `b` carries no appearance at all.
@@ -918,7 +901,7 @@ mod tests {
         p.set_appearance(
             theme("rgb"),
             textured(),
-            Some(explicit(&[[0., 0.], [1., 0.], [0., 1.], [0., 0.]])),
+            Some(explicit_uv(&[[0., 0.], [1., 0.], [0., 1.], [0., 0.]])),
         )
         .unwrap();
 

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -24,11 +24,16 @@
 //!
 //! 3D constructors build the coordinate-free [`PolygonMesh3DData`] a
 //! [`Solid`](crate::solid::Solid) shell also stores, so the frame-carrying
-//! [`PolygonMesh3D`] is a thin wrapper. All meshes are built bare (no UV, no
-//! appearance); attach an appearance afterwards via `appearance_mut`.
+//! [`PolygonMesh3D`] is a thin wrapper. `from_parts` / `from_raw_parts` build
+//! bare (attach appearance later via `appearance_mut`); `from_polygons` welds
+//! the constituent polygons' appearance and UV across into the mesh.
 
 use std::collections::HashMap;
 
+use crate::appearance::{
+    Appearance, ChannelId, FaceBinding, Material, MaterialIndex, Side, TexMatrix, ThemeBinding,
+    ThemeId, UvSet, UvSource,
+};
 use crate::coordinate::Coordinate;
 use crate::error::Error;
 use crate::index::{IndexBuffer, IndexWidth};
@@ -40,11 +45,22 @@ impl PolygonMesh3DData {
     /// Build coordinate-free mesh data from independent face polygons, deduplicating
     /// their corners into a shared vertex pool. Each polygon becomes one face
     /// (exterior then holes), stored open.
+    ///
+    /// Appearance and UV are merged across the faces (see [`merge_appearance`]):
+    /// material palettes concatenate, themes union, each face gets a `PerFace`
+    /// binding, and every per-face UV is welded into one mesh-wide array per
+    /// `(theme, side, channel)` — dropping each ring's closing duplicate to match
+    /// the open corner buffer, baking any `WorldToTexture` matrix to explicit
+    /// corners, and zero-filling faces a theme does not cover (their binding is
+    /// `None`, so the filler is never sampled). Bare input (no appearance on any
+    /// polygon) yields a bare mesh.
     pub fn from_polygons<'a>(polygons: impl IntoIterator<Item = &'a Polygon3D>) -> Self {
+        let polygons: Vec<&Polygon3D> = polygons.into_iter().collect();
         let faces = polygons
-            .into_iter()
+            .iter()
             .map(|p| std::iter::once(p.exterior()).chain(p.interiors()));
         let (vertices, face_indices, face_offsets, interior_offsets) = dedup_faces(faces);
+        let (uv_sets, appearance) = merge_appearance(&polygons);
         let (face_indices, face_offsets, interior_offsets) =
             pack_csr(vertices.len(), face_indices, face_offsets, interior_offsets);
         Self {
@@ -52,8 +68,8 @@ impl PolygonMesh3DData {
             face_indices,
             face_offsets,
             interior_offsets,
-            uv_sets: Vec::new(),
-            appearance: None,
+            uv_sets,
+            appearance,
         }
     }
 
@@ -418,9 +434,204 @@ fn split_elevation(vertices: Vec<[f64; 3]>) -> (Vec<[f64; 2]>, Box<[f64]>) {
     (xy, z.into_boxed_slice())
 }
 
+// ─── Appearance merge ─────────────────────────────────────────────────────────
+//
+// `from_polygons` welds each face's per-polygon appearance and UV into the one
+// mesh-wide form. The faces are walked in the same order `dedup_faces` keeps
+// them (input order, empty faces skipped), so the per-corner UV lands 1:1 on the
+// corner buffer.
+
+/// The number of mesh corners a polygon contributes — its rings with each
+/// closing duplicate dropped, matching `dedup_faces` / [`open_ring`]. A face
+/// with zero corners is skipped by `dedup_faces`, so it is dropped here too.
+fn corner_count(polygon: &Polygon3D) -> usize {
+    std::iter::once(polygon.exterior())
+        .chain(polygon.interiors())
+        .map(|ring| open_ring(ring).len())
+        .sum()
+}
+
+/// One polygon's UV reduced to mesh-corner order for a single `UvSource`:
+/// rings concatenated (exterior then interiors), each closing duplicate dropped.
+/// `Explicit` slices the parallel array; `WorldToTexture` bakes the matrix at
+/// each corner vertex.
+fn polygon_uv_corners(polygon: &Polygon3D, source: &UvSource) -> Vec<[f64; 2]> {
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    for ring in std::iter::once(polygon.exterior()).chain(polygon.interiors()) {
+        let open = open_ring(ring);
+        match source {
+            UvSource::Explicit(uv) => out.extend_from_slice(&uv[pos..pos + open.len()]),
+            UvSource::WorldToTexture(matrix) => {
+                out.extend(open.iter().map(|&vertex| bake(matrix, vertex)));
+            }
+        }
+        pos += ring.len();
+    }
+    out
+}
+
+/// Bake a `WorldToTexture` projective matrix at a vertex: `(s, t) = (s'/q', t'/q')`.
+fn bake(matrix: &TexMatrix, [x, y, z]: [f64; 3]) -> [f64; 2] {
+    let apply = |row: [f64; 4]| row[0] * x + row[1] * y + row[2] * z + row[3];
+    let s = apply(matrix.0[0]);
+    let t = apply(matrix.0[1]);
+    let q = apply(matrix.0[2]);
+    [s / q, t / q]
+}
+
+/// The single material a polygon's (single-face) binding resolves to, if bound.
+fn single_face_index(binding: &FaceBinding) -> Option<u32> {
+    match binding {
+        FaceBinding::Uniform(index) => Some(index.get()),
+        FaceBinding::PerFace(faces) => faces.first().copied().flatten().map(|index| index.get()),
+    }
+}
+
+/// Whether a polygon binds a back-side material under `theme`.
+fn has_back(polygon: &Polygon3D, theme: &ThemeId) -> bool {
+    polygon
+        .appearance()
+        .as_ref()
+        .and_then(|app| app.themes.iter().find(|binding| &binding.theme == theme))
+        .is_some_and(|binding| binding.back.is_some())
+}
+
+/// Build a `PerFace` binding for one theme and side over the kept faces, remapping
+/// each polygon's local material index into the merged palette via `offset`.
+fn build_binding(
+    kept: &[&Polygon3D],
+    offset: &[usize],
+    theme: &ThemeId,
+    side: Side,
+) -> FaceBinding {
+    let per_face = kept
+        .iter()
+        .enumerate()
+        .map(|(i, polygon)| -> Option<MaterialIndex> {
+            let app = polygon.appearance().as_ref()?;
+            let binding = app.themes.iter().find(|b| &b.theme == theme)?;
+            let face = match side {
+                Side::Front => &binding.front,
+                Side::Back => binding.back.as_ref()?,
+            };
+            let local = single_face_index(face)?;
+            MaterialIndex::new(offset[i] as u32 + local)
+        })
+        .collect();
+    FaceBinding::PerFace(per_face)
+}
+
+/// Weld the per-polygon appearance and UV of the kept faces into the mesh-wide
+/// `(uv_sets, appearance)`. Returns `(empty, None)` if no face carries appearance.
+fn merge_appearance(polygons: &[&Polygon3D]) -> (Vec<UvSet>, Option<Appearance>) {
+    let kept: Vec<&Polygon3D> = polygons
+        .iter()
+        .copied()
+        .filter(|p| corner_count(p) > 0)
+        .collect();
+
+    if kept.iter().all(|p| p.appearance().is_none()) {
+        return (Vec::new(), None);
+    }
+
+    // Concatenate the material palettes, recording each face's offset for index
+    // remapping; a bare face adds nothing but keeps its slot.
+    let mut materials: Vec<Material> = Vec::new();
+    let mut offset: Vec<usize> = Vec::with_capacity(kept.len());
+    for polygon in &kept {
+        offset.push(materials.len());
+        if let Some(app) = polygon.appearance() {
+            materials.extend(app.materials.iter().cloned());
+        }
+    }
+
+    // Theme union (first-seen) and the active default theme.
+    let mut theme_order: Vec<ThemeId> = Vec::new();
+    for polygon in &kept {
+        if let Some(app) = polygon.appearance() {
+            for binding in &app.themes {
+                if !theme_order.contains(&binding.theme) {
+                    theme_order.push(binding.theme.clone());
+                }
+            }
+        }
+    }
+    let default_theme = kept
+        .iter()
+        .find_map(|p| p.appearance().as_ref().map(|app| app.default_theme.clone()))
+        .expect("a kept face carries appearance");
+
+    let themes: Vec<ThemeBinding> = theme_order
+        .iter()
+        .map(|theme| {
+            let front = build_binding(&kept, &offset, theme, Side::Front);
+            let back = kept
+                .iter()
+                .any(|p| has_back(p, theme))
+                .then(|| build_binding(&kept, &offset, theme, Side::Back));
+            ThemeBinding {
+                theme: theme.clone(),
+                front,
+                back,
+            }
+        })
+        .collect();
+
+    // UV-set key union (first-seen), then one mesh-wide array per key.
+    let mut keys: Vec<(Option<ThemeId>, Side, Option<ChannelId>)> = Vec::new();
+    for polygon in &kept {
+        for set in polygon.uv_sets() {
+            let key = (set.theme.clone(), set.side, set.channel);
+            if !keys.contains(&key) {
+                keys.push(key);
+            }
+        }
+    }
+    let uv_sets = keys
+        .into_iter()
+        .map(|(theme, side, channel)| {
+            let mut data: Vec<[f64; 2]> = Vec::new();
+            for polygon in &kept {
+                match polygon
+                    .uv_sets()
+                    .iter()
+                    .find(|s| s.theme == theme && s.side == side && s.channel == channel)
+                {
+                    Some(set) => data.extend(polygon_uv_corners(polygon, &set.uv)),
+                    None => data.resize(data.len() + corner_count(polygon), [0.0, 0.0]),
+                }
+            }
+            UvSet {
+                theme,
+                side,
+                channel,
+                uv: UvSource::Explicit(data.into_boxed_slice()),
+            }
+        })
+        .collect();
+
+    (
+        uv_sets,
+        Some(Appearance {
+            materials,
+            themes,
+            default_theme,
+        }),
+    )
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use reearth_flow_common::image::MimeType;
+
     use super::*;
+    use crate::appearance::{
+        Filter, PhongMaterial, Raster, RasterData, Sampler, Texture, WrapMode,
+    };
 
     fn ones(buf: &IndexBuffer<1>) -> Vec<u32> {
         match buf {
@@ -574,5 +785,170 @@ mod tests {
             PolygonMesh3DData::from_raw_parts(verts, vec![0, 1, 2, 0, 1, 2], vec![3], vec![3],)
                 .is_err()
         );
+    }
+
+    // ── from_polygons appearance / UV merge ──
+
+    fn theme(name: &str) -> ThemeId {
+        ThemeId(Arc::from(name))
+    }
+
+    fn texture() -> Texture {
+        Texture {
+            raster: Arc::new(Raster::InMemory(RasterData {
+                mime_type: MimeType::ImagePng,
+                bytes: Bytes::from_static(&[0u8]),
+            })),
+            sampler: Sampler {
+                wrap_s: WrapMode::Repeat,
+                wrap_t: WrapMode::Repeat,
+                mag_filter: Filter::Linear,
+                min_filter: Filter::LinearMipmap,
+            },
+            transform: None,
+            uv_channel: Default::default(),
+        }
+    }
+
+    fn textured() -> Material {
+        Material::Phong(PhongMaterial {
+            diffuse: [1.0, 1.0, 1.0],
+            specular: [0.0; 3],
+            emissive: [0.0; 3],
+            ambient_intensity: 0.0,
+            shininess: 0.0,
+            transparency: 0.0,
+            diffuse_map: Some(texture()),
+            emissive_map: None,
+            normal_map: None,
+        })
+    }
+
+    fn explicit(uv: &[[f64; 2]]) -> UvSource {
+        UvSource::Explicit(uv.to_vec().into_boxed_slice())
+    }
+
+    fn unit_quad_uv() -> UvSource {
+        explicit(&[[0., 0.], [1., 0.], [1., 1.], [0., 1.]])
+    }
+
+    #[test]
+    fn from_polygons_welds_single_textured_face() {
+        let mut p = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
+        p.set_appearance(theme("rgb"), textured(), Some(unit_quad_uv()))
+            .unwrap();
+
+        let m = PolygonMesh3DData::from_polygons([&p]);
+        let app = m.appearance.as_ref().unwrap();
+        assert_eq!(app.materials.len(), 1);
+        assert_eq!(app.default_theme, theme("rgb"));
+        let FaceBinding::PerFace(front) = &app.themes[0].front else {
+            panic!("expected PerFace");
+        };
+        assert_eq!(front, &[MaterialIndex::new(0)]);
+        assert!(app.themes[0].back.is_none());
+        let UvSource::Explicit(uv) = &m.uv_sets[0].uv else {
+            panic!("expected Explicit");
+        };
+        assert_eq!(uv.len(), 4);
+    }
+
+    #[test]
+    fn from_polygons_concatenates_two_faces() {
+        let mut a = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
+        a.set_appearance(theme("rgb"), textured(), Some(unit_quad_uv()))
+            .unwrap();
+        let mut b = quad([[2., 0., 0.], [3., 0., 0.], [3., 1., 0.], [2., 1., 0.]]);
+        b.set_appearance(theme("rgb"), textured(), Some(unit_quad_uv()))
+            .unwrap();
+
+        let m = PolygonMesh3DData::from_polygons([&a, &b]);
+        let app = m.appearance.as_ref().unwrap();
+        assert_eq!(app.materials.len(), 2);
+        let FaceBinding::PerFace(front) = &app.themes[0].front else {
+            panic!("expected PerFace");
+        };
+        assert_eq!(front, &[MaterialIndex::new(0), MaterialIndex::new(1)]);
+        let UvSource::Explicit(uv) = &m.uv_sets[0].uv else {
+            panic!("expected Explicit");
+        };
+        assert_eq!(uv.len(), 8);
+    }
+
+    #[test]
+    fn from_polygons_zero_fills_an_uncovered_face() {
+        let mut a = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
+        a.set_appearance(
+            theme("rgb"),
+            textured(),
+            Some(explicit(&[[0.2, 0.2], [0.4, 0.2], [0.4, 0.4], [0.2, 0.4]])),
+        )
+        .unwrap();
+        // `b` carries no appearance at all.
+        let b = quad([[2., 0., 0.], [3., 0., 0.], [3., 1., 0.], [2., 1., 0.]]);
+
+        let m = PolygonMesh3DData::from_polygons([&a, &b]);
+        let app = m.appearance.as_ref().unwrap();
+        assert_eq!(app.materials.len(), 1, "only the textured face contributes");
+        let FaceBinding::PerFace(front) = &app.themes[0].front else {
+            panic!("expected PerFace");
+        };
+        assert_eq!(front, &[MaterialIndex::new(0), None]);
+        let UvSource::Explicit(uv) = &m.uv_sets[0].uv else {
+            panic!("expected Explicit");
+        };
+        assert_eq!(uv.len(), 8);
+        assert_eq!(&uv[0..4], &[[0.2, 0.2], [0.4, 0.2], [0.4, 0.4], [0.2, 0.4]]);
+        assert_eq!(&uv[4..8], &[[0., 0.], [0., 0.], [0., 0.], [0., 0.]]);
+    }
+
+    #[test]
+    fn from_polygons_drops_closing_uv() {
+        // Closed triangle: coords [a, b, c, a] (4); the mesh keeps 3 open corners.
+        let mut p = Polygon3D::from_rings(
+            Coordinate::Euclidean,
+            [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 0.]],
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
+        p.set_appearance(
+            theme("rgb"),
+            textured(),
+            Some(explicit(&[[0., 0.], [1., 0.], [0., 1.], [0., 0.]])),
+        )
+        .unwrap();
+
+        let m = PolygonMesh3DData::from_polygons([&p]);
+        let UvSource::Explicit(uv) = &m.uv_sets[0].uv else {
+            panic!("expected Explicit");
+        };
+        assert_eq!(uv.len(), 3);
+        assert_eq!(&uv[..], &[[0., 0.], [1., 0.], [0., 1.]]);
+    }
+
+    #[test]
+    fn from_polygons_bakes_world_to_texture() {
+        let mut p = quad([[0., 0., 0.], [2., 0., 0.], [2., 3., 0.], [0., 3., 0.]]);
+        // s = x, t = y, q = 1  ->  uv = (x, y).
+        let matrix = TexMatrix([[1., 0., 0., 0.], [0., 1., 0., 0.], [0., 0., 0., 1.]]);
+        p.set_appearance(
+            theme("rgb"),
+            textured(),
+            Some(UvSource::WorldToTexture(matrix)),
+        )
+        .unwrap();
+
+        let m = PolygonMesh3DData::from_polygons([&p]);
+        let UvSource::Explicit(uv) = &m.uv_sets[0].uv else {
+            panic!("expected baked Explicit");
+        };
+        assert_eq!(&uv[..], &[[0., 0.], [2., 0.], [2., 3.], [0., 3.]]);
+    }
+
+    #[test]
+    fn from_polygons_bare_input_stays_bare() {
+        let a = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
+        let m = PolygonMesh3DData::from_polygons([&a]);
+        assert!(m.appearance.is_none());
+        assert!(m.uv_sets.is_empty());
     }
 }

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -541,7 +541,9 @@ fn build_binding(
                 Side::Back => binding.back.as_ref()?,
             };
             let local = single_face_index(face)?;
-            MaterialIndex::new(offset[i] as u32 + local)
+            // Overflow (only from an oversized palette) falls through to an unbound face.
+            let merged = u32::try_from(offset[i]).ok()?.checked_add(local)?;
+            MaterialIndex::new(merged)
         })
         .collect();
     FaceBinding::PerFace(per_face)

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -450,13 +450,6 @@ fn pack_csr(
     )
 }
 
-// ─── Appearance merge ─────────────────────────────────────────────────────────
-//
-// `from_polygons` welds each face's per-polygon appearance and UV into the one
-// mesh-wide form. The faces are walked in the same order `dedup_faces` keeps
-// them (input order, empty faces skipped), so the per-corner UV lands 1:1 on the
-// corner buffer.
-
 /// The number of mesh corners a polygon contributes — its rings with each
 /// closing duplicate dropped, matching `dedup_faces` / [`open_ring`]. A face
 /// with zero corners is skipped by `dedup_faces`, so it is dropped here too.

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -467,12 +467,12 @@ fn corner_count(polygon: &Polygon3D) -> usize {
         .sum()
 }
 
-/// One polygon's UV reduced to mesh-corner order for a single `UvSource`:
-/// rings concatenated (exterior then interiors), each closing duplicate dropped.
-/// `Explicit` slices the parallel array; `WorldToTexture` bakes the matrix at
-/// each corner vertex.
-fn polygon_uv_corners(polygon: &Polygon3D, source: &UvSource) -> Vec<[f64; 2]> {
-    let mut out = Vec::new();
+/// Append one polygon's UV in mesh-corner order for a single `UvSource` directly
+/// onto `out`: rings concatenated (exterior then interiors), each closing
+/// duplicate dropped. `Explicit` slices the parallel array; `WorldToTexture` bakes
+/// the matrix at each corner vertex. Writes straight into the caller's reserved
+/// buffer — no per-face temporary.
+fn extend_polygon_uv(out: &mut Vec<[f64; 2]>, polygon: &Polygon3D, source: &UvSource) {
     let mut pos = 0usize;
     for ring in std::iter::once(polygon.exterior()).chain(polygon.interiors()) {
         let open = open_ring(ring);
@@ -484,7 +484,6 @@ fn polygon_uv_corners(polygon: &Polygon3D, source: &UvSource) -> Vec<[f64; 2]> {
         }
         pos += ring.len();
     }
-    out
 }
 
 /// Bake a `WorldToTexture` projective matrix at a vertex: `(s, t) = (s'/q', t'/q')`.
@@ -618,7 +617,7 @@ fn merge_appearance(
     // Index each face's UV sets by key once (so the per-key build is a map lookup,
     // not a linear scan) and precompute each face's corner count (recomputing it
     // per key would re-walk every ring).
-    type UvKey = (Option<ThemeId>, Side, Option<ChannelId>);
+    type UvKey = (Option<ThemeId>, Side, ChannelId);
     let corner_counts: Vec<usize> = kept.iter().map(|p| corner_count(p)).collect();
     let total_corners: usize = corner_counts.iter().sum();
     let per_face_uv: Vec<HashMap<UvKey, &UvSource>> = kept
@@ -652,7 +651,7 @@ fn merge_appearance(
             let mut data: Vec<[f64; 2]> = Vec::with_capacity(total_corners);
             for (i, polygon) in kept.iter().enumerate() {
                 match per_face_uv[i].get(&key).copied() {
-                    Some(uv) => data.extend(polygon_uv_corners(polygon, uv)),
+                    Some(uv) => extend_polygon_uv(&mut data, polygon, uv),
                     None => data.resize(data.len() + corner_counts[i], [0.0, 0.0]),
                 }
             }

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -54,6 +54,11 @@ impl PolygonMesh3DData {
     /// corners, and zero-filling faces a theme does not cover (their binding is
     /// `None`, so the filler is never sampled). Bare input (no appearance on any
     /// polygon) yields a bare mesh.
+    ///
+    /// A welded multi-face mesh's faces carry *different* `WorldToTexture` matrices
+    /// and cannot share one, so any matrix UV is baked to per-corner `Explicit` here
+    /// (a single-surface triangulation keeps its one matrix instead — see
+    /// [`UvSource`]).
     pub fn from_polygons<'a>(polygons: impl IntoIterator<Item = &'a Polygon3D>) -> Self {
         let polygons: Vec<&Polygon3D> = polygons.into_iter().collect();
         let faces = polygons

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -60,12 +60,23 @@ impl PolygonMesh3DData {
     /// (a single-surface triangulation keeps its one matrix instead — see
     /// [`UvSource`]).
     pub fn from_polygons<'a>(polygons: impl IntoIterator<Item = &'a Polygon3D>) -> Self {
+        Self::from_polygons_with_default_theme(polygons, None)
+    }
+
+    /// As [`from_polygons`](Self::from_polygons), but pins the merged mesh's active
+    /// default theme. `default_theme` should name one of the welded themes; `None`
+    /// keeps the auto rule (the shared default when every appearance-carrying face
+    /// agrees on one, otherwise the first kept face's default).
+    pub fn from_polygons_with_default_theme<'a>(
+        polygons: impl IntoIterator<Item = &'a Polygon3D>,
+        default_theme: Option<ThemeId>,
+    ) -> Self {
         let polygons: Vec<&Polygon3D> = polygons.into_iter().collect();
         let faces = polygons
             .iter()
             .map(|p| std::iter::once(p.exterior()).chain(p.interiors()));
         let (vertices, face_indices, face_offsets, interior_offsets) = dedup_faces(faces);
-        let (uv_sets, appearance) = merge_appearance(&polygons);
+        let (uv_sets, appearance) = merge_appearance(&polygons, default_theme);
         let (face_indices, face_offsets, interior_offsets) =
             pack_csr(vertices.len(), face_indices, face_offsets, interior_offsets);
         Self {
@@ -136,6 +147,17 @@ impl PolygonMesh3D {
         coordinate: Coordinate,
         polygons: impl IntoIterator<Item = &'a Polygon3D>,
     ) -> Result<Self, Error> {
+        Self::from_polygons_with_default_theme(coordinate, polygons, None)
+    }
+
+    /// As [`from_polygons`](Self::from_polygons), but pins the merged mesh's active
+    /// default theme; see
+    /// [`PolygonMesh3DData::from_polygons_with_default_theme`].
+    pub fn from_polygons_with_default_theme<'a>(
+        coordinate: Coordinate,
+        polygons: impl IntoIterator<Item = &'a Polygon3D>,
+        default_theme: Option<ThemeId>,
+    ) -> Result<Self, Error> {
         let polygons: Vec<&Polygon3D> = polygons.into_iter().collect();
         for p in &polygons {
             if p.coordinate() != &coordinate {
@@ -146,7 +168,7 @@ impl PolygonMesh3D {
         }
         Ok(Self::new(
             coordinate,
-            PolygonMesh3DData::from_polygons(polygons),
+            PolygonMesh3DData::from_polygons_with_default_theme(polygons, default_theme),
         ))
     }
 
@@ -213,7 +235,14 @@ impl PolygonMesh2D {
         faces: impl IntoIterator<Item = impl IntoIterator<Item = u32>>,
     ) -> Result<Self, Error> {
         let (face_indices, face_offsets) = index_faces(vertices.len(), faces)?;
-        let (xy, z) = split_elevation(vertices);
+        // Split the `[x, y, z]` vertices into the 2D pool and a parallel elevation buffer.
+        let mut xy = Vec::with_capacity(vertices.len());
+        let mut z = Vec::with_capacity(vertices.len());
+        for [x, y, elevation] in vertices {
+            xy.push([x, y]);
+            z.push(elevation);
+        }
+        let z = z.into_boxed_slice();
         let (face_indices, face_offsets, interior_offsets) =
             pack_csr(xy.len(), face_indices, face_offsets, Vec::new());
         Ok(Self {
@@ -257,20 +286,6 @@ impl PolygonMesh2D {
     }
 }
 
-/// Index of `coord` in `vertices`, inserting it (and assigning the next index) on
-/// first sight. Dedup is on exact `f64` bits.
-fn dedup_index<const N: usize>(
-    vertices: &mut Vec<[f64; N]>,
-    seen: &mut HashMap<[u64; N], u32>,
-    coord: [f64; N],
-) -> u32 {
-    *seen.entry(coord.map(f64::to_bits)).or_insert_with(|| {
-        let index = vertices.len() as u32;
-        vertices.push(coord);
-        index
-    })
-}
-
 /// Drop a ring's closing vertex when it duplicates the first, yielding the open
 /// ring (closure is implied by the face / hole boundary in the mesh).
 fn open_ring<const N: usize>(ring: &[[f64; N]]) -> &[[f64; N]] {
@@ -305,7 +320,14 @@ where
             }
             is_exterior = false;
             for &coord in open_ring(ring) {
-                face_indices.push(dedup_index(&mut vertices, &mut seen, coord));
+                // Index of `coord` in the pool, inserting it on first sight; dedup
+                // is on exact `f64` bits.
+                let index = *seen.entry(coord.map(f64::to_bits)).or_insert_with(|| {
+                    let next = vertices.len() as u32;
+                    vertices.push(coord);
+                    next
+                });
+                face_indices.push(index);
             }
         }
         if face_indices.len() == index_start {
@@ -428,17 +450,6 @@ fn pack_csr(
     )
 }
 
-/// Split a 3D vertex buffer into its 2D footprint and a parallel elevation buffer.
-fn split_elevation(vertices: Vec<[f64; 3]>) -> (Vec<[f64; 2]>, Box<[f64]>) {
-    let mut xy = Vec::with_capacity(vertices.len());
-    let mut z = Vec::with_capacity(vertices.len());
-    for [x, y, elevation] in vertices {
-        xy.push([x, y]);
-        z.push(elevation);
-    }
-    (xy, z.into_boxed_slice())
-}
-
 // ─── Appearance merge ─────────────────────────────────────────────────────────
 //
 // `from_polygons` welds each face's per-polygon appearance and UV into the one
@@ -539,7 +550,14 @@ fn build_binding(
 
 /// Weld the per-polygon appearance and UV of the kept faces into the mesh-wide
 /// `(uv_sets, appearance)`. Returns `(empty, None)` if no face carries appearance.
-fn merge_appearance(polygons: &[&Polygon3D]) -> (Vec<UvSet>, Option<Appearance>) {
+///
+/// `default_override` pins the merged mesh's active default theme; `None` keeps
+/// the auto rule (the shared default when every appearance-carrying face agrees,
+/// otherwise the first kept face's default).
+fn merge_appearance(
+    polygons: &[&Polygon3D],
+    default_override: Option<ThemeId>,
+) -> (Vec<UvSet>, Option<Appearance>) {
     let kept: Vec<&Polygon3D> = polygons
         .iter()
         .copied()
@@ -572,10 +590,14 @@ fn merge_appearance(polygons: &[&Polygon3D]) -> (Vec<UvSet>, Option<Appearance>)
             }
         }
     }
-    let default_theme = kept
-        .iter()
-        .find_map(|p| p.appearance().as_ref().map(|app| app.default_theme.clone()))
-        .expect("a kept face carries appearance");
+    // An explicit override wins; otherwise take the first kept face's default,
+    // which equals the shared default when every face agrees on one (rule 1) and
+    // is the documented fallback when they diverge (rule 2).
+    let default_theme = default_override.unwrap_or_else(|| {
+        kept.iter()
+            .find_map(|p| p.appearance().as_ref().map(|app| app.default_theme.clone()))
+            .expect("a kept face carries appearance")
+    });
 
     let themes: Vec<ThemeBinding> = theme_order
         .iter()
@@ -856,6 +878,31 @@ mod tests {
             panic!("expected Explicit");
         };
         assert_eq!(uv.len(), 8);
+    }
+
+    #[test]
+    fn from_polygons_resolves_default_theme() {
+        // `a` defaults to "rgb", `b` to "infrared" — the faces diverge.
+        let mut a = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
+        a.set_appearance(theme("rgb"), bare(), None).unwrap();
+        let mut b = quad([[2., 0., 0.], [3., 0., 0.], [3., 1., 0.], [2., 1., 0.]]);
+        b.set_appearance(theme("infrared"), bare(), None).unwrap();
+
+        // Auto, diverging: falls back to the first kept face's default (rule 2).
+        let m = PolygonMesh3DData::from_polygons([&a, &b]);
+        assert_eq!(m.appearance.as_ref().unwrap().default_theme, theme("rgb"));
+
+        // Auto, uniform: every face agrees, so that shared default is chosen (rule 1).
+        let m = PolygonMesh3DData::from_polygons([&a, &a]);
+        assert_eq!(m.appearance.as_ref().unwrap().default_theme, theme("rgb"));
+
+        // Explicit override pins the active theme regardless of the faces.
+        let m =
+            PolygonMesh3DData::from_polygons_with_default_theme([&a, &b], Some(theme("infrared")));
+        assert_eq!(
+            m.appearance.as_ref().unwrap().default_theme,
+            theme("infrared")
+        );
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -12,7 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::appearance::{Appearance, UvSet};
+use crate::appearance::{Appearance, Side, UvSet};
 use crate::coordinate::Coordinate;
 use crate::index::IndexBuffer;
 
@@ -112,5 +112,92 @@ impl PolygonMesh3D {
     #[inline]
     pub fn appearance_mut(&mut self) -> &mut Option<Appearance> {
         &mut self.data.appearance
+    }
+}
+
+impl PolygonMesh3DData {
+    /// Drop all back-side appearance — back face→material bindings and any
+    /// `Side::Back` UV sets — keeping only the front. A [`Solid`](crate::solid::Solid)
+    /// shell's back face is the solid's interior (or the inside of a void), which
+    /// is never rendered, so back textures are meaningless there; `Solid`
+    /// construction calls this on every shell.
+    pub(crate) fn make_front_only(&mut self) {
+        if let Some(appearance) = &mut self.appearance {
+            for binding in &mut appearance.themes {
+                binding.back = None;
+            }
+        }
+        self.uv_sets.retain(|uv| uv.side != Side::Back);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::appearance::{
+        FaceBinding, Material, MaterialIndex, PhongMaterial, ThemeBinding, ThemeId, UvSource,
+    };
+
+    fn bare_phong() -> Material {
+        Material::Phong(PhongMaterial {
+            diffuse: [1.0, 1.0, 1.0],
+            specular: [0.0, 0.0, 0.0],
+            emissive: [0.0, 0.0, 0.0],
+            ambient_intensity: 0.0,
+            shininess: 0.0,
+            transparency: 0.0,
+            diffuse_map: None,
+            emissive_map: None,
+            normal_map: None,
+        })
+    }
+
+    fn uv(side: Side) -> UvSet {
+        UvSet {
+            theme: Some(ThemeId(Arc::from("t"))),
+            side,
+            channel: None,
+            uv: UvSource::Explicit(Box::new([])),
+        }
+    }
+
+    #[test]
+    fn make_front_only_drops_back_binding_and_uv() {
+        let mut m = PolygonMesh3DData::from_parts(
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [[0u32, 1, 2]],
+        )
+        .unwrap();
+        m.appearance = Some(Appearance {
+            materials: vec![bare_phong(), bare_phong()],
+            themes: vec![ThemeBinding {
+                theme: ThemeId(Arc::from("t")),
+                front: FaceBinding::Uniform(MaterialIndex::new(0).unwrap()),
+                back: Some(FaceBinding::Uniform(MaterialIndex::new(1).unwrap())),
+            }],
+            default_theme: ThemeId(Arc::from("t")),
+        });
+        m.uv_sets = vec![uv(Side::Front), uv(Side::Back)];
+
+        m.make_front_only();
+
+        assert!(m.appearance.as_ref().unwrap().themes[0].back.is_none());
+        assert_eq!(m.uv_sets.len(), 1);
+        assert_eq!(m.uv_sets[0].side, Side::Front);
+    }
+
+    #[test]
+    fn make_front_only_is_a_noop_when_already_front() {
+        let mut m = PolygonMesh3DData::from_parts(
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [[0u32, 1, 2]],
+        )
+        .unwrap();
+        m.uv_sets = vec![uv(Side::Front)];
+        m.make_front_only();
+        assert_eq!(m.uv_sets.len(), 1);
+        assert!(m.appearance.is_none());
     }
 }

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -128,14 +128,16 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::appearance::{FaceBinding, MaterialIndex, Side, ThemeBinding, ThemeId, UvSource};
+    use crate::appearance::{
+        ChannelId, FaceBinding, MaterialIndex, Side, ThemeBinding, ThemeId, UvSource,
+    };
     use crate::test_support::bare;
 
     fn uv(side: Side) -> UvSet {
         UvSet {
             theme: Some(ThemeId(Arc::from("t"))),
             side,
-            channel: None,
+            channel: ChannelId::default(),
             uv: UvSource::Explicit(Box::new([])),
         }
     }

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -12,7 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::appearance::{Appearance, Side, UvSet};
+use crate::appearance::{Appearance, UvSet};
 use crate::coordinate::Coordinate;
 use crate::index::IndexBuffer;
 
@@ -116,18 +116,10 @@ impl PolygonMesh3D {
 }
 
 impl PolygonMesh3DData {
-    /// Drop all back-side appearance — back face→material bindings and any
-    /// `Side::Back` UV sets — keeping only the front. A [`Solid`](crate::solid::Solid)
-    /// shell's back face is the solid's interior (or the inside of a void), which
-    /// is never rendered, so back textures are meaningless there; `Solid`
-    /// construction calls this on every shell.
+    /// Drop all back-side appearance, keeping only the front; see
+    /// [`crate::appearance::make_front_only`].
     pub(crate) fn make_front_only(&mut self) {
-        if let Some(appearance) = &mut self.appearance {
-            for binding in &mut appearance.themes {
-                binding.back = None;
-            }
-        }
-        self.uv_sets.retain(|uv| uv.side != Side::Back);
+        crate::appearance::make_front_only(&mut self.appearance, &mut self.uv_sets);
     }
 }
 
@@ -136,23 +128,8 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::appearance::{
-        FaceBinding, Material, MaterialIndex, PhongMaterial, ThemeBinding, ThemeId, UvSource,
-    };
-
-    fn bare_phong() -> Material {
-        Material::Phong(PhongMaterial {
-            diffuse: [1.0, 1.0, 1.0],
-            specular: [0.0, 0.0, 0.0],
-            emissive: [0.0, 0.0, 0.0],
-            ambient_intensity: 0.0,
-            shininess: 0.0,
-            transparency: 0.0,
-            diffuse_map: None,
-            emissive_map: None,
-            normal_map: None,
-        })
-    }
+    use crate::appearance::{FaceBinding, MaterialIndex, Side, ThemeBinding, ThemeId, UvSource};
+    use crate::test_support::bare;
 
     fn uv(side: Side) -> UvSet {
         UvSet {
@@ -171,7 +148,7 @@ mod tests {
         )
         .unwrap();
         m.appearance = Some(Appearance {
-            materials: vec![bare_phong(), bare_phong()],
+            materials: vec![bare(), bare()],
             themes: vec![ThemeBinding {
                 theme: ThemeId(Arc::from("t")),
                 front: FaceBinding::Uniform(MaterialIndex::new(0).unwrap()),

--- a/engine/runtime/geometry/src/solid/constructor.rs
+++ b/engine/runtime/geometry/src/solid/constructor.rs
@@ -24,13 +24,39 @@ impl From<TriangularMesh3DData> for Shell {
     }
 }
 
+impl Shell {
+    /// Drop back-side appearance from this shell's mesh, whichever kind it is.
+    /// A solid boundary's back face is never rendered (see
+    /// [`PolygonMesh3DData::make_front_only`](crate::polygon_mesh::PolygonMesh3DData)).
+    fn make_front_only(&mut self) {
+        match self {
+            Shell::PolygonMesh(mesh) => mesh.make_front_only(),
+            Shell::TriangularMesh(mesh) => mesh.make_front_only(),
+        }
+    }
+}
+
 impl Solid {
     /// A solid bounded by `exterior` with the given interior (void) shells, in
     /// `coordinate`.
-    pub fn new(coordinate: Coordinate, exterior: impl Into<Shell>, interiors: Vec<Shell>) -> Self {
+    ///
+    /// Every shell — exterior and interiors — is normalised to **front-side only**:
+    /// a solid's boundary faces are oriented outward (or inward for voids), so the
+    /// back of any boundary is the solid's interior and is never rendered. Any
+    /// back-side appearance a shell mesh carried is dropped here.
+    pub fn new(
+        coordinate: Coordinate,
+        exterior: impl Into<Shell>,
+        mut interiors: Vec<Shell>,
+    ) -> Self {
+        let mut exterior = exterior.into();
+        exterior.make_front_only();
+        for shell in &mut interiors {
+            shell.make_front_only();
+        }
         Self {
             coordinate,
-            exterior: exterior.into(),
+            exterior,
             interiors,
         }
     }

--- a/engine/runtime/geometry/src/test_support.rs
+++ b/engine/runtime/geometry/src/test_support.rs
@@ -1,0 +1,84 @@
+//! Shared appearance test fixtures.
+//!
+//! The polygon, polygon-mesh and triangular-mesh constructor tests all need the
+//! same handful of `Material` / `Texture` / `UvSource` builders. Keeping them in
+//! one place means a new field on `Texture` or `PhongMaterial` is fixed once, not
+//! in three drifting copies.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use reearth_flow_common::image::MimeType;
+
+use crate::appearance::{
+    Filter, Material, PhongMaterial, Raster, RasterData, Sampler, Texture, ThemeId, UvSource,
+    WrapMode,
+};
+
+/// A theme named `name`.
+pub(crate) fn theme(name: &str) -> ThemeId {
+    ThemeId(Arc::from(name))
+}
+
+/// A repeat/linear sampler.
+pub(crate) fn sampler() -> Sampler {
+    Sampler {
+        wrap_s: WrapMode::Repeat,
+        wrap_t: WrapMode::Repeat,
+        mag_filter: Filter::Linear,
+        min_filter: Filter::LinearMipmap,
+    }
+}
+
+/// A 1-byte in-memory PNG texture on the default UV channel.
+pub(crate) fn texture() -> Texture {
+    Texture {
+        raster: Arc::new(Raster::InMemory(RasterData {
+            mime_type: MimeType::ImagePng,
+            bytes: Bytes::from_static(&[0u8]),
+        })),
+        sampler: sampler(),
+        transform: None,
+        uv_channel: Default::default(),
+    }
+}
+
+/// A white Phong material with `map` as its diffuse texture (if any).
+pub(crate) fn phong(map: Option<Texture>) -> Material {
+    Material::Phong(PhongMaterial {
+        diffuse: [1.0, 1.0, 1.0],
+        specular: [0.0; 3],
+        emissive: [0.0; 3],
+        ambient_intensity: 0.0,
+        shininess: 0.0,
+        transparency: 0.0,
+        diffuse_map: map,
+        emissive_map: None,
+        normal_map: None,
+    })
+}
+
+/// A textured material (diffuse map set), which requires a UV set.
+pub(crate) fn textured() -> Material {
+    phong(Some(texture()))
+}
+
+/// A colour-only material (no maps), which must not carry a UV set.
+pub(crate) fn bare() -> Material {
+    phong(None)
+}
+
+/// An `Explicit` UV source from `corners`.
+pub(crate) fn explicit_uv(corners: &[[f64; 2]]) -> UvSource {
+    UvSource::Explicit(corners.to_vec().into_boxed_slice())
+}
+
+/// An `Explicit` UV source of `n` zero corners (the length is what matters).
+pub(crate) fn uv(n: usize) -> UvSource {
+    explicit_uv(&vec![[0.0, 0.0]; n])
+}
+
+/// The four `[0,1]²` corners of a unit quad.
+pub(crate) fn unit_quad_uv() -> UvSource {
+    explicit_uv(&[[0., 0.], [1., 0.], [1., 1.], [0., 1.]])
+}

--- a/engine/runtime/geometry/src/test_support.rs
+++ b/engine/runtime/geometry/src/test_support.rs
@@ -11,8 +11,8 @@ use bytes::Bytes;
 use reearth_flow_common::image::MimeType;
 
 use crate::appearance::{
-    Filter, Material, PhongMaterial, Raster, RasterData, Sampler, Texture, ThemeId, UvSource,
-    WrapMode,
+    ChannelId, Filter, Material, PhongMaterial, Raster, RasterData, Sampler, Texture, ThemeId,
+    UvSource, WrapMode,
 };
 
 /// A theme named `name`.
@@ -61,6 +61,21 @@ pub(crate) fn phong(map: Option<Texture>) -> Material {
 /// A textured material (diffuse map set), which requires a UV set.
 pub(crate) fn textured() -> Material {
     phong(Some(texture()))
+}
+
+/// A genuine multi-UV-channel material: diffuse map on channel `a`, normal map on
+/// channel `b` — so it references two channels and needs a UV set for each.
+pub(crate) fn two_channel(a: u32, b: u32) -> Material {
+    let on = |channel: u32| {
+        let mut t = texture();
+        t.uv_channel = ChannelId(channel);
+        t
+    };
+    let Material::Phong(mut m) = phong(Some(on(a))) else {
+        unreachable!("phong builds a Phong material");
+    };
+    m.normal_map = Some(on(b));
+    Material::Phong(m)
 }
 
 /// A colour-only material (no maps), which must not carry a UV set.

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -318,12 +318,6 @@ impl TriangularMesh2D {
     }
 }
 
-// ─── Appearance ──────────────────────────────────────────────────────────────
-//
-// One theme is added per call (shared by the 2D and 3D setters). UV is per-corner
-// — `3 * triangle_count` entries — and the binding is genuinely multi-face, so a
-// `PerFace` binding carries one material per triangle.
-
 /// Add one theme's appearance to a triangle mesh's `appearance` / `uv_sets`.
 /// `binding` indexes `materials` locally; its indices are offset into the
 /// accumulated palette. Validates the binding shape, the material/UV coupling and

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -23,11 +23,11 @@
 //! [`TriangularMesh3D`] is a thin wrapper. All meshes are built bare (no UV, no
 //! appearance); attach an appearance afterwards via `appearance_mut`.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::appearance::{
-    append_theme, validate_uv_coupling, Appearance, FaceBinding, Material, MaterialIndex, Side,
-    ThemeId, UvSet, UvSource,
+    append_theme, single_channel_uv, validate_uv_coupling, Appearance, ChannelId, FaceBinding,
+    Material, MaterialIndex, Side, ThemeId, UvSet, UvSource,
 };
 use crate::coordinate::Coordinate;
 use crate::error::Error;
@@ -105,20 +105,21 @@ impl TriangularMesh3DData {
         uv: Option<UvSource>,
     ) -> Result<(), Error> {
         let binding = FaceBinding::Uniform(MaterialIndex::new(0).expect("0 is not u32::MAX"));
-        self.set_appearance_with_binding(theme, vec![material], binding, uv)
+        self.set_appearance_with_binding(theme, vec![material], binding, single_channel_uv(uv))
     }
 
     /// Add a multi-material, front-side appearance for one theme with an explicit
     /// per-triangle `binding`. `binding` indexes `materials` locally
     /// (`0..materials.len()`); those indices are offset into the accumulated
-    /// palette. A `PerFace` binding's length must equal the triangle count.
+    /// palette. A `PerFace` binding's length must equal the triangle count. `uvs`
+    /// supplies one UV set per channel the bound materials' maps sample.
     /// Additive and validated like [`set_appearance`](Self::set_appearance).
     pub fn set_appearance_with_binding(
         &mut self,
         theme: ThemeId,
         materials: Vec<Material>,
         binding: FaceBinding,
-        uv: Option<UvSource>,
+        uvs: BTreeMap<ChannelId, UvSource>,
     ) -> Result<(), Error> {
         add_theme(
             self.indices.len(),
@@ -127,7 +128,7 @@ impl TriangularMesh3DData {
             theme,
             materials,
             binding,
-            uv,
+            uvs,
         )
     }
 }
@@ -192,10 +193,10 @@ impl TriangularMesh3D {
         theme: ThemeId,
         materials: Vec<Material>,
         binding: FaceBinding,
-        uv: Option<UvSource>,
+        uvs: BTreeMap<ChannelId, UvSource>,
     ) -> Result<(), Error> {
         self.data
-            .set_appearance_with_binding(theme, materials, binding, uv)
+            .set_appearance_with_binding(theme, materials, binding, uvs)
     }
 }
 
@@ -293,7 +294,7 @@ impl TriangularMesh2D {
         uv: Option<UvSource>,
     ) -> Result<(), Error> {
         let binding = FaceBinding::Uniform(MaterialIndex::new(0).expect("0 is not u32::MAX"));
-        self.set_appearance_with_binding(theme, vec![material], binding, uv)
+        self.set_appearance_with_binding(theme, vec![material], binding, single_channel_uv(uv))
     }
 
     /// Add a multi-material appearance for one theme; see
@@ -303,7 +304,7 @@ impl TriangularMesh2D {
         theme: ThemeId,
         materials: Vec<Material>,
         binding: FaceBinding,
-        uv: Option<UvSource>,
+        uvs: BTreeMap<ChannelId, UvSource>,
     ) -> Result<(), Error> {
         add_theme(
             self.indices.len(),
@@ -312,7 +313,7 @@ impl TriangularMesh2D {
             theme,
             materials,
             binding,
-            uv,
+            uvs,
         )
     }
 }
@@ -335,23 +336,23 @@ fn add_theme(
     theme: ThemeId,
     materials: Vec<Material>,
     binding: FaceBinding,
-    uv: Option<UvSource>,
+    uvs: BTreeMap<ChannelId, UvSource>,
 ) -> Result<(), Error> {
     validate_binding(&binding, materials.len(), triangle_count)?;
     validate_uv_coupling(
-        references_texture(&binding, &materials),
-        &uv,
+        &referenced_channels(&binding, &materials),
+        &uvs,
         triangle_count * 3,
     )?;
 
-    let new_uv_sets = uv
-        .map(|uv| UvSet {
+    let new_uv_sets = uvs
+        .into_iter()
+        .map(|(channel, uv)| UvSet {
             theme: Some(theme.clone()),
             side: Side::Front,
-            channel: None,
+            channel,
             uv,
         })
-        .into_iter()
         .collect();
     append_theme(
         appearance,
@@ -398,17 +399,20 @@ fn validate_binding(
     Ok(())
 }
 
-/// Whether any material the binding references carries a texture (and so needs UV).
-fn references_texture(binding: &FaceBinding, materials: &[Material]) -> bool {
-    let textured = |index: MaterialIndex| {
-        materials
-            .get(index.get() as usize)
-            .is_some_and(Material::has_texture)
+/// The distinct UV channels every material the binding references samples — the
+/// channels a UV set must be supplied for.
+fn referenced_channels(binding: &FaceBinding, materials: &[Material]) -> BTreeSet<ChannelId> {
+    let mut channels = BTreeSet::new();
+    let mut add = |index: MaterialIndex| {
+        if let Some(material) = materials.get(index.get() as usize) {
+            channels.extend(material.referenced_channels());
+        }
     };
     match binding {
-        FaceBinding::Uniform(index) => textured(*index),
-        FaceBinding::PerFace(faces) => faces.iter().flatten().copied().any(textured),
+        FaceBinding::Uniform(index) => add(*index),
+        FaceBinding::PerFace(faces) => faces.iter().flatten().copied().for_each(add),
     }
+    channels
 }
 
 /// Narrowest index width that can address `vertex_count` vertices (largest index
@@ -647,8 +651,13 @@ mod tests {
     fn set_appearance_with_per_face_binding() {
         let mut m = two_triangles();
         let binding = FaceBinding::PerFace(vec![MaterialIndex::new(0), MaterialIndex::new(1)]);
-        m.set_appearance_with_binding(theme("rgb"), vec![textured(), bare()], binding, Some(uv(6)))
-            .unwrap();
+        m.set_appearance_with_binding(
+            theme("rgb"),
+            vec![textured(), bare()],
+            binding,
+            single_channel_uv(Some(uv(6))),
+        )
+        .unwrap();
         let app = m.appearance.as_ref().unwrap();
         assert_eq!(app.materials.len(), 2);
         let FaceBinding::PerFace(faces) = &app.themes[0].front else {
@@ -662,11 +671,59 @@ mod tests {
     }
 
     #[test]
+    fn multi_channel_appearance_keeps_a_uv_set_per_channel() {
+        let mut m = two_triangles();
+        let uvs = BTreeMap::from([(ChannelId(0), uv(6)), (ChannelId(1), uv(6))]);
+        let binding = FaceBinding::Uniform(MaterialIndex::new(0).unwrap());
+        m.set_appearance_with_binding(theme("rgb"), vec![two_channel(0, 1)], binding, uvs)
+            .unwrap();
+
+        // One UV set per referenced channel, each tagged with its channel.
+        assert_eq!(m.uv_sets.len(), 2);
+        let mut channels: Vec<_> = m.uv_sets.iter().map(|s| s.channel).collect();
+        channels.sort();
+        assert_eq!(channels, vec![ChannelId(0), ChannelId(1)]);
+    }
+
+    #[test]
+    fn missing_channel_uv_is_rejected() {
+        let mut m = two_triangles();
+        // Material samples channels 0 and 1, but only channel 0 is supplied.
+        let uvs = BTreeMap::from([(ChannelId(0), uv(6))]);
+        let binding = FaceBinding::Uniform(MaterialIndex::new(0).unwrap());
+        let err = m
+            .set_appearance_with_binding(theme("rgb"), vec![two_channel(0, 1)], binding, uvs)
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+    }
+
+    #[test]
+    fn orphan_channel_uv_is_rejected() {
+        let mut m = two_triangles();
+        // Channel 2 has a UV but no map samples it.
+        let uvs = BTreeMap::from([
+            (ChannelId(0), uv(6)),
+            (ChannelId(1), uv(6)),
+            (ChannelId(2), uv(6)),
+        ]);
+        let binding = FaceBinding::Uniform(MaterialIndex::new(0).unwrap());
+        let err = m
+            .set_appearance_with_binding(theme("rgb"), vec![two_channel(0, 1)], binding, uvs)
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+    }
+
+    #[test]
     fn per_face_binding_length_must_match_triangle_count() {
         let mut m = two_triangles(); // 2 triangles
         let binding = FaceBinding::PerFace(vec![MaterialIndex::new(0)]); // only 1 entry
         let err = m
-            .set_appearance_with_binding(theme("rgb"), vec![textured()], binding, Some(uv(6)))
+            .set_appearance_with_binding(
+                theme("rgb"),
+                vec![textured()],
+                binding,
+                single_channel_uv(Some(uv(6))),
+            )
             .unwrap_err();
         assert!(matches!(err, Error::InvalidAppearance(_)));
     }
@@ -676,7 +733,12 @@ mod tests {
         let mut m = one_triangle();
         let binding = FaceBinding::Uniform(MaterialIndex::new(5).unwrap()); // no such material
         let err = m
-            .set_appearance_with_binding(theme("rgb"), vec![textured()], binding, Some(uv(3)))
+            .set_appearance_with_binding(
+                theme("rgb"),
+                vec![textured()],
+                binding,
+                single_channel_uv(Some(uv(3))),
+            )
             .unwrap_err();
         assert!(matches!(err, Error::InvalidAppearance(_)));
     }

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -26,7 +26,7 @@
 use std::collections::HashMap;
 
 use crate::appearance::{
-    validate_uv_coupling, Appearance, FaceBinding, Material, MaterialIndex, Side, ThemeBinding,
+    append_theme, validate_uv_coupling, Appearance, FaceBinding, Material, MaterialIndex, Side,
     ThemeId, UvSet, UvSource,
 };
 use crate::coordinate::Coordinate;
@@ -229,11 +229,17 @@ impl TriangularMesh2D {
     ) -> Result<Self, Error> {
         let width = index_width_for(vertices.len());
         let triangles = triangles_checked(indices, vertices.len())?;
-        let (xy, z) = split_elevation(vertices);
+        // Split the `[x, y, z]` vertices into the 2D pool and a parallel elevation buffer.
+        let mut xy = Vec::with_capacity(vertices.len());
+        let mut z = Vec::with_capacity(vertices.len());
+        for [x, y, elevation] in vertices {
+            xy.push([x, y]);
+            z.push(elevation);
+        }
         Ok(Self {
             coordinate,
             vertices: xy,
-            z: Some(z),
+            z: Some(z.into_boxed_slice()),
             indices: pack_checked(width, triangles),
             uv_sets: Vec::new(),
             appearance: None,
@@ -331,14 +337,6 @@ fn add_theme(
     binding: FaceBinding,
     uv: Option<UvSource>,
 ) -> Result<(), Error> {
-    if let Some(app) = appearance.as_ref() {
-        if app.themes.iter().any(|b| b.theme == theme) {
-            return Err(Error::invalid_appearance(format!(
-                "theme `{}` is already set",
-                theme.0
-            )));
-        }
-    }
     validate_binding(&binding, materials.len(), triangle_count)?;
     validate_uv_coupling(
         references_texture(&binding, &materials),
@@ -346,28 +344,24 @@ fn add_theme(
         triangle_count * 3,
     )?;
 
-    let app = appearance.get_or_insert_with(|| Appearance {
-        materials: Vec::new(),
-        themes: Vec::new(),
-        default_theme: theme.clone(),
-    });
-    let offset = app.materials.len() as u32;
-    app.materials.extend(materials);
-    let front = offset_binding(binding, offset)?;
-    app.themes.push(ThemeBinding {
-        theme: theme.clone(),
-        front,
-        back: None,
-    });
-    if let Some(uv) = uv {
-        uv_sets.push(UvSet {
-            theme: Some(theme),
+    let new_uv_sets = uv
+        .map(|uv| UvSet {
+            theme: Some(theme.clone()),
             side: Side::Front,
             channel: None,
             uv,
-        });
-    }
-    Ok(())
+        })
+        .into_iter()
+        .collect();
+    append_theme(
+        appearance,
+        uv_sets,
+        theme,
+        materials,
+        binding,
+        None,
+        new_uv_sets,
+    )
 }
 
 /// Check a binding references only `0..palette_len` and, when `PerFace`, has one
@@ -417,23 +411,6 @@ fn references_texture(binding: &FaceBinding, materials: &[Material]) -> bool {
     }
 }
 
-/// Shift a binding's local material indices into the merged palette by `offset`.
-fn offset_binding(binding: FaceBinding, offset: u32) -> Result<FaceBinding, Error> {
-    let shift = |index: MaterialIndex| {
-        MaterialIndex::new(index.get() + offset)
-            .ok_or_else(|| Error::invalid_appearance("material palette too large"))
-    };
-    Ok(match binding {
-        FaceBinding::Uniform(index) => FaceBinding::Uniform(shift(index)?),
-        FaceBinding::PerFace(faces) => FaceBinding::PerFace(
-            faces
-                .into_iter()
-                .map(|opt| opt.map(shift).transpose())
-                .collect::<Result<_, _>>()?,
-        ),
-    })
-}
-
 /// Narrowest index width that can address `vertex_count` vertices (largest index
 /// `vertex_count - 1`); `IndexWidth::U8` for the empty mesh.
 fn index_width_for(vertex_count: usize) -> IndexWidth {
@@ -480,20 +457,6 @@ fn pack_checked(width: IndexWidth, triangles: Vec<[u32; 3]>) -> IndexBuffer<3> {
     IndexBuffer::with_exact_width(width, Some(triangles.len()), triangles)
 }
 
-/// Index of `coord` in `vertices`, inserting it (and assigning the next index) on
-/// first sight. Dedup is on exact `f64` bits.
-fn dedup_index<const N: usize>(
-    vertices: &mut Vec<[f64; N]>,
-    seen: &mut HashMap<[u64; N], u32>,
-    coord: [f64; N],
-) -> u32 {
-    *seen.entry(coord.map(f64::to_bits)).or_insert_with(|| {
-        let index = vertices.len() as u32;
-        vertices.push(coord);
-        index
-    })
-}
-
 /// Deduplicate a flat triangle-corner stream into a vertex pool and a grown index
 /// buffer, shared by the 2D and 3D soup constructors. A trailing partial triangle
 /// is dropped.
@@ -505,29 +468,23 @@ fn soup_buffers<const N: usize>(
     let mut src = iter.into_iter();
     let vertices_ref = &mut vertices;
     let seen_ref = &mut seen;
+    // Index of `coord` in the pool, inserting it on first sight; dedup is on exact
+    // `f64` bits.
+    let mut dedup = move |coord: [f64; N]| {
+        *seen_ref.entry(coord.map(f64::to_bits)).or_insert_with(|| {
+            let index = vertices_ref.len() as u32;
+            vertices_ref.push(coord);
+            index
+        })
+    };
     let triangles = std::iter::from_fn(move || {
         let a = src.next()?;
         let b = src.next()?;
         let c = src.next()?;
-        Some([
-            dedup_index(vertices_ref, seen_ref, a),
-            dedup_index(vertices_ref, seen_ref, b),
-            dedup_index(vertices_ref, seen_ref, c),
-        ])
+        Some([dedup(a), dedup(b), dedup(c)])
     });
     let indices = IndexBuffer::from_indices(triangles);
     (vertices, indices)
-}
-
-/// Split a 3D vertex buffer into its 2D footprint and a parallel elevation buffer.
-fn split_elevation(vertices: Vec<[f64; 3]>) -> (Vec<[f64; 2]>, Box<[f64]>) {
-    let mut xy = Vec::with_capacity(vertices.len());
-    let mut z = Vec::with_capacity(vertices.len());
-    for [x, y, elevation] in vertices {
-        xy.push([x, y]);
-        z.push(elevation);
-    }
-    (xy, z.into_boxed_slice())
 }
 
 #[cfg(test)]

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -25,6 +25,9 @@
 
 use std::collections::HashMap;
 
+use crate::appearance::{
+    Appearance, FaceBinding, Material, MaterialIndex, Side, ThemeBinding, ThemeId, UvSet, UvSource,
+};
 use crate::coordinate::Coordinate;
 use crate::error::Error;
 use crate::index::{IndexBuffer, IndexWidth};
@@ -86,6 +89,46 @@ impl TriangularMesh3DData {
             appearance: None,
         }
     }
+
+    /// Add a single-material, front-side appearance for one theme — a `Uniform`
+    /// binding, so the whole mesh uses `material` under that theme. **Additive**:
+    /// call once per theme to build a multi-theme mesh; the first theme added
+    /// becomes the default. `uv` is required iff `material` is textured (an
+    /// `Explicit` array must have `3 * triangle_count` entries — one per corner),
+    /// and forbidden otherwise. Errors (leaving the mesh unchanged) on a duplicate
+    /// theme or a material / UV / length violation.
+    pub fn set_appearance(
+        &mut self,
+        theme: ThemeId,
+        material: Material,
+        uv: Option<UvSource>,
+    ) -> Result<(), Error> {
+        let binding = FaceBinding::Uniform(MaterialIndex::new(0).expect("0 is not u32::MAX"));
+        self.set_appearance_with_binding(theme, vec![material], binding, uv)
+    }
+
+    /// Add a multi-material, front-side appearance for one theme with an explicit
+    /// per-triangle `binding`. `binding` indexes `materials` locally
+    /// (`0..materials.len()`); those indices are offset into the accumulated
+    /// palette. A `PerFace` binding's length must equal the triangle count.
+    /// Additive and validated like [`set_appearance`](Self::set_appearance).
+    pub fn set_appearance_with_binding(
+        &mut self,
+        theme: ThemeId,
+        materials: Vec<Material>,
+        binding: FaceBinding,
+        uv: Option<UvSource>,
+    ) -> Result<(), Error> {
+        add_theme(
+            self.indices.len(),
+            &mut self.appearance,
+            &mut self.uv_sets,
+            theme,
+            materials,
+            binding,
+            uv,
+        )
+    }
 }
 
 impl TriangularMesh3D {
@@ -128,6 +171,30 @@ impl TriangularMesh3D {
     /// Build from a triangle soup; see [`TriangularMesh3DData::from_soup`].
     pub fn from_soup(coordinate: Coordinate, iter: impl IntoIterator<Item = [f64; 3]>) -> Self {
         Self::new(coordinate, TriangularMesh3DData::from_soup(iter))
+    }
+
+    /// Add a single-material appearance for one theme; see
+    /// [`TriangularMesh3DData::set_appearance`].
+    pub fn set_appearance(
+        &mut self,
+        theme: ThemeId,
+        material: Material,
+        uv: Option<UvSource>,
+    ) -> Result<(), Error> {
+        self.data.set_appearance(theme, material, uv)
+    }
+
+    /// Add a multi-material appearance for one theme; see
+    /// [`TriangularMesh3DData::set_appearance_with_binding`].
+    pub fn set_appearance_with_binding(
+        &mut self,
+        theme: ThemeId,
+        materials: Vec<Material>,
+        binding: FaceBinding,
+        uv: Option<UvSource>,
+    ) -> Result<(), Error> {
+        self.data
+            .set_appearance_with_binding(theme, materials, binding, uv)
     }
 }
 
@@ -209,6 +276,180 @@ impl TriangularMesh2D {
             appearance: None,
         }
     }
+
+    /// Add a single-material appearance for one theme; see
+    /// [`TriangularMesh3DData::set_appearance`].
+    pub fn set_appearance(
+        &mut self,
+        theme: ThemeId,
+        material: Material,
+        uv: Option<UvSource>,
+    ) -> Result<(), Error> {
+        let binding = FaceBinding::Uniform(MaterialIndex::new(0).expect("0 is not u32::MAX"));
+        self.set_appearance_with_binding(theme, vec![material], binding, uv)
+    }
+
+    /// Add a multi-material appearance for one theme; see
+    /// [`TriangularMesh3DData::set_appearance_with_binding`].
+    pub fn set_appearance_with_binding(
+        &mut self,
+        theme: ThemeId,
+        materials: Vec<Material>,
+        binding: FaceBinding,
+        uv: Option<UvSource>,
+    ) -> Result<(), Error> {
+        add_theme(
+            self.indices.len(),
+            &mut self.appearance,
+            &mut self.uv_sets,
+            theme,
+            materials,
+            binding,
+            uv,
+        )
+    }
+}
+
+// ─── Appearance ──────────────────────────────────────────────────────────────
+//
+// One theme is added per call (shared by the 2D and 3D setters). UV is per-corner
+// — `3 * triangle_count` entries — and the binding is genuinely multi-face, so a
+// `PerFace` binding carries one material per triangle.
+
+/// Add one theme's appearance to a triangle mesh's `appearance` / `uv_sets`.
+/// `binding` indexes `materials` locally; its indices are offset into the
+/// accumulated palette. Validates the binding shape, the material/UV coupling and
+/// (for `Explicit`) the UV length against `3 * triangle_count`. On any error the
+/// mesh is left unchanged; on success the first theme added becomes the default.
+fn add_theme(
+    triangle_count: usize,
+    appearance: &mut Option<Appearance>,
+    uv_sets: &mut Vec<UvSet>,
+    theme: ThemeId,
+    materials: Vec<Material>,
+    binding: FaceBinding,
+    uv: Option<UvSource>,
+) -> Result<(), Error> {
+    if let Some(app) = appearance.as_ref() {
+        if app.themes.iter().any(|b| b.theme == theme) {
+            return Err(Error::invalid_appearance(format!(
+                "theme `{}` is already set",
+                theme.0
+            )));
+        }
+    }
+    validate_binding(&binding, materials.len(), triangle_count)?;
+
+    // A textured face needs UV; a colour-only theme must not carry an orphan set.
+    match (references_texture(&binding, &materials), &uv) {
+        (true, None) => {
+            return Err(Error::invalid_appearance(
+                "a bound material is textured but no UV was supplied",
+            ));
+        }
+        (false, Some(_)) => {
+            return Err(Error::invalid_appearance(
+                "no bound material is textured but a UV was supplied (orphan UV)",
+            ));
+        }
+        _ => {}
+    }
+    if let Some(UvSource::Explicit(coords)) = &uv {
+        let corners = triangle_count * 3;
+        if coords.len() != corners {
+            return Err(Error::invalid_appearance(format!(
+                "UV length {} does not match the corner count {corners}",
+                coords.len()
+            )));
+        }
+    }
+
+    let app = appearance.get_or_insert_with(|| Appearance {
+        materials: Vec::new(),
+        themes: Vec::new(),
+        default_theme: theme.clone(),
+    });
+    let offset = app.materials.len() as u32;
+    app.materials.extend(materials);
+    let front = offset_binding(binding, offset)?;
+    app.themes.push(ThemeBinding {
+        theme: theme.clone(),
+        front,
+        back: None,
+    });
+    if let Some(uv) = uv {
+        uv_sets.push(UvSet {
+            theme: Some(theme),
+            side: Side::Front,
+            channel: None,
+            uv,
+        });
+    }
+    Ok(())
+}
+
+/// Check a binding references only `0..palette_len` and, when `PerFace`, has one
+/// entry per triangle.
+fn validate_binding(
+    binding: &FaceBinding,
+    palette_len: usize,
+    triangle_count: usize,
+) -> Result<(), Error> {
+    let in_range = |index: MaterialIndex| (index.get() as usize) < palette_len;
+    match binding {
+        FaceBinding::Uniform(index) => {
+            if !in_range(*index) {
+                return Err(Error::invalid_appearance(format!(
+                    "material index {} is out of range for {palette_len} materials",
+                    index.get()
+                )));
+            }
+        }
+        FaceBinding::PerFace(faces) => {
+            if faces.len() != triangle_count {
+                return Err(Error::invalid_appearance(format!(
+                    "per-face binding length {} does not match the triangle count {triangle_count}",
+                    faces.len()
+                )));
+            }
+            if faces.iter().flatten().any(|index| !in_range(*index)) {
+                return Err(Error::invalid_appearance(format!(
+                    "a per-face material index is out of range for {palette_len} materials"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Whether any material the binding references carries a texture (and so needs UV).
+fn references_texture(binding: &FaceBinding, materials: &[Material]) -> bool {
+    let textured = |index: MaterialIndex| {
+        materials
+            .get(index.get() as usize)
+            .is_some_and(Material::has_texture)
+    };
+    match binding {
+        FaceBinding::Uniform(index) => textured(*index),
+        FaceBinding::PerFace(faces) => faces.iter().flatten().copied().any(textured),
+    }
+}
+
+/// Shift a binding's local material indices into the merged palette by `offset`.
+fn offset_binding(binding: FaceBinding, offset: u32) -> Result<FaceBinding, Error> {
+    let shift = |index: MaterialIndex| {
+        MaterialIndex::new(index.get() + offset)
+            .ok_or_else(|| Error::invalid_appearance("material palette too large"))
+    };
+    Ok(match binding {
+        FaceBinding::Uniform(index) => FaceBinding::Uniform(shift(index)?),
+        FaceBinding::PerFace(faces) => FaceBinding::PerFace(
+            faces
+                .into_iter()
+                .map(|opt| opt.map(shift).transpose())
+                .collect::<Result<_, _>>()?,
+        ),
+    })
 }
 
 /// Narrowest index width that can address `vertex_count` vertices (largest index
@@ -309,7 +550,15 @@ fn split_elevation(vertices: Vec<[f64; 3]>) -> (Vec<[f64; 2]>, Box<[f64]>) {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use reearth_flow_common::image::MimeType;
+
     use super::*;
+    use crate::appearance::{
+        Filter, PhongMaterial, Raster, RasterData, Sampler, Texture, WrapMode,
+    };
 
     fn triples(buf: &IndexBuffer<3>) -> Vec<[u32; 3]> {
         match buf {
@@ -393,5 +642,194 @@ mod tests {
         let unchecked =
             unsafe { TriangularMesh3DData::from_parts_unchecked(verts, 1, [0u32, 1, 2]) };
         assert_eq!(checked, unchecked);
+    }
+
+    // ── Appearance setters ──
+
+    fn theme(name: &str) -> ThemeId {
+        ThemeId(Arc::from(name))
+    }
+
+    fn texture() -> Texture {
+        Texture {
+            raster: Arc::new(Raster::InMemory(RasterData {
+                mime_type: MimeType::ImagePng,
+                bytes: Bytes::from_static(&[0u8]),
+            })),
+            sampler: Sampler {
+                wrap_s: WrapMode::Repeat,
+                wrap_t: WrapMode::Repeat,
+                mag_filter: Filter::Linear,
+                min_filter: Filter::LinearMipmap,
+            },
+            transform: None,
+            uv_channel: Default::default(),
+        }
+    }
+
+    fn phong(map: Option<Texture>) -> Material {
+        Material::Phong(PhongMaterial {
+            diffuse: [1.0, 1.0, 1.0],
+            specular: [0.0; 3],
+            emissive: [0.0; 3],
+            ambient_intensity: 0.0,
+            shininess: 0.0,
+            transparency: 0.0,
+            diffuse_map: map,
+            emissive_map: None,
+            normal_map: None,
+        })
+    }
+
+    fn textured() -> Material {
+        phong(Some(texture()))
+    }
+
+    fn bare() -> Material {
+        phong(None)
+    }
+
+    fn uv(n: usize) -> UvSource {
+        UvSource::Explicit(vec![[0.0, 0.0]; n].into_boxed_slice())
+    }
+
+    /// One triangle (3 corners).
+    fn one_triangle() -> TriangularMesh3DData {
+        TriangularMesh3DData::from_parts(
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap()
+    }
+
+    /// Two triangles (6 corners) over a quad.
+    fn two_triangles() -> TriangularMesh3DData {
+        TriangularMesh3DData::from_parts(
+            vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ],
+            [0u32, 1, 2, 0, 2, 3],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn set_appearance_uniform_textured() {
+        let mut m = one_triangle();
+        m.set_appearance(theme("rgb"), textured(), Some(uv(3)))
+            .unwrap();
+        let app = m.appearance.as_ref().unwrap();
+        assert_eq!(app.materials.len(), 1);
+        assert_eq!(app.default_theme, theme("rgb"));
+        assert!(matches!(app.themes[0].front, FaceBinding::Uniform(_)));
+        assert!(app.themes[0].back.is_none());
+        assert_eq!(m.uv_sets.len(), 1);
+        assert_eq!(m.uv_sets[0].side, Side::Front);
+    }
+
+    #[test]
+    fn set_appearance_uniform_bare_has_no_uv() {
+        let mut m = one_triangle();
+        m.set_appearance(theme("rgb"), bare(), None).unwrap();
+        assert_eq!(m.appearance.as_ref().unwrap().materials.len(), 1);
+        assert!(m.uv_sets.is_empty());
+    }
+
+    #[test]
+    fn set_appearance_textured_without_uv_is_rejected() {
+        let mut m = one_triangle();
+        let err = m
+            .set_appearance(theme("rgb"), textured(), None)
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+        assert!(m.appearance.is_none(), "left unchanged");
+    }
+
+    #[test]
+    fn set_appearance_uv_length_must_match_corner_count() {
+        let mut m = one_triangle();
+        // 3 corners expected, 4 supplied.
+        let err = m
+            .set_appearance(theme("rgb"), textured(), Some(uv(4)))
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+    }
+
+    #[test]
+    fn set_appearance_with_per_face_binding() {
+        let mut m = two_triangles();
+        let binding = FaceBinding::PerFace(vec![MaterialIndex::new(0), MaterialIndex::new(1)]);
+        m.set_appearance_with_binding(theme("rgb"), vec![textured(), bare()], binding, Some(uv(6)))
+            .unwrap();
+        let app = m.appearance.as_ref().unwrap();
+        assert_eq!(app.materials.len(), 2);
+        let FaceBinding::PerFace(faces) = &app.themes[0].front else {
+            panic!("expected PerFace");
+        };
+        assert_eq!(faces, &[MaterialIndex::new(0), MaterialIndex::new(1)]);
+        let UvSource::Explicit(coords) = &m.uv_sets[0].uv else {
+            panic!("expected Explicit");
+        };
+        assert_eq!(coords.len(), 6);
+    }
+
+    #[test]
+    fn per_face_binding_length_must_match_triangle_count() {
+        let mut m = two_triangles(); // 2 triangles
+        let binding = FaceBinding::PerFace(vec![MaterialIndex::new(0)]); // only 1 entry
+        let err = m
+            .set_appearance_with_binding(theme("rgb"), vec![textured()], binding, Some(uv(6)))
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+    }
+
+    #[test]
+    fn binding_index_out_of_range_is_rejected() {
+        let mut m = one_triangle();
+        let binding = FaceBinding::Uniform(MaterialIndex::new(5).unwrap()); // no such material
+        let err = m
+            .set_appearance_with_binding(theme("rgb"), vec![textured()], binding, Some(uv(3)))
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
+    }
+
+    #[test]
+    fn themes_accumulate_one_at_a_time() {
+        let mut m = two_triangles();
+        m.set_appearance(theme("rgb"), textured(), Some(uv(6)))
+            .unwrap();
+        m.set_appearance(theme("infrared"), bare(), None).unwrap();
+
+        let app = m.appearance.as_ref().unwrap();
+        assert_eq!(app.themes.len(), 2);
+        assert_eq!(
+            app.default_theme,
+            theme("rgb"),
+            "first theme is the default"
+        );
+        assert_eq!(app.materials.len(), 2);
+        // The second theme's local index 0 is offset to palette slot 1.
+        let FaceBinding::Uniform(rgb) = app.themes[0].front else {
+            panic!();
+        };
+        let FaceBinding::Uniform(infrared) = app.themes[1].front else {
+            panic!();
+        };
+        assert_eq!(rgb.get(), 0);
+        assert_eq!(infrared.get(), 1);
+        // Only the textured theme contributes a UV set.
+        assert_eq!(m.uv_sets.len(), 1);
+        assert_eq!(m.uv_sets[0].theme.as_ref(), Some(&theme("rgb")));
+    }
+
+    #[test]
+    fn duplicate_theme_is_rejected() {
+        let mut m = one_triangle();
+        m.set_appearance(theme("rgb"), bare(), None).unwrap();
+        let err = m.set_appearance(theme("rgb"), bare(), None).unwrap_err();
+        assert!(matches!(err, Error::InvalidAppearance(_)));
     }
 }

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -26,7 +26,8 @@
 use std::collections::HashMap;
 
 use crate::appearance::{
-    Appearance, FaceBinding, Material, MaterialIndex, Side, ThemeBinding, ThemeId, UvSet, UvSource,
+    validate_uv_coupling, Appearance, FaceBinding, Material, MaterialIndex, Side, ThemeBinding,
+    ThemeId, UvSet, UvSource,
 };
 use crate::coordinate::Coordinate;
 use crate::error::Error;
@@ -339,30 +340,11 @@ fn add_theme(
         }
     }
     validate_binding(&binding, materials.len(), triangle_count)?;
-
-    // A textured face needs UV; a colour-only theme must not carry an orphan set.
-    match (references_texture(&binding, &materials), &uv) {
-        (true, None) => {
-            return Err(Error::invalid_appearance(
-                "a bound material is textured but no UV was supplied",
-            ));
-        }
-        (false, Some(_)) => {
-            return Err(Error::invalid_appearance(
-                "no bound material is textured but a UV was supplied (orphan UV)",
-            ));
-        }
-        _ => {}
-    }
-    if let Some(UvSource::Explicit(coords)) = &uv {
-        let corners = triangle_count * 3;
-        if coords.len() != corners {
-            return Err(Error::invalid_appearance(format!(
-                "UV length {} does not match the corner count {corners}",
-                coords.len()
-            )));
-        }
-    }
+    validate_uv_coupling(
+        references_texture(&binding, &materials),
+        &uv,
+        triangle_count * 3,
+    )?;
 
     let app = appearance.get_or_insert_with(|| Appearance {
         materials: Vec::new(),
@@ -550,15 +532,8 @@ fn split_elevation(vertices: Vec<[f64; 3]>) -> (Vec<[f64; 2]>, Box<[f64]>) {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use bytes::Bytes;
-    use reearth_flow_common::image::MimeType;
-
     use super::*;
-    use crate::appearance::{
-        Filter, PhongMaterial, Raster, RasterData, Sampler, Texture, WrapMode,
-    };
+    use crate::test_support::*;
 
     fn triples(buf: &IndexBuffer<3>) -> Vec<[u32; 3]> {
         match buf {
@@ -645,53 +620,6 @@ mod tests {
     }
 
     // ── Appearance setters ──
-
-    fn theme(name: &str) -> ThemeId {
-        ThemeId(Arc::from(name))
-    }
-
-    fn texture() -> Texture {
-        Texture {
-            raster: Arc::new(Raster::InMemory(RasterData {
-                mime_type: MimeType::ImagePng,
-                bytes: Bytes::from_static(&[0u8]),
-            })),
-            sampler: Sampler {
-                wrap_s: WrapMode::Repeat,
-                wrap_t: WrapMode::Repeat,
-                mag_filter: Filter::Linear,
-                min_filter: Filter::LinearMipmap,
-            },
-            transform: None,
-            uv_channel: Default::default(),
-        }
-    }
-
-    fn phong(map: Option<Texture>) -> Material {
-        Material::Phong(PhongMaterial {
-            diffuse: [1.0, 1.0, 1.0],
-            specular: [0.0; 3],
-            emissive: [0.0; 3],
-            ambient_intensity: 0.0,
-            shininess: 0.0,
-            transparency: 0.0,
-            diffuse_map: map,
-            emissive_map: None,
-            normal_map: None,
-        })
-    }
-
-    fn textured() -> Material {
-        phong(Some(texture()))
-    }
-
-    fn bare() -> Material {
-        phong(None)
-    }
-
-    fn uv(n: usize) -> UvSource {
-        UvSource::Explicit(vec![[0.0, 0.0]; n].into_boxed_slice())
-    }
 
     /// One triangle (3 corners).
     fn one_triangle() -> TriangularMesh3DData {

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::appearance::{Appearance, UvSet};
+use crate::appearance::{Appearance, Side, UvSet};
 use crate::coordinate::Coordinate;
 use crate::index::IndexBuffer;
 
@@ -89,5 +89,79 @@ impl TriangularMesh3D {
     #[inline]
     pub fn appearance_mut(&mut self) -> &mut Option<Appearance> {
         &mut self.data.appearance
+    }
+}
+
+impl TriangularMesh3DData {
+    /// Drop all back-side appearance — back face→material bindings and any
+    /// `Side::Back` UV sets — keeping only the front. A [`Solid`](crate::solid::Solid)
+    /// shell's back face is the solid's interior (or the inside of a void), which
+    /// is never rendered, so back textures are meaningless there; `Solid`
+    /// construction calls this on every shell.
+    pub(crate) fn make_front_only(&mut self) {
+        if let Some(appearance) = &mut self.appearance {
+            for binding in &mut appearance.themes {
+                binding.back = None;
+            }
+        }
+        self.uv_sets.retain(|uv| uv.side != Side::Back);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::appearance::{
+        FaceBinding, Material, MaterialIndex, PhongMaterial, ThemeBinding, ThemeId, UvSource,
+    };
+
+    fn bare_phong() -> Material {
+        Material::Phong(PhongMaterial {
+            diffuse: [1.0, 1.0, 1.0],
+            specular: [0.0, 0.0, 0.0],
+            emissive: [0.0, 0.0, 0.0],
+            ambient_intensity: 0.0,
+            shininess: 0.0,
+            transparency: 0.0,
+            diffuse_map: None,
+            emissive_map: None,
+            normal_map: None,
+        })
+    }
+
+    fn uv(side: Side) -> UvSet {
+        UvSet {
+            theme: Some(ThemeId(Arc::from("t"))),
+            side,
+            channel: None,
+            uv: UvSource::Explicit(Box::new([])),
+        }
+    }
+
+    #[test]
+    fn make_front_only_drops_back_binding_and_uv() {
+        let mut m = TriangularMesh3DData::from_parts(
+            vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap();
+        m.appearance = Some(Appearance {
+            materials: vec![bare_phong(), bare_phong()],
+            themes: vec![ThemeBinding {
+                theme: ThemeId(Arc::from("t")),
+                front: FaceBinding::Uniform(MaterialIndex::new(0).unwrap()),
+                back: Some(FaceBinding::Uniform(MaterialIndex::new(1).unwrap())),
+            }],
+            default_theme: ThemeId(Arc::from("t")),
+        });
+        m.uv_sets = vec![uv(Side::Front), uv(Side::Back)];
+
+        m.make_front_only();
+
+        assert!(m.appearance.as_ref().unwrap().themes[0].back.is_none());
+        assert_eq!(m.uv_sets.len(), 1);
+        assert_eq!(m.uv_sets[0].side, Side::Front);
     }
 }

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -105,14 +105,16 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::appearance::{FaceBinding, MaterialIndex, Side, ThemeBinding, ThemeId, UvSource};
+    use crate::appearance::{
+        ChannelId, FaceBinding, MaterialIndex, Side, ThemeBinding, ThemeId, UvSource,
+    };
     use crate::test_support::bare;
 
     fn uv(side: Side) -> UvSet {
         UvSet {
             theme: Some(ThemeId(Arc::from("t"))),
             side,
-            channel: None,
+            channel: ChannelId::default(),
             uv: UvSource::Explicit(Box::new([])),
         }
     }

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::appearance::{Appearance, Side, UvSet};
+use crate::appearance::{Appearance, UvSet};
 use crate::coordinate::Coordinate;
 use crate::index::IndexBuffer;
 
@@ -93,18 +93,10 @@ impl TriangularMesh3D {
 }
 
 impl TriangularMesh3DData {
-    /// Drop all back-side appearance — back face→material bindings and any
-    /// `Side::Back` UV sets — keeping only the front. A [`Solid`](crate::solid::Solid)
-    /// shell's back face is the solid's interior (or the inside of a void), which
-    /// is never rendered, so back textures are meaningless there; `Solid`
-    /// construction calls this on every shell.
+    /// Drop all back-side appearance, keeping only the front; see
+    /// [`crate::appearance::make_front_only`].
     pub(crate) fn make_front_only(&mut self) {
-        if let Some(appearance) = &mut self.appearance {
-            for binding in &mut appearance.themes {
-                binding.back = None;
-            }
-        }
-        self.uv_sets.retain(|uv| uv.side != Side::Back);
+        crate::appearance::make_front_only(&mut self.appearance, &mut self.uv_sets);
     }
 }
 
@@ -113,23 +105,8 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::appearance::{
-        FaceBinding, Material, MaterialIndex, PhongMaterial, ThemeBinding, ThemeId, UvSource,
-    };
-
-    fn bare_phong() -> Material {
-        Material::Phong(PhongMaterial {
-            diffuse: [1.0, 1.0, 1.0],
-            specular: [0.0, 0.0, 0.0],
-            emissive: [0.0, 0.0, 0.0],
-            ambient_intensity: 0.0,
-            shininess: 0.0,
-            transparency: 0.0,
-            diffuse_map: None,
-            emissive_map: None,
-            normal_map: None,
-        })
-    }
+    use crate::appearance::{FaceBinding, MaterialIndex, Side, ThemeBinding, ThemeId, UvSource};
+    use crate::test_support::bare;
 
     fn uv(side: Side) -> UvSet {
         UvSet {
@@ -148,7 +125,7 @@ mod tests {
         )
         .unwrap();
         m.appearance = Some(Appearance {
-            materials: vec![bare_phong(), bare_phong()],
+            materials: vec![bare(), bare()],
             themes: vec![ThemeBinding {
                 theme: ThemeId(Arc::from("t")),
                 front: FaceBinding::Uniform(MaterialIndex::new(0).unwrap()),

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.57"
+version = "0.2.58"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.247"
+version = "0.1.248"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR implements appearance setters for the new geometry.

## What I've done
For each of the leaf types that can have appearances (namely `Polygon`, `PolygonMesh`, and `TriangularMesh`), appearance setters are implemented. Note that `PolygonMesh` doesn't have a standalone setter; instead, its `from_polygons()` would merge the appearances of the polygons accordingly, and it suffices for most applications.
`Solid` is a leaf type that doesn't have appearance directly, but it could have an appearance when its boundary surfaces have it. Boundary surfaces cannot have back-side appearance. Thus its constructor now explicitly checks that the appearance of the boundary surfaces, if any, must be the front-side only. 