### PR TITLE
fix(engine): fix _lod attribute for data-convert bldg workflow

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -6501,7 +6501,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "futures",
  "once_cell",
@@ -6521,7 +6521,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "approx",
  "async-trait",
@@ -6567,7 +6567,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "Inflector",
  "approx",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6714,7 +6714,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6765,7 +6765,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "image 0.25.9",
  "rstar 0.12.2",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "bytes",
  "clap",
@@ -6814,7 +6814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6854,7 +6854,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "chrono",
  "futures",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "approx",
  "bvh",
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6961,7 +6961,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6970,7 +6970,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7000,7 +7000,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7034,7 +7034,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7051,7 +7051,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "bytes",
  "futures",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "bytes",
  "futures",
@@ -7099,7 +7099,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7148,7 +7148,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7185,7 +7185,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.355"
+version = "0.0.356"
 dependencies = [
  "async-trait",
  "backon",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.355"
+version = "0.0.356"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg.yml
@@ -518,7 +518,8 @@ graphs:
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
       - attribute: _lod
         method: create
-        value: '1'
+        value: |
+          env.get("__lod")
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0ec
     name: VerticalReprojectorByLod1
     type: action
@@ -552,7 +553,8 @@ graphs:
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
       - attribute: _lod
         method: create
-        value: '2'
+        value: |
+          env.get("__lod")
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d2
     name: VerticalReprojectorByLod2
     type: action
@@ -586,7 +588,8 @@ graphs:
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
       - attribute: _lod
         method: create
-        value: '2'
+        value: |
+          env.get("__lod")
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d3
     name: VerticalReprojectorByLod2NoTexture
     type: action
@@ -620,7 +623,8 @@ graphs:
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
       - attribute: _lod
         method: create
-        value: '3'
+        value: |
+          env.get("__lod")
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d4
     name: VerticalReprojectorByLod3
     type: action
@@ -654,7 +658,8 @@ graphs:
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
       - attribute: _lod
         method: create
-        value: '3'
+        value: |
+          env.get("__lod")
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d5
     name: VerticalReprojectorByLod3NoTexture
     type: action
@@ -688,7 +693,8 @@ graphs:
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
       - attribute: _lod
         method: create
-        value: '4'
+        value: |
+          env.get("__lod")
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d6
     name: VerticalReprojectorByLod4
     type: action
@@ -722,7 +728,8 @@ graphs:
           (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
       - attribute: _lod
         method: create
-        value: '4'
+        value: |
+          env.get("__lod")
   - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d7
     name: VerticalReprojectorByLod4NoTexture
     type: action

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
@@ -224,11 +224,6 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
-            # Derive _lod by recovering the highest LOD from the bitmask (same for all LODs). Notes:
-            # 1. FeatureLodFilter reduces metadata.lod to a single-bit mask representing the LOD,
-            #    which the __lod getter exposes via highest_lod().
-            # 2. Setting _lod before FeatureLodFilter would incorrectly capture the original highest LOD.
-            # 3. FeatureLodFilter routes best fallback. LOD0~2 features should also exist in lod4 branch with _lod=2.
             - attribute: _lod
               method: create
               value: |

--- a/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/data-convert/plateau4/01-bldg/workflow.yml
@@ -224,9 +224,15 @@ graphs:
               method: create
               value: |
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
+            # Derive _lod by recovering the highest LOD from the bitmask (same for all LODs). Notes:
+            # 1. FeatureLodFilter reduces metadata.lod to a single-bit mask representing the LOD,
+            #    which the __lod getter exposes via highest_lod().
+            # 2. Setting _lod before FeatureLodFilter would incorrectly capture the original highest LOD.
+            # 3. FeatureLodFilter routes best fallback. LOD0~2 features should also exist in lod4 branch with _lod=2.
             - attribute: _lod
               method: create
-              value: "1"
+              value: |
+                env.get("__lod")
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0ec
         name: VerticalReprojectorByLod1
@@ -263,7 +269,8 @@ graphs:
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
             - attribute: _lod
               method: create
-              value: "2"
+              value: |
+                env.get("__lod")
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d2
         name: VerticalReprojectorByLod2
         type: action
@@ -299,7 +306,8 @@ graphs:
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
             - attribute: _lod
               method: create
-              value: "2"
+              value: |
+                env.get("__lod")
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d3
         name: VerticalReprojectorByLod2NoTexture
@@ -336,7 +344,8 @@ graphs:
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
             - attribute: _lod
               method: create
-              value: "3"
+              value: |
+                env.get("__lod")
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d4
         name: VerticalReprojectorByLod3
@@ -373,7 +382,8 @@ graphs:
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
             - attribute: _lod
               method: create
-              value: "3"
+              value: |
+                env.get("__lod")
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d5
         name: VerticalReprojectorByLod3NoTexture
@@ -410,7 +420,8 @@ graphs:
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
             - attribute: _lod
               method: create
-              value: "4"
+              value: |
+                env.get("__lod")
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d6
         name: VerticalReprojectorByLod4
@@ -447,7 +458,8 @@ graphs:
                  (env.get("__value")._ymin + env.get("__value")._ymax) * 0.5
             - attribute: _lod
               method: create
-              value: "4"
+              value: |
+                env.get("__lod")
 
       - id: 8b05f9d4-1cb2-4071-a1da-c968431bc0d7
         name: VerticalReprojectorByLod4NoTexture


### PR DESCRIPTION
# Overview

This PR adapted #2050 to plateau5 branch to fix _lod attribute mismatch.

The actual problematic PR is #2006, merged earlier than #1953 (mentioned in #2050). `up to lod2 feature sent to lod4 branch` became _lod=4 but should be _lod=2.