### PR TITLE
fix(ui): handle authentication errors and improve loading state management [FLOW-DEV-206]

### DIFF
--- a/ui/src/features/AuthenticationWrapper/index.tsx
+++ b/ui/src/features/AuthenticationWrapper/index.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 
+import { LoadingSplashscreen } from "@flow/components";
 import ErrorPage from "@flow/components/errors/ErrorPage";
 import { useAuthenticationRequired } from "@flow/lib/auth";
 
@@ -8,13 +9,21 @@ type Props = {
 };
 
 const AuthenticationWrapper: React.FC<Props> = ({ children }) => {
-  const [isAuthenticated, error] = useAuthenticationRequired();
+  const { isAuthenticated, isLoading, error } = useAuthenticationRequired();
+
+  if (isAuthenticated) {
+    return children ? children : null;
+  }
+
+  if (isLoading) {
+    return <LoadingSplashscreen />;
+  }
 
   if (error) {
     return <ErrorPage errorMessage={error} />;
   }
 
-  return isAuthenticated && children ? children : null;
+  return null;
 };
 
 export default AuthenticationWrapper;

--- a/ui/src/features/AuthenticationWrapper/index.tsx
+++ b/ui/src/features/AuthenticationWrapper/index.tsx
@@ -1,6 +1,6 @@
-import { withAuthenticationRequired } from "@auth0/auth0-react";
 import { ReactNode } from "react";
 
+import ErrorPage from "@flow/components/errors/ErrorPage";
 import { useAuthenticationRequired } from "@flow/lib/auth";
 
 type Props = {
@@ -8,16 +8,13 @@ type Props = {
 };
 
 const AuthenticationWrapper: React.FC<Props> = ({ children }) => {
-  const [isAuthenticated] = useAuthenticationRequired(); // TODO: show error
+  const [isAuthenticated, error] = useAuthenticationRequired();
+
+  if (error) {
+    return <ErrorPage errorMessage={error} />;
+  }
+
   return isAuthenticated && children ? children : null;
 };
 
-const withAuthorization = (): ((
-  component: React.FC<Props>,
-) => React.FC<Props>) => {
-  return withAuthenticationRequired as unknown as (
-    component: React.FC<Props>,
-  ) => React.FC<Props>;
-};
-
-export default withAuthorization()(AuthenticationWrapper);
+export default AuthenticationWrapper;

--- a/ui/src/lib/auth/useAuth.ts
+++ b/ui/src/lib/auth/useAuth.ts
@@ -43,7 +43,11 @@ export const useAuth = () => {
   return auth;
 };
 
-export function useAuthenticationRequired(): [boolean, string | undefined] {
+export function useAuthenticationRequired(): {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | undefined;
+} {
   const {
     isAuthenticated,
     isLoading,
@@ -71,5 +75,5 @@ export function useAuthenticationRequired(): [boolean, string | undefined] {
     login();
   }, [authError, isAuthenticated, isLoading, login, logout, error, done]);
 
-  return [isAuthenticated, error];
+  return { isAuthenticated, isLoading, error };
 }

--- a/ui/src/lib/auth/useAuth.ts
+++ b/ui/src/lib/auth/useAuth.ts
@@ -52,8 +52,10 @@ export function useAuthenticationRequired(): [boolean, string | undefined] {
     logout,
   } = useAuth();
 
+  const [error, done] = useCleanUrl();
+
   useEffect(() => {
-    if (isLoading || isAuthenticated) {
+    if (isLoading || isAuthenticated || !done) {
       return;
     }
 
@@ -62,10 +64,12 @@ export function useAuthenticationRequired(): [boolean, string | undefined] {
       return;
     }
 
-    login();
-  }, [authError, isAuthenticated, isLoading, login, logout]);
+    if (error) {
+      return;
+    }
 
-  const [error] = useCleanUrl();
+    login();
+  }, [authError, isAuthenticated, isLoading, login, logout, error, done]);
 
   return [isAuthenticated, error];
 }


### PR DESCRIPTION
# Overview
This PR fixes an infinite redirect loop in the UI authentication flow that affected users whose Auth0 sign-in fails (unauthorized user, unverified email, access denied, etc.), and improves how the app handles Auth0 redirect/query-string artifacts and loading states. Previously a failed sign-in bounced the user endlessly between the app and Auth0, and the app could render a blank screen during auth resolution or silently render nothing on failure.

## Root cause
AuthenticationWrapper was guarded by two redirect mechanisms: Auth0's withAuthenticationRequired HOC and the internal useAuthenticationRequired() hook. The HOC re-triggers loginWithRedirect on every unauthenticated render without inspecting the auth error, so when Auth0 returned an error the user was immediately redirected back to Auth0 → errored again → looped forever. The internal hook tried to handle errors (logout → ?flowerror=…), but only checked the live Auth0 error, which is gone after the logout round-trip — so it just called login() again. The persisted flowerror was read but never used to break the cycle (// TODO: show error).

## What I've done

- Remove the redundant withAuthenticationRequired Higher Order Component (HOC) from AuthenticationWrapper. It was the uncontrollable redirect path (no error check, no backoff); useAuthenticationRequired already provides redirect-when unauthenticated and can be made to break the loop.
- Break the loop in useAuthenticationRequired: delay login() until the redirect URL has been parsed/cleaned (done), and skip login() when an auth error from a previous attempt is present — surfacing the error instead of re-redirecting.
- Surface authentication error messages in AuthenticationWrapper via the shared ErrorPage component (with a Reload action to re-attempt login), instead of rendering nothing.
- Show a loading splash (LoadingSplashscreen) while auth is still resolving (initialization / silent refresh / redirect handling), instead of a blank screen — and let already-authenticated users through even if a stale ?flowerror= lingers in the URL, so nested routes own their own loading/error UI.
- Single source of auth state: useAuthenticationRequired now returns { isAuthenticated, isLoading, error } so the wrapper reads all auth state from one hook (replaces the prior tuple + separate useAuth() call).

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
