### PR TITLE
feat(engine): add PLATEAU4.WaterBodyTinValidator for flood-family quality check

### DIFF
--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
       - name: Fetch base branch
-        run: git fetch origin main
+        run: git fetch origin plateau5
       - name: set up
         uses: actions/setup-go@v5
         with:
@@ -26,7 +26,7 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1
-          args: --timeout=10m --new-from-rev=origin/main --timeout=10m
+          args: --timeout=10m --new-from-rev=origin/plateau5
           working-directory: server/api
 
   ci-api-test:

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5681,7 +5681,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plateau-gis-quality-checker"
-version = "0.0.309"
+version = "0.0.310"
 dependencies = [
  "directories",
  "log",
@@ -5710,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -6501,7 +6501,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "futures",
  "once_cell",
@@ -6521,7 +6521,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "approx",
  "async-trait",
@@ -6567,7 +6567,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "Inflector",
  "approx",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -6646,7 +6646,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "ahash 0.8.12",
  "async-trait",
@@ -6714,7 +6714,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -6765,7 +6765,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "image 0.25.9",
  "rstar 0.12.2",
@@ -6776,7 +6776,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "bytes",
  "clap",
@@ -6814,7 +6814,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "approx",
  "async-recursion",
@@ -6854,7 +6854,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-eval-expr"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "chrono",
  "futures",
@@ -6868,7 +6868,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6897,7 +6897,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "approx",
  "bvh",
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
@@ -6961,7 +6961,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6970,7 +6970,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7000,7 +7000,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7034,7 +7034,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -7051,7 +7051,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -7063,7 +7063,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "bytes",
  "futures",
@@ -7080,7 +7080,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "bytes",
  "futures",
@@ -7099,7 +7099,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7148,7 +7148,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "ahash 0.8.12",
  "bytes",
@@ -7185,7 +7185,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.356"
+version = "0.0.357"
 dependencies = [
  "async-trait",
  "backon",
@@ -11053,7 +11053,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.211"
+version = "0.1.212"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.356"
+version = "0.0.357"
 
 [profile.dev]
 opt-level = 0

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -8729,6 +8729,91 @@ Detect unshared edges in triangular meshes - edges that appear only once. REQUIR
 ### Category
 * PLATEAU
 
+## PLATEAU4.WaterBodyTinValidator
+### Type
+* processor
+### Description
+Validates WaterBody TIN surfaces end-to-end for the flood-family quality check: extracts faces from CityGML, reprojects, detects degenerate triangles and unshared edges, and emits one summary per file.
+### Parameters
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "WaterBodyTinValidator Parameters",
+  "type": "object",
+  "required": [
+    "targetEpsgCode"
+  ],
+  "properties": {
+    "cityGmlPathAttribute": {
+      "description": "Attribute holding the CityGML file path (default: \"path\").",
+      "default": "path",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        }
+      ]
+    },
+    "corruptGeometryTolerance": {
+      "description": "Tolerance for corrupt-geometry degenerate check (default: 0.01).",
+      "default": 0.01,
+      "type": "number",
+      "format": "double"
+    },
+    "duplicateConsecutivePointsTolerance": {
+      "description": "Tolerance for duplicate-consecutive-points degenerate check (default: 0.009).",
+      "default": 0.009,
+      "type": "number",
+      "format": "double"
+    },
+    "sourceEpsgCode": {
+      "description": "Source EPSG code (default: 6697, JGD2011 geographic — FaceExtractor output).",
+      "default": 6697,
+      "type": "integer",
+      "format": "int64"
+    },
+    "targetEpsgCode": {
+      "description": "Target EPSG code expression for reprojection (e.g. `env.get(\"prcs\")`).",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Expr"
+        }
+      ]
+    },
+    "unsharedEdgeGroupBy": {
+      "description": "Group-by attributes for unshared-edge detection (default: [_fld_scale, udxDirs]).",
+      "default": [
+        "_fld_scale",
+        "udxDirs"
+      ],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Attribute"
+      }
+    },
+    "unsharedEdgeTolerance": {
+      "description": "Tolerance for unshared-edge matching in meters (default: 0.1).",
+      "default": 0.1,
+      "type": "number",
+      "format": "double"
+    }
+  },
+  "definitions": {
+    "Attribute": {
+      "type": "string"
+    },
+    "Expr": {
+      "type": "string"
+    }
+  }
+}
+```
+### Input Ports
+* default
+### Output Ports
+* summary
+### Category
+* PLATEAU
+
 ## PlanarityFilter
 ### Type
 * processor

--- a/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
+++ b/engine/plateau-gis-quality-checker/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Re:Earth Flow GIS Quality Checker"
 name = "plateau-gis-quality-checker"
-version = "0.0.309"
+version = "0.0.310"
 
 authors.workspace = true
 edition.workspace = true

--- a/engine/runtime/action-plateau-processor/Cargo.toml
+++ b/engine/runtime/action-plateau-processor/Cargo.toml
@@ -51,6 +51,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 spade.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/engine/runtime/action-plateau-processor/src/plateau4.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4.rs
@@ -20,3 +20,4 @@ pub(crate) mod tran_xlink_detector;
 pub(crate) mod udx_folder_extractor;
 pub(crate) mod unmatched_xlink_detector;
 pub(crate) mod unshared_edge_detector;
+pub(crate) mod water_body_tin_validator;

--- a/engine/runtime/action-plateau-processor/src/plateau4/errors.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/errors.rs
@@ -77,6 +77,10 @@ pub(super) enum PlateauProcessorError {
     GmlNameCodeSpaceValidatorFactory(String),
     #[error("GmlNameCodeSpaceValidator error: {0}")]
     GmlNameCodeSpaceValidator(String),
+    #[error("WaterBodyTinValidator Factory error: {0}")]
+    WaterBodyTinValidatorFactory(String),
+    #[error("WaterBodyTinValidator error: {0}")]
+    WaterBodyTinValidator(String),
 }
 
 pub(super) type Result<T, E = PlateauProcessorError> = std::result::Result<T, E>;

--- a/engine/runtime/action-plateau-processor/src/plateau4/face_extractor.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/face_extractor.rs
@@ -10,6 +10,7 @@ use reearth_flow_runtime::{
     forwarder::ProcessorChannelForwarder,
     node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
 };
+use reearth_flow_storage::resolve::StorageResolver;
 use reearth_flow_types::{Attribute, AttributeValue, Feature};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -117,15 +118,15 @@ impl Default for FaceExtractorParam {
     }
 }
 
-#[derive(Debug, Clone)]
-struct ValidationResult {
-    is_incorrect_num_vertices: bool,
-    is_not_closed: bool,
-    is_wrong_orientation: bool,
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ValidationResult {
+    pub(crate) is_incorrect_num_vertices: bool,
+    pub(crate) is_not_closed: bool,
+    pub(crate) is_wrong_orientation: bool,
 }
 
 impl ValidationResult {
-    fn has_error(&self) -> bool {
+    pub(crate) fn has_error(&self) -> bool {
         self.is_incorrect_num_vertices || self.is_not_closed || self.is_wrong_orientation
     }
 }
@@ -207,100 +208,208 @@ pub(crate) struct FaceExtractor {
     buffer: FileBuffer,
 }
 
+pub(crate) fn validate_vertex_count(coords: &[(f64, f64, f64)]) -> bool {
+    // Expected vertex count for TIN triangles: 4 (3 vertices + closing point)
+    coords.len() == 4
+}
+
+pub(crate) fn validate_closure(coords: &[(f64, f64, f64)]) -> bool {
+    if coords.is_empty() {
+        return false;
+    }
+    let first = coords.first().unwrap();
+    let last = coords.last().unwrap();
+    first.0 == last.0 && first.1 == last.1 && first.2 == last.2
+}
+
+pub(crate) fn validate_orientation(coords: &[(f64, f64, f64)]) -> bool {
+    if coords.len() < 3 {
+        return false;
+    }
+
+    // Calculate normal vector using cross product of first two edges
+    // For a triangle with vertices A, B, C:
+    // v1 = B - A
+    // v2 = C - A
+    // normal = v1 × v2
+    // Left-hand rule (FME_LEFT_HAND_RULE): normal.z > 0
+
+    let p0 = coords[0];
+    let p1 = coords[1];
+    let p2 = coords[2];
+
+    let v1_x = p1.0 - p0.0;
+    let v1_y = p1.1 - p0.1;
+
+    let v2_x = p2.0 - p0.0;
+    let v2_y = p2.1 - p0.1;
+
+    // Cross product z component: v1.x * v2.y - v1.y * v2.x
+    let normal_z = v1_x * v2_y - v1_y * v2_x;
+
+    // Left-hand rule: normal should point upward (positive z)
+    normal_z > 0.0
+}
+
+pub(crate) fn validate_pos_list(coords: &[(f64, f64, f64)]) -> ValidationResult {
+    let mut result = ValidationResult::default();
+
+    if !validate_vertex_count(coords) {
+        result.is_incorrect_num_vertices = true;
+    }
+
+    if !validate_closure(coords) {
+        result.is_not_closed = true;
+    }
+
+    // Only validate orientation for triangles (correct vertex count)
+    if !result.is_incorrect_num_vertices && !validate_orientation(coords) {
+        result.is_wrong_orientation = true;
+    }
+
+    result
+}
+
+pub(crate) fn parse_pos_list(pos_text: &str) -> Result<Vec<(f64, f64, f64)>, BoxedError> {
+    let values: Vec<f64> = pos_text
+        .split_whitespace()
+        .map(|s| s.parse::<f64>())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            PlateauProcessorError::FaceExtractor(format!("Failed to parse coordinate: {e}"))
+        })?;
+
+    if !values.len().is_multiple_of(3) {
+        return Err(PlateauProcessorError::FaceExtractor(
+            "posList length must be multiple of 3".to_string(),
+        )
+        .into());
+    }
+
+    // Parse as (lat, lon, height) and convert to (lon, lat, height)
+    // FME code: coords = [(x, y, z) for x, y, z in zip(v[1::3], v[::3], v[2::3])]
+    // This means: x=v[1], y=v[0], z=v[2] (swap first two components)
+    let coords: Vec<(f64, f64, f64)> = values
+        .chunks(3)
+        .map(|chunk| (chunk[1], chunk[0], chunk[2]))
+        .collect();
+
+    Ok(coords)
+}
+
+/// Stream every `wtr:WaterBody` and collect its `gml:posList` texts, paired with
+/// the WaterBody's `gml:id`. Callers that don't need the id can discard it.
+pub(crate) fn collect_water_body_pos_lists(
+    xml_content: &str,
+) -> Result<Vec<(String, String)>, BoxedError> {
+    let collected: Rc<RefCell<Vec<(String, String)>>> = Rc::new(RefCell::new(Vec::new()));
+    let stream_error: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+
+    let transformer = StreamTransformer::new(xml_content)
+        .with_root_namespaces()
+        .map_err(|e| {
+            PlateauProcessorError::FaceExtractor(format!(
+                "Failed to create StreamTransformer: {e:?}"
+            ))
+        })?;
+
+    let collected_clone = Rc::clone(&collected);
+    let stream_error_clone = Rc::clone(&stream_error);
+    transformer
+        .on("//wtr:WaterBody", move |node| {
+            if stream_error_clone.borrow().is_some() {
+                return;
+            }
+
+            let doc = node.document();
+            let mut xml_ctx = match xml::create_context(doc) {
+                Ok(ctx) => ctx,
+                Err(e) => {
+                    *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
+                    return;
+                }
+            };
+            for (prefix, uri) in node.namespaces() {
+                let _ = xml_ctx.register_namespace(prefix, uri);
+            }
+            let root_node = match xml::get_root_readonly_node(doc) {
+                Ok(n) => n,
+                Err(e) => {
+                    *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
+                    return;
+                }
+            };
+
+            let gml_id = root_node
+                .get_attribute_ns("id", "http://www.opengis.net/gml")
+                .unwrap_or_else(|| "unknown".to_string());
+
+            let pos_lists =
+                match xml::find_readonly_nodes_by_xpath(&xml_ctx, ".//gml:posList", &root_node) {
+                    Ok(nodes) => nodes,
+                    Err(e) => {
+                        *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
+                        return;
+                    }
+                };
+
+            for pos_list_node in pos_lists {
+                let pos_text = pos_list_node.get_content().unwrap_or_default();
+                collected_clone
+                    .borrow_mut()
+                    .push((gml_id.clone(), pos_text));
+            }
+        })
+        .for_each()
+        .map_err(|e| {
+            PlateauProcessorError::FaceExtractor(format!("StreamTransformer error: {e:?}"))
+        })?;
+
+    if let Some(err) = Rc::try_unwrap(stream_error)
+        .expect("all callback references should be dropped after for_each()")
+        .into_inner()
+    {
+        return Err(PlateauProcessorError::FaceExtractor(err).into());
+    }
+
+    Ok(Rc::try_unwrap(collected)
+        .expect("all callback references should be dropped after for_each()")
+        .into_inner())
+}
+
+/// Derive `_json_filename` from the `udxDirs` attribute (flatten `/` to `_`) and
+/// insert it into the feature. No-op when `udxDirs` is absent or not a string.
+pub(crate) fn set_json_filename_from_udx_dirs(feature: &mut Feature) {
+    if let Some(AttributeValue::String(udx_dirs)) =
+        feature.attributes.get(&Attribute::new("udxDirs")).cloned()
+    {
+        let json_filename = format!("summary_{}.json", udx_dirs.replace('/', "_"));
+        feature.attributes_mut().insert(
+            Attribute::new("_json_filename"),
+            AttributeValue::String(json_filename),
+        );
+    }
+}
+
+/// Read a CityGML file (via the storage abstraction) into a UTF-8 string.
+pub(crate) fn read_file(
+    file_path: &str,
+    storage_resolver: &StorageResolver,
+) -> Result<String, BoxedError> {
+    let uri = Uri::from_str(file_path)
+        .map_err(|e| PlateauProcessorError::FaceExtractor(format!("Failed to parse URI: {e}")))?;
+    let storage = storage_resolver.resolve(&uri).map_err(|e| {
+        PlateauProcessorError::FaceExtractor(format!("Failed to resolve storage: {e}"))
+    })?;
+    let content = storage
+        .get_sync(uri.path().as_path())
+        .map_err(|e| PlateauProcessorError::FaceExtractor(format!("Failed to read file: {e}")))?;
+    String::from_utf8(content.to_vec()).map_err(|e| {
+        PlateauProcessorError::FaceExtractor(format!("Failed to convert to UTF-8: {e}")).into()
+    })
+}
+
 impl FaceExtractor {
-    fn validate_vertex_count(coords: &[(f64, f64, f64)]) -> bool {
-        // Expected vertex count for TIN triangles: 4 (3 vertices + closing point)
-        coords.len() == 4
-    }
-
-    fn validate_closure(coords: &[(f64, f64, f64)]) -> bool {
-        if coords.is_empty() {
-            return false;
-        }
-        let first = coords.first().unwrap();
-        let last = coords.last().unwrap();
-        first.0 == last.0 && first.1 == last.1 && first.2 == last.2
-    }
-
-    fn validate_orientation(coords: &[(f64, f64, f64)]) -> bool {
-        if coords.len() < 3 {
-            return false;
-        }
-
-        // Calculate normal vector using cross product of first two edges
-        // For a triangle with vertices A, B, C:
-        // v1 = B - A
-        // v2 = C - A
-        // normal = v1 × v2
-        // Left-hand rule (FME_LEFT_HAND_RULE): normal.z > 0
-
-        let p0 = coords[0];
-        let p1 = coords[1];
-        let p2 = coords[2];
-
-        let v1_x = p1.0 - p0.0;
-        let v1_y = p1.1 - p0.1;
-
-        let v2_x = p2.0 - p0.0;
-        let v2_y = p2.1 - p0.1;
-
-        // Cross product z component: v1.x * v2.y - v1.y * v2.x
-        let normal_z = v1_x * v2_y - v1_y * v2_x;
-
-        // Left-hand rule: normal should point upward (positive z)
-        normal_z > 0.0
-    }
-
-    fn validate_pos_list(coords: &[(f64, f64, f64)]) -> ValidationResult {
-        let mut result = ValidationResult {
-            is_incorrect_num_vertices: false,
-            is_not_closed: false,
-            is_wrong_orientation: false,
-        };
-
-        if !Self::validate_vertex_count(coords) {
-            result.is_incorrect_num_vertices = true;
-        }
-
-        if !Self::validate_closure(coords) {
-            result.is_not_closed = true;
-        }
-
-        // Only validate orientation for triangles (correct vertex count)
-        if !result.is_incorrect_num_vertices && !Self::validate_orientation(coords) {
-            result.is_wrong_orientation = true;
-        }
-
-        result
-    }
-
-    fn parse_pos_list(&self, pos_text: &str) -> Result<Vec<(f64, f64, f64)>, BoxedError> {
-        let values: Vec<f64> = pos_text
-            .split_whitespace()
-            .map(|s| s.parse::<f64>())
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                PlateauProcessorError::FaceExtractor(format!("Failed to parse coordinate: {e}"))
-            })?;
-
-        if !values.len().is_multiple_of(3) {
-            return Err(PlateauProcessorError::FaceExtractor(
-                "posList length must be multiple of 3".to_string(),
-            )
-            .into());
-        }
-
-        // Parse as (lat, lon, height) and convert to (lon, lat, height)
-        // FME code: coords = [(x, y, z) for x, y, z in zip(v[1::3], v[::3], v[2::3])]
-        // This means: x=v[1], y=v[0], z=v[2] (swap first two components)
-        let coords: Vec<(f64, f64, f64)> = values
-            .chunks(3)
-            .map(|chunk| (chunk[1], chunk[0], chunk[2]))
-            .collect();
-
-        Ok(coords)
-    }
-
     fn process_xml(
         &mut self,
         ctx: &ExecutorContext,
@@ -313,87 +422,14 @@ impl FaceExtractor {
             .set_base_feature(file_path.clone(), ctx.feature.clone());
 
         // Collect (gml_id, pos_text) pairs via streaming, then process them
-        let collected: Rc<RefCell<Vec<(String, String)>>> = Rc::new(RefCell::new(Vec::new()));
-        let stream_error: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
-
-        let transformer = StreamTransformer::new(&xml_content)
-            .with_root_namespaces()
-            .map_err(|e| {
-                PlateauProcessorError::FaceExtractor(format!(
-                    "Failed to create StreamTransformer: {e:?}"
-                ))
-            })?;
-
-        let collected_clone = Rc::clone(&collected);
-        let stream_error_clone = Rc::clone(&stream_error);
-        transformer
-            .on("//wtr:WaterBody", move |node| {
-                if stream_error_clone.borrow().is_some() {
-                    return;
-                }
-
-                let doc = node.document();
-                let mut xml_ctx = match xml::create_context(doc) {
-                    Ok(ctx) => ctx,
-                    Err(e) => {
-                        *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
-                        return;
-                    }
-                };
-                for (prefix, uri) in node.namespaces() {
-                    let _ = xml_ctx.register_namespace(prefix, uri);
-                }
-                let root_node = match xml::get_root_readonly_node(doc) {
-                    Ok(n) => n,
-                    Err(e) => {
-                        *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
-                        return;
-                    }
-                };
-
-                let gml_id = root_node
-                    .get_attribute_ns("id", "http://www.opengis.net/gml")
-                    .unwrap_or_else(|| "unknown".to_string());
-
-                let pos_lists =
-                    match xml::find_readonly_nodes_by_xpath(&xml_ctx, ".//gml:posList", &root_node)
-                    {
-                        Ok(nodes) => nodes,
-                        Err(e) => {
-                            *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
-                            return;
-                        }
-                    };
-
-                for pos_list_node in pos_lists {
-                    let pos_text = pos_list_node.get_content().unwrap_or_default();
-                    collected_clone
-                        .borrow_mut()
-                        .push((gml_id.clone(), pos_text));
-                }
-            })
-            .for_each()
-            .map_err(|e| {
-                PlateauProcessorError::FaceExtractor(format!("StreamTransformer error: {e:?}"))
-            })?;
-
-        if let Some(err) = Rc::try_unwrap(stream_error)
-            .expect("all callback references should be dropped after for_each()")
-            .into_inner()
-        {
-            return Err(PlateauProcessorError::FaceExtractor(err).into());
-        }
-
-        let collected = Rc::try_unwrap(collected)
-            .expect("all callback references should be dropped after for_each()")
-            .into_inner();
+        let collected = collect_water_body_pos_lists(&xml_content)?;
 
         for (gml_id, pos_text) in collected {
             // Parse coordinates
-            let coords = self.parse_pos_list(&pos_text)?;
+            let coords = parse_pos_list(&pos_text)?;
 
             // Validate
-            let result = Self::validate_pos_list(&coords);
+            let result = validate_pos_list(&coords);
 
             // Create feature for this surface
             let mut feature = ctx.feature.clone();
@@ -508,16 +544,7 @@ impl FaceExtractor {
             );
 
             // Add _json_filename attribute for JSON output
-            // Replace / with _ in udxDirs to create flat filename
-            if let Some(AttributeValue::String(udx_dirs)) =
-                summary_feature.attributes.get(&Attribute::new("udxDirs"))
-            {
-                let json_filename = format!("summary_{}.json", udx_dirs.replace('/', "_"));
-                summary_feature.attributes_mut().insert(
-                    Attribute::new("_json_filename"),
-                    AttributeValue::String(json_filename),
-                );
-            }
+            set_json_filename_from_udx_dirs(&mut summary_feature);
 
             fw.send(ctx.as_executor_context(summary_feature, SUMMARY_PORT.clone()));
         }
@@ -548,21 +575,7 @@ impl Processor for FaceExtractor {
         }
 
         // Parse URI and read file
-        let uri = Uri::from_str(&file_path_str).map_err(|e| {
-            PlateauProcessorError::FaceExtractor(format!("Failed to parse URI: {e}"))
-        })?;
-
-        let storage = ctx.storage_resolver.resolve(&uri).map_err(|e| {
-            PlateauProcessorError::FaceExtractor(format!("Failed to resolve storage: {e}"))
-        })?;
-
-        let content = storage.get_sync(uri.path().as_path()).map_err(|e| {
-            PlateauProcessorError::FaceExtractor(format!("Failed to read file: {e}"))
-        })?;
-
-        let xml_content = String::from_utf8(content.to_vec()).map_err(|e| {
-            PlateauProcessorError::FaceExtractor(format!("Failed to convert to UTF-8: {e}"))
-        })?;
+        let xml_content = read_file(&file_path_str, &ctx.storage_resolver)?;
 
         self.process_xml(&ctx, fw, file_path_str, xml_content)?;
 
@@ -589,20 +602,11 @@ impl Processor for FaceExtractor {
 mod tests {
     use super::*;
 
-    fn create_validator() -> FaceExtractor {
-        FaceExtractor {
-            params: FaceExtractorParam::default(),
-            buffer: FileBuffer::new(),
-        }
-    }
-
     #[test]
     fn test_parse_pos_list_valid() {
-        let validator = create_validator();
-
         // Test case: 4 vertices (triangle + closing point)
         let input = "35.01 135.01 0.0 35.01 135.02 0.0 35.02 135.01 0.0 35.01 135.01 0.0";
-        let result = validator.parse_pos_list(input).unwrap();
+        let result = parse_pos_list(input).unwrap();
 
         // FME coordinate swap: (lat, lon, height) → (lon, lat, height)
         assert_eq!(result.len(), 4);
@@ -614,11 +618,9 @@ mod tests {
 
     #[test]
     fn test_parse_pos_list_invalid_length() {
-        let validator = create_validator();
-
         // Not a multiple of 3
         let input = "35.01 135.01";
-        let result = validator.parse_pos_list(input);
+        let result = parse_pos_list(input);
         assert!(result.is_err());
     }
 
@@ -631,15 +633,15 @@ mod tests {
             (0.0, 1.0, 0.0),
             (0.0, 0.0, 0.0),
         ];
-        assert!(FaceExtractor::validate_vertex_count(&coords));
+        assert!(validate_vertex_count(&coords));
 
         // Invalid: 2 vertices
         let coords = vec![(0.0, 0.0, 0.0), (1.0, 0.0, 0.0)];
-        assert!(!FaceExtractor::validate_vertex_count(&coords));
+        assert!(!validate_vertex_count(&coords));
 
         // Invalid: 3 vertices
         let coords = vec![(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)];
-        assert!(!FaceExtractor::validate_vertex_count(&coords));
+        assert!(!validate_vertex_count(&coords));
 
         // Invalid: 5 vertices
         let coords = vec![
@@ -649,7 +651,7 @@ mod tests {
             (0.0, 1.0, 0.0),
             (0.0, 0.0, 0.0),
         ];
-        assert!(!FaceExtractor::validate_vertex_count(&coords));
+        assert!(!validate_vertex_count(&coords));
     }
 
     #[test]
@@ -661,15 +663,15 @@ mod tests {
             (0.0, 1.0, 0.0),
             (0.0, 0.0, 0.0),
         ];
-        assert!(FaceExtractor::validate_closure(&coords));
+        assert!(validate_closure(&coords));
 
         // Invalid: not closed
         let coords = vec![(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)];
-        assert!(!FaceExtractor::validate_closure(&coords));
+        assert!(!validate_closure(&coords));
 
         // Invalid: empty
         let coords = vec![];
-        assert!(!FaceExtractor::validate_closure(&coords));
+        assert!(!validate_closure(&coords));
     }
 
     #[test]
@@ -682,7 +684,7 @@ mod tests {
             (0.0, 1.0, 0.0),
             (0.0, 0.0, 0.0),
         ];
-        assert!(FaceExtractor::validate_orientation(&coords));
+        assert!(validate_orientation(&coords));
 
         // Invalid: clockwise (right-hand rule, normal_z < 0)
         let coords = vec![
@@ -691,11 +693,11 @@ mod tests {
             (1.0, 0.0, 0.0),
             (0.0, 0.0, 0.0),
         ];
-        assert!(!FaceExtractor::validate_orientation(&coords));
+        assert!(!validate_orientation(&coords));
 
         // Invalid: less than 3 vertices
         let coords = vec![(0.0, 0.0, 0.0), (1.0, 0.0, 0.0)];
-        assert!(!FaceExtractor::validate_orientation(&coords));
+        assert!(!validate_orientation(&coords));
     }
 
     #[test]
@@ -705,7 +707,7 @@ mod tests {
         // - Not closed
         // - Orientation is not checked when vertex count is wrong
         let coords = vec![(0.0, 0.0, 0.0), (1.0, 1.0, 0.0)];
-        let result = FaceExtractor::validate_pos_list(&coords);
+        let result = validate_pos_list(&coords);
 
         assert!(result.is_incorrect_num_vertices);
         assert!(result.is_not_closed);
@@ -721,7 +723,7 @@ mod tests {
             (1.0, 0.0, 0.0),
             (0.0, 0.0, 0.0),
         ];
-        let result = FaceExtractor::validate_pos_list(&coords);
+        let result = validate_pos_list(&coords);
 
         assert!(!result.is_incorrect_num_vertices);
         assert!(!result.is_not_closed);
@@ -738,7 +740,7 @@ mod tests {
             (0.0, 1.0, 0.0),
             (0.0, 0.0, 0.0),
         ];
-        let result = FaceExtractor::validate_pos_list(&coords);
+        let result = validate_pos_list(&coords);
 
         assert!(!result.is_incorrect_num_vertices);
         assert!(!result.is_not_closed);

--- a/engine/runtime/action-plateau-processor/src/plateau4/mapping.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/mapping.rs
@@ -23,6 +23,7 @@ use super::{
     udx_folder_extractor::UDXFolderExtractorFactory,
     unmatched_xlink_detector::UnmatchedXlinkDetectorFactory,
     unshared_edge_detector::UnsharedEdgeDetectorFactory,
+    water_body_tin_validator::WaterBodyTinValidatorFactory,
 };
 
 pub(crate) static ACTION_FACTORY_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
@@ -47,6 +48,7 @@ pub(crate) static ACTION_FACTORY_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Laz
         Box::<FaceExtractorFactory>::default(),
         Box::<UnsharedEdgeDetectorFactory>::default(),
         Box::<CompositeSurfaceContinuityFilterFactory>::default(),
+        Box::<WaterBodyTinValidatorFactory>::default(),
     ];
     factories
         .into_iter()

--- a/engine/runtime/action-plateau-processor/src/plateau4/water_body_tin_validator.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/water_body_tin_validator.rs
@@ -21,7 +21,6 @@ use std::collections::{BinaryHeap, HashMap, VecDeque};
 use std::fs::File;
 use std::io::{BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::sync::Arc;
 
 use once_cell::sync::Lazy;
@@ -30,9 +29,6 @@ use proj::Proj;
 use rayon::prelude::*;
 use std::cell::RefCell;
 
-use fastxml::transform::StreamTransformer;
-use reearth_flow_common::uri::Uri;
-use reearth_flow_common::xml;
 use reearth_flow_geometry::types::coordinate::Coordinate;
 use reearth_flow_geometry::types::coordnum::CoordNum;
 use reearth_flow_geometry::types::geometry::Geometry2D;
@@ -54,6 +50,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::errors::PlateauProcessorError;
+use super::face_extractor::{
+    collect_water_body_pos_lists, parse_pos_list, read_file, set_json_filename_from_udx_dirs,
+    validate_pos_list,
+};
 
 static SUMMARY_PORT: Lazy<Port> = Lazy::new(|| Port::new("summary"));
 
@@ -106,9 +106,7 @@ impl ProcessorFactory for WaterBodyTinValidatorFactory {
     fn description(&self) -> &str {
         "Validates WaterBody TIN surfaces end-to-end for the flood-family quality \
          check: extracts faces from CityGML, reprojects, detects degenerate \
-         triangles and unshared edges, and emits one summary per file. \
-         Consolidates FaceExtractor, HorizontalReprojector, GeometryValidator, \
-         TwoDimensionForcer and UnsharedEdgeDetector into a single action."
+         triangles and unshared edges, and emits one summary per file."
     }
 
     fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
@@ -225,14 +223,6 @@ pub(crate) struct WaterBodyTinValidator {
     global_params: Option<HashMap<String, Value>>,
     /// One input feature per gml file, buffered until `finish()`.
     buffer: Vec<Feature>,
-}
-
-/// Per-face validation outcome (mirrors FaceExtractor).
-#[derive(Debug, Clone, Copy, Default)]
-struct FaceValidation {
-    is_incorrect_num_vertices: bool,
-    is_not_closed: bool,
-    is_wrong_orientation: bool,
 }
 
 /// Per-file accumulated counts.
@@ -407,12 +397,12 @@ fn process_one_file(
     let file_path = file_path_attr.to_string();
 
     let xml_content = read_file(&file_path, storage_resolver)?;
-    let pos_lists = collect_pos_lists(&xml_content)?;
+    let pos_lists = collect_water_body_pos_lists(&xml_content)?;
 
     let mut counts = FileCounts::default();
     let mut edges = Vec::new();
 
-    for pos_text in pos_lists {
+    for (_, pos_text) in pos_lists {
         let coords = parse_pos_list(&pos_text)?;
         counts.num_instances += 1;
 
@@ -490,157 +480,6 @@ fn compute_group_key(feature: &Feature, group_by: &[Attribute]) -> AttributeValu
     )
 }
 
-fn read_file(
-    file_path: &str,
-    storage_resolver: &Arc<StorageResolver>,
-) -> Result<String, BoxedError> {
-    let uri = Uri::from_str(file_path).map_err(|e| {
-        PlateauProcessorError::WaterBodyTinValidator(format!("Failed to parse URI: {e}"))
-    })?;
-    let storage = storage_resolver.resolve(&uri).map_err(|e| {
-        PlateauProcessorError::WaterBodyTinValidator(format!("Failed to resolve storage: {e}"))
-    })?;
-    let content = storage.get_sync(uri.path().as_path()).map_err(|e| {
-        PlateauProcessorError::WaterBodyTinValidator(format!("Failed to read file: {e}"))
-    })?;
-    String::from_utf8(content.to_vec()).map_err(|e| {
-        PlateauProcessorError::WaterBodyTinValidator(format!("Failed to convert to UTF-8: {e}"))
-            .into()
-    })
-}
-
-/// Collect `gml:posList` text from every `wtr:WaterBody` (mirrors FaceExtractor).
-fn collect_pos_lists(xml_content: &str) -> Result<Vec<String>, BoxedError> {
-    let collected: std::rc::Rc<RefCell<Vec<String>>> = std::rc::Rc::new(RefCell::new(Vec::new()));
-    let stream_error: std::rc::Rc<RefCell<Option<String>>> = std::rc::Rc::new(RefCell::new(None));
-
-    let transformer = StreamTransformer::new(xml_content)
-        .with_root_namespaces()
-        .map_err(|e| {
-            PlateauProcessorError::WaterBodyTinValidator(format!(
-                "Failed to create StreamTransformer: {e:?}"
-            ))
-        })?;
-
-    let collected_clone = std::rc::Rc::clone(&collected);
-    let stream_error_clone = std::rc::Rc::clone(&stream_error);
-    transformer
-        .on("//wtr:WaterBody", move |node| {
-            if stream_error_clone.borrow().is_some() {
-                return;
-            }
-            let doc = node.document();
-            let mut xml_ctx = match xml::create_context(doc) {
-                Ok(ctx) => ctx,
-                Err(e) => {
-                    *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
-                    return;
-                }
-            };
-            for (prefix, uri) in node.namespaces() {
-                let _ = xml_ctx.register_namespace(prefix, uri);
-            }
-            let root_node = match xml::get_root_readonly_node(doc) {
-                Ok(n) => n,
-                Err(e) => {
-                    *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
-                    return;
-                }
-            };
-            let pos_lists =
-                match xml::find_readonly_nodes_by_xpath(&xml_ctx, ".//gml:posList", &root_node) {
-                    Ok(nodes) => nodes,
-                    Err(e) => {
-                        *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
-                        return;
-                    }
-                };
-            for pos_list_node in pos_lists {
-                let pos_text = pos_list_node.get_content().unwrap_or_default();
-                collected_clone.borrow_mut().push(pos_text);
-            }
-        })
-        .for_each()
-        .map_err(|e| {
-            PlateauProcessorError::WaterBodyTinValidator(format!("StreamTransformer error: {e:?}"))
-        })?;
-
-    if let Some(err) = std::rc::Rc::try_unwrap(stream_error)
-        .expect("all callback references should be dropped after for_each()")
-        .into_inner()
-    {
-        return Err(PlateauProcessorError::WaterBodyTinValidator(err).into());
-    }
-
-    Ok(std::rc::Rc::try_unwrap(collected)
-        .expect("all callback references should be dropped after for_each()")
-        .into_inner())
-}
-
-/// Parse a posList into `(lon, lat, height)` triples (swaps lat/lon, matches FME).
-fn parse_pos_list(pos_text: &str) -> Result<Vec<(f64, f64, f64)>, BoxedError> {
-    let values: Vec<f64> = pos_text
-        .split_whitespace()
-        .map(|s| s.parse::<f64>())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| {
-            PlateauProcessorError::WaterBodyTinValidator(format!("Failed to parse coordinate: {e}"))
-        })?;
-
-    if !values.len().is_multiple_of(3) {
-        return Err(PlateauProcessorError::WaterBodyTinValidator(
-            "posList length must be multiple of 3".to_string(),
-        )
-        .into());
-    }
-
-    Ok(values
-        .chunks(3)
-        .map(|chunk| (chunk[1], chunk[0], chunk[2]))
-        .collect())
-}
-
-fn validate_pos_list(coords: &[(f64, f64, f64)]) -> FaceValidation {
-    let mut result = FaceValidation::default();
-
-    // Vertex count: TIN triangles expect 4 (3 vertices + closing point).
-    if coords.len() != 4 {
-        result.is_incorrect_num_vertices = true;
-    }
-
-    // Closure: first == last.
-    let closed = match (coords.first(), coords.last()) {
-        (Some(first), Some(last)) => first.0 == last.0 && first.1 == last.1 && first.2 == last.2,
-        _ => false,
-    };
-    if !closed {
-        result.is_not_closed = true;
-    }
-
-    // Orientation (only when vertex count is correct): left-hand rule, normal.z > 0,
-    // computed on geographic coords (x=lon, y=lat) just like FaceExtractor.
-    if !result.is_incorrect_num_vertices && !validate_orientation(coords) {
-        result.is_wrong_orientation = true;
-    }
-
-    result
-}
-
-fn validate_orientation(coords: &[(f64, f64, f64)]) -> bool {
-    if coords.len() < 3 {
-        return false;
-    }
-    let p0 = coords[0];
-    let p1 = coords[1];
-    let p2 = coords[2];
-    let v1_x = p1.0 - p0.0;
-    let v1_y = p1.1 - p0.1;
-    let v2_x = p2.0 - p0.0;
-    let v2_y = p2.1 - p0.1;
-    let normal_z = v1_x * v2_y - v1_y * v2_x;
-    normal_z > 0.0
-}
-
 fn extract_polygon_edges(polygon: &Polygon2D<f64>, file_idx: u32, edges: &mut Vec<Edge>) {
     let coords: Vec<_> = polygon.exterior().coords().collect();
     for window in coords.windows(2) {
@@ -681,15 +520,7 @@ fn build_summary(base_feature: Feature, counts: &FileCounts, num_unshared: u64) 
     attrs.insert(Attribute::new("_num_unshared_edges"), num(num_unshared));
 
     // _json_filename derived from udxDirs (flatten '/' to '_'), matching FaceExtractor.
-    if let Some(AttributeValue::String(udx_dirs)) =
-        feature.attributes.get(&Attribute::new("udxDirs")).cloned()
-    {
-        let json_filename = format!("summary_{}.json", udx_dirs.replace('/', "_"));
-        feature.attributes_mut().insert(
-            Attribute::new("_json_filename"),
-            AttributeValue::String(json_filename),
-        );
-    }
+    set_json_filename_from_udx_dirs(&mut feature);
 
     feature
 }

--- a/engine/runtime/action-plateau-processor/src/plateau4/water_body_tin_validator.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/water_body_tin_validator.rs
@@ -1,0 +1,1044 @@
+//! WaterBody TIN surface validator for the flood-family quality check
+//! (fld / htd / ifld / tnm / rfld).
+//!
+//! This is a single action that fuses what would otherwise be a chain of
+//! separate nodes — `FaceExtractor`, `HorizontalReprojector`,
+//! `TwoDimensionForcer`, `GeometryValidator`, and `UnsharedEdgeDetector`.
+//! They are merged into one action for performance: the huge number of
+//! intermediate per-face features stays inside the action instead of crossing
+//! channels between nodes, and each gml file can be processed in parallel with
+//! rayon.
+//!
+//! The action is accumulating: per-face work runs (in parallel) in `finish()`,
+//! and per-file summaries are emitted only after cross-file unshared-edge
+//! detection (grouped by river) completes.
+//!
+//! The unshared-edge core (fixed-point edges, disk-backed K-way merge, sliding
+//! window micro-gap scan) is adapted from `unshared_edge_detector.rs`; here the
+//! sink counts micro-gap edges per source file instead of emitting LineStrings.
+
+use std::collections::{BinaryHeap, HashMap, VecDeque};
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use proj::Proj;
+use rayon::prelude::*;
+use std::cell::RefCell;
+
+use fastxml::transform::StreamTransformer;
+use reearth_flow_common::uri::Uri;
+use reearth_flow_common::xml;
+use reearth_flow_geometry::types::coordinate::Coordinate;
+use reearth_flow_geometry::types::coordnum::CoordNum;
+use reearth_flow_geometry::types::geometry::Geometry2D;
+use reearth_flow_geometry::types::line_string::LineString2D;
+use reearth_flow_geometry::types::polygon::Polygon2D;
+use reearth_flow_geometry::validation::{ValidationType, Validator};
+use reearth_flow_runtime::{
+    cache::executor_cache_subdir,
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    forwarder::ProcessorChannelForwarder,
+    node::{Port, Processor, ProcessorFactory, DEFAULT_PORT},
+};
+use reearth_flow_storage::resolve::StorageResolver;
+use reearth_flow_types::{Attribute, AttributeValue, Expr, Feature};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::errors::PlateauProcessorError;
+
+static SUMMARY_PORT: Lazy<Port> = Lazy::new(|| Port::new("summary"));
+
+/// Fixed-point scale factor (micrometer precision). Assumes projected meters.
+const FIXED_POINT_SCALE: f64 = 1_000_000.0;
+/// In-memory buffer threshold before flushing edges to disk (10 MB).
+const ACCUMULATOR_BUFFER_BYTE_THRESHOLD: usize = 10_485_760;
+/// Maximum number of chunk files to merge in one K-way pass.
+const MERGE_FAN_IN: usize = 64;
+/// Binary size of one serialized edge: 4 x i64 + 1 x u32 = 36 bytes.
+const EDGE_BINARY_SIZE: usize = 36;
+
+/// Default source CRS for FaceExtractor-style geographic geometry (JGD2011).
+const DEFAULT_SOURCE_EPSG: i64 = 6697;
+
+// Thread-local PROJ cache (proj::Proj is not Send). Each rayon worker keeps its
+// own transformer, mirroring HorizontalReprojector.
+thread_local! {
+    static PROJ_CACHE: RefCell<HashMap<(String, String), Proj>> = RefCell::new(HashMap::new());
+}
+
+fn with_proj<F, R>(from_crs: &str, to_crs: &str, f: F) -> Result<R, BoxedError>
+where
+    F: FnOnce(&Proj) -> Result<R, BoxedError>,
+{
+    PROJ_CACHE.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        let key = (from_crs.to_string(), to_crs.to_string());
+        if !cache.contains_key(&key) {
+            let proj = Proj::new_known_crs(from_crs, to_crs, None).map_err(|e| {
+                PlateauProcessorError::WaterBodyTinValidator(format!(
+                    "Failed to create PROJ {from_crs} -> {to_crs}: {e}"
+                ))
+            })?;
+            cache.insert(key.clone(), proj);
+        }
+        let proj = cache.get(&key).unwrap();
+        f(proj)
+    })
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WaterBodyTinValidatorFactory;
+
+impl ProcessorFactory for WaterBodyTinValidatorFactory {
+    fn name(&self) -> &str {
+        "PLATEAU4.WaterBodyTinValidator"
+    }
+
+    fn description(&self) -> &str {
+        "Validates WaterBody TIN surfaces end-to-end for the flood-family quality \
+         check: extracts faces from CityGML, reprojects, detects degenerate \
+         triangles and unshared edges, and emits one summary per file. \
+         Consolidates FaceExtractor, HorizontalReprojector, GeometryValidator, \
+         TwoDimensionForcer and UnsharedEdgeDetector into a single action."
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        Some(schemars::schema_for!(WaterBodyTinValidatorParam))
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["PLATEAU"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![DEFAULT_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![SUMMARY_PORT.clone()]
+    }
+
+    fn build(
+        &self,
+        _ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        let params: WaterBodyTinValidatorParam = if let Some(ref with) = with {
+            let value: Value = serde_json::to_value(with).map_err(|e| {
+                PlateauProcessorError::WaterBodyTinValidatorFactory(format!(
+                    "Failed to serialize `with` parameter: {e}"
+                ))
+            })?;
+            serde_json::from_value(value).map_err(|e| {
+                PlateauProcessorError::WaterBodyTinValidatorFactory(format!(
+                    "Failed to deserialize `with` parameter: {e}"
+                ))
+            })?
+        } else {
+            return Err(PlateauProcessorError::WaterBodyTinValidatorFactory(
+                "Missing required parameter `with`".to_string(),
+            )
+            .into());
+        };
+
+        if params.unshared_edge_tolerance <= 0.0 {
+            return Err(PlateauProcessorError::WaterBodyTinValidatorFactory(format!(
+                "unsharedEdgeTolerance must be positive, got {}",
+                params.unshared_edge_tolerance
+            ))
+            .into());
+        }
+
+        Ok(Box::new(WaterBodyTinValidator {
+            params,
+            global_params: with,
+            buffer: Vec::new(),
+        }))
+    }
+}
+
+/// # WaterBodyTinValidator Parameters
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WaterBodyTinValidatorParam {
+    /// Attribute holding the CityGML file path (default: "path").
+    #[serde(default = "default_gml_path_attribute")]
+    pub city_gml_path_attribute: Attribute,
+
+    /// Target EPSG code expression for reprojection (e.g. `env.get("prcs")`).
+    pub target_epsg_code: Expr,
+
+    /// Source EPSG code (default: 6697, JGD2011 geographic — FaceExtractor output).
+    #[serde(default = "default_source_epsg")]
+    pub source_epsg_code: i64,
+
+    /// Tolerance for unshared-edge matching in meters (default: 0.1).
+    #[serde(default = "default_unshared_edge_tolerance")]
+    pub unshared_edge_tolerance: f64,
+
+    /// Group-by attributes for unshared-edge detection (default: [_fld_scale, udxDirs]).
+    #[serde(default = "default_unshared_edge_group_by")]
+    pub unshared_edge_group_by: Vec<Attribute>,
+
+    /// Tolerance for duplicate-consecutive-points degenerate check (default: 0.009).
+    #[serde(default = "default_duplicate_consecutive_points_tolerance")]
+    pub duplicate_consecutive_points_tolerance: f64,
+
+    /// Tolerance for corrupt-geometry degenerate check (default: 0.01).
+    #[serde(default = "default_corrupt_geometry_tolerance")]
+    pub corrupt_geometry_tolerance: f64,
+}
+
+fn default_gml_path_attribute() -> Attribute {
+    Attribute::new("path")
+}
+fn default_source_epsg() -> i64 {
+    DEFAULT_SOURCE_EPSG
+}
+fn default_unshared_edge_tolerance() -> f64 {
+    0.1
+}
+fn default_unshared_edge_group_by() -> Vec<Attribute> {
+    vec![Attribute::new("_fld_scale"), Attribute::new("udxDirs")]
+}
+fn default_duplicate_consecutive_points_tolerance() -> f64 {
+    0.009
+}
+fn default_corrupt_geometry_tolerance() -> f64 {
+    0.01
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WaterBodyTinValidator {
+    params: WaterBodyTinValidatorParam,
+    global_params: Option<HashMap<String, Value>>,
+    /// One input feature per gml file, buffered until `finish()`.
+    buffer: Vec<Feature>,
+}
+
+/// Per-face validation outcome (mirrors FaceExtractor).
+#[derive(Debug, Clone, Copy, Default)]
+struct FaceValidation {
+    is_incorrect_num_vertices: bool,
+    is_not_closed: bool,
+    is_wrong_orientation: bool,
+}
+
+/// Per-file accumulated counts.
+#[derive(Debug, Clone, Copy, Default)]
+struct FileCounts {
+    num_instances: usize,
+    num_incorrect_num_vertices: usize,
+    num_not_closed: usize,
+    num_wrong_orientation: usize,
+    num_degenerate_triangles: usize,
+}
+
+/// Per-file result carried to summary emission (edges are spilled separately).
+struct FileResult {
+    file_idx: u32,
+    base_feature: Feature,
+    counts: FileCounts,
+}
+
+impl Processor for WaterBodyTinValidator {
+    fn is_accumulating(&self) -> bool {
+        true
+    }
+
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        _fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        // One feature per gml file; the heavy work runs (in parallel) in finish().
+        self.buffer.push(ctx.feature.clone());
+        Ok(())
+    }
+
+    fn finish(
+        &mut self,
+        ctx: NodeContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+
+        // Resolve target EPSG once (expression is env-based, feature-independent).
+        let target_epsg = self.eval_target_epsg(&ctx)?;
+        let from_crs = format!("EPSG:{}", self.params.source_epsg_code);
+        let to_crs = format!("EPSG:{target_epsg}");
+
+        let validation_types = [
+            ValidationType::DuplicateConsecutivePoints(
+                self.params.duplicate_consecutive_points_tolerance,
+            ),
+            ValidationType::CorruptGeometry(Some(self.params.corrupt_geometry_tolerance)),
+        ];
+
+        // Disk-backed per-group edge spills, keyed by the group-by attribute values.
+        let temp_dir = self.make_temp_dir(fw)?;
+        let spills: Mutex<GroupSpills> = Mutex::new(GroupSpills::new(temp_dir.clone()));
+
+        let storage_resolver = Arc::clone(&ctx.storage_resolver);
+        let group_by = &self.params.unshared_edge_group_by;
+
+        // Parallel per-file: parse -> validate -> reproject -> degenerate check ->
+        // edge extraction. Edges are appended to the shared group spills; only the
+        // small per-file result is returned.
+        let mut results: Vec<FileResult> = self
+            .buffer
+            .par_iter()
+            .enumerate()
+            .map(|(idx, feature)| -> Result<FileResult, BoxedError> {
+                let file_idx = idx as u32;
+                let (base_feature, counts, group_key, edges) = process_one_file(
+                    file_idx,
+                    feature,
+                    &self.params.city_gml_path_attribute,
+                    &from_crs,
+                    &to_crs,
+                    &validation_types,
+                    group_by,
+                    &storage_resolver,
+                )?;
+
+                if !edges.is_empty() {
+                    spills.lock().append(group_key, edges)?;
+                }
+
+                Ok(FileResult {
+                    file_idx,
+                    base_feature,
+                    counts,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Cross-file unshared-edge detection per river group -> per-file counts.
+        let mut spills = spills.into_inner();
+        spills.flush_all()?;
+        let unshared_counts = spills.detect_unshared(self.params.unshared_edge_tolerance)?;
+
+        // Emit one summary per file with all five counts.
+        results.sort_by_key(|r| r.file_idx);
+        for result in results {
+            let num_unshared = unshared_counts.get(&result.file_idx).copied().unwrap_or(0);
+            let summary = build_summary(result.base_feature, &result.counts, num_unshared);
+            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                &ctx,
+                summary,
+                SUMMARY_PORT.clone(),
+            ));
+        }
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "WaterBodyTinValidator"
+    }
+}
+
+impl WaterBodyTinValidator {
+    fn eval_target_epsg(&self, ctx: &NodeContext) -> Result<i64, BoxedError> {
+        let expr_engine = Arc::clone(&ctx.expr_engine);
+        let ast = expr_engine
+            .compile(self.params.target_epsg_code.as_ref())
+            .map_err(|e| {
+                PlateauProcessorError::WaterBodyTinValidator(format!(
+                    "Failed to compile target EPSG expression: {e:?}"
+                ))
+            })?;
+        let feature = &self.buffer[0];
+        let scope = feature.new_scope(expr_engine, &self.global_params);
+        let value: i64 = scope.eval_ast(&ast).map_err(|e| {
+            PlateauProcessorError::WaterBodyTinValidator(format!(
+                "Failed to evaluate target EPSG expression: {e}"
+            ))
+        })?;
+        Ok(value)
+    }
+
+    fn make_temp_dir(&self, fw: &ProcessorChannelForwarder) -> Result<PathBuf, BoxedError> {
+        let dir = executor_cache_subdir(fw.executor_id(), "processors")
+            .join(format!("water-body-tin-validator-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir)?;
+        Ok(dir)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-file processing
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+fn process_one_file(
+    file_idx: u32,
+    feature: &Feature,
+    path_attribute: &Attribute,
+    from_crs: &str,
+    to_crs: &str,
+    validation_types: &[ValidationType],
+    group_by: &[Attribute],
+    storage_resolver: &Arc<StorageResolver>,
+) -> Result<(Feature, FileCounts, AttributeValue, Vec<Edge>), BoxedError> {
+    let group_key = compute_group_key(feature, group_by);
+
+    let file_path_attr = feature.attributes.get(path_attribute).ok_or_else(|| {
+        PlateauProcessorError::WaterBodyTinValidator(format!(
+            "path attribute `{}` not found",
+            path_attribute
+        ))
+    })?;
+    let file_path = file_path_attr.to_string();
+
+    let xml_content = read_file(&file_path, storage_resolver)?;
+    let pos_lists = collect_pos_lists(&xml_content)?;
+
+    let mut counts = FileCounts::default();
+    let mut edges = Vec::new();
+
+    for pos_text in pos_lists {
+        let coords = parse_pos_list(&pos_text)?;
+        counts.num_instances += 1;
+
+        let validation = validate_pos_list(&coords);
+        if validation.is_incorrect_num_vertices {
+            counts.num_incorrect_num_vertices += 1;
+        }
+        if validation.is_not_closed {
+            counts.num_not_closed += 1;
+        }
+        if validation.is_wrong_orientation {
+            counts.num_wrong_orientation += 1;
+        }
+
+        // Empty geometry: FaceExtractor never builds a polygon, so downstream
+        // GeometryValidator rejects it (not counted degenerate) and it yields no
+        // edges. Validation counts above already reflect it.
+        if coords.is_empty() {
+            continue;
+        }
+
+        // Reproject (lon,lat) -> plane rectangular meters and force 2D.
+        let projected: Vec<(f64, f64)> = with_proj(from_crs, to_crs, |proj| {
+            coords
+                .iter()
+                .map(|(lon, lat, _)| {
+                    proj.convert((*lon, *lat)).map_err(|e| {
+                        PlateauProcessorError::WaterBodyTinValidator(format!(
+                            "Reprojection failed: {e}"
+                        ))
+                        .into()
+                    })
+                })
+                .collect::<Result<Vec<_>, BoxedError>>()
+        })?;
+
+        let exterior: Vec<_> = projected
+            .iter()
+            .map(|(x, y)| Coordinate::new_(*x, *y))
+            .collect();
+        let polygon = Polygon2D::new(LineString2D::new(exterior), vec![]);
+
+        // Degenerate (line-like / point-like) detection, matching GeometryValidator
+        // on the reprojected 2D geometry.
+        let geometry = Geometry2D::Polygon(polygon.clone());
+        let is_degenerate = validation_types
+            .iter()
+            .any(|vt| geometry.validate(vt.clone()).is_some());
+        if is_degenerate {
+            counts.num_degenerate_triangles += 1;
+        }
+
+        // Unshared-edge extraction excludes structurally invalid faces (matches
+        // UnsharedEdgeDetector::has_validation_error); wrong orientation is kept.
+        if !validation.is_incorrect_num_vertices && !validation.is_not_closed {
+            extract_polygon_edges(&polygon, file_idx, &mut edges);
+        }
+    }
+
+    Ok((feature.clone(), counts, group_key, edges))
+}
+
+fn compute_group_key(feature: &Feature, group_by: &[Attribute]) -> AttributeValue {
+    AttributeValue::Array(
+        group_by
+            .iter()
+            .map(|attr| {
+                feature
+                    .attributes
+                    .get(attr)
+                    .cloned()
+                    .unwrap_or(AttributeValue::Null)
+            })
+            .collect(),
+    )
+}
+
+fn read_file(
+    file_path: &str,
+    storage_resolver: &Arc<StorageResolver>,
+) -> Result<String, BoxedError> {
+    let uri = Uri::from_str(file_path).map_err(|e| {
+        PlateauProcessorError::WaterBodyTinValidator(format!("Failed to parse URI: {e}"))
+    })?;
+    let storage = storage_resolver.resolve(&uri).map_err(|e| {
+        PlateauProcessorError::WaterBodyTinValidator(format!("Failed to resolve storage: {e}"))
+    })?;
+    let content = storage.get_sync(uri.path().as_path()).map_err(|e| {
+        PlateauProcessorError::WaterBodyTinValidator(format!("Failed to read file: {e}"))
+    })?;
+    String::from_utf8(content.to_vec()).map_err(|e| {
+        PlateauProcessorError::WaterBodyTinValidator(format!("Failed to convert to UTF-8: {e}"))
+            .into()
+    })
+}
+
+/// Collect `gml:posList` text from every `wtr:WaterBody` (mirrors FaceExtractor).
+fn collect_pos_lists(xml_content: &str) -> Result<Vec<String>, BoxedError> {
+    let collected: std::rc::Rc<RefCell<Vec<String>>> = std::rc::Rc::new(RefCell::new(Vec::new()));
+    let stream_error: std::rc::Rc<RefCell<Option<String>>> = std::rc::Rc::new(RefCell::new(None));
+
+    let transformer = StreamTransformer::new(xml_content)
+        .with_root_namespaces()
+        .map_err(|e| {
+            PlateauProcessorError::WaterBodyTinValidator(format!(
+                "Failed to create StreamTransformer: {e:?}"
+            ))
+        })?;
+
+    let collected_clone = std::rc::Rc::clone(&collected);
+    let stream_error_clone = std::rc::Rc::clone(&stream_error);
+    transformer
+        .on("//wtr:WaterBody", move |node| {
+            if stream_error_clone.borrow().is_some() {
+                return;
+            }
+            let doc = node.document();
+            let mut xml_ctx = match xml::create_context(doc) {
+                Ok(ctx) => ctx,
+                Err(e) => {
+                    *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
+                    return;
+                }
+            };
+            for (prefix, uri) in node.namespaces() {
+                let _ = xml_ctx.register_namespace(prefix, uri);
+            }
+            let root_node = match xml::get_root_readonly_node(doc) {
+                Ok(n) => n,
+                Err(e) => {
+                    *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
+                    return;
+                }
+            };
+            let pos_lists =
+                match xml::find_readonly_nodes_by_xpath(&xml_ctx, ".//gml:posList", &root_node) {
+                    Ok(nodes) => nodes,
+                    Err(e) => {
+                        *stream_error_clone.borrow_mut() = Some(format!("{e:?}"));
+                        return;
+                    }
+                };
+            for pos_list_node in pos_lists {
+                let pos_text = pos_list_node.get_content().unwrap_or_default();
+                collected_clone.borrow_mut().push(pos_text);
+            }
+        })
+        .for_each()
+        .map_err(|e| {
+            PlateauProcessorError::WaterBodyTinValidator(format!("StreamTransformer error: {e:?}"))
+        })?;
+
+    if let Some(err) = std::rc::Rc::try_unwrap(stream_error)
+        .expect("all callback references should be dropped after for_each()")
+        .into_inner()
+    {
+        return Err(PlateauProcessorError::WaterBodyTinValidator(err).into());
+    }
+
+    Ok(std::rc::Rc::try_unwrap(collected)
+        .expect("all callback references should be dropped after for_each()")
+        .into_inner())
+}
+
+/// Parse a posList into `(lon, lat, height)` triples (swaps lat/lon, matches FME).
+fn parse_pos_list(pos_text: &str) -> Result<Vec<(f64, f64, f64)>, BoxedError> {
+    let values: Vec<f64> = pos_text
+        .split_whitespace()
+        .map(|s| s.parse::<f64>())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            PlateauProcessorError::WaterBodyTinValidator(format!("Failed to parse coordinate: {e}"))
+        })?;
+
+    if !values.len().is_multiple_of(3) {
+        return Err(PlateauProcessorError::WaterBodyTinValidator(
+            "posList length must be multiple of 3".to_string(),
+        )
+        .into());
+    }
+
+    Ok(values
+        .chunks(3)
+        .map(|chunk| (chunk[1], chunk[0], chunk[2]))
+        .collect())
+}
+
+fn validate_pos_list(coords: &[(f64, f64, f64)]) -> FaceValidation {
+    let mut result = FaceValidation::default();
+
+    // Vertex count: TIN triangles expect 4 (3 vertices + closing point).
+    if coords.len() != 4 {
+        result.is_incorrect_num_vertices = true;
+    }
+
+    // Closure: first == last.
+    let closed = match (coords.first(), coords.last()) {
+        (Some(first), Some(last)) => first.0 == last.0 && first.1 == last.1 && first.2 == last.2,
+        _ => false,
+    };
+    if !closed {
+        result.is_not_closed = true;
+    }
+
+    // Orientation (only when vertex count is correct): left-hand rule, normal.z > 0,
+    // computed on geographic coords (x=lon, y=lat) just like FaceExtractor.
+    if !result.is_incorrect_num_vertices && !validate_orientation(coords) {
+        result.is_wrong_orientation = true;
+    }
+
+    result
+}
+
+fn validate_orientation(coords: &[(f64, f64, f64)]) -> bool {
+    if coords.len() < 3 {
+        return false;
+    }
+    let p0 = coords[0];
+    let p1 = coords[1];
+    let p2 = coords[2];
+    let v1_x = p1.0 - p0.0;
+    let v1_y = p1.1 - p0.1;
+    let v2_x = p2.0 - p0.0;
+    let v2_y = p2.1 - p0.1;
+    let normal_z = v1_x * v2_y - v1_y * v2_x;
+    normal_z > 0.0
+}
+
+fn extract_polygon_edges(polygon: &Polygon2D<f64>, file_idx: u32, edges: &mut Vec<Edge>) {
+    let coords: Vec<_> = polygon.exterior().coords().collect();
+    for window in coords.windows(2) {
+        let p1 = FixedPoint::from_coordinate(window[0]);
+        let p2 = FixedPoint::from_coordinate(window[1]);
+        if p1 != p2 {
+            edges.push(Edge::new(p1, p2, file_idx));
+        }
+    }
+}
+
+/// Build a per-file summary feature carrying all five error counts.
+fn build_summary(base_feature: Feature, counts: &FileCounts, num_unshared: u64) -> Feature {
+    let mut feature = base_feature;
+    let attrs = feature.attributes_mut();
+
+    attrs.insert(Attribute::new("__is_summary"), num(1));
+    attrs.insert(
+        Attribute::new("_num_instances"),
+        num(counts.num_instances as u64),
+    );
+    attrs.insert(
+        Attribute::new("_num_incorrect_num_vertices"),
+        num(counts.num_incorrect_num_vertices as u64),
+    );
+    attrs.insert(
+        Attribute::new("_num_not_closed"),
+        num(counts.num_not_closed as u64),
+    );
+    attrs.insert(
+        Attribute::new("_num_wrong_orientation"),
+        num(counts.num_wrong_orientation as u64),
+    );
+    attrs.insert(
+        Attribute::new("_num_degenerate_triangles"),
+        num(counts.num_degenerate_triangles as u64),
+    );
+    attrs.insert(Attribute::new("_num_unshared_edges"), num(num_unshared));
+
+    // _json_filename derived from udxDirs (flatten '/' to '_'), matching FaceExtractor.
+    if let Some(AttributeValue::String(udx_dirs)) =
+        feature.attributes.get(&Attribute::new("udxDirs")).cloned()
+    {
+        let json_filename = format!("summary_{}.json", udx_dirs.replace('/', "_"));
+        feature.attributes_mut().insert(
+            Attribute::new("_json_filename"),
+            AttributeValue::String(json_filename),
+        );
+    }
+
+    feature
+}
+
+fn num(v: u64) -> AttributeValue {
+    AttributeValue::Number(serde_json::Number::from(v))
+}
+
+// ---------------------------------------------------------------------------
+// Unshared-edge detection (disk-backed, adapted from unshared_edge_detector.rs)
+// ---------------------------------------------------------------------------
+
+/// Per-group disk-backed edge spill.
+struct GroupSpill {
+    dir: PathBuf,
+    buffer: Vec<Edge>,
+    buffer_bytes: usize,
+    chunk_count: usize,
+}
+
+impl GroupSpill {
+    fn flush(&mut self) -> Result<(), BoxedError> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+        self.buffer.sort();
+        std::fs::create_dir_all(&self.dir)?;
+        let chunk_path = self.dir.join(format!("chunk_{:06}.bin", self.chunk_count));
+        let mut writer = BufWriter::new(File::create(&chunk_path)?);
+        for edge in &self.buffer {
+            write_edge(&mut writer, edge)?;
+        }
+        writer.flush()?;
+        self.chunk_count += 1;
+        self.buffer.clear();
+        self.buffer_bytes = 0;
+        Ok(())
+    }
+}
+
+/// Collection of per-group spills, keyed by group-by attribute values.
+struct GroupSpills {
+    base_dir: PathBuf,
+    groups: HashMap<AttributeValue, GroupSpill>,
+    group_count: usize,
+}
+
+impl GroupSpills {
+    fn new(base_dir: PathBuf) -> Self {
+        Self {
+            base_dir,
+            groups: HashMap::new(),
+            group_count: 0,
+        }
+    }
+
+    fn append(&mut self, key: AttributeValue, edges: Vec<Edge>) -> Result<(), BoxedError> {
+        let group_count = &mut self.group_count;
+        let base_dir = &self.base_dir;
+        let group = self.groups.entry(key).or_insert_with(|| {
+            let idx = *group_count;
+            *group_count += 1;
+            GroupSpill {
+                dir: base_dir.join(format!("group_{idx:06}")),
+                buffer: Vec::new(),
+                buffer_bytes: 0,
+                chunk_count: 0,
+            }
+        });
+        group.buffer_bytes += edges.len() * EDGE_BINARY_SIZE;
+        group.buffer.extend(edges);
+        if group.buffer_bytes >= ACCUMULATOR_BUFFER_BYTE_THRESHOLD {
+            group.flush()?;
+        }
+        Ok(())
+    }
+
+    fn flush_all(&mut self) -> Result<(), BoxedError> {
+        for group in self.groups.values_mut() {
+            group.flush()?;
+        }
+        Ok(())
+    }
+
+    /// Detect micro-gap (unshared) edges per group and count them per source file.
+    fn detect_unshared(&self, tolerance: f64) -> Result<HashMap<u32, u64>, BoxedError> {
+        let per_group: Vec<Result<HashMap<u32, u64>, BoxedError>> = self
+            .groups
+            .values()
+            .collect::<Vec<_>>()
+            .par_iter()
+            .map(|group| detect_group_unshared(&group.dir, group.chunk_count, tolerance))
+            .collect();
+
+        let mut totals: HashMap<u32, u64> = HashMap::new();
+        for group_result in per_group {
+            for (file_idx, count) in group_result? {
+                *totals.entry(file_idx).or_insert(0) += count;
+            }
+        }
+        Ok(totals)
+    }
+}
+
+/// Process one group's chunks: multi-pass K-way merge + sliding-window scan,
+/// counting micro-gap edges per source file. Adapted from
+/// `unshared_edge_detector::process_group_chunks`, but counts instead of emits.
+fn detect_group_unshared(
+    dir: &Path,
+    chunk_count: usize,
+    tolerance: f64,
+) -> Result<HashMap<u32, u64>, BoxedError> {
+    let mut counts: HashMap<u32, u64> = HashMap::new();
+    if chunk_count == 0 {
+        return Ok(counts);
+    }
+
+    let mut chunk_paths: Vec<PathBuf> = (0..chunk_count)
+        .map(|i| dir.join(format!("chunk_{i:06}.bin")))
+        .collect();
+
+    // Multi-pass merge until few enough chunks for a single final pass.
+    let mut pass: usize = 0;
+    while chunk_paths.len() > MERGE_FAN_IN {
+        pass += 1;
+        let mut next_paths = Vec::new();
+        for (group_idx, group) in chunk_paths.chunks(MERGE_FAN_IN).enumerate() {
+            let out_path = dir.join(format!("pass_{pass:03}_chunk_{group_idx:06}.bin"));
+            merge_edge_chunks_to_file(group, &out_path)?;
+            next_paths.push(out_path);
+        }
+        for p in &chunk_paths {
+            let _ = std::fs::remove_file(p);
+        }
+        chunk_paths = next_paths;
+    }
+
+    let tol_fixed = (tolerance * FIXED_POINT_SCALE) as i64;
+    let mut readers: Vec<BufReader<File>> = chunk_paths
+        .iter()
+        .map(|p| File::open(p).map(BufReader::new))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut heap: BinaryHeap<HeapEntry> = BinaryHeap::new();
+    for (i, reader) in readers.iter_mut().enumerate() {
+        if let Some(edge) = read_edge(reader) {
+            heap.push(HeapEntry { edge, chunk_idx: i });
+        }
+    }
+
+    // pending: groups of near-equal edges, ordered by ref edge insertion.
+    let mut pending: VecDeque<(Edge, Vec<Edge>)> = VecDeque::new();
+
+    while let Some(entry) = heap.pop() {
+        let e = entry.edge;
+        if let Some(next) = read_edge(&mut readers[entry.chunk_idx]) {
+            heap.push(HeapEntry {
+                edge: next,
+                chunk_idx: entry.chunk_idx,
+            });
+        }
+
+        while pending
+            .front()
+            .is_some_and(|(ref_edge, _)| ref_edge.start.x + tol_fixed < e.start.x)
+        {
+            if let Some(group) = pending.pop_front() {
+                count_microgaps(group, &mut counts);
+            }
+        }
+
+        let mut placed = false;
+        for (ref_edge, members) in &mut pending {
+            if e.matches(ref_edge, tolerance) {
+                members.push(e.clone());
+                placed = true;
+                break;
+            }
+        }
+        if !placed {
+            pending.push_back((e.clone(), vec![e]));
+        }
+    }
+
+    for group in pending.drain(..) {
+        count_microgaps(group, &mut counts);
+    }
+
+    Ok(counts)
+}
+
+/// Count each member of a qualifying micro-gap group against its source file.
+/// A group is a micro-gap when it has >1 member that are not all identical.
+fn count_microgaps(group: (Edge, Vec<Edge>), counts: &mut HashMap<u32, u64>) {
+    let (_, members) = group;
+    if members.len() <= 1 {
+        return;
+    }
+    let first = &members[0];
+    let all_identical = members
+        .iter()
+        .all(|e| e.start == first.start && e.end == first.end);
+    if all_identical {
+        return;
+    }
+    for edge in &members {
+        *counts.entry(edge.file_idx).or_insert(0) += 1;
+    }
+}
+
+fn write_edge<W: Write>(writer: &mut W, edge: &Edge) -> std::io::Result<()> {
+    writer.write_all(&edge.start.x.to_le_bytes())?;
+    writer.write_all(&edge.start.y.to_le_bytes())?;
+    writer.write_all(&edge.end.x.to_le_bytes())?;
+    writer.write_all(&edge.end.y.to_le_bytes())?;
+    writer.write_all(&edge.file_idx.to_le_bytes())?;
+    Ok(())
+}
+
+fn read_edge<R: Read>(reader: &mut R) -> Option<Edge> {
+    let mut buf = [0u8; EDGE_BINARY_SIZE];
+    reader.read_exact(&mut buf).ok()?;
+    let sx = i64::from_le_bytes(buf[0..8].try_into().unwrap());
+    let sy = i64::from_le_bytes(buf[8..16].try_into().unwrap());
+    let ex = i64::from_le_bytes(buf[16..24].try_into().unwrap());
+    let ey = i64::from_le_bytes(buf[24..32].try_into().unwrap());
+    let file_idx = u32::from_le_bytes(buf[32..36].try_into().unwrap());
+    Some(Edge {
+        start: FixedPoint { x: sx, y: sy },
+        end: FixedPoint { x: ex, y: ey },
+        file_idx,
+    })
+}
+
+fn merge_edge_chunks_to_file(
+    chunk_paths: &[PathBuf],
+    out_path: &PathBuf,
+) -> Result<(), BoxedError> {
+    let mut readers: Vec<BufReader<File>> = chunk_paths
+        .iter()
+        .map(|p| File::open(p).map(BufReader::new))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut heap: BinaryHeap<HeapEntry> = BinaryHeap::new();
+    for (i, reader) in readers.iter_mut().enumerate() {
+        if let Some(edge) = read_edge(reader) {
+            heap.push(HeapEntry { edge, chunk_idx: i });
+        }
+    }
+    let mut writer = BufWriter::new(File::create(out_path)?);
+    while let Some(entry) = heap.pop() {
+        write_edge(&mut writer, &entry.edge)?;
+        if let Some(next) = read_edge(&mut readers[entry.chunk_idx]) {
+            heap.push(HeapEntry {
+                edge: next,
+                chunk_idx: entry.chunk_idx,
+            });
+        }
+    }
+    writer.flush()?;
+    Ok(())
+}
+
+/// Directed edge with fixed-point coordinates. `(A,B)` and `(B,A)` normalize to
+/// the same edge; `Ord`/`Eq` compare only coordinates (not `file_idx`).
+#[derive(Debug, Clone)]
+struct Edge {
+    start: FixedPoint,
+    end: FixedPoint,
+    file_idx: u32,
+}
+
+impl PartialEq for Edge {
+    fn eq(&self, other: &Self) -> bool {
+        self.start == other.start && self.end == other.end
+    }
+}
+impl Eq for Edge {}
+impl PartialOrd for Edge {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for Edge {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.start.cmp(&other.start).then(self.end.cmp(&other.end))
+    }
+}
+
+impl Edge {
+    fn new(p1: FixedPoint, p2: FixedPoint, file_idx: u32) -> Self {
+        if (p1.x, p1.y) < (p2.x, p2.y) {
+            Self {
+                start: p1,
+                end: p2,
+                file_idx,
+            }
+        } else {
+            Self {
+                start: p2,
+                end: p1,
+                file_idx,
+            }
+        }
+    }
+
+    fn matches(&self, other: &Self, tolerance: f64) -> bool {
+        self.start.within_tolerance(&other.start, tolerance)
+            && self.end.within_tolerance(&other.end, tolerance)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct FixedPoint {
+    x: i64,
+    y: i64,
+}
+
+impl FixedPoint {
+    fn from_coordinate<Z: CoordNum>(coord: &Coordinate<f64, Z>) -> Self {
+        Self {
+            x: (coord.x * FIXED_POINT_SCALE).round() as i64,
+            y: (coord.y * FIXED_POINT_SCALE).round() as i64,
+        }
+    }
+
+    fn within_tolerance(&self, other: &Self, tolerance: f64) -> bool {
+        let tolerance_fixed = (tolerance * FIXED_POINT_SCALE) as i64;
+        (self.x - other.x).abs() <= tolerance_fixed && (self.y - other.y).abs() <= tolerance_fixed
+    }
+}
+
+/// Min-heap entry for K-way merge (`BinaryHeap` is a max-heap; reverse to min).
+struct HeapEntry {
+    edge: Edge,
+    chunk_idx: usize,
+}
+impl PartialEq for HeapEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.edge == other.edge
+    }
+}
+impl Eq for HeapEntry {}
+impl PartialOrd for HeapEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for HeapEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        other.edge.cmp(&self.edge)
+    }
+}

--- a/engine/runtime/action-plateau-processor/src/plateau4/water_body_tin_validator.rs
+++ b/engine/runtime/action-plateau-processor/src/plateau4/water_body_tin_validator.rs
@@ -48,6 +48,7 @@ use reearth_flow_types::{Attribute, AttributeValue, Expr, Feature};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tempfile::TempDir;
 
 use super::errors::PlateauProcessorError;
 use super::face_extractor::{
@@ -280,7 +281,8 @@ impl Processor for WaterBodyTinValidator {
 
         // Disk-backed per-group edge spills, keyed by the group-by attribute values.
         let temp_dir = self.make_temp_dir(fw)?;
-        let spills: Mutex<GroupSpills> = Mutex::new(GroupSpills::new(temp_dir.clone()));
+        let spills: Mutex<GroupSpills> =
+            Mutex::new(GroupSpills::new(temp_dir.path().to_path_buf()));
 
         let storage_resolver = Arc::clone(&ctx.storage_resolver);
         let group_by = &self.params.unshared_edge_group_by;
@@ -334,7 +336,6 @@ impl Processor for WaterBodyTinValidator {
             ));
         }
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
         Ok(())
     }
 
@@ -363,10 +364,12 @@ impl WaterBodyTinValidator {
         Ok(value)
     }
 
-    fn make_temp_dir(&self, fw: &ProcessorChannelForwarder) -> Result<PathBuf, BoxedError> {
-        let dir = executor_cache_subdir(fw.executor_id(), "processors")
-            .join(format!("water-body-tin-validator-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir)?;
+    fn make_temp_dir(&self, fw: &ProcessorChannelForwarder) -> Result<TempDir, BoxedError> {
+        let parent = executor_cache_subdir(fw.executor_id(), "processors");
+        std::fs::create_dir_all(&parent)?;
+        let dir = tempfile::Builder::new()
+            .prefix("water-body-tin-validator-")
+            .tempdir_in(&parent)?;
         Ok(dir)
     }
 }

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld.yml
@@ -1725,88 +1725,19 @@ graphs:
       groupBy:
       - _udx_dirs
       countStart: 1
-  - id: 5a3b2c1d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
-    name: FaceExtractor
+  - id: 7a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
+    name: WaterBodyTinValidator
     type: action
-    action: PLATEAU4.FaceExtractor
+    action: PLATEAU4.WaterBodyTinValidator
     with:
       cityGmlPathAttribute: path
-  - id: 6a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d
-    name: HorizontalReprojector
-    type: action
-    action: HorizontalReprojector
-    with:
       targetEpsgCode: env.get("prcs")
-  - id: 7b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e
-    name: GeometryValidator
-    type: action
-    action: GeometryValidator
-    with:
-      validationTypes:
-      - duplicateConsecutivePoints: 0.009
-      - corruptGeometry: 0.01
-  - id: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-    name: TwoDimensionForcer
-    type: action
-    action: TwoDimensionForcer
-    with: {}
-  - id: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b
-    name: PLATEAU4.UnsharedEdgeDetector
-    type: action
-    action: PLATEAU4.UnsharedEdgeDetector
-    with:
-      tolerance: 0.1
-      groupBy:
+      unsharedEdgeTolerance: 0.1
+      unsharedEdgeGroupBy:
       - _fld_scale
       - udxDirs
-  - id: c8d9e0f1-a2b3-4c5d-6e7f-8a9b0c1d2e3f
-    name: UnsharedEdgeCounter
-    type: action
-    action: AttributeAggregator
-    with:
-      aggregateAttributes:
-      - newAttribute: udxDirs
-        attribute: udxDirs
-      - newAttribute: _file_index
-        attribute: _file_index
-      calculationAttribute: _num_unshared_edges
-      calculationValue: 1
-      method: count
-  - id: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
-    name: DegenerateTriangleCounter
-    type: action
-    action: AttributeAggregator
-    with:
-      aggregateAttributes:
-      - newAttribute: udxDirs
-        attribute: udxDirs
-      - newAttribute: _file_index
-        attribute: _file_index
-      calculationAttribute: _num_degenerate_triangles
-      calculationValue: 1
-      method: count
-  - id: c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f
-    name: MergeSummaryWithDegenerateCount
-    type: action
-    action: FeatureMerger
-    with:
-      requestorAttribute:
-      - udxDirs
-      - _file_index
-      supplierAttribute:
-      - udxDirs
-      - _file_index
-  - id: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-    name: MergeSummaryWithUnsharedEdges
-    type: action
-    action: FeatureMerger
-    with:
-      requestorAttribute:
-      - udxDirs
-      - _file_index
-      supplierAttribute:
-      - udxDirs
-      - _file_index
+      duplicateConsecutivePointsTolerance: 0.009
+      corruptGeometryTolerance: 0.01
   - id: 9d0e1f2a-3b4c-5d6e-7f8a-9b0c1d2e3f4a
     name: PrepareSummaryForCSV
     type: action
@@ -2022,73 +1953,13 @@ graphs:
     toPort: default
   - id: 9705ee13-25e6-4237-b60e-4e89828a1774
     from: 5d6e7f8a-9b0c-1d2e-3f4a-5b6c7d8e9f0a
-    to: 5a3b2c1d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
+    to: 7a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
     fromPort: default
     toPort: default
-  - id: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-    from: 5a3b2c1d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
-    to: 6a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d
-    fromPort: all
-    toPort: default
-  - id: 9c7d8e9f-0a1b-2c3d-4e5f-6a7b8c9d0e1f
-    from: 6a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d
-    to: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-    fromPort: default
-    toPort: default
-  - id: 8c6d7e8f-9a0b-1c2d-3e4f-5a6b7c8d9e0f
-    from: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-    to: 7b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e
-    fromPort: default
-    toPort: default
-  - id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d
-    from: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-    to: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b
-    fromPort: default
-    toPort: default
-  - id: 8f6a7b8c-9d0e-1f2a-3b4c-5d6e7f8a9b0c
-    from: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b
-    to: c8d9e0f1-a2b3-4c5d-6e7f-8a9b0c1d2e3f
-    fromPort: unshared
-    toPort: default
-  - id: b0c9d8e7-f6a5-4b3c-2d1e-0f9a8b7c6d5e
-    from: 7b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e
-    to: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
-    fromPort: failed
-    toPort: default
-  - id: 9a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
-    from: c8d9e0f1-a2b3-4c5d-6e7f-8a9b0c1d2e3f
-    to: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-    fromPort: default
-    toPort: supplier
-  - id: 9d7e8f9a-0b1c-2d3e-4f5a-6b7c8d9e0f1a
-    from: 5a3b2c1d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
-    to: c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f
-    fromPort: summary
-    toPort: requestor
-  - id: d2e3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
-    from: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
-    to: c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f
-    fromPort: default
-    toPort: supplier
-  - id: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
-    from: c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f
-    to: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-    fromPort: merged
-    toPort: requestor
-  - id: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c6a
-    from: c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f
-    to: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-    fromPort: unmerged
-    toPort: requestor
   - id: 1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e
-    from: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
+    from: 7a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
     to: 9d0e1f2a-3b4c-5d6e-7f8a-9b0c1d2e3f4a
-    fromPort: merged
-    toPort: default
-  - id: 1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6f
-    from: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-    to: 9d0e1f2a-3b4c-5d6e-7f8a-9b0c1d2e3f4a
-    fromPort: unmerged
+    fromPort: summary
     toPort: default
   - id: e2f3a4b5-c6d7-8e9f-0a1b-2c3d4e5f6a7b
     from: 9d0e1f2a-3b4c-5d6e-7f8a-9b0c1d2e3f4a
@@ -2096,14 +1967,9 @@ graphs:
     fromPort: default
     toPort: default
   - id: 2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f
-    from: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
+    from: 7a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
     to: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
-    fromPort: merged
-    toPort: default
-  - id: 2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e80
-    from: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-    to: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
-    fromPort: unmerged
+    fromPort: summary
     toPort: default
   - id: 3d4e5f6a-7b8c-9d0e-1f2a-3b4c5d6e7f8a
     from: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d

--- a/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld/workflow.yml
+++ b/engine/runtime/examples/fixture/workflow/quality-check/plateau4/06-fld/workflow.yml
@@ -165,115 +165,20 @@ graphs:
             - "_udx_dirs"
           countStart: 1
 
-      # WaterBody Surface Validation
-      # FaceExtractor reads CityGML XML directly (like FME PythonCaller)
-      # Outputs individual triangle geometries with validation results
-      - id: 5a3b2c1d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
-        name: FaceExtractor
+      # WaterBody TIN surface validation
+      - id: 7a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
+        name: WaterBodyTinValidator
         type: action
-        action: PLATEAU4.FaceExtractor
+        action: PLATEAU4.WaterBodyTinValidator
         with:
           cityGmlPathAttribute: "path"
-
-      # HorizontalReprojector: Convert from geographic (EPSG:6697) to plane rectangular coordinates
-      # Applied to all output geometries from FaceExtractor
-      - id: 6a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d
-        name: HorizontalReprojector
-        type: action
-        action: HorizontalReprojector
-        with:
           targetEpsgCode: env.get("prcs")
-
-      # GeometryValidator: Validate geometry for degenerate triangles and duplicate consecutive points
-      - id: 7b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e
-        name: GeometryValidator
-        type: action
-        action: GeometryValidator
-        with:
-          validationTypes:
-            - duplicateConsecutivePoints: 0.009
-            - corruptGeometry: 0.01
-
-      # TwoDimensionForcer: Convert 3D geometry to 2D before edge matching
-      - id: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-        name: TwoDimensionForcer
-        type: action
-        action: TwoDimensionForcer
-        with: {}
-
-      # PLATEAU4.UnsharedEdgeDetector: Detect unshared edges in triangular meshes
-      # Edge-based approach: Find edges that appear only once in the mesh
-      #
-      # Algorithm:
-      # 1. Extract all edges from all triangles
-      # 2. Count edge occurrences (with tolerance for approximate matching)
-      # 3. Find edges with count = 1 (unshared edges)
-      # 4. Output each unshared edge as a LineString feature
-      - id: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b
-        name: PLATEAU4.UnsharedEdgeDetector
-        type: action
-        action: PLATEAU4.UnsharedEdgeDetector
-        with:
-          tolerance: 0.1  # meter(s)
-          groupBy:
+          unsharedEdgeTolerance: 0.1  # meter(s)
+          unsharedEdgeGroupBy:
             - "_fld_scale"
             - "udxDirs"
-
-      # AttributeAggregator: Count unshared edges
-      - id: c8d9e0f1-a2b3-4c5d-6e7f-8a9b0c1d2e3f
-        name: UnsharedEdgeCounter
-        type: action
-        action: AttributeAggregator
-        with:
-          aggregateAttributes:
-            - newAttribute: "udxDirs"
-              attribute: "udxDirs"
-            - newAttribute: "_file_index"
-              attribute: "_file_index"
-          calculationAttribute: "_num_unshared_edges"
-          calculationValue: 1
-          method: count
-
-      # AttributeAggregator: Count TooFewPoints errors (degenerate triangles)
-      - id: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
-        name: DegenerateTriangleCounter
-        type: action
-        action: AttributeAggregator
-        with:
-          aggregateAttributes:
-            - newAttribute: "udxDirs"
-              attribute: "udxDirs"
-            - newAttribute: "_file_index"
-              attribute: "_file_index"
-          calculationAttribute: "_num_degenerate_triangles"
-          calculationValue: 1
-          method: count
-
-      # FeatureMerger: Merge FaceExtractor summary with degenerate triangle count
-      - id: c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f
-        name: MergeSummaryWithDegenerateCount
-        type: action
-        action: FeatureMerger
-        with:
-          requestorAttribute:
-            - "udxDirs"
-            - "_file_index"
-          supplierAttribute:
-            - "udxDirs"
-            - "_file_index"
-
-      # FeatureMerger: Merge summary with unshared edge count
-      - id: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-        name: MergeSummaryWithUnsharedEdges
-        type: action
-        action: FeatureMerger
-        with:
-          requestorAttribute:
-            - "udxDirs"
-            - "_file_index"
-          supplierAttribute:
-            - "udxDirs"
-            - "_file_index"
+          duplicateConsecutivePointsTolerance: 0.009
+          corruptGeometryTolerance: 0.01
 
       # CSV Output Preparation
       # Maps only the columns needed for CSV output
@@ -524,102 +429,18 @@ graphs:
         fromPort: default
         toPort: default
 
-      # Counter to FaceExtractor (direct connection)
+      # Counter to WaterBodyTinValidator (one feature per gml file)
       - id: 9705ee13-25e6-4237-b60e-4e89828a1774
         from: 5d6e7f8a-9b0c-1d2e-3f4a-5b6c7d8e9f0a
-        to: 5a3b2c1d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
+        to: 7a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
         fromPort: default
         toPort: default
 
-      # FaceExtractor all port to HorizontalReprojector
-      - id: a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6d
-        from: 5a3b2c1d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
-        to: 6a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d
-        fromPort: all
-        toPort: default
-
-      # HorizontalReprojector to TwoDimensionForcer (Convert all 3D to 2D)
-      - id: 9c7d8e9f-0a1b-2c3d-4e5f-6a7b8c9d0e1f
-        from: 6a4b5c6d-7e8f-9a0b-1c2d-3e4f5a6b7c8d
-        to: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-        fromPort: default
-        toPort: default
-
-      # TwoDimensionForcer to GeometryValidator
-      - id: 8c6d7e8f-9a0b-1c2d-3e4f-5a6b7c8d9e0f
-        from: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-        to: 7b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e
-        fromPort: default
-        toPort: default
-
-      # TwoDimensionForcer to UnsharedEdgeDetector (all triangles)
-      - id: a7b8c9d0-e1f2-3a4b-5c6d-7e8f9a0b1c2d
-        from: f1a2b3c4-d5e6-7f8a-9b0c-1d2e3f4a5b6c
-        to: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b
-        fromPort: default
-        toPort: default
-
-      # UnsharedEdgeDetector unshared port to UnsharedEdgeCounter
-      - id: 8f6a7b8c-9d0e-1f2a-3b4c-5d6e7f8a9b0c
-        from: e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b
-        to: c8d9e0f1-a2b3-4c5d-6e7f-8a9b0c1d2e3f
-        fromPort: unshared
-        toPort: default
-
-      # GeometryValidator FAILED port to DegenerateTriangleCounter
-      - id: b0c9d8e7-f6a5-4b3c-2d1e-0f9a8b7c6d5e
-        from: 7b5c6d7e-8f9a-0b1c-2d3e-4f5a6b7c8d9e
-        to: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
-        fromPort: failed
-        toPort: default
-
-      # MicroGapCounter to MergeSummaryWithUnsharedEdges (supplier port)
-      - id: 9a7b8c9d-0e1f-2a3b-4c5d-6e7f8a9b0c1d
-        from: c8d9e0f1-a2b3-4c5d-6e7f-8a9b0c1d2e3f
-        to: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-        fromPort: default
-        toPort: supplier
-
-      # FaceExtractor summary to FeatureMerger (requestor port)
-      - id: 9d7e8f9a-0b1c-2d3e-4f5a-6b7c8d9e0f1a
-        from: 5a3b2c1d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
-        to: c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f
-        fromPort: summary
-        toPort: requestor
-
-      # DegenerateTriangleCounter to FeatureMerger (supplier port)
-      - id: d2e3f4a5-b6c7-8d9e-0f1a-2b3c4d5e6f7a
-        from: a9b8c7d6-e5f4-3a2b-1c0d-9e8f7a6b5c4d
-        to: c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f
-        fromPort: default
-        toPort: supplier
-
-      # MergeSummaryWithDegenerateCount merged to MergeSummaryWithUnsharedEdges (requestor)
-      - id: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
-        from: c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f
-        to: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-        fromPort: merged
-        toPort: requestor
-
-      # MergeSummaryWithDegenerateCount unmerged to MergeSummaryWithUnsharedEdges (files with zero degenerate triangles)
-      - id: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c6a
-        from: c0d1e2f3-a4b5-6c7d-8e9f-0a1b2c3d4e5f
-        to: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-        fromPort: unmerged
-        toPort: requestor
-
-      # MergeSummaryWithUnsharedEdges merged port to CSV preparation
+      # WaterBodyTinValidator summary to CSV preparation
       - id: 1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e
-        from: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
+        from: 7a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
         to: 9d0e1f2a-3b4c-5d6e-7f8a-9b0c1d2e3f4a
-        fromPort: merged
-        toPort: default
-
-      # MergeSummaryWithUnsharedEdges unmerged port to CSV preparation (files with zero errors)
-      - id: 1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6f
-        from: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-        to: 9d0e1f2a-3b4c-5d6e-7f8a-9b0c1d2e3f4a
-        fromPort: unmerged
+        fromPort: summary
         toPort: default
 
       # CSV preparation to CSV writer
@@ -629,18 +450,11 @@ graphs:
         fromPort: default
         toPort: default
 
-      # MergeSummaryWithUnsharedEdges merged port to JSON preparation
+      # WaterBodyTinValidator summary to JSON preparation
       - id: 2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e7f
-        from: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
+        from: 7a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5e
         to: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
-        fromPort: merged
-        toPort: default
-
-      # MergeSummaryWithUnsharedEdges unmerged port to JSON preparation (files with zero errors)
-      - id: 2c3d4e5f-6a7b-8c9d-0e1f-2a3b4c5d6e80
-        from: d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a
-        to: 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d
-        fromPort: unmerged
+        fromPort: summary
         toPort: default
 
       # JSON preparation to JSON writer

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -8755,6 +8755,91 @@
       ]
     },
     {
+      "name": "PLATEAU4.WaterBodyTinValidator",
+      "type": "processor",
+      "description": "Validates WaterBody TIN surfaces end-to-end for the flood-family quality check: extracts faces from CityGML, reprojects, detects degenerate triangles and unshared edges, and emits one summary per file.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "WaterBodyTinValidator Parameters",
+        "type": "object",
+        "required": [
+          "targetEpsgCode"
+        ],
+        "properties": {
+          "cityGmlPathAttribute": {
+            "description": "Attribute holding the CityGML file path (default: \"path\").",
+            "default": "path",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "corruptGeometryTolerance": {
+            "description": "Tolerance for corrupt-geometry degenerate check (default: 0.01).",
+            "default": 0.01,
+            "type": "number",
+            "format": "double"
+          },
+          "duplicateConsecutivePointsTolerance": {
+            "description": "Tolerance for duplicate-consecutive-points degenerate check (default: 0.009).",
+            "default": 0.009,
+            "type": "number",
+            "format": "double"
+          },
+          "sourceEpsgCode": {
+            "description": "Source EPSG code (default: 6697, JGD2011 geographic — FaceExtractor output).",
+            "default": 6697,
+            "type": "integer",
+            "format": "int64"
+          },
+          "targetEpsgCode": {
+            "description": "Target EPSG code expression for reprojection (e.g. `env.get(\"prcs\")`).",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              }
+            ]
+          },
+          "unsharedEdgeGroupBy": {
+            "description": "Group-by attributes for unshared-edge detection (default: [_fld_scale, udxDirs]).",
+            "default": [
+              "_fld_scale",
+              "udxDirs"
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "unsharedEdgeTolerance": {
+            "description": "Tolerance for unshared-edge matching in meters (default: 0.1).",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "summary"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
       "name": "PlanarityFilter",
       "type": "processor",
       "description": "Filter Features by Geometry Planarity",

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -8755,6 +8755,91 @@
       ]
     },
     {
+      "name": "PLATEAU4.WaterBodyTinValidator",
+      "type": "processor",
+      "description": "Validates WaterBody TIN surfaces end-to-end for the flood-family quality check: extracts faces from CityGML, reprojects, detects degenerate triangles and unshared edges, and emits one summary per file.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "WaterBodyTinValidator Parameters",
+        "type": "object",
+        "required": [
+          "targetEpsgCode"
+        ],
+        "properties": {
+          "cityGmlPathAttribute": {
+            "description": "Attribute holding the CityGML file path (default: \"path\").",
+            "default": "path",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "corruptGeometryTolerance": {
+            "description": "Tolerance for corrupt-geometry degenerate check (default: 0.01).",
+            "default": 0.01,
+            "type": "number",
+            "format": "double"
+          },
+          "duplicateConsecutivePointsTolerance": {
+            "description": "Tolerance for duplicate-consecutive-points degenerate check (default: 0.009).",
+            "default": 0.009,
+            "type": "number",
+            "format": "double"
+          },
+          "sourceEpsgCode": {
+            "description": "Source EPSG code (default: 6697, JGD2011 geographic — FaceExtractor output).",
+            "default": 6697,
+            "type": "integer",
+            "format": "int64"
+          },
+          "targetEpsgCode": {
+            "description": "Target EPSG code expression for reprojection (e.g. `env.get(\"prcs\")`).",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              }
+            ]
+          },
+          "unsharedEdgeGroupBy": {
+            "description": "Group-by attributes for unshared-edge detection (default: [_fld_scale, udxDirs]).",
+            "default": [
+              "_fld_scale",
+              "udxDirs"
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "unsharedEdgeTolerance": {
+            "description": "Tolerance for unshared-edge matching in meters (default: 0.1).",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "summary"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
       "name": "PlanarityFilter",
       "type": "processor",
       "description": "Filter geometry by type",

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -8755,6 +8755,91 @@
       ]
     },
     {
+      "name": "PLATEAU4.WaterBodyTinValidator",
+      "type": "processor",
+      "description": "Validates WaterBody TIN surfaces end-to-end for the flood-family quality check: extracts faces from CityGML, reprojects, detects degenerate triangles and unshared edges, and emits one summary per file.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "WaterBodyTinValidator Parameters",
+        "type": "object",
+        "required": [
+          "targetEpsgCode"
+        ],
+        "properties": {
+          "cityGmlPathAttribute": {
+            "description": "Attribute holding the CityGML file path (default: \"path\").",
+            "default": "path",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "corruptGeometryTolerance": {
+            "description": "Tolerance for corrupt-geometry degenerate check (default: 0.01).",
+            "default": 0.01,
+            "type": "number",
+            "format": "double"
+          },
+          "duplicateConsecutivePointsTolerance": {
+            "description": "Tolerance for duplicate-consecutive-points degenerate check (default: 0.009).",
+            "default": 0.009,
+            "type": "number",
+            "format": "double"
+          },
+          "sourceEpsgCode": {
+            "description": "Source EPSG code (default: 6697, JGD2011 geographic — FaceExtractor output).",
+            "default": 6697,
+            "type": "integer",
+            "format": "int64"
+          },
+          "targetEpsgCode": {
+            "description": "Target EPSG code expression for reprojection (e.g. `env.get(\"prcs\")`).",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              }
+            ]
+          },
+          "unsharedEdgeGroupBy": {
+            "description": "Group-by attributes for unshared-edge detection (default: [_fld_scale, udxDirs]).",
+            "default": [
+              "_fld_scale",
+              "udxDirs"
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "unsharedEdgeTolerance": {
+            "description": "Tolerance for unshared-edge matching in meters (default: 0.1).",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "summary"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
       "name": "PlanarityFilter",
       "type": "processor",
       "description": "Filtra la geometría por tipo",

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -8755,6 +8755,91 @@
       ]
     },
     {
+      "name": "PLATEAU4.WaterBodyTinValidator",
+      "type": "processor",
+      "description": "Validates WaterBody TIN surfaces end-to-end for the flood-family quality check: extracts faces from CityGML, reprojects, detects degenerate triangles and unshared edges, and emits one summary per file.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "WaterBodyTinValidator Parameters",
+        "type": "object",
+        "required": [
+          "targetEpsgCode"
+        ],
+        "properties": {
+          "cityGmlPathAttribute": {
+            "description": "Attribute holding the CityGML file path (default: \"path\").",
+            "default": "path",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "corruptGeometryTolerance": {
+            "description": "Tolerance for corrupt-geometry degenerate check (default: 0.01).",
+            "default": 0.01,
+            "type": "number",
+            "format": "double"
+          },
+          "duplicateConsecutivePointsTolerance": {
+            "description": "Tolerance for duplicate-consecutive-points degenerate check (default: 0.009).",
+            "default": 0.009,
+            "type": "number",
+            "format": "double"
+          },
+          "sourceEpsgCode": {
+            "description": "Source EPSG code (default: 6697, JGD2011 geographic — FaceExtractor output).",
+            "default": 6697,
+            "type": "integer",
+            "format": "int64"
+          },
+          "targetEpsgCode": {
+            "description": "Target EPSG code expression for reprojection (e.g. `env.get(\"prcs\")`).",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              }
+            ]
+          },
+          "unsharedEdgeGroupBy": {
+            "description": "Group-by attributes for unshared-edge detection (default: [_fld_scale, udxDirs]).",
+            "default": [
+              "_fld_scale",
+              "udxDirs"
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "unsharedEdgeTolerance": {
+            "description": "Tolerance for unshared-edge matching in meters (default: 0.1).",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "summary"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
       "name": "PlanarityFilter",
       "type": "processor",
       "description": "Filter Features by Geometry Planarity",

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -8755,6 +8755,91 @@
       ]
     },
     {
+      "name": "PLATEAU4.WaterBodyTinValidator",
+      "type": "processor",
+      "description": "Validates WaterBody TIN surfaces end-to-end for the flood-family quality check: extracts faces from CityGML, reprojects, detects degenerate triangles and unshared edges, and emits one summary per file.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "WaterBodyTinValidator Parameters",
+        "type": "object",
+        "required": [
+          "targetEpsgCode"
+        ],
+        "properties": {
+          "cityGmlPathAttribute": {
+            "description": "Attribute holding the CityGML file path (default: \"path\").",
+            "default": "path",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "corruptGeometryTolerance": {
+            "description": "Tolerance for corrupt-geometry degenerate check (default: 0.01).",
+            "default": 0.01,
+            "type": "number",
+            "format": "double"
+          },
+          "duplicateConsecutivePointsTolerance": {
+            "description": "Tolerance for duplicate-consecutive-points degenerate check (default: 0.009).",
+            "default": 0.009,
+            "type": "number",
+            "format": "double"
+          },
+          "sourceEpsgCode": {
+            "description": "Source EPSG code (default: 6697, JGD2011 geographic — FaceExtractor output).",
+            "default": 6697,
+            "type": "integer",
+            "format": "int64"
+          },
+          "targetEpsgCode": {
+            "description": "Target EPSG code expression for reprojection (e.g. `env.get(\"prcs\")`).",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              }
+            ]
+          },
+          "unsharedEdgeGroupBy": {
+            "description": "Group-by attributes for unshared-edge detection (default: [_fld_scale, udxDirs]).",
+            "default": [
+              "_fld_scale",
+              "udxDirs"
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "unsharedEdgeTolerance": {
+            "description": "Tolerance for unshared-edge matching in meters (default: 0.1).",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "summary"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
       "name": "PlanarityFilter",
       "type": "processor",
       "description": "タイプに基づいてジオメトリをフィルタリングする",

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -8755,6 +8755,91 @@
       ]
     },
     {
+      "name": "PLATEAU4.WaterBodyTinValidator",
+      "type": "processor",
+      "description": "Validates WaterBody TIN surfaces end-to-end for the flood-family quality check: extracts faces from CityGML, reprojects, detects degenerate triangles and unshared edges, and emits one summary per file.",
+      "parameter": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "WaterBodyTinValidator Parameters",
+        "type": "object",
+        "required": [
+          "targetEpsgCode"
+        ],
+        "properties": {
+          "cityGmlPathAttribute": {
+            "description": "Attribute holding the CityGML file path (default: \"path\").",
+            "default": "path",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "corruptGeometryTolerance": {
+            "description": "Tolerance for corrupt-geometry degenerate check (default: 0.01).",
+            "default": 0.01,
+            "type": "number",
+            "format": "double"
+          },
+          "duplicateConsecutivePointsTolerance": {
+            "description": "Tolerance for duplicate-consecutive-points degenerate check (default: 0.009).",
+            "default": 0.009,
+            "type": "number",
+            "format": "double"
+          },
+          "sourceEpsgCode": {
+            "description": "Source EPSG code (default: 6697, JGD2011 geographic — FaceExtractor output).",
+            "default": 6697,
+            "type": "integer",
+            "format": "int64"
+          },
+          "targetEpsgCode": {
+            "description": "Target EPSG code expression for reprojection (e.g. `env.get(\"prcs\")`).",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Expr"
+              }
+            ]
+          },
+          "unsharedEdgeGroupBy": {
+            "description": "Group-by attributes for unshared-edge detection (default: [_fld_scale, udxDirs]).",
+            "default": [
+              "_fld_scale",
+              "udxDirs"
+            ],
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "unsharedEdgeTolerance": {
+            "description": "Tolerance for unshared-edge matching in meters (default: 0.1).",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
+          "Expr": {
+            "type": "string"
+          }
+        }
+      },
+      "builtin": false,
+      "inputPorts": [
+        "default"
+      ],
+      "outputPorts": [
+        "summary"
+      ],
+      "categories": [
+        "PLATEAU"
+      ]
+    },
+    {
       "name": "PlanarityFilter",
       "type": "processor",
       "description": "根据类型筛选几何",

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.211"
+version = "0.1.212"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview

Adds a new `PLATEAU4.WaterBodyTinValidator` action that validates WaterBody TIN surfaces end-to-end for the flood-family quality check.

## What I've done

- Added `PLATEAU4.WaterBodyTinValidator`, a single accumulating action that fuses the previous `FaceExtractor` → `HorizontalReprojector` → `GeometryValidator` → `TwoDimensionForcer` → `PLATEAU4.UnsharedEdgeDetector` chain. It extracts faces from CityGML, reprojects, detects degenerate triangles and unshared edges (disk-backed K-way merge), and emits one summary feature per file. Processing each GML file in parallel with `rayon` keeps intermediate per-face features inside the action for better performance.
- Rewrote `06-fld/workflow.yml` to use the single `WaterBodyTinValidator` node in place of the multi-node chain.

## What I haven't done

## How I tested

- `cargo make format`, `cargo make clippy`, and `cargo make test` pass for the `reearth-flow-action-plateau-processor` crate.

## Screenshot

## Which point I want you to review particularly

## Memo