### PR TITLE
docs(engine): FlowExpr specification for math and regex modules

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "futures",
  "once_cell",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "approx",
  "async-trait",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "Inflector",
  "approx",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "bytes",
  "clap",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "approx",
  "bvh",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5161,7 +5161,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "bytes",
  "futures",
@@ -5207,7 +5207,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "bytes",
  "futures",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "ahash",
  "bytes",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.421"
+version = "0.0.422"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.421"
+version = "0.0.422"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/expr/docs/spec/3-builtin-methods.md
+++ b/engine/runtime/expr/docs/spec/3-builtin-methods.md
@@ -72,6 +72,20 @@ For string `s`, `s.rfind(sub)` returns the codepoint index of the last occurrenc
 
 For string `s`, `s.join(list)` returns a string formed by concatenating string elements of `list` with `s` as separator.
 
+### `format`
+
+For string `s`, `s.format(arg0, arg1, ...)` returns a new string produced by replacing each placeholder in `s` with the corresponding formatted argument.
+
+A placeholder is written `{field}` or `{field:spec}`. `field` is either empty (automatic index, incremented for each auto-indexed placeholder in left-to-right order) or a decimal integer (explicit index into the argument list).
+
+`{{` and `}}` produce a literal `{` and `}` respectively.
+
+The format spec determines how the argument is rendered:
+
+- `f`: the argument as a float with 6 decimal places.
+- `.Nf` where N is a non-negative integer: the argument as a float with N decimal places.
+- `d`: the argument as a decimal integer.
+
 ## list methods
 
 ### `append`

--- a/engine/runtime/expr/docs/spec/4-math-module.md
+++ b/engine/runtime/expr/docs/spec/4-math-module.md
@@ -1,0 +1,76 @@
+# (DRAFT) Math Module
+
+The `math` module provides mathematical functions and constants.
+All functions accept both `int` and `float` for numeric arguments and return `float`.
+
+## math.pi
+
+The mathematical constant π ≈ 3.14159265358979.
+
+## math.e
+
+The mathematical constant e ≈ 2.71828182845905.
+
+## math.abs
+
+`math.abs(x)` returns the absolute value of `x`.
+
+## math.floor
+
+`math.floor(x)` returns the largest integer value less than or equal to `x`, as a float.
+
+## math.ceil
+
+`math.ceil(x)` returns the smallest integer value greater than or equal to `x`, as a float.
+
+## math.round
+
+`math.round(x)` returns `x` rounded to the nearest integer, as a float.
+Ties are rounded away from zero.
+
+## math.sqrt
+
+`math.sqrt(x)` returns the square root of `x`.
+
+## math.exp
+
+`math.exp(x)` returns e raised to the power `x`.
+
+## math.log
+
+`math.log(x)` returns the natural logarithm of `x`.
+
+`math.log(x, base)` returns the logarithm of `x` in the given `base`.
+
+## math.log2
+
+`math.log2(x)` returns the base-2 logarithm of `x`.
+
+## math.log10
+
+`math.log10(x)` returns the base-10 logarithm of `x`.
+
+## math.sin
+
+`math.sin(x)` returns the sine of `x` in radians.
+
+## math.cos
+
+`math.cos(x)` returns the cosine of `x` in radians.
+
+## math.tan
+
+`math.tan(x)` returns the tangent of `x` in radians.
+
+## math.atan2
+
+`math.atan2(y, x)` returns the angle in radians between the positive x-axis and the point `(x, y)`.
+The return value is in the range `[-π, π]`.
+
+## math.radians
+
+`math.radians(x)` converts `x` from degrees to radians.
+
+## math.degrees
+
+`math.degrees(x)` converts `x` from radians to degrees.

--- a/engine/runtime/expr/docs/spec/4-math-module.md
+++ b/engine/runtime/expr/docs/spec/4-math-module.md
@@ -24,7 +24,7 @@ The mathematical constant e.
 
 ## math.round
 
-`math.round(x)` returns `x` rounded to the nearest integer, as a float.
+`math.round(x)` returns `x` rounded to the nearest integer.
 
 > Note: round behavior (away-from-zero or banker's round) is not stabilized by this spec.
 
@@ -78,11 +78,6 @@ The mathematical constant e.
 
 `math.atan2(y, x)` returns the angle in radians between the positive x-axis and the point `(x, y)`.
 The return value is in the range `[-pi, pi]`.
-
-## math.hypot
-
-`math.hypot(x, ...)` returns the Euclidean norm of the given coordinates, `sqrt(x1*x1 + x2*x2 + ...)`.
-With no arguments, returns `0.0`.
 
 ## math.radians
 

--- a/engine/runtime/expr/docs/spec/4-math-module.md
+++ b/engine/runtime/expr/docs/spec/4-math-module.md
@@ -13,18 +13,19 @@ The mathematical constant e.
 ## math.abs
 
 `math.abs(x)` returns the absolute value of `x`.
+The result is an `int` when `x` is an `int`, and a `float` when `x` is a `float`.
 
 ## math.floor
 
-`math.floor(x)` returns the largest integer value less than or equal to `x`.
+`math.floor(x)` returns the largest `int` less than or equal to `x`.
 
 ## math.ceil
 
-`math.ceil(x)` returns the smallest integer value greater than or equal to `x`.
+`math.ceil(x)` returns the smallest `int` greater than or equal to `x`.
 
 ## math.round
 
-`math.round(x)` returns `x` rounded to the nearest integer.
+`math.round(x)` returns the `int` nearest to `x`.
 
 > Note: round behavior at `n + 0.5` (away-from-zero or banker's round) is not specified by this spec.
 

--- a/engine/runtime/expr/docs/spec/4-math-module.md
+++ b/engine/runtime/expr/docs/spec/4-math-module.md
@@ -16,11 +16,11 @@ The mathematical constant e.
 
 ## math.floor
 
-`math.floor(x)` returns the largest integer value less than or equal to `x`
+`math.floor(x)` returns the largest integer value less than or equal to `x`.
 
 ## math.ceil
 
-`math.ceil(x)` returns the smallest integer value greater than or equal to `x`
+`math.ceil(x)` returns the smallest integer value greater than or equal to `x`.
 
 ## math.round
 

--- a/engine/runtime/expr/docs/spec/4-math-module.md
+++ b/engine/runtime/expr/docs/spec/4-math-module.md
@@ -1,7 +1,6 @@
 # (DRAFT) Math Module
 
 The `math` module provides mathematical functions and constants.
-All functions accept both `int` and `float` for numeric arguments and return `float`.
 
 ## math.pi
 
@@ -26,7 +25,6 @@ The mathematical constant e ≈ 2.71828182845905.
 ## math.round
 
 `math.round(x)` returns `x` rounded to the nearest integer, as a float.
-Ties are rounded away from zero.
 
 ## math.sqrt
 

--- a/engine/runtime/expr/docs/spec/4-math-module.md
+++ b/engine/runtime/expr/docs/spec/4-math-module.md
@@ -4,11 +4,11 @@ The `math` module provides mathematical functions and constants.
 
 ## math.pi
 
-The mathematical constant π ≈ 3.14159265358979.
+The mathematical constant pi.
 
 ## math.e
 
-The mathematical constant e ≈ 2.71828182845905.
+The mathematical constant e.
 
 ## math.abs
 
@@ -16,15 +16,17 @@ The mathematical constant e ≈ 2.71828182845905.
 
 ## math.floor
 
-`math.floor(x)` returns the largest integer value less than or equal to `x`, as a float.
+`math.floor(x)` returns the largest integer value less than or equal to `x`
 
 ## math.ceil
 
-`math.ceil(x)` returns the smallest integer value greater than or equal to `x`, as a float.
+`math.ceil(x)` returns the smallest integer value greater than or equal to `x`
 
 ## math.round
 
 `math.round(x)` returns `x` rounded to the nearest integer, as a float.
+
+> Note: round behavior (away-from-zero or banker's round) is not stabilized by this spec.
 
 ## math.sqrt
 
@@ -60,10 +62,27 @@ The mathematical constant e ≈ 2.71828182845905.
 
 `math.tan(x)` returns the tangent of `x` in radians.
 
+## math.asin
+
+`math.asin(x)` returns the arcsine of `x` in radians.
+
+## math.acos
+
+`math.acos(x)` returns the arccosine of `x` in radians.
+
+## math.atan
+
+`math.atan(x)` returns the arctangent of `x` in radians.
+
 ## math.atan2
 
 `math.atan2(y, x)` returns the angle in radians between the positive x-axis and the point `(x, y)`.
-The return value is in the range `[-π, π]`.
+The return value is in the range `[-pi, pi]`.
+
+## math.hypot
+
+`math.hypot(x, ...)` returns the Euclidean norm of the given coordinates, `sqrt(x1*x1 + x2*x2 + ...)`.
+With no arguments, returns `0.0`.
 
 ## math.radians
 
@@ -72,3 +91,23 @@ The return value is in the range `[-π, π]`.
 ## math.degrees
 
 `math.degrees(x)` converts `x` from radians to degrees.
+
+## math.inf
+
+The floating-point positive infinity.
+
+## math.nan
+
+The floating-point not-a-number value.
+
+## math.is_inf
+
+`math.is_inf(x)` returns `true` if `x` is positive or negative infinity, `false` otherwise.
+
+## math.is_nan
+
+`math.is_nan(x)` returns `true` if `x` is not-a-number, `false` otherwise.
+
+## math.is_finite
+
+`math.is_finite(x)` returns `true` if `x` is neither infinite nor not-a-number, `false` otherwise.

--- a/engine/runtime/expr/docs/spec/4-math-module.md
+++ b/engine/runtime/expr/docs/spec/4-math-module.md
@@ -26,7 +26,7 @@ The mathematical constant e.
 
 `math.round(x)` returns `x` rounded to the nearest integer.
 
-> Note: round behavior (away-from-zero or banker's round) is not stabilized by this spec.
+> Note: round behavior at `n + 0.5` (away-from-zero or banker's round) is not specified by this spec.
 
 ## math.sqrt
 

--- a/engine/runtime/expr/docs/spec/5-regex.md
+++ b/engine/runtime/expr/docs/spec/5-regex.md
@@ -4,9 +4,15 @@
 
 ## pattern language
 
-Patterns should support POSIX Extended Regular Expression (ERE) syntax, excluding locale-specific bracket constructs: collating symbols (`[.ch.]`) and equivalence classes (`[=a=]`).
+Supported constructs:
 
-A capture group is a sub-expression enclosed in parentheses `(...)`.
+- Literals and escapes: `\n`, `\t`, `\\`, Unicode escapes `\u{HHHH}`
+- Dot: `.` matches any character except newline
+- Character classes: `[abc]`, `[a-z]`, `[^...]`; shorthand `\d`, `\D`, `\w`, `\W`, `\s`, `\S`
+- Anchors: `^` (start of input), `$` (end of input)
+- Quantifiers: `*`, `+`, `?`, `{n}`, `{n,}`, `{n,m}`; append `?` for non-greedy
+- Alternation: `a|b`
+- Capture group: `(...)` — a sub-expression whose matched text is extracted separately
 
 ## find
 

--- a/engine/runtime/expr/docs/spec/5-regex.md
+++ b/engine/runtime/expr/docs/spec/5-regex.md
@@ -1,0 +1,31 @@
+# (DRAFT) Regular Expression
+
+`Regex` is a type object. `Regex(pattern)` constructs a regex object from the string `pattern`.
+
+## pattern language
+
+The escape character within a pattern is `\`. A literal `(` is written `\(`.
+
+A capture group is a sub-expression enclosed in parentheses `(...)`.
+
+## find
+
+For regex `r`, `r.find(s)` returns the first match of `r` in string `s`, or `null` if there is no match.
+
+The form of the return value depends on the number of capture groups in `r`:
+
+- No capture groups: the matched substring.
+- One capture group: the text captured by that group, or `null` if the group did not participate.
+- Multiple capture groups: a list of captured texts in definition order; a non-participating group yields `null` in its position.
+
+## find_all
+
+For regex `r`, `r.find_all(s)` returns a list of all non-overlapping matches of `r` in `s`, in left-to-right order. Returns an empty list if there are no matches.
+
+Each element has the same form as a successful `find` result for that occurrence.
+
+## split
+
+For regex `r`, `r.split(s)` splits string `s` on each non-overlapping match of `r`, returning a list of the parts between matches.
+
+`r.split(s, limit)` splits at most `limit` times, producing at most `limit + 1` parts.

--- a/engine/runtime/expr/docs/spec/5-regex.md
+++ b/engine/runtime/expr/docs/spec/5-regex.md
@@ -4,7 +4,7 @@
 
 ## pattern language
 
-The escape character within a pattern is `\`. A literal `(` is written `\(`.
+Patterns should support POSIX Extended Regular Expression (ERE) syntax, excluding locale-specific bracket constructs: collating symbols (`[.ch.]`) and equivalence classes (`[=a=]`).
 
 A capture group is a sub-expression enclosed in parentheses `(...)`.
 

--- a/engine/runtime/expr/src/core/builtins/math.rs
+++ b/engine/runtime/expr/src/core/builtins/math.rs
@@ -1,5 +1,15 @@
+use crate::core::error::eval_error;
 use crate::core::value::{Module, NativeFn, Value};
 use crate::expect_arity;
+
+fn float_to_int(name: &str, v: f64) -> crate::core::error::Result<Value> {
+    let i = v as i64;
+    if i as f64 == v {
+        Ok(Value::Int(i))
+    } else {
+        Err(eval_error(format!("{name}: value out of integer range")))
+    }
+}
 
 fn unary_float(name: &'static str, f: fn(f64) -> f64) -> Value {
     let full_name = format!("math.{name}");
@@ -9,13 +19,56 @@ fn unary_float(name: &'static str, f: fn(f64) -> f64) -> Value {
     }))
 }
 
+fn unary_bool(name: &'static str, f: fn(f64) -> bool) -> Value {
+    let full_name = format!("math.{name}");
+    Value::Fn(NativeFn::new(move |args| {
+        expect_arity(&full_name, args, 1, 1)?;
+        Ok(Value::Bool(f(args[0].as_f64()?)))
+    }))
+}
+
 pub fn builtin_math() -> Value {
     let mut m = Module::new();
-    m.insert("sin".into(), unary_float("sin", f64::sin));
-    m.insert("cos".into(), unary_float("cos", f64::cos));
-    m.insert("floor".into(), unary_float("floor", f64::floor));
+    m.insert("pi".into(), Value::Float(std::f64::consts::PI));
+    m.insert("e".into(), Value::Float(std::f64::consts::E));
+    m.insert("inf".into(), Value::Float(f64::INFINITY));
+    m.insert("nan".into(), Value::Float(f64::NAN));
+
+    m.insert(
+        "abs".into(),
+        Value::Fn(NativeFn::new(|args| {
+            expect_arity("math.abs", args, 1, 1)?;
+            match &args[0] {
+                Value::Int(n) => Ok(Value::Int(n.abs())),
+                _ => Ok(Value::Float(args[0].as_f64()?.abs())),
+            }
+        })),
+    );
+    m.insert(
+        "floor".into(),
+        Value::Fn(NativeFn::new(|args| {
+            expect_arity("math.floor", args, 1, 1)?;
+            float_to_int("math.floor", args[0].as_f64()?.floor())
+        })),
+    );
+    m.insert(
+        "ceil".into(),
+        Value::Fn(NativeFn::new(|args| {
+            expect_arity("math.ceil", args, 1, 1)?;
+            float_to_int("math.ceil", args[0].as_f64()?.ceil())
+        })),
+    );
     // math.round is away-from-zero which is natural in GIS context
-    m.insert("round".into(), unary_float("round", f64::round));
+    m.insert(
+        "round".into(),
+        Value::Fn(NativeFn::new(|args| {
+            expect_arity("math.round", args, 1, 1)?;
+            float_to_int("math.round", args[0].as_f64()?.round())
+        })),
+    );
+    m.insert("sqrt".into(), unary_float("sqrt", f64::sqrt));
+    m.insert("exp".into(), unary_float("exp", f64::exp));
+
     m.insert(
         "log".into(),
         Value::Fn(NativeFn::new(|args| {
@@ -30,7 +83,75 @@ pub fn builtin_math() -> Value {
     );
     m.insert("log2".into(), unary_float("log2", f64::log2));
     m.insert("log10".into(), unary_float("log10", f64::log10));
+
+    m.insert("sin".into(), unary_float("sin", f64::sin));
+    m.insert("cos".into(), unary_float("cos", f64::cos));
+    m.insert("tan".into(), unary_float("tan", f64::tan));
+    m.insert("asin".into(), unary_float("asin", f64::asin));
+    m.insert("acos".into(), unary_float("acos", f64::acos));
+    m.insert("atan".into(), unary_float("atan", f64::atan));
+    m.insert(
+        "atan2".into(),
+        Value::Fn(NativeFn::new(|args| {
+            expect_arity("math.atan2", args, 2, 2)?;
+            Ok(Value::Float(args[0].as_f64()?.atan2(args[1].as_f64()?)))
+        })),
+    );
     m.insert("radians".into(), unary_float("radians", f64::to_radians));
-    m.insert("pi".into(), Value::Float(std::f64::consts::PI));
+    m.insert("degrees".into(), unary_float("degrees", f64::to_degrees));
+
+    m.insert(
+        "is_inf".into(),
+        unary_bool("is_inf", |x| x.is_infinite()),
+    );
+    m.insert("is_nan".into(), unary_bool("is_nan", |x| x.is_nan()));
+    m.insert(
+        "is_finite".into(),
+        unary_bool("is_finite", |x| x.is_finite()),
+    );
+
     Value::module(m)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::test_utils::assert_eval;
+    use crate::core::value::Value;
+
+    #[test]
+    fn test_abs() {
+        assert_eval("math.abs(-3)", &[], Value::Int(3));
+        assert_eval("math.abs(-2.5)", &[], Value::Float(2.5));
+    }
+
+    #[test]
+    fn test_floor() {
+        assert_eval("math.floor(2.9)", &[], Value::Int(2));
+        assert_eval("math.floor(-2.1)", &[], Value::Int(-3));
+    }
+
+    #[test]
+    fn test_ceil() {
+        assert_eval("math.ceil(2.1)", &[], Value::Int(3));
+        assert_eval("math.ceil(-2.9)", &[], Value::Int(-2));
+    }
+
+    #[test]
+    fn test_round() {
+        assert_eval("math.round(2.4)", &[], Value::Int(2));
+        assert_eval("math.round(2.6)", &[], Value::Int(3));
+    }
+
+    #[test]
+    fn test_log() {
+        assert_eval("math.log(math.e)", &[], Value::Float(1.0));
+        assert_eval("math.log(8.0, 2.0)", &[], Value::Float(3.0));
+    }
+
+    #[test]
+    fn test_atan2() {
+        // verifies (y, x) argument order
+        assert_eval("math.atan2(1.0, 0.0)", &[], Value::Float(std::f64::consts::FRAC_PI_2));
+        assert_eval("math.atan2(0.0, 1.0)", &[], Value::Float(0.0));
+    }
 }

--- a/engine/runtime/expr/src/core/builtins/math.rs
+++ b/engine/runtime/expr/src/core/builtins/math.rs
@@ -132,7 +132,7 @@ pub fn builtin_math() -> Value {
 
 #[cfg(test)]
 mod tests {
-    use crate::core::test_utils::{assert_eval, try_run};
+    use crate::core::test_utils::assert_eval;
     use crate::core::value::Value;
 
     #[test]

--- a/engine/runtime/expr/src/core/builtins/math.rs
+++ b/engine/runtime/expr/src/core/builtins/math.rs
@@ -100,10 +100,7 @@ pub fn builtin_math() -> Value {
     m.insert("radians".into(), unary_float("radians", f64::to_radians));
     m.insert("degrees".into(), unary_float("degrees", f64::to_degrees));
 
-    m.insert(
-        "is_inf".into(),
-        unary_bool("is_inf", |x| x.is_infinite()),
-    );
+    m.insert("is_inf".into(), unary_bool("is_inf", |x| x.is_infinite()));
     m.insert("is_nan".into(), unary_bool("is_nan", |x| x.is_nan()));
     m.insert(
         "is_finite".into(),
@@ -151,7 +148,11 @@ mod tests {
     #[test]
     fn test_atan2() {
         // verifies (y, x) argument order
-        assert_eval("math.atan2(1.0, 0.0)", &[], Value::Float(std::f64::consts::FRAC_PI_2));
+        assert_eval(
+            "math.atan2(1.0, 0.0)",
+            &[],
+            Value::Float(std::f64::consts::FRAC_PI_2),
+        );
         assert_eval("math.atan2(0.0, 1.0)", &[], Value::Float(0.0));
     }
 }

--- a/engine/runtime/expr/src/core/builtins/math.rs
+++ b/engine/runtime/expr/src/core/builtins/math.rs
@@ -1,14 +1,22 @@
-use crate::core::error::eval_error;
+use crate::core::error::{eval_error, Result};
 use crate::core::value::{Module, NativeFn, Value};
 use crate::expect_arity;
 
-fn float_to_int(name: &str, v: f64) -> crate::core::error::Result<Value> {
-    let i = v as i64;
-    if i as f64 == v {
-        Ok(Value::Int(i))
-    } else {
-        Err(eval_error(format!("{name}: value out of integer range")))
+fn float_to_int(name: &str, x: f64) -> Result<i64> {
+    if !x.is_finite() {
+        return Err(eval_error(format!(
+            "{name}: cannot convert non-finite value to int"
+        )));
     }
+    if x.fract() != 0.0 {
+        return Err(eval_error(format!(
+            "{name}: float value has fractional part"
+        )));
+    }
+    if x < i64::MIN as f64 || x >= i64::MAX as f64 {
+        return Err(eval_error(format!("{name}: float value out of i64 range")));
+    }
+    Ok(x as i64)
 }
 
 fn unary_float(name: &'static str, f: fn(f64) -> f64) -> Value {
@@ -39,7 +47,10 @@ pub fn builtin_math() -> Value {
         Value::Fn(NativeFn::new(|args| {
             expect_arity("math.abs", args, 1, 1)?;
             match &args[0] {
-                Value::Int(n) => Ok(Value::Int(n.abs())),
+                Value::Int(n) => n
+                    .checked_abs()
+                    .map(Value::Int)
+                    .ok_or_else(|| eval_error("math.abs: integer overflow")),
                 _ => Ok(Value::Float(args[0].as_f64()?.abs())),
             }
         })),
@@ -48,14 +59,20 @@ pub fn builtin_math() -> Value {
         "floor".into(),
         Value::Fn(NativeFn::new(|args| {
             expect_arity("math.floor", args, 1, 1)?;
-            float_to_int("math.floor", args[0].as_f64()?.floor())
+            if let Value::Int(_) = &args[0] {
+                return Ok(args[0].clone());
+            }
+            float_to_int("math.floor", args[0].as_f64()?.floor()).map(Value::Int)
         })),
     );
     m.insert(
         "ceil".into(),
         Value::Fn(NativeFn::new(|args| {
             expect_arity("math.ceil", args, 1, 1)?;
-            float_to_int("math.ceil", args[0].as_f64()?.ceil())
+            if let Value::Int(_) = &args[0] {
+                return Ok(args[0].clone());
+            }
+            float_to_int("math.ceil", args[0].as_f64()?.ceil()).map(Value::Int)
         })),
     );
     // math.round is away-from-zero which is natural in GIS context
@@ -63,7 +80,10 @@ pub fn builtin_math() -> Value {
         "round".into(),
         Value::Fn(NativeFn::new(|args| {
             expect_arity("math.round", args, 1, 1)?;
-            float_to_int("math.round", args[0].as_f64()?.round())
+            if let Value::Int(_) = &args[0] {
+                return Ok(args[0].clone());
+            }
+            float_to_int("math.round", args[0].as_f64()?.round()).map(Value::Int)
         })),
     );
     m.insert("sqrt".into(), unary_float("sqrt", f64::sqrt));
@@ -112,7 +132,7 @@ pub fn builtin_math() -> Value {
 
 #[cfg(test)]
 mod tests {
-    use crate::core::test_utils::assert_eval;
+    use crate::core::test_utils::{assert_eval, try_run};
     use crate::core::value::Value;
 
     #[test]

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -43,8 +43,15 @@ impl ImmutableObject for RegexObject {
                 let s = args[0].as_str()?;
                 let parts = if args.len() == 2 {
                     let limit = args[1].as_int()?;
+                    if limit < 0 {
+                        return Err(eval_error("Regex.split: limit must be non-negative"));
+                    }
+                    let n = limit
+                        .checked_add(1)
+                        .ok_or_else(|| eval_error("Regex.split: limit overflow"))?
+                        as usize;
                     self.regex
-                        .splitn(s, (limit + 1) as usize)
+                        .splitn(s, n)
                         .map(|p| Value::String(p.to_string()))
                         .collect()
                 } else {

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -38,6 +38,23 @@ impl ImmutableObject for RegexObject {
                 expect_arity("Regex.find_all", args, 1, 1)?;
                 Ok(Value::list(regex_find_all(&self.regex, args[0].as_str()?)))
             }
+            "split" => {
+                expect_arity("Regex.split", args, 1, 2)?;
+                let s = args[0].as_str()?;
+                let parts = if args.len() == 2 {
+                    let limit = args[1].as_int()?;
+                    self.regex
+                        .splitn(s, (limit + 1) as usize)
+                        .map(|p| Value::String(p.to_string()))
+                        .collect()
+                } else {
+                    self.regex
+                        .split(s)
+                        .map(|p| Value::String(p.to_string()))
+                        .collect()
+                };
+                Ok(Value::list(parts))
+            }
             m => Err(eval_error(format!("Regex has no method '{m}'"))),
         }
     }
@@ -156,6 +173,26 @@ mod tests {
                 Value::list(vec![Value::from("123"), Value::Null]),
                 Value::list(vec![Value::from("456"), Value::from("x")]),
             ]),
+        );
+    }
+
+    #[test]
+    fn test_regex_split() {
+        assert_val(
+            &run(r#"Regex(r"\d+").split("a1b2c")"#, &[]),
+            &Value::list(vec![Value::from("a"), Value::from("b"), Value::from("c")]),
+        );
+        assert_val(
+            &run(r#"Regex(r",").split("a,,b")"#, &[]),
+            &Value::list(vec![Value::from("a"), Value::from(""), Value::from("b")]),
+        );
+        assert_val(
+            &run(r#"Regex(r"\d+").split("no digits")"#, &[]),
+            &Value::list(vec![Value::from("no digits")]),
+        );
+        assert_val(
+            &run(r#"Regex(r"\d+").split("a1b2c3d", 2)"#, &[]),
+            &Value::list(vec![Value::from("a"), Value::from("b"), Value::from("c3d")]),
         );
     }
 

--- a/engine/runtime/expr/src/core/builtins/regex.rs
+++ b/engine/runtime/expr/src/core/builtins/regex.rs
@@ -201,6 +201,11 @@ mod tests {
             &run(r#"Regex(r"\d+").split("a1b2c3d", 2)"#, &[]),
             &Value::list(vec![Value::from("a"), Value::from("b"), Value::from("c3d")]),
         );
+        // limit 0 → no splits, whole string as a single part
+        assert_val(
+            &run(r#"Regex(r"\d+").split("a1b2c", 0)"#, &[]),
+            &Value::list(vec![Value::from("a1b2c")]),
+        );
     }
 
     #[test]

--- a/engine/runtime/types/src/expr.rs
+++ b/engine/runtime/types/src/expr.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use indexmap::IndexMap;
@@ -6,16 +7,13 @@ use nutype::nutype;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use std::rc::Rc;
-
 use reearth_flow_expr::{
     compile, env_bind, env_remove, eval_error, expect_arity, Env as ExprEnv, FromValue,
     Result as ExprResult, TypeValue as ExprTypeValue, Value as ExprValue,
 };
 
-use crate::error::{Error as TypesError, Result as TypesResult};
-
 use crate::attribute::{Attribute, AttributeValue};
+use crate::error::{Error as TypesError, Result as TypesResult};
 use crate::feature::Feature;
 
 impl From<reearth_flow_expr::Error> for TypesError {


### PR DESCRIPTION
# Overview

This PR completes FlowExpr specification for math module and Regex object.

## Changes

- Add math module constants and functions: e, inf, nan, abs, ceil, sqrt, exp, tan, asin, acos, atan, atan2, degrees, is_inf, is_nan, is_finite
- `regex.rs` add split method
- Add spec docs: `4-math-module.md`, `5-regex.md`
- Extend `3-builtin-methods.md` with str.format

## Notes

- Spec has higher priority and should NOT just document every implementation detail.
- float round with precision is not stabilized due to the `round(2.675)` problem.
- math.hypot is probably useful but not implemented/documented due to the accumulative error problem.