### PR TITLE
fix(ui): refactor previewSchema to save status to nodeMetaData [FLOW-DEV-211]

### DIFF
--- a/ui/src/features/Editor/usePreviewSchema/PreviewSchemaMonitors.tsx
+++ b/ui/src/features/Editor/usePreviewSchema/PreviewSchemaMonitors.tsx
@@ -6,11 +6,12 @@ import { toJobStatus } from "@flow/lib/gql/convert";
 import { useJob } from "@flow/lib/gql/job";
 import { useSubscription } from "@flow/lib/gql/subscriptions/useSubscription";
 import { useSubscriptionSetup } from "@flow/lib/gql/subscriptions/useSubscriptionSetup";
-import type { ReaderSchemaProbe } from "@flow/stores";
 import type { Job } from "@flow/types";
 
+import type { RunningSchemaProbe } from ".";
+
 type MonitorProps = {
-  probe: ReaderSchemaProbe;
+  probe: RunningSchemaProbe;
   accessToken?: string;
   onComplete: (nodeId: string, job: Job) => void;
   onError: (nodeId: string) => void;
@@ -72,8 +73,8 @@ const PreviewSchemaJobMonitor: React.FC<MonitorProps> = ({
 
   useEffect(() => {
     if (settledRef.current) return;
-    // A resumed probe whose job no longer exists (fetched, but no job) is
-    // stale — fail it rather than spin forever.
+    // A resumed/orphaned probe whose job no longer exists (fetched, but no job)
+    // is stale — fail it rather than spin forever.
     if (isFetched && !job) {
       settledRef.current = true;
       onError(nodeId);
@@ -93,7 +94,7 @@ const PreviewSchemaJobMonitor: React.FC<MonitorProps> = ({
 };
 
 type Props = {
-  probes: ReaderSchemaProbe[];
+  probes: RunningSchemaProbe[];
   onComplete: (nodeId: string, job: Job) => void;
   onError: (nodeId: string) => void;
 };
@@ -116,17 +117,15 @@ const PreviewSchemaMonitors: React.FC<Props> = ({
 
   return (
     <>
-      {probes
-        .filter((probe) => probe.jobId && probe.status === "running")
-        .map((probe) => (
-          <PreviewSchemaJobMonitor
-            key={probe.jobId}
-            probe={probe}
-            accessToken={accessToken}
-            onComplete={onComplete}
-            onError={onError}
-          />
-        ))}
+      {probes.map((probe) => (
+        <PreviewSchemaJobMonitor
+          key={probe.jobId}
+          probe={probe}
+          accessToken={accessToken}
+          onComplete={onComplete}
+          onError={onError}
+        />
+      ))}
     </>
   );
 };

--- a/ui/src/features/Editor/usePreviewSchema/index.ts
+++ b/ui/src/features/Editor/usePreviewSchema/index.ts
@@ -28,7 +28,10 @@ export default ({
 }: {
   rawWorkflows: Workflow[];
   openNodeId?: string;
-  onPersistSchema: (nodeId: string, schema: NodeSchemaMeta | undefined) => void;
+  onPersistSchema: (
+    nodeId: string,
+    patch: Partial<NodeSchemaMeta> | undefined,
+  ) => void;
   sampleSize?: number;
 }) => {
   const [currentProject] = useCurrentProject();
@@ -61,52 +64,11 @@ export default ({
     };
   }, []);
 
-  // In-memory bookkeeping is per-project; clear it when the project changes.
-  useEffect(() => {
-    debounceTimers.current.forEach((timer) => clearTimeout(timer));
-    debounceTimers.current.clear();
-    lastProbedParams.current.clear();
-  }, [projectId]);
-
-  const getNodeSchema = useCallback(
-    (nodeId: string): NodeSchemaMeta | undefined => {
-      for (const workflow of rawWorkflowsRef.current) {
-        const node = workflow.nodes?.find((n) => n.id === nodeId);
-        if (node) return node.data?.nodeMetadata?.schema;
-      }
-      return undefined;
-    },
-    [],
-  );
-
-  const persistStatus = useCallback(
-    (
-      nodeId: string,
-      status: "running" | "failed",
-      extra?: { jobId?: string; note?: string },
-    ) => {
-      const existing = getNodeSchema(nodeId);
-      onPersistSchemaRef.current(nodeId, {
-        ports: existing?.ports ?? {},
-        sampleSize: existing?.sampleSize,
-        sampledAt: existing?.sampledAt,
-        // On failure surface the engine's reason (for debugging); while running
-        // keep whatever note was previously shown.
-        note: status === "failed" ? extra?.note : existing?.note,
-        status,
-        ...(extra?.jobId ? { jobId: extra.jobId } : {}),
-      });
-    },
-    [getNodeSchema],
-  );
-
-  const markFailed = useCallback(
-    (nodeId: string, note?: string) => {
-      lastProbedParams.current.delete(nodeId);
-      persistStatus(nodeId, "failed", { note });
-    },
-    [persistStatus],
-  );
+  const markFailed = useCallback((nodeId: string, note?: string) => {
+    // Allow an identical re-save to retry a failed probe.
+    lastProbedParams.current.delete(nodeId);
+    onPersistSchemaRef.current(nodeId, { status: "failed", note });
+  }, []);
 
   const runProbe = useCallback(
     async (nodeId: string) => {
@@ -129,9 +91,12 @@ export default ({
         markFailed(nodeId);
         return;
       }
-      persistStatus(nodeId, "running", { jobId: data.job.id });
+      onPersistSchemaRef.current(nodeId, {
+        status: "running",
+        jobId: data.job.id,
+      });
     },
-    [currentProject, previewSchema, sampleSize, persistStatus, markFailed],
+    [currentProject, previewSchema, sampleSize, markFailed],
   );
 
   const handleNodeParamsSaved = useCallback(

--- a/ui/src/features/Editor/usePreviewSchema/index.ts
+++ b/ui/src/features/Editor/usePreviewSchema/index.ts
@@ -1,9 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { useProject, useWorkflowVariables } from "@flow/lib/gql";
-import { useIndexedDB } from "@flow/lib/indexedDB";
 import { useCurrentProject } from "@flow/stores";
-import type { ReaderSchemaProbeStatus } from "@flow/stores";
 import type { Job, Node, NodeSchemaMeta, Workflow } from "@flow/types";
 import { createEngineReadyWorkflow } from "@flow/utils/toEngineWorkflow/engineReadyWorkflow";
 
@@ -11,10 +9,16 @@ import { buildReaderAttributeSuggestions } from "./readerAttributeSuggestions";
 import {
   fetchSchemaReport,
   findSchemaReportUrl,
+  getNodeReportFailure,
   toNodeSchemaMeta,
 } from "./schemaReport";
 
 const PROBE_DEBOUNCE_MS = 600;
+
+export type RunningSchemaProbe = {
+  nodeId: string;
+  jobId: string;
+};
 
 export default ({
   rawWorkflows,
@@ -30,9 +34,6 @@ export default ({
   const [currentProject] = useCurrentProject();
   const projectId = currentProject?.id;
   const { previewSchema } = useProject();
-
-  const { value: previewSchemaState, updateValue } =
-    useIndexedDB("previewSchema");
 
   const { useGetWorkflowVariables } = useWorkflowVariables();
   const { workflowVariables } = useGetWorkflowVariables(projectId ?? "");
@@ -61,40 +62,50 @@ export default ({
   }, []);
 
   // In-memory bookkeeping is per-project; clear it when the project changes.
-  // (Persisted probes are project-scoped, so they don't need clearing here.)
   useEffect(() => {
     debounceTimers.current.forEach((timer) => clearTimeout(timer));
     debounceTimers.current.clear();
     lastProbedParams.current.clear();
   }, [projectId]);
 
-  const writeProbe = useCallback(
-    (nodeId: string, jobId: string, status: ReaderSchemaProbeStatus) => {
-      if (!projectId) return;
-      if (status === "failed") lastProbedParams.current.delete(nodeId);
-      void updateValue((prev) => {
-        const probes = (prev.probes ?? []).filter(
-          (probe) =>
-            !(probe.projectId === projectId && probe.nodeId === nodeId),
-        );
-        probes.push({ projectId, nodeId, jobId, status });
-        return { probes };
-      });
+  const getNodeSchema = useCallback(
+    (nodeId: string): NodeSchemaMeta | undefined => {
+      for (const workflow of rawWorkflowsRef.current) {
+        const node = workflow.nodes?.find((n) => n.id === nodeId);
+        if (node) return node.data?.nodeMetadata?.schema;
+      }
+      return undefined;
     },
-    [projectId, updateValue],
+    [],
   );
 
-  const clearProbe = useCallback(
-    (nodeId: string) => {
-      if (!projectId) return;
-      void updateValue((prev) => ({
-        probes: (prev.probes ?? []).filter(
-          (probe) =>
-            !(probe.projectId === projectId && probe.nodeId === nodeId),
-        ),
-      }));
+  const persistStatus = useCallback(
+    (
+      nodeId: string,
+      status: "running" | "failed",
+      extra?: { jobId?: string; note?: string },
+    ) => {
+      const existing = getNodeSchema(nodeId);
+      onPersistSchemaRef.current(nodeId, {
+        ports: existing?.ports ?? {},
+        sampleSize: existing?.sampleSize,
+        sampledAt: existing?.sampledAt,
+        // On failure surface the engine's reason (for debugging); while running
+        // keep whatever note was previously shown.
+        note: status === "failed" ? extra?.note : existing?.note,
+        status,
+        ...(extra?.jobId ? { jobId: extra.jobId } : {}),
+      });
     },
-    [projectId, updateValue],
+    [getNodeSchema],
+  );
+
+  const markFailed = useCallback(
+    (nodeId: string, note?: string) => {
+      lastProbedParams.current.delete(nodeId);
+      persistStatus(nodeId, "failed", { note });
+    },
+    [persistStatus],
   );
 
   const runProbe = useCallback(
@@ -115,12 +126,12 @@ export default ({
       );
 
       if (!data.job?.id) {
-        writeProbe(nodeId, "", "failed");
+        markFailed(nodeId);
         return;
       }
-      writeProbe(nodeId, data.job.id, "running");
+      persistStatus(nodeId, "running", { jobId: data.job.id });
     },
-    [currentProject, previewSchema, sampleSize, writeProbe],
+    [currentProject, previewSchema, sampleSize, persistStatus, markFailed],
   );
 
   const handleNodeParamsSaved = useCallback(
@@ -151,42 +162,67 @@ export default ({
     async (nodeId: string, job: Job) => {
       const url = findSchemaReportUrl(job.outputURLs);
       if (!url) {
-        writeProbe(nodeId, job.id, "failed");
+        markFailed(nodeId);
         return;
       }
       try {
         const report = await fetchSchemaReport(url);
         const nodeReport = report.nodes[nodeId];
-        if (nodeReport) {
-          onPersistSchemaRef.current(
-            nodeId,
-            toNodeSchemaMeta(
-              nodeReport,
-              report.sampleSize,
-              new Date().toISOString(),
-            ),
-          );
+        // The job produced a report but it doesn't cover this node.
+        if (!nodeReport) {
+          markFailed(nodeId);
+          return;
         }
-        clearProbe(nodeId);
+        // The job completes even when the reader couldn't sample its data; the
+        // engine only flags that with a note + open/empty port. Treat that as a
+        // failure (surfacing the reason) rather than a hollow "complete".
+        const failureNote = getNodeReportFailure(nodeReport);
+        if (failureNote) {
+          markFailed(nodeId, failureNote);
+          return;
+        }
+        onPersistSchemaRef.current(
+          nodeId,
+          toNodeSchemaMeta(
+            nodeReport,
+            report.sampleSize,
+            new Date().toISOString(),
+          ),
+        );
       } catch {
-        writeProbe(nodeId, job.id, "failed");
+        markFailed(nodeId);
       }
     },
-    [clearProbe, writeProbe],
+    [markFailed],
   );
 
   const handleProbeError = useCallback(
-    (nodeId: string) => writeProbe(nodeId, "", "failed"),
-    [writeProbe],
+    (nodeId: string) => markFailed(nodeId),
+    [markFailed],
   );
 
-  const schemaProbes = useMemo(
-    () =>
-      (previewSchemaState?.probes ?? []).filter(
-        (probe) => probe.projectId === projectId,
-      ),
-    [previewSchemaState, projectId],
-  );
+  const schemaProbes = useMemo<RunningSchemaProbe[]>(() => {
+    const probes: RunningSchemaProbe[] = [];
+    for (const workflow of rawWorkflows) {
+      for (const node of workflow.nodes ?? []) {
+        const schema = node.data?.nodeMetadata?.schema;
+        if (schema?.status === "running" && schema.jobId) {
+          probes.push({ nodeId: node.id, jobId: schema.jobId });
+        }
+      }
+    }
+    return probes;
+  }, [rawWorkflows]);
+
+  useEffect(() => {
+    for (const workflow of rawWorkflows) {
+      for (const node of workflow.nodes ?? []) {
+        if (node.data?.nodeMetadata?.schema?.status === "failed") {
+          lastProbedParams.current.delete(node.id);
+        }
+      }
+    }
+  }, [rawWorkflows]);
 
   const readerAttributeSuggestions = useMemo(
     () => buildReaderAttributeSuggestions(rawWorkflows, openNodeId),

--- a/ui/src/features/Editor/usePreviewSchema/index.ts
+++ b/ui/src/features/Editor/usePreviewSchema/index.ts
@@ -47,8 +47,6 @@ export default ({
   rawWorkflowsRef.current = rawWorkflows;
   const workflowVariablesRef = useRef(workflowVariables);
   workflowVariablesRef.current = workflowVariables;
-  const onPersistSchemaRef = useRef(onPersistSchema);
-  onPersistSchemaRef.current = onPersistSchema;
 
   const debounceTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
     new Map(),
@@ -64,11 +62,12 @@ export default ({
     };
   }, []);
 
-  const markFailed = useCallback((nodeId: string, note?: string) => {
-    // Allow an identical re-save to retry a failed probe.
-    lastProbedParams.current.delete(nodeId);
-    onPersistSchemaRef.current(nodeId, { status: "failed", note });
-  }, []);
+  const markFailed = useCallback(
+    (nodeId: string, note?: string) => {
+      onPersistSchema(nodeId, { status: "failed", note });
+    },
+    [onPersistSchema],
+  );
 
   const runProbe = useCallback(
     async (nodeId: string) => {
@@ -91,12 +90,12 @@ export default ({
         markFailed(nodeId);
         return;
       }
-      onPersistSchemaRef.current(nodeId, {
+      onPersistSchema(nodeId, {
         status: "running",
         jobId: data.job.id,
       });
     },
-    [currentProject, previewSchema, sampleSize, markFailed],
+    [currentProject, previewSchema, sampleSize, markFailed, onPersistSchema],
   );
 
   const handleNodeParamsSaved = useCallback(
@@ -107,7 +106,13 @@ export default ({
       }
 
       const signature = JSON.stringify(node.data.params);
-      if (lastProbedParams.current.get(node.id) === signature) return;
+      const failed =
+        rawWorkflowsRef.current
+          .flatMap((workflow) => workflow.nodes ?? [])
+          .find((n) => n.id === node.id)?.data?.nodeMetadata?.schema?.status ===
+        "failed";
+      if (!failed && lastProbedParams.current.get(node.id) === signature)
+        return;
       lastProbedParams.current.set(node.id, signature);
 
       const existing = debounceTimers.current.get(node.id);
@@ -146,7 +151,7 @@ export default ({
           markFailed(nodeId, failureNote);
           return;
         }
-        onPersistSchemaRef.current(
+        onPersistSchema(
           nodeId,
           toNodeSchemaMeta(
             nodeReport,
@@ -158,7 +163,7 @@ export default ({
         markFailed(nodeId);
       }
     },
-    [markFailed],
+    [markFailed, onPersistSchema],
   );
 
   const handleProbeError = useCallback(
@@ -177,16 +182,6 @@ export default ({
       }
     }
     return probes;
-  }, [rawWorkflows]);
-
-  useEffect(() => {
-    for (const workflow of rawWorkflows) {
-      for (const node of workflow.nodes ?? []) {
-        if (node.data?.nodeMetadata?.schema?.status === "failed") {
-          lastProbedParams.current.delete(node.id);
-        }
-      }
-    }
   }, [rawWorkflows]);
 
   const readerAttributeSuggestions = useMemo(

--- a/ui/src/features/Editor/usePreviewSchema/schemaReport.test.ts
+++ b/ui/src/features/Editor/usePreviewSchema/schemaReport.test.ts
@@ -46,6 +46,7 @@ describe("toNodeSchemaMeta", () => {
       sampleSize: 10,
       sampledAt: "2026-06-17T00:00:00.000Z",
       note: "sampled 2",
+      status: "complete",
     });
   });
 });

--- a/ui/src/features/Editor/usePreviewSchema/schemaReport.test.ts
+++ b/ui/src/features/Editor/usePreviewSchema/schemaReport.test.ts
@@ -3,6 +3,7 @@ import type { NodeReport, SchemaReport } from "@flow/types";
 import {
   fetchSchemaReport,
   findSchemaReportUrl,
+  getNodeReportFailure,
   toNodeSchemaMeta,
 } from "./schemaReport";
 
@@ -48,6 +49,40 @@ describe("toNodeSchemaMeta", () => {
       note: "sampled 2",
       status: "complete",
     });
+  });
+});
+
+describe("getNodeReportFailure", () => {
+  test("returns undefined when there is no note (clean success)", () => {
+    const nodeReport: NodeReport = {
+      name: "reader",
+      ports: {
+        default: { open: false, fields: [{ name: "id", type: "String" }] },
+      },
+    };
+    expect(getNodeReportFailure(nodeReport)).toBeUndefined();
+  });
+
+  test("returns the note when the reader sampled nothing (data error)", () => {
+    const nodeReport: NodeReport = {
+      name: "reader",
+      note: "source run failed: CSV column mismatch",
+      ports: { default: { open: true, fields: [] } },
+    };
+    expect(getNodeReportFailure(nodeReport)).toBe(
+      "source run failed: CSV column mismatch",
+    );
+  });
+
+  test("ignores a note when fields were inferred (open schema, not a failure)", () => {
+    const nodeReport: NodeReport = {
+      name: "reader",
+      note: "open schema",
+      ports: {
+        default: { open: true, fields: [{ name: "id", type: "String" }] },
+      },
+    };
+    expect(getNodeReportFailure(nodeReport)).toBeUndefined();
   });
 });
 

--- a/ui/src/features/Editor/usePreviewSchema/schemaReport.ts
+++ b/ui/src/features/Editor/usePreviewSchema/schemaReport.ts
@@ -24,6 +24,16 @@ export const fetchSchemaReport = async (url: string): Promise<SchemaReport> => {
   return (await response.json()) as SchemaReport;
 };
 
+export const getNodeReportFailure = (
+  nodeReport: NodeReport,
+): string | undefined => {
+  if (!nodeReport.note) return undefined;
+  const hasFields = Object.values(nodeReport.ports ?? {}).some(
+    (port) => port.fields.length > 0,
+  );
+  return hasFields ? undefined : nodeReport.note;
+};
+
 /** Map a node's report entry into the metadata persisted on the node. */
 export const toNodeSchemaMeta = (
   nodeReport: NodeReport,
@@ -31,6 +41,7 @@ export const toNodeSchemaMeta = (
   sampledAt: string,
 ): NodeSchemaMeta => ({
   ports: nodeReport.ports,
+  status: "complete",
   sampleSize,
   sampledAt,
   note: nodeReport.note,

--- a/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/CustomHandle/Handles.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/CustomHandle/Handles.tsx
@@ -73,7 +73,7 @@ const Handles: React.FC<Props> = ({
     <Collapsible className="flex flex-col" open={!isCollapsed}>
       <div className="flex justify-between gap-0.5">
         {nodeType === "reader" && (
-          <SchemaIndicator nodeId={id} schema={nodeData.nodeMetadata?.schema} />
+          <SchemaIndicator schema={nodeData.nodeMetadata?.schema} />
         )}
         {nodeType !== "reader" &&
           hasMoreThanFiveInputHandles &&

--- a/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/SchemaIndicator/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/SchemaIndicator/index.tsx
@@ -13,12 +13,9 @@ import {
 } from "@flow/components";
 import { TYPE_COLOR } from "@flow/features/Editor/components/ParamsDialog/components/ValueEditorDialog/components/flowExprConstants";
 import { useT } from "@flow/lib/i18n";
-import { useIndexedDB } from "@flow/lib/indexedDB";
-import { useCurrentProject } from "@flow/stores";
 import type { FieldReport, NodeSchemaMeta } from "@flow/types";
 
 type Props = {
-  nodeId: string;
   schema?: NodeSchemaMeta;
 };
 
@@ -36,17 +33,12 @@ const collectFields = (schema?: NodeSchemaMeta): FieldReport[] => {
   return fields;
 };
 
-const SchemaIndicator: React.FC<Props> = ({ nodeId, schema }) => {
+const SchemaIndicator: React.FC<Props> = ({ schema }) => {
   const t = useT();
-  const [currentProject] = useCurrentProject();
-  const { value: previewSchemaState } = useIndexedDB("previewSchema");
-  const probe = previewSchemaState?.probes?.find(
-    (p) => p.nodeId === nodeId && p.projectId === currentProject?.id,
-  );
 
   const fields = useMemo(() => collectFields(schema), [schema]);
-
-  if (probe?.status === "running") {
+  console.log("SCHEMA INDICATOR RENDER", schema, fields);
+  if (schema?.status === "running") {
     return (
       <div className="flex translate-x-0.5 items-center">
         <CircleNotchIcon className="size-3 animate-spin text-muted-foreground" />
@@ -54,7 +46,7 @@ const SchemaIndicator: React.FC<Props> = ({ nodeId, schema }) => {
     );
   }
 
-  if (probe?.status === "failed") {
+  if (schema?.status === "failed") {
     return (
       <TooltipProvider>
         <Tooltip>
@@ -63,8 +55,15 @@ const SchemaIndicator: React.FC<Props> = ({ nodeId, schema }) => {
               <WarningCircleIcon className="size-3 text-warning" />
             </div>
           </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {t("Schema preview failed. Re-save to retry.")}
+          <TooltipContent side="bottom" className="max-w-64">
+            <div className="flex flex-col gap-1">
+              <span>{t("Schema preview failed. Re-save to retry.")}</span>
+              {schema.note && (
+                <span className="font-mono text-[10px] wrap-break-word text-muted-foreground">
+                  {schema.note}
+                </span>
+              )}
+            </div>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/SchemaIndicator/index.tsx
+++ b/ui/src/lib/reactFlow/nodeTypes/GeneralNode/components/SchemaIndicator/index.tsx
@@ -37,7 +37,6 @@ const SchemaIndicator: React.FC<Props> = ({ schema }) => {
   const t = useT();
 
   const fields = useMemo(() => collectFields(schema), [schema]);
-  console.log("SCHEMA INDICATOR RENDER", schema, fields);
   if (schema?.status === "running") {
     return (
       <div className="flex translate-x-0.5 items-center">
@@ -59,7 +58,7 @@ const SchemaIndicator: React.FC<Props> = ({ schema }) => {
             <div className="flex flex-col gap-1">
               <span>{t("Schema preview failed. Re-save to retry.")}</span>
               {schema.note && (
-                <span className="font-mono text-[10px] wrap-break-word text-muted-foreground">
+                <span className="break-wordstext-muted-foreground font-mono text-[10px]">
                   {schema.note}
                 </span>
               )}

--- a/ui/src/lib/yjs/useYNode.ts
+++ b/ui/src/lib/yjs/useYNode.ts
@@ -378,11 +378,8 @@ export default ({
     [currentYWorkflow, rawWorkflows, yWorkflows, undoTrackerActionWrapper],
   );
 
-  // Persist a node's probed attribute schema onto its metadata. This is
-  // derived data (not a user edit), so it is written with a distinct origin
-  // that the UndoManager does not track — undo/redo should not touch it.
   const handleYNodeSchemaUpdate = useCallback(
-    (nodeId: string, schema: NodeSchemaMeta | undefined) =>
+    (nodeId: string, patch: Partial<NodeSchemaMeta> | undefined) =>
       undoTrackerActionWrapper(() => {
         const yNodes = currentYWorkflow?.get("nodes") as YNodesMap | undefined;
         if (!yNodes) return;
@@ -390,8 +387,17 @@ export default ({
         if (!yData) return;
         const prevMetadata =
           (yData.get("nodeMetadata") as NodeMetadata | undefined) ?? {};
-        const nodeMetadata: NodeMetadata = { ...prevMetadata, schema };
-        yData.set("nodeMetadata", nodeMetadata);
+        if (!patch) {
+          yData.set("nodeMetadata", { ...prevMetadata, schema: undefined });
+          return;
+        }
+        const schema: NodeSchemaMeta = {
+          ports: {},
+          ...prevMetadata.schema,
+          ...patch,
+        };
+        if (!patch.jobId) delete schema.jobId;
+        yData.set("nodeMetadata", { ...prevMetadata, schema });
       }, "schema-update"),
     [currentYWorkflow, undoTrackerActionWrapper],
   );

--- a/ui/src/stores/indexedDB.ts
+++ b/ui/src/stores/indexedDB.ts
@@ -30,19 +30,6 @@ export type DebugRunState = {
   jobs: JobState[];
 };
 
-export type ReaderSchemaProbeStatus = "running" | "failed";
-
-export type ReaderSchemaProbe = {
-  projectId: string;
-  nodeId: string;
-  jobId: string;
-  status: ReaderSchemaProbeStatus;
-};
-
-export type PreviewSchemaState = {
-  probes: ReaderSchemaProbe[];
-};
-
 export type PreferencesState = {
   theme: string;
 };
@@ -50,7 +37,6 @@ export type PreferencesState = {
 export type AppState = {
   [GENERAL_KEY]: GeneralState;
   [DEBUG_RUN_KEY]: DebugRunState;
-  [PREVIEW_SCHEMA_KEY]: PreviewSchemaState;
   [PREFERENCES_KEY]: PreferencesState;
 };
 
@@ -61,9 +47,8 @@ export const STORE_NAME = "appState";
 
 const GENERAL_KEY = "general";
 const DEBUG_RUN_KEY = "debugRun";
-const PREVIEW_SCHEMA_KEY = "previewSchema";
 const PREFERENCES_KEY = "preferences";
-const KEYS = [GENERAL_KEY, DEBUG_RUN_KEY, PREVIEW_SCHEMA_KEY, PREFERENCES_KEY];
+const KEYS = [GENERAL_KEY, DEBUG_RUN_KEY, PREFERENCES_KEY];
 
 const initialState: AppState = {
   [GENERAL_KEY]: {
@@ -71,9 +56,6 @@ const initialState: AppState = {
   },
   [DEBUG_RUN_KEY]: {
     jobs: [],
-  },
-  [PREVIEW_SCHEMA_KEY]: {
-    probes: [],
   },
   [PREFERENCES_KEY]: {
     theme: "dark",

--- a/ui/src/types/schemaPreview.ts
+++ b/ui/src/types/schemaPreview.ts
@@ -42,6 +42,8 @@ export type SchemaReport = {
 
 export type NodeSchemaMeta = {
   ports: Record<string, PortReport>;
+  status?: "running" | "failed" | "complete";
+  jobId?: string;
   sampleSize?: number;
   sampledAt?: string;
   note?: string;


### PR DESCRIPTION
# Overview
Refactors the UI “preview schema” tracking so probe/job status is persisted on each node’s `nodeMetadata.schema` (instead of a separate IndexedDB `previewSchema` store), enabling status-driven UI indicators and resuming monitors based on workflow state.
## What I've done
- Added `status`/`jobId` to `NodeSchemaMeta` and updated report-to-metadata mapping to mark schema as `"complete"`.
- Removed the `previewSchema` IndexedDB slice and migrated status tracking to node metadata updates inside `usePreviewSchema`.
- Updated schema indicator rendering/monitors to derive “running/failed” state from node metadata.
- Show note if attributes is empty or failed detailing why
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
