### PR TITLE
feat(engine): cherry-picking LineOnLineOverlayer performance fixes and timeout revert

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5681,7 +5681,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.308"
+version = "0.0.309"
 dependencies = [
  "directories",
  "log",
@@ -5710,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6501,7 +6501,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "futures",
  "once_cell",
@@ -6521,7 +6521,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "approx",
  "async-trait",
@@ -6567,7 +6567,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "Inflector",
  "approx",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6714,7 +6714,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6765,7 +6765,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "image 0.25.9",
  "rstar 0.12.2",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "bytes",
  "clap",
@@ -6814,7 +6814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6854,7 +6854,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "chrono",
  "futures",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "approx",
  "bvh",
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6961,7 +6961,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6970,7 +6970,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7000,7 +7000,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7034,7 +7034,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7051,7 +7051,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "bytes",
  "futures",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "bytes",
  "futures",
@@ -7099,7 +7099,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7148,7 +7148,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7185,7 +7185,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.354"
+version = "0.0.355"
 dependencies = [
  "async-trait",
  "backon",
@@ -11053,7 +11053,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.210"
+version = "0.1.211"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.354"
+version = "0.0.355"
 
 [profile.dev]
 opt-level = 0

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.308"
+version = "0.0.309"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
+++ b/engine/runtime/action-processor/src/geometry/line_on_line_overlayer.rs
@@ -1,6 +1,14 @@
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufRead, BufReader, BufWriter, Read as _, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
 use indexmap::IndexMap;
 use once_cell::sync::Lazy;
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use reearth_flow_geometry::algorithm::line_intersection::LineIntersection;
 use reearth_flow_geometry::algorithm::line_string_ops::{
     LineStringOps, LineStringSplitResult, LineStringWithTree2D,
@@ -10,23 +18,24 @@ use reearth_flow_geometry::types::coordinate::Coordinate2D;
 use reearth_flow_geometry::types::geometry::Geometry2D;
 use reearth_flow_geometry::types::line_string::LineString2D;
 use reearth_flow_geometry::types::no_value::NoValue;
-use reearth_flow_geometry::types::point::Point;
-use reearth_flow_runtime::node::REJECTED_PORT;
+use reearth_flow_geometry::types::point::{Point, Point2D};
 use reearth_flow_runtime::{
+    cache::executor_cache_subdir,
     errors::BoxedError,
     event::EventHub,
     executor_operation::{ExecutorContext, NodeContext},
     forwarder::ProcessorChannelForwarder,
-    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT, REJECTED_PORT},
 };
 use reearth_flow_types::metadata::Metadata;
-use reearth_flow_types::{Attribute, AttributeValue, Attributes, Feature, GeometryValue};
+use reearth_flow_types::{Attribute, AttributeValue, Attributes, Feature, Geometry, GeometryValue};
+use rstar::{RTree, RTreeObject, AABB};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
-use std::collections::HashMap;
 
 use super::errors::GeometryProcessorError;
+use crate::ACCUMULATOR_BUFFER_BYTE_THRESHOLD;
 
 pub static POINT_PORT: Lazy<Port> = Lazy::new(|| Port::new("point"));
 pub static LINE_PORT: Lazy<Port> = Lazy::new(|| Port::new("line"));
@@ -89,7 +98,12 @@ impl ProcessorFactory for LineOnLineOverlayerFactory {
             overlaid_lists_attr_name: params
                 .overlaid_lists_attr_name
                 .unwrap_or_else(|| "overlaidLists".to_string()),
+            group_map: HashMap::new(),
+            group_count: 0,
+            temp_dir: None,
             buffer: HashMap::new(),
+            buffer_bytes: 0,
+            executor_id: None,
         }))
     }
 }
@@ -106,21 +120,143 @@ pub struct LineOnLineOverlayerParam {
     overlaid_lists_attr_name: Option<String>,
 }
 
-#[allow(clippy::type_complexity)]
-#[derive(Debug, Clone)]
 pub struct LineOnLineOverlayer {
     group_by: Option<Vec<Attribute>>,
     tolerance: f64,
     overlaid_lists_attr_name: String,
-    buffer: HashMap<AttributeValue, Vec<Feature>>,
+    // Disk-backed state
+    group_map: HashMap<AttributeValue, usize>,
+    group_count: usize,
+    temp_dir: Option<PathBuf>,
+    /// group_idx -> Vec<(aabbs_json_for_feature, feature_json)>.
+    /// `aabbs_json_for_feature` is a JSON array `[[minx, miny, maxx, maxy], ...]` with one
+    /// entry per sub-line-string of the feature. Row i of `aabbs.jsonl` matches row i of
+    /// `features.jsonl`.
+    buffer: HashMap<usize, Vec<(String, String)>>,
+    buffer_bytes: usize,
+    executor_id: Option<uuid::Uuid>,
+}
+
+impl std::fmt::Debug for LineOnLineOverlayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LineOnLineOverlayer")
+            .field("group_count", &self.group_count)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Clone for LineOnLineOverlayer {
+    fn clone(&self) -> Self {
+        Self {
+            group_by: self.group_by.clone(),
+            tolerance: self.tolerance,
+            overlaid_lists_attr_name: self.overlaid_lists_attr_name.clone(),
+            group_map: HashMap::new(),
+            group_count: 0,
+            temp_dir: None,
+            buffer: HashMap::new(),
+            buffer_bytes: 0,
+            executor_id: self.executor_id,
+        }
+    }
+}
+
+fn engine_cache_dir(executor_id: uuid::Uuid) -> PathBuf {
+    executor_cache_subdir(executor_id, "processors")
+}
+
+impl LineOnLineOverlayer {
+    fn ensure_temp_dir(&mut self) -> Result<&PathBuf, BoxedError> {
+        if self.temp_dir.is_none() {
+            let executor_id = self.executor_id.unwrap_or_else(uuid::Uuid::nil);
+            let dir = engine_cache_dir(executor_id).join(format!("lol-{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&dir)?;
+            self.temp_dir = Some(dir);
+        }
+        Ok(self.temp_dir.as_ref().unwrap())
+    }
+
+    fn ensure_group_dir(&mut self, group_idx: usize) -> Result<PathBuf, BoxedError> {
+        let dir = self.ensure_temp_dir()?.clone();
+        let group_dir = dir.join(format!("group_{group_idx:06}"));
+        std::fs::create_dir_all(&group_dir)?;
+        Ok(group_dir)
+    }
+
+    fn append_to_group(
+        &mut self,
+        group_idx: usize,
+        aabbs_json: String,
+        feature_json: String,
+    ) -> Result<(), BoxedError> {
+        self.buffer_bytes += aabbs_json.len() + feature_json.len();
+        self.buffer
+            .entry(group_idx)
+            .or_default()
+            .push((aabbs_json, feature_json));
+
+        if self.buffer_bytes >= ACCUMULATOR_BUFFER_BYTE_THRESHOLD {
+            self.flush_buffer()?;
+        }
+        Ok(())
+    }
+
+    fn flush_buffer(&mut self) -> Result<(), BoxedError> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+
+        for (group_idx, entries) in std::mem::take(&mut self.buffer) {
+            let group_dir = self.ensure_group_dir(group_idx)?;
+
+            let aabbs_file = File::options()
+                .create(true)
+                .append(true)
+                .open(group_dir.join("aabbs.jsonl"))?;
+            let mut aabb_w = BufWriter::new(aabbs_file);
+            let feats_file = File::options()
+                .create(true)
+                .append(true)
+                .open(group_dir.join("features.jsonl"))?;
+            let mut feat_w = BufWriter::new(feats_file);
+
+            for (aabbs_json, feature_json) in &entries {
+                aabb_w.write_all(aabbs_json.as_bytes())?;
+                aabb_w.write_all(b"\n")?;
+                feat_w.write_all(feature_json.as_bytes())?;
+                feat_w.write_all(b"\n")?;
+            }
+            aabb_w.flush()?;
+            feat_w.flush()?;
+        }
+
+        self.buffer_bytes = 0;
+        Ok(())
+    }
+}
+
+impl Drop for LineOnLineOverlayer {
+    fn drop(&mut self) {
+        if let Some(ref dir) = self.temp_dir {
+            let _ = std::fs::remove_dir_all(dir);
+        }
+    }
 }
 
 impl Processor for LineOnLineOverlayer {
+    fn is_accumulating(&self) -> bool {
+        true
+    }
+
     fn process(
         &mut self,
         ctx: ExecutorContext,
         fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
+        if self.executor_id.is_none() {
+            self.executor_id = Some(fw.executor_id());
+        }
+
         let feature = &ctx.feature;
         let geometry = &feature.geometry;
         if geometry.is_empty() {
@@ -128,10 +264,13 @@ impl Processor for LineOnLineOverlayer {
             return Ok(());
         }
         match &geometry.value {
-            GeometryValue::None => {
-                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
-            }
-            GeometryValue::FlowGeometry2D(_) => {
+            GeometryValue::FlowGeometry2D(geom_2d) => {
+                let line_strings = extract_line_strings(geom_2d);
+                if line_strings.is_empty() {
+                    fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
+                    return Ok(());
+                }
+
                 let key = if let Some(group_by) = &self.group_by {
                     AttributeValue::Array(
                         group_by
@@ -142,21 +281,19 @@ impl Processor for LineOnLineOverlayer {
                 } else {
                     AttributeValue::Null
                 };
+                let group_idx = if let Some(&idx) = self.group_map.get(&key) {
+                    idx
+                } else {
+                    let idx = self.group_count;
+                    self.group_map.insert(key, idx);
+                    self.group_count += 1;
+                    idx
+                };
 
-                if !self.buffer.contains_key(&key) {
-                    let overlaid = self.overlay()?;
-                    for feature in &overlaid.line {
-                        fw.send(ctx.new_with_feature_and_port(feature.clone(), LINE_PORT.clone()));
-                    }
-                    for feature in &overlaid.point {
-                        fw.send(ctx.new_with_feature_and_port(feature.clone(), POINT_PORT.clone()));
-                    }
-                    self.buffer.clear();
-                }
-                self.buffer
-                    .entry(key.clone())
-                    .or_default()
-                    .push(feature.clone());
+                let aabbs: Vec<[f64; 4]> = line_strings.iter().map(aabb_of_line_string).collect();
+                let aabbs_json = serde_json::to_string(&aabbs)?;
+                let feature_json = serde_json::to_string(&ctx.feature)?;
+                self.append_to_group(group_idx, aabbs_json, feature_json)?;
             }
             _ => {
                 fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()));
@@ -170,20 +307,51 @@ impl Processor for LineOnLineOverlayer {
         ctx: NodeContext,
         fw: &ProcessorChannelForwarder,
     ) -> Result<(), BoxedError> {
-        let overlaid = self.overlay()?;
-        for feature in &overlaid.line {
-            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
-                &ctx,
-                feature.clone(),
-                LINE_PORT.clone(),
-            ));
+        self.flush_buffer()?;
+
+        let temp_dir = match &self.temp_dir {
+            Some(d) => d.clone(),
+            None => return Ok(()),
+        };
+
+        let output_id = uuid::Uuid::new_v4();
+        let line_path = temp_dir.join(format!("lol-line-{output_id}.jsonl.zst"));
+        let point_path = temp_dir.join(format!("lol-point-{output_id}.jsonl.zst"));
+        let mut line_writer = BufWriter::new(zstd::Encoder::new(File::create(&line_path)?, 1)?);
+        let mut point_writer = BufWriter::new(zstd::Encoder::new(File::create(&point_path)?, 1)?);
+        let mut line_count: usize = 0;
+        let mut point_count: usize = 0;
+
+        for group_idx in 0..self.group_count {
+            let group_dir = temp_dir.join(format!("group_{group_idx:06}"));
+            let (lc, pc) = process_group(
+                &group_dir,
+                self.tolerance,
+                self.group_by.as_deref(),
+                &self.overlaid_lists_attr_name,
+                &mut line_writer,
+                &mut point_writer,
+            )?;
+            line_count += lc;
+            point_count += pc;
         }
-        for feature in &overlaid.point {
-            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
-                &ctx,
-                feature.clone(),
-                POINT_PORT.clone(),
-            ));
+
+        line_writer
+            .into_inner()
+            .map_err(|e| e.into_error())?
+            .finish()?;
+        point_writer
+            .into_inner()
+            .map_err(|e| e.into_error())?
+            .finish()?;
+
+        let context = ctx.as_context();
+
+        if line_count > 0 {
+            fw.send_file(line_path, LINE_PORT.clone(), context.clone());
+        }
+        if point_count > 0 {
+            fw.send_file(point_path, POINT_PORT.clone(), context);
         }
 
         Ok(())
@@ -194,356 +362,481 @@ impl Processor for LineOnLineOverlayer {
     }
 }
 
-struct OverlayedFeatures {
-    point: Vec<Feature>,
-    line: Vec<Feature>,
+fn extract_line_strings(geom: &Geometry2D<f64>) -> Vec<LineString2D<f64>> {
+    match geom {
+        Geometry2D::LineString(line) => vec![line.clone()],
+        Geometry2D::MultiLineString(multi) => multi.0.clone(),
+        Geometry2D::Polygon(polygon) => vec![polygon.exterior().clone()],
+        Geometry2D::MultiPolygon(multi) => multi.0.iter().map(|p| p.exterior().clone()).collect(),
+        _ => Vec::new(),
+    }
 }
 
-impl OverlayedFeatures {
-    fn new() -> Self {
-        Self {
-            point: Vec::new(),
-            line: Vec::new(),
+fn aabb_of_line_string(ls: &LineString2D<f64>) -> [f64; 4] {
+    let env = ls.envelope();
+    let lo = env.lower();
+    let hi = env.upper();
+    [lo.x(), lo.y(), hi.x(), hi.y()]
+}
+
+fn aabb_to_rstar(aabb: [f64; 4]) -> AABB<Point2D<f64>> {
+    AABB::from_corners(
+        Point2D::new_(aabb[0], aabb[1], NoValue),
+        Point2D::new_(aabb[2], aabb[3], NoValue),
+    )
+}
+
+struct DiskBackedFeatures {
+    path: PathBuf,
+    offsets: Vec<u64>,
+    lengths: Vec<usize>,
+}
+
+impl DiskBackedFeatures {
+    fn scan(path: &Path) -> Result<Self, BoxedError> {
+        let file = File::open(path)?;
+        let mut reader = BufReader::new(file);
+        let mut offsets = Vec::new();
+        let mut lengths = Vec::new();
+        let mut offset: u64 = 0;
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let bytes_read = reader.read_line(&mut line)?;
+            if bytes_read == 0 {
+                break;
+            }
+            let trimmed_len = line.trim_end_matches('\n').len();
+            if trimmed_len > 0 {
+                offsets.push(offset);
+                lengths.push(trimmed_len);
+            }
+            offset += bytes_read as u64;
+        }
+        Ok(Self {
+            path: path.to_path_buf(),
+            offsets,
+            lengths,
+        })
+    }
+
+    // Opens a fresh fd per call so `&self` callers can be parallelised in the future.
+    // The current sole caller is sequential, so the N file opens are wasted — but
+    // they scale linearly and the target is a local filesystem, so the overhead
+    // is bounded.
+    fn read_feature(&self, i: usize) -> Result<Feature, BoxedError> {
+        let mut file = File::open(&self.path)?;
+        file.seek(SeekFrom::Start(self.offsets[i]))?;
+        let mut buf = vec![0u8; self.lengths[i]];
+        file.read_exact(&mut buf)?;
+        Ok(serde_json::from_slice(&buf)?)
+    }
+
+    fn len(&self) -> usize {
+        self.offsets.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.offsets.is_empty()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct AabbEntry {
+    feature_idx: usize,
+    ls_local_idx: usize,
+    aabb: AABB<Point2D<f64>>,
+}
+
+impl RTreeObject for AabbEntry {
+    type Envelope = AABB<Point2D<f64>>;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.aabb
+    }
+}
+
+fn process_group<W: Write>(
+    group_dir: &Path,
+    tolerance: f64,
+    group_by: Option<&[Attribute]>,
+    overlaid_lists_attr_name: &str,
+    line_writer: &mut W,
+    point_writer: &mut W,
+) -> Result<(usize, usize), BoxedError> {
+    let aabbs_path = group_dir.join("aabbs.jsonl");
+    let features_path = group_dir.join("features.jsonl");
+    if !aabbs_path.exists() || !features_path.exists() {
+        return Ok((0, 0));
+    }
+
+    let aabbs_per_feature: Vec<Vec<[f64; 4]>> = {
+        let file = File::open(&aabbs_path)?;
+        let reader = BufReader::new(file);
+        let mut out = Vec::new();
+        for line in reader.lines() {
+            let line = line?;
+            if line.is_empty() {
+                continue;
+            }
+            let v: Vec<[f64; 4]> = serde_json::from_str(&line)?;
+            out.push(v);
+        }
+        out
+    };
+
+    let total_entries: usize = aabbs_per_feature.iter().map(|v| v.len()).sum();
+    let mut entries: Vec<AabbEntry> = Vec::with_capacity(total_entries);
+    for (feature_idx, lss) in aabbs_per_feature.iter().enumerate() {
+        for (ls_local_idx, aabb) in lss.iter().enumerate() {
+            entries.push(AabbEntry {
+                feature_idx,
+                ls_local_idx,
+                aabb: aabb_to_rstar(*aabb),
+            });
         }
     }
-
-    fn extend(&mut self, other: Self) {
-        self.point.extend(other.point);
-        self.line.extend(other.line);
+    if entries.is_empty() {
+        return Ok((0, 0));
     }
-}
 
-impl LineOnLineOverlayer {
-    fn overlay(&self) -> Result<OverlayedFeatures, BoxedError> {
-        let mut overlaid = OverlayedFeatures::new();
-        for buffer in self.buffer.values() {
-            let buffered_features_2d = buffer
+    let disk_feats = DiskBackedFeatures::scan(&features_path)?;
+    if disk_feats.len() != aabbs_per_feature.len() {
+        return Err(Box::new(
+            GeometryProcessorError::LineOnLineOverlayerFactory(format!(
+                "aabbs/features row count mismatch in {}: aabbs={}, features={}",
+                group_dir.display(),
+                aabbs_per_feature.len(),
+                disk_feats.len(),
+            )),
+        ));
+    }
+    let mut attributes_by_feature: Vec<Arc<Attributes>> = Vec::with_capacity(disk_feats.len());
+    let mut lss_per_feature: Vec<Vec<LineString2D<f64>>> = Vec::with_capacity(disk_feats.len());
+    for i in 0..disk_feats.len() {
+        let feat = disk_feats.read_feature(i)?;
+        let lss = match &feat.geometry.value {
+            GeometryValue::FlowGeometry2D(g2) => extract_line_strings(g2),
+            _ => Vec::new(),
+        };
+        attributes_by_feature.push(feat.attributes);
+        lss_per_feature.push(lss);
+    }
+
+    let overlay = overlay_entries(entries, &lss_per_feature, tolerance);
+
+    let mut line_count: usize = 0;
+    for meta in &overlay.line_strings_with_metadata {
+        let source_feature_idxs = &meta.source_feature_idxs;
+
+        let mut attributes = Attributes::new();
+        attributes.insert(
+            Attribute::new("overlayCount"),
+            AttributeValue::Number(Number::from(source_feature_idxs.len())),
+        );
+
+        let mut overlaid_list: Vec<AttributeValue> = Vec::with_capacity(source_feature_idxs.len());
+        for &fi in source_feature_idxs {
+            let attrs = &attributes_by_feature[fi];
+            let attrs_map: HashMap<String, AttributeValue> = attrs
+                .as_ref()
                 .iter()
-                .filter(|f| matches!(&f.geometry.value, GeometryValue::FlowGeometry2D(_)))
-                .collect::<Vec<_>>();
-            overlaid.extend(self.overlay_2d(buffered_features_2d)?);
+                .map(|(k, v)| (k.clone().inner(), v.clone()))
+                .collect();
+            overlaid_list.push(AttributeValue::Map(attrs_map));
+        }
+        attributes.insert(
+            Attribute::new(overlaid_lists_attr_name),
+            AttributeValue::Array(overlaid_list),
+        );
+
+        if let Some(group_by) = group_by {
+            let first_fi = source_feature_idxs[0];
+            let first_attrs = &attributes_by_feature[first_fi];
+            for gb in group_by {
+                if let Some(value) = first_attrs.get(gb) {
+                    attributes.insert(gb.clone(), value.clone());
+                } else {
+                    return Err(Box::new(
+                        GeometryProcessorError::LineOnLineOverlayerFactory(
+                            "Group by attribute not found in feature".to_string(),
+                        ),
+                    ));
+                }
+            }
         }
 
-        Ok(overlaid)
+        let geometry = Geometry {
+            value: GeometryValue::FlowGeometry2D(Geometry2D::LineString(meta.line_string.clone())),
+            ..Default::default()
+        };
+        let out = Feature::new_with_attributes_and_geometry(attributes, geometry, Metadata::new());
+        serde_json::to_writer(&mut *line_writer, &out)?;
+        line_writer.write_all(b"\n")?;
+        line_count += 1;
     }
 
-    fn overlay_2d(&self, features_2d: Vec<&Feature>) -> Result<OverlayedFeatures, BoxedError> {
-        // mapping from line string index to feature index
-        let mut map_ls_to_features = Vec::new();
-        let line_strings = features_2d
-            .iter()
-            .enumerate()
-            .filter_map(|(i, f)| f.geometry.value.as_flow_geometry_2d().map(|f| (i, f)))
-            .filter_map(|(i, g)| {
-                if let Geometry2D::LineString(line) = g {
-                    map_ls_to_features.push(i);
-                    Some(vec![line.clone()])
-                } else if let Geometry2D::MultiLineString(multi_line) = g {
-                    // Add one entry for each line in the multi-line
-                    for _ in 0..multi_line.0.len() {
-                        map_ls_to_features.push(i);
-                    }
-                    Some(multi_line.0.clone())
-                } else if let Geometry2D::Polygon(polygon) = g {
-                    // Extract exterior ring as LineString
-                    map_ls_to_features.push(i);
-                    Some(vec![polygon.exterior().clone()])
-                } else if let Geometry2D::MultiPolygon(multi_polygon) = g {
-                    // Extract all exterior rings as LineStrings
-                    // Add one entry for each polygon in the multi-polygon
-                    for _ in 0..multi_polygon.0.len() {
-                        map_ls_to_features.push(i);
-                    }
-                    Some(
-                        multi_polygon
-                            .0
-                            .iter()
-                            .map(|p| p.exterior().clone())
-                            .collect(),
-                    )
-                } else {
-                    None
-                }
-            })
-            .flatten()
-            .collect::<Vec<_>>();
+    // Point attributes come from the last feature in the group (by insertion order),
+    // filtered by group_by if set — preserves pre-rewrite convention.
+    let last_feature_idx = if disk_feats.is_empty() {
+        None
+    } else {
+        Some(disk_feats.len() - 1)
+    };
 
-        let line_string_intersection_result =
-            line_string_intersection_2d(&line_strings, self.tolerance);
-
-        let mut overlaid = OverlayedFeatures::new();
-
-        for ls in &line_string_intersection_result.line_strings_with_metadata {
-            let LineString2DWithMetadata {
-                line_string: result_ls,
-                overlay_count,
-                overlay_ids,
-            } = ls;
-            let mut attributes = Attributes::new();
-            attributes.insert(
-                Attribute::new("overlayCount"),
-                AttributeValue::Number(Number::from(*overlay_count)),
-            );
-            attributes.insert(
-                Attribute::new(&self.overlaid_lists_attr_name),
-                AttributeValue::Array(
-                    overlay_ids
-                        .iter()
-                        .map(|&id| {
-                            AttributeValue::Map(
-                                features_2d[map_ls_to_features[id]]
-                                    .attributes
-                                    .as_ref()
-                                    .clone()
-                                    .into_iter()
-                                    .map(|(k, v)| (k.inner(), v))
-                                    .collect::<HashMap<_, _>>(),
-                            )
-                        })
-                        .collect::<Vec<_>>(),
-                ),
-            );
-
-            // Add common attributes. These are attributes that are listed in `group_by` and exist in all overlaid features.
-            if let Some(group_by) = &self.group_by {
-                let attr = &features_2d[map_ls_to_features[overlay_ids[0]]].attributes;
-                for group_by in group_by {
-                    if let Some(value) = attr.get(group_by) {
-                        attributes.insert(group_by.clone(), value.clone());
-                    } else {
-                        return Err(Box::new(
-                            GeometryProcessorError::LineOnLineOverlayerFactory(
-                                "Group by attribute not found in feature".to_string(),
-                            ),
-                        ));
-                    }
-                }
-            };
-            let geometry = reearth_flow_types::Geometry {
-                value: GeometryValue::FlowGeometry2D(Geometry2D::LineString(result_ls.clone())),
-                ..Default::default()
-            };
-            let feature =
-                Feature::new_with_attributes_and_geometry(attributes, geometry, Metadata::new());
-            overlaid.line.push(feature);
-        }
-
-        let last_feature = features_2d.last().unwrap();
-
-        for result_coords in line_string_intersection_result.split_coords {
-            let attributes = if let Some(group_by) = &self.group_by {
+    let mut point_count: usize = 0;
+    for coord in &overlay.split_coords {
+        let attributes: IndexMap<Attribute, AttributeValue> =
+            if let (Some(group_by), Some(lfi)) = (group_by, last_feature_idx) {
+                let attrs = &attributes_by_feature[lfi];
                 group_by
                     .iter()
-                    .filter_map(|attr| {
-                        let value = last_feature.get(attr).cloned()?;
-                        Some((attr.clone(), value))
-                    })
-                    .collect::<IndexMap<_, _>>()
+                    .filter_map(|gb| attrs.get(gb).cloned().map(|v| (gb.clone(), v)))
+                    .collect()
             } else {
                 IndexMap::new()
             };
-
-            let geometry = reearth_flow_types::Geometry {
-                value: GeometryValue::FlowGeometry2D(Geometry2D::Point(Point(result_coords))),
-                ..Default::default()
-            };
-            let feature =
-                Feature::new_with_attributes_and_geometry(attributes, geometry, Metadata::new());
-            overlaid.point.push(feature);
-        }
-
-        Ok(overlaid)
+        let geometry = Geometry {
+            value: GeometryValue::FlowGeometry2D(Geometry2D::Point(Point(*coord))),
+            ..Default::default()
+        };
+        let out = Feature::new_with_attributes_and_geometry(attributes, geometry, Metadata::new());
+        serde_json::to_writer(&mut *point_writer, &out)?;
+        point_writer.write_all(b"\n")?;
+        point_count += 1;
     }
-}
 
-/// Coordinates of the intersection point to output
-#[derive(Debug, Clone)]
-struct OverlayResultCoordinates {
-    i_by: usize,
-    i_other: usize,
-    coordinates: Coordinate2D<f64>,
+    Ok((line_count, point_count))
 }
 
 #[derive(Debug, Clone)]
 struct LineString2DWithMetadata<T: GeoFloat> {
     line_string: LineString2D<T>,
-    /// Number of original line strings that contributed to this line string
-    overlay_count: usize,
-    /// Indices of original line strings that contributed to this line string
-    /// It must be of size `overlay_count`
-    overlay_ids: Vec<usize>,
+    /// feature_idx of each source feature that contributed to this segment.
+    /// Deduplicated — each feature appears at most once.
+    source_feature_idxs: Vec<usize>,
 }
 
-/// Result of overlaying line strings
 #[derive(Debug, Clone)]
 struct OverlayResult {
     line_strings_with_metadata: Vec<LineString2DWithMetadata<f64>>,
     split_coords: Vec<Coordinate2D<f64>>,
 }
 
-/// Calculate the intersection between line strings
-fn line_string_intersection_2d(
-    line_strings: &[LineString2D<f64>],
+fn overlay_entries(
+    entries: Vec<AabbEntry>,
+    lss_per_feature: &[Vec<LineString2D<f64>>],
     tolerance: f64,
 ) -> OverlayResult {
-    // Pre-compute bounding boxes so the inner loop can skip pairs whose
-    // envelopes don't overlap (cheap AABB test vs expensive intersection).
-    use rstar::{Envelope, RTreeObject};
-    let envelopes: Vec<_> = line_strings.iter().map(|ls| ls.envelope()).collect();
+    let rtree: RTree<AabbEntry> = RTree::bulk_load(entries);
+    let rtree_items: Vec<&AabbEntry> = rtree.iter().collect();
 
-    let results = line_strings.par_iter().enumerate().map(|(i, line_string)| {
-        let packed_line_string = LineStringWithTree2D::new(line_string.clone());
+    type PerEntryResult = (Vec<(usize, LineString2D<f64>)>, Vec<Coordinate2D<f64>>);
+    let per_entry_results: Vec<PerEntryResult> = rtree_items
+        .par_iter()
+        .map(|&entry_i| {
+            let self_ls = &lss_per_feature[entry_i.feature_idx][entry_i.ls_local_idx];
+            let packed = LineStringWithTree2D::new(self_ls.clone());
 
-        struct IntersectionWithIndex {
-            i_by: usize,
-            i_other: usize,
-            intersection: LineIntersection<f64, NoValue>,
-        }
-
-        let env_i = &envelopes[i];
-        let inters_with_index = (0..line_strings.len())
-            .filter(|&j| j != i && env_i.intersects(&envelopes[j]))
-            .map(|j| (j, &line_strings[j]))
-            .filter_map(|(j, other_line_string)| {
-                let intersections = packed_line_string.intersection(other_line_string);
-                if intersections.is_empty() {
-                    return None;
+            // Lazy iteration over R-tree candidates; never materialises the pair list.
+            let mut intersection_coords: Vec<Coordinate2D<f64>> = Vec::new();
+            for entry_j in rtree.locate_in_envelope_intersecting(&entry_i.aabb) {
+                if entry_j.feature_idx == entry_i.feature_idx {
+                    continue;
                 }
-
-                let inters = intersections
-                    .into_iter()
-                    .map(|intersection| IntersectionWithIndex {
-                        i_by: i,
-                        i_other: j,
-                        intersection,
-                    })
-                    .collect::<Vec<_>>();
-
-                Some(inters)
-            })
-            .collect::<Vec<_>>();
-
-        let split_coords_with_index = inters_with_index
-            .iter()
-            .flatten()
-            .flat_map(|inter| {
-                let coords = match inter.intersection {
-                    LineIntersection::SinglePoint { intersection, .. } => vec![intersection],
-                    LineIntersection::Collinear { intersection } => {
-                        // treat collinear as points
-                        vec![intersection.start, intersection.end]
+                let other_ls = &lss_per_feature[entry_j.feature_idx][entry_j.ls_local_idx];
+                for intersection in packed.intersection(other_ls) {
+                    match intersection {
+                        LineIntersection::SinglePoint { intersection, .. } => {
+                            intersection_coords.push(intersection);
+                        }
+                        LineIntersection::Collinear { intersection } => {
+                            intersection_coords.push(intersection.start);
+                            intersection_coords.push(intersection.end);
+                        }
                     }
-                };
+                }
+            }
 
-                coords
-                    .into_iter()
-                    .map(|coordinates| OverlayResultCoordinates {
-                        coordinates,
-                        i_by: inter.i_by,
-                        i_other: inter.i_other,
-                    })
-            })
-            .collect::<Vec<_>>();
+            let LineStringSplitResult {
+                split_line_strings,
+                split_coords,
+            } = packed.split(&intersection_coords, tolerance);
 
-        let split_coords = split_coords_with_index
+            let segs: Vec<(usize, LineString2D<f64>)> = split_line_strings
+                .into_iter()
+                .map(|l| (entry_i.feature_idx, l))
+                .collect();
+
+            (segs, split_coords)
+        })
+        .collect();
+
+    let mut segments: Vec<(usize, LineString2D<f64>)> = Vec::new();
+    let mut split_coords_flat: Vec<Coordinate2D<f64>> = Vec::new();
+    for (segs, coords) in per_entry_results {
+        segments.extend(segs);
+        split_coords_flat.extend(coords);
+    }
+
+    // Drop sub-tolerance segments — zero-length stubs and near-coincident endpoint slivers
+    // aren't meaningful overlays and previously dominated the line-port output.
+    segments.retain(|(_, ls)| line_string_length_2d(ls) >= tolerance);
+
+    // Two source entries that overlapped geometrically produce identical split segments from
+    // different per-entry tasks; we cluster them here.
+    let seg_aabbs: Vec<AABB<Point2D<f64>>> = segments.iter().map(|(_, ls)| ls.envelope()).collect();
+
+    #[derive(Clone, Copy)]
+    struct SegEntry {
+        idx: usize,
+        aabb: AABB<Point2D<f64>>,
+    }
+    impl RTreeObject for SegEntry {
+        type Envelope = AABB<Point2D<f64>>;
+        fn envelope(&self) -> Self::Envelope {
+            self.aabb
+        }
+    }
+    let seg_rtree: RTree<SegEntry> = RTree::bulk_load(
+        seg_aabbs
             .iter()
-            .map(|split| split.coordinates)
-            .collect::<Vec<_>>();
+            .enumerate()
+            .map(|(idx, aabb)| SegEntry { idx, aabb: *aabb })
+            .collect(),
+    );
 
-        let LineStringSplitResult {
-            split_line_strings,
-            split_coords,
-        } = packed_line_string.split(&split_coords, tolerance);
-
-        let split_line_strings_with_indices = split_line_strings
-            .into_iter()
-            .map(|l| (i, l))
-            .collect::<Vec<_>>();
-
-        let split_coords_with_indices = split_coords
-            .iter()
-            .map(|&v| {
-                let indices = split_coords_with_index
-                    .iter()
-                    .filter(|&o| (v - o.coordinates).norm() < tolerance)
-                    .flat_map(|o| [o.i_by, o.i_other])
-                    .collect::<Vec<_>>();
-                (v, indices)
-            })
-            .collect::<Vec<_>>();
-
-        (split_line_strings_with_indices, split_coords_with_indices)
-    });
-
-    let (result_line_strings, split_coords_with_indices): (Vec<_>, Vec<_>) = results.unzip();
-    let line_strings_with_indices = result_line_strings
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
-    let split_coords_with_indices = split_coords_with_indices
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
-
-    // We have all the intersection points and line strings now.
-    // What remains is to compute duplicates and overlay counts.
-    let mut line_strings_with_metadata = Vec::new();
-    let mut processed = vec![false; line_strings_with_indices.len()];
-    for (i, (idx1, ls1)) in line_strings_with_indices.iter().enumerate() {
+    let mut processed = vec![false; segments.len()];
+    let mut line_strings_with_metadata: Vec<LineString2DWithMetadata<f64>> = Vec::new();
+    for i in 0..segments.len() {
         if processed[i] {
             continue;
         }
-        let mut overlay_count = 1; // itself
-        let mut overlay_ids = vec![*idx1];
-        for j in i + 1..line_strings_with_indices.len() {
-            let ls2 = &line_strings_with_indices[j].1;
-            let idx2 = &line_strings_with_indices[j].0;
-            if ls1
-                .0
-                .iter()
-                .zip(ls2.0.iter())
-                .all(|(&c1, &c2)| (c1 - c2).norm() < tolerance)
-                || ls1
-                    .0
-                    .iter()
-                    .rev()
-                    .zip(ls2.0.iter())
-                    .all(|(&c1, &c2)| (c1 - c2).norm() < tolerance)
-            {
-                overlay_count += 1;
-                overlay_ids.push(*idx2);
+        let (feat_i, ls1) = segments[i].clone();
+        // A single feature may contribute multiple matching segments (e.g. a closed ring
+        // whose split produces several arcs that all coincide with the rep segment). Count
+        // each feature at most once; extra matching segments dedupe silently.
+        let mut source_feature_idxs = vec![feat_i];
+        let mut included_feats: std::collections::HashSet<usize> =
+            std::collections::HashSet::from([feat_i]);
+
+        for cand in seg_rtree.locate_in_envelope_intersecting(&seg_aabbs[i]) {
+            let j = cand.idx;
+            if j <= i || processed[j] {
+                continue;
+            }
+            let (feat_j, ls2) = (segments[j].0, &segments[j].1);
+            if segments_match(&ls1, ls2, tolerance) {
+                if !included_feats.insert(feat_j) {
+                    processed[j] = true;
+                    continue;
+                }
+                source_feature_idxs.push(feat_j);
                 processed[j] = true;
             }
         }
-        let ls_with_metadata = LineString2DWithMetadata {
-            line_string: ls1.clone(),
-            overlay_count,
-            overlay_ids,
-        };
-        line_strings_with_metadata.push(ls_with_metadata);
+
+        line_strings_with_metadata.push(LineString2DWithMetadata {
+            line_string: ls1,
+            source_feature_idxs,
+        });
     }
 
-    // Split coordinate duplicates
-    let mut unique_split_coords = Vec::new();
-    let mut processed_coords = vec![false; split_coords_with_indices.len()];
-    for (i, coord1) in split_coords_with_indices.iter().enumerate() {
-        if processed_coords[i] {
+    // Each physical intersection is discovered by both sides of the crossing plus extras
+    // from 3+-way near-coincidences, so dedup by tolerance-expanded envelope.
+    #[derive(Clone, Copy)]
+    struct PointEntry {
+        idx: usize,
+        point: Point2D<f64>,
+    }
+    impl RTreeObject for PointEntry {
+        type Envelope = AABB<Point2D<f64>>;
+        fn envelope(&self) -> Self::Envelope {
+            AABB::from_point(self.point)
+        }
+    }
+
+    let point_rtree: RTree<PointEntry> = RTree::bulk_load(
+        split_coords_flat
+            .iter()
+            .enumerate()
+            .map(|(idx, c)| PointEntry {
+                idx,
+                point: Point2D::new_(c.x, c.y, NoValue),
+            })
+            .collect(),
+    );
+
+    let mut processed_pts = vec![false; split_coords_flat.len()];
+    let mut unique_coords: Vec<Coordinate2D<f64>> = Vec::new();
+    for i in 0..split_coords_flat.len() {
+        if processed_pts[i] {
             continue;
         }
-        unique_split_coords.push(coord1.clone());
-        for (j, coord2) in split_coords_with_indices.iter().enumerate().skip(i + 1) {
-            if (coord1.0 - coord2.0).norm() < tolerance {
-                processed_coords[j] = true;
-                // Merge the line string indices
-                unique_split_coords.last_mut().unwrap().1.extend(&coord2.1);
+        processed_pts[i] = true;
+        let c_i = split_coords_flat[i];
+        unique_coords.push(c_i);
+
+        let search_env = AABB::from_corners(
+            Point2D::new_(c_i.x - tolerance, c_i.y - tolerance, NoValue),
+            Point2D::new_(c_i.x + tolerance, c_i.y + tolerance, NoValue),
+        );
+        for cand in point_rtree.locate_in_envelope_intersecting(&search_env) {
+            let j = cand.idx;
+            if j <= i || processed_pts[j] {
+                continue;
+            }
+            let c_j = split_coords_flat[j];
+            if (c_i - c_j).norm() < tolerance {
+                processed_pts[j] = true;
             }
         }
     }
 
     OverlayResult {
         line_strings_with_metadata,
-        split_coords: unique_split_coords.into_iter().map(|(c, _)| c).collect(),
+        split_coords: unique_coords,
     }
+}
+
+fn line_string_length_2d(ls: &LineString2D<f64>) -> f64 {
+    ls.0.windows(2).map(|w| (w[1] - w[0]).norm()).sum()
+}
+
+fn segments_match(a: &LineString2D<f64>, b: &LineString2D<f64>, tolerance: f64) -> bool {
+    if a.0.len() != b.0.len() {
+        return false;
+    }
+    let forward =
+        a.0.iter()
+            .zip(b.0.iter())
+            .all(|(&c1, &c2)| (c1 - c2).norm() < tolerance);
+    if forward {
+        return true;
+    }
+    a.0.iter()
+        .rev()
+        .zip(b.0.iter())
+        .all(|(&c1, &c2)| (c1 - c2).norm() < tolerance)
+}
+
+#[cfg(test)]
+fn line_string_intersection_2d(
+    line_strings: &[LineString2D<f64>],
+    tolerance: f64,
+) -> OverlayResult {
+    let lss_per_feature: Vec<Vec<LineString2D<f64>>> =
+        line_strings.iter().map(|ls| vec![ls.clone()]).collect();
+    let entries: Vec<AabbEntry> = line_strings
+        .iter()
+        .enumerate()
+        .map(|(i, ls)| AabbEntry {
+            feature_idx: i,
+            ls_local_idx: 0,
+            aabb: ls.envelope(),
+        })
+        .collect();
+    overlay_entries(entries, &lss_per_feature, tolerance)
 }
 
 #[cfg(test)]
@@ -552,7 +845,6 @@ mod tests {
 
     #[test]
     fn test_overlay() {
-        // Test the overlay functionality
         let line_string1 = LineString2D::new(vec![
             Coordinate2D::new_(0.0, 0.0),
             Coordinate2D::new_(5.0, 5.0),
@@ -564,7 +856,6 @@ mod tests {
 
         let overlay_result = line_string_intersection_2d(&[line_string1, line_string2], 0.1);
 
-        // Assert the overlay result
         let OverlayResult {
             line_strings_with_metadata,
             split_coords,
@@ -602,7 +893,7 @@ mod tests {
         assert_eq!(line_strings_with_metadata.len(), 4);
         let mut overlay_counts = line_strings_with_metadata
             .iter()
-            .map(|ls| ls.overlay_count)
+            .map(|ls| ls.source_feature_idxs.len())
             .collect::<Vec<_>>();
         overlay_counts.sort();
         assert_eq!(overlay_counts, vec![1, 2, 2, 3]);
@@ -648,7 +939,6 @@ mod tests {
 
         let overlay_result = line_string_intersection_2d(&[line_string1, line_string2], 0.1);
 
-        // Assert the overlay result
         let OverlayResult {
             line_strings_with_metadata,
             split_coords,
@@ -656,7 +946,7 @@ mod tests {
         assert_eq!(line_strings_with_metadata.len(), 4);
         assert!(line_strings_with_metadata
             .iter()
-            .all(|ls| ls.overlay_count == 1));
+            .all(|ls| ls.source_feature_idxs.len() == 1));
         assert_eq!(split_coords.len(), 1);
     }
 
@@ -684,7 +974,6 @@ mod tests {
         let overlay_result =
             line_string_intersection_2d(&[line_string1, line_string2, line_string3], 0.1);
 
-        // Assert the overlay result
         let OverlayResult {
             line_strings_with_metadata,
             split_coords,
@@ -692,10 +981,207 @@ mod tests {
         assert_eq!(line_strings_with_metadata.len(), 5);
         let mut overlap_counts = line_strings_with_metadata
             .iter()
-            .map(|ls| ls.overlay_count)
+            .map(|ls| ls.source_feature_idxs.len())
             .collect::<Vec<_>>();
         overlap_counts.sort();
         assert_eq!(overlap_counts, vec![1, 1, 1, 2, 2]);
         assert_eq!(split_coords.len(), 2);
+    }
+
+    #[test]
+    fn test_overlay_sub_tolerance_segments_dropped() {
+        // Two collinear lines with a 0.005-long overlap, well below tolerance=0.1.
+        // The overlap would have emitted a matched short-segment pair previously.
+        let line_string1 = LineString2D::new(vec![
+            Coordinate2D::new_(0.0, 0.0),
+            Coordinate2D::new_(1.005, 0.0),
+        ]);
+        let line_string2 = LineString2D::new(vec![
+            Coordinate2D::new_(1.0, 0.0),
+            Coordinate2D::new_(2.0, 0.0),
+        ]);
+
+        let tolerance = 0.1;
+        let result = line_string_intersection_2d(&[line_string1, line_string2], tolerance);
+
+        for meta in &result.line_strings_with_metadata {
+            let len = line_string_length_2d(&meta.line_string);
+            assert!(len >= tolerance, "sub-tolerance segment emitted: len={len}");
+        }
+        assert!(result
+            .line_strings_with_metadata
+            .iter()
+            .all(|m| m.source_feature_idxs.len() == 1));
+    }
+
+    #[test]
+    fn test_overlay_same_feature_duplicate_rings_not_double_counted() {
+        // Feature 0 has two identical sub-line-strings (like a degenerate MultiPolygon);
+        // Feature 1 is a separate collinear line overlapping part of them.
+        // Expect: overlap segment has overlay_count=2 (feat 0 + feat 1), not 3.
+        let f0_a = LineString2D::new(vec![
+            Coordinate2D::new_(0.0, 0.0),
+            Coordinate2D::new_(4.0, 0.0),
+        ]);
+        let f0_b = f0_a.clone();
+        let f1 = LineString2D::new(vec![
+            Coordinate2D::new_(1.0, 0.0),
+            Coordinate2D::new_(3.0, 0.0),
+        ]);
+
+        let lss_per_feature = vec![vec![f0_a.clone(), f0_b.clone()], vec![f1.clone()]];
+        let entries = vec![
+            AabbEntry {
+                feature_idx: 0,
+                ls_local_idx: 0,
+                aabb: f0_a.envelope(),
+            },
+            AabbEntry {
+                feature_idx: 0,
+                ls_local_idx: 1,
+                aabb: f0_b.envelope(),
+            },
+            AabbEntry {
+                feature_idx: 1,
+                ls_local_idx: 0,
+                aabb: f1.envelope(),
+            },
+        ];
+
+        let result = overlay_entries(entries, &lss_per_feature, 0.01);
+
+        for meta in &result.line_strings_with_metadata {
+            let feats = &meta.source_feature_idxs;
+            let unique: std::collections::HashSet<_> = feats.iter().copied().collect();
+            assert_eq!(
+                feats.len(),
+                unique.len(),
+                "source_feature_idxs contains duplicates: {feats:?}"
+            );
+        }
+
+        let overlapping: Vec<_> = result
+            .line_strings_with_metadata
+            .iter()
+            .filter(|m| m.source_feature_idxs.len() >= 2)
+            .collect();
+        assert!(!overlapping.is_empty(), "expected an overlap segment");
+        for m in &overlapping {
+            assert_eq!(m.source_feature_idxs.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_overlay_multiple_same_feature_candidates_dedupe() {
+        // Feature 1 contributes two identical sub-line-strings that both match the rep segment
+        // from feature 0 — neither is the rep, but both are the same feature. The old
+        // "candidate-same-as-rep" check wouldn't catch this; the feature-set dedup must.
+        let f0 = LineString2D::new(vec![
+            Coordinate2D::new_(0.0, 0.0),
+            Coordinate2D::new_(4.0, 0.0),
+        ]);
+        let f1_a = LineString2D::new(vec![
+            Coordinate2D::new_(1.0, 0.0),
+            Coordinate2D::new_(3.0, 0.0),
+        ]);
+        let f1_b = f1_a.clone();
+
+        let lss_per_feature = vec![vec![f0.clone()], vec![f1_a.clone(), f1_b.clone()]];
+        let entries = vec![
+            AabbEntry {
+                feature_idx: 0,
+                ls_local_idx: 0,
+                aabb: f0.envelope(),
+            },
+            AabbEntry {
+                feature_idx: 1,
+                ls_local_idx: 0,
+                aabb: f1_a.envelope(),
+            },
+            AabbEntry {
+                feature_idx: 1,
+                ls_local_idx: 1,
+                aabb: f1_b.envelope(),
+            },
+        ];
+
+        let result = overlay_entries(entries, &lss_per_feature, 0.01);
+
+        let overlap: Vec<_> = result
+            .line_strings_with_metadata
+            .iter()
+            .filter(|m| m.source_feature_idxs.len() >= 2)
+            .collect();
+        assert!(!overlap.is_empty(), "expected an overlap segment");
+        for m in &overlap {
+            let feats: std::collections::HashSet<usize> =
+                m.source_feature_idxs.iter().copied().collect();
+            assert_eq!(
+                feats.len(),
+                m.source_feature_idxs.len(),
+                "duplicate feature_idx in source_feature_idxs: {:?}",
+                m.source_feature_idxs
+            );
+            assert_eq!(m.source_feature_idxs.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_process_group_two_crossing_lines() {
+        let dir =
+            engine_cache_dir(uuid::Uuid::nil()).join(format!("test-lol-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let group_dir = dir.join("group_000000");
+        std::fs::create_dir_all(&group_dir).unwrap();
+
+        let f1 = {
+            let ls = LineString2D::new(vec![
+                Coordinate2D::new_(0.0, 0.0),
+                Coordinate2D::new_(5.0, 5.0),
+            ]);
+            let geom =
+                Geometry::with_value(GeometryValue::FlowGeometry2D(Geometry2D::LineString(ls)));
+            Feature::new_with_attributes_and_geometry(Attributes::new(), geom, Metadata::new())
+        };
+        let f2 = {
+            let ls = LineString2D::new(vec![
+                Coordinate2D::new_(0.0, 5.0),
+                Coordinate2D::new_(5.0, 0.0),
+            ]);
+            let geom =
+                Geometry::with_value(GeometryValue::FlowGeometry2D(Geometry2D::LineString(ls)));
+            Feature::new_with_attributes_and_geometry(Attributes::new(), geom, Metadata::new())
+        };
+
+        {
+            let mut w = BufWriter::new(File::create(group_dir.join("aabbs.jsonl")).unwrap());
+            let a1: Vec<[f64; 4]> = vec![[0.0, 0.0, 5.0, 5.0]];
+            let a2: Vec<[f64; 4]> = vec![[0.0, 0.0, 5.0, 5.0]];
+            writeln!(w, "{}", serde_json::to_string(&a1).unwrap()).unwrap();
+            writeln!(w, "{}", serde_json::to_string(&a2).unwrap()).unwrap();
+            w.flush().unwrap();
+        }
+        {
+            let mut w = BufWriter::new(File::create(group_dir.join("features.jsonl")).unwrap());
+            writeln!(w, "{}", serde_json::to_string(&f1).unwrap()).unwrap();
+            writeln!(w, "{}", serde_json::to_string(&f2).unwrap()).unwrap();
+            w.flush().unwrap();
+        }
+
+        let mut line_buf: Vec<u8> = Vec::new();
+        let mut point_buf: Vec<u8> = Vec::new();
+        let (lc, pc) = process_group(
+            &group_dir,
+            0.01,
+            None,
+            "overlaidLists",
+            &mut line_buf,
+            &mut point_buf,
+        )
+        .unwrap();
+        assert_eq!(lc, 4);
+        assert_eq!(pc, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran.yml
@@ -2511,7 +2511,7 @@ graphs:
       - fileIndex
       - gmlId
       - package
-      tolerance: 1e-9
+      tolerance: 0.01
   - id: 0c979585-82b2-41aa-909c-00d9b8d017d0
     name: FeatureSorter
     type: action
@@ -2552,7 +2552,7 @@ graphs:
       groupBy:
       - lod
       - package
-      tolerance: 1e-9
+      tolerance: 0.01
   - id: 5dab814a-c4c6-47e0-8688-1c5667c775fb
     name: LineOnLineOverlayerLOD23
     type: action
@@ -2561,7 +2561,7 @@ graphs:
       groupBy:
       - lod
       - package
-      tolerance: 1e-9
+      tolerance: 0.01
   - id: b03dfe7a-a32a-4334-90a1-23c7486576dc
     name: FilterOverlaps
     type: action
@@ -2607,7 +2607,7 @@ graphs:
       - lod
       - package
       generateList: areaOverlapList
-      tolerance: 1e-9
+      tolerance: 0.01
   - id: b0568e70-1c73-4ee0-8bae-8db3687e3d7d
     name: FilterAreaOverlaps
     type: action

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/03-tran/workflow.yml
@@ -329,7 +329,7 @@ graphs:
             - fileIndex
             - gmlId
             - package
-          tolerance: 0.000000001
+          tolerance: 0.01
 
       # FeatureSorter
       - id: 0c979585-82b2-41aa-909c-00d9b8d017d0
@@ -379,7 +379,7 @@ graphs:
           groupBy:
             - lod
             - package
-          tolerance: 0.000000001
+          tolerance: 0.01
 
       # Detect overlaps between different Road instances for LOD2 and LOD3
       - id: 5dab814a-c4c6-47e0-8688-1c5667c775fb
@@ -390,7 +390,7 @@ graphs:
           groupBy:
             - lod
             - package
-          tolerance: 0.000000001
+          tolerance: 0.01
 
       # Filter features with overlaps (lines that have overlap attribute > 1)
       - id: b03dfe7a-a32a-4334-90a1-23c7486576dc
@@ -447,7 +447,7 @@ graphs:
             - lod
             - package
           generateList: areaOverlapList
-          tolerance: 0.000000001
+          tolerance: 0.01
 
       # Filter for overlapping areas
       - id: b0568e70-1c73-4ee0-8bae-8db3687e3d7d

--- a/engine/runtime/runtime/src/errors.rs
+++ b/engine/runtime/runtime/src/errors.rs
@@ -115,19 +115,6 @@ impl<T> From<crossbeam::channel::SendError<T>> for ExecutionError {
     }
 }
 
-impl<T> From<crossbeam::channel::SendTimeoutError<T>> for ExecutionError {
-    fn from(e: crossbeam::channel::SendTimeoutError<T>) -> Self {
-        match e {
-            crossbeam::channel::SendTimeoutError::Timeout(_) => {
-                ExecutionError::CannotSendToChannel("SendTimeoutError: channel full".to_string())
-            }
-            crossbeam::channel::SendTimeoutError::Disconnected(_) => {
-                ExecutionError::CannotSendToChannel("SendTimeoutError: disconnected".to_string())
-            }
-        }
-    }
-}
-
 #[derive(Debug, Error)]
 #[error("Cannot convert f64 to json: {0}")]
 pub struct CannotConvertF64ToJson(pub f64);

--- a/engine/runtime/runtime/src/executor/processor_node.rs
+++ b/engine/runtime/runtime/src/executor/processor_node.rs
@@ -454,52 +454,11 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for ProcessorNode<F> {
         };
 
         channel_manager.wait_until_downstream_empty(std::time::Duration::from_secs(300));
-        // Cache processor name before spawning finish thread — the thread
-        // holds processor.write() and if it times out the lock is never
-        // released, so processor.read() after would deadlock.
-        let processor_name = self.processor.read().name().to_string();
         channel_manager.reset_send_count();
-
-        // Run finish() on a dedicated thread with a hard deadline so it
-        // cannot block the shutdown path indefinitely (e.g., when sending
-        // features to a full downstream channel).
-        let finish_deadline = Duration::from_secs(300);
-        let (finish_tx, finish_rx) =
-            crossbeam::channel::bounded::<Result<(), crate::errors::BoxedError>>(1);
-        let processor_clone = Arc::clone(&processor);
-        let ctx_clone = ctx.clone();
-        let cm_clone = Arc::clone(&self.channel_manager);
-        let finish_tx_inline = finish_tx.clone();
-        if std::thread::Builder::new()
-            .name("finish-timeout".into())
-            .spawn(move || {
-                let cm_guard = cm_clone.read();
-                let cm: &ProcessorChannelForwarder = &cm_guard;
-                let result = processor_clone.write().finish(ctx_clone, cm);
-                let _ = finish_tx.send(result);
-            })
-            .is_err()
-        {
-            // Thread spawn failed — run finish inline (no timeout protection).
-            tracing::warn!(
-                node_id = ?self.node_handle.id,
-                "Failed to spawn finish-timeout thread, running finish() inline",
-            );
-            let inline_result = processor.write().finish(ctx.clone(), channel_manager);
-            let _ = finish_tx_inline.send(inline_result);
-        }
-        let result: Result<(), ExecutionError> = match finish_rx.recv_timeout(finish_deadline) {
-            Ok(inner) => inner.map_err(|e| ExecutionError::CannotSendToChannel(format!("{e:?}"))),
-            Err(_) => {
-                tracing::warn!(
-                    node_id = ?self.node_handle.id,
-                    processor = %processor_name,
-                    "on_terminate: finish() timed out after {:?}, proceeding to send Terminate",
-                    finish_deadline,
-                );
-                Ok(())
-            }
-        };
+        let result = processor
+            .write()
+            .finish(ctx.clone(), channel_manager)
+            .map_err(|e| ExecutionError::CannotSendToChannel(format!("{e:?}")));
         let finish_feature_count = channel_manager.get_send_count();
 
         drop(_accumulating_guard);
@@ -511,7 +470,7 @@ impl<F: Future + Unpin + Debug> ReceiverLoop for ProcessorNode<F> {
             self.node_name.clone(),
             format!(
                 "{} finish process complete. elapsed = {:?}, features = {}",
-                processor_name,
+                self.processor.read().name(),
                 now.elapsed(),
                 finish_feature_count
             ),

--- a/engine/runtime/runtime/src/forwarder.rs
+++ b/engine/runtime/runtime/src/forwarder.rs
@@ -3,18 +3,12 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use crossbeam::channel::Sender;
 
 use crate::cache::executor_cache_subdir;
 use reearth_flow_types::Feature;
 use tokio::runtime::Handle;
-
-/// Timeout for Terminate message sends during shutdown. If a downstream
-/// channel stays full for this duration, the send fails rather than blocking
-/// forever.
-const CHANNEL_SEND_TIMEOUT: Duration = Duration::from_secs(300);
 
 use crate::errors::ExecutionError;
 use crate::event::{Event, EventHub};
@@ -264,11 +258,9 @@ impl ChannelManager {
     pub fn send_non_op(&self, op: ExecutorOperation) -> Result<(), ExecutionError> {
         if let Some((last_sender, senders)) = self.senders.split_last() {
             for sender in senders {
-                sender
-                    .sender
-                    .send_timeout(op.clone(), CHANNEL_SEND_TIMEOUT)?;
+                sender.sender.send(op.clone())?;
             }
-            last_sender.sender.send_timeout(op, CHANNEL_SEND_TIMEOUT)?;
+            last_sender.sender.send(op)?;
         }
         Ok(())
     }
@@ -569,20 +561,12 @@ impl ChannelManager {
         let feature_id = ctx.feature.id;
         let port = ctx.port.clone();
         let node_id = self.owner.id.clone().into_inner();
-        match self.send_op(ctx) {
-            Ok(()) => {
-                self.increment_send_count(1);
-            }
-            Err(e) => {
-                tracing::error!(
-                    ?node_id,
-                    ?feature_id,
-                    ?port,
-                    ?e,
-                    "Failed to send operation, dropping feature",
-                );
-            }
-        }
+        self.send_op(ctx).unwrap_or_else(|e| {
+            panic!(
+                "Failed to send operation: node_id = {node_id:?}, feature_id = {feature_id:?}, port = {port:?}, error = {e:?}"
+            )
+        });
+        self.increment_send_count(1);
     }
 }
 

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.20"
+version = "0.2.21"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.210"
+version = "0.1.211"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
This PR cherry-picks `LineOnLineOverlayer` performance fixes ( #2054 ) and timeout revert ( #2028 ) from the main branch.

The only non-trivial part of the cherry-pick was the removal of `reearth-flow-types::metadata::Metadata` by 5b22d19f9; we had to include `Metadata::new()` into the construction of features.