### PR TITLE
fix(ci): lint api against plateau5 instead of main

### DIFF
--- a/.github/workflows/ci_api.yml
+++ b/.github/workflows/ci_api.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
       - name: Fetch base branch
-        run: git fetch origin main
+        run: git fetch origin plateau5
       - name: set up
         uses: actions/setup-go@v5
         with:
@@ -26,7 +26,7 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1
-          args: --timeout=10m --new-from-rev=origin/main --timeout=10m
+          args: --timeout=10m --new-from-rev=origin/plateau5
           working-directory: server/api
 
   ci-api-test:


### PR DESCRIPTION
## What

Change the `ci-api-lint` job in `.github/workflows/ci_api.yml` to diff against `origin/plateau5` instead of the hardcoded `origin/main`.

## Why

The lint step uses `golangci-lint --new-from-rev=origin/main`, which only reports issues on lines that differ from `origin/main`. On the `plateau5` compatibility line this is the wrong base: once unrelated changes land on `main` (e.g. #2185 rewrote `server/api/internal/usecase/interactor/trigger.go`), the `origin/main` two-dot diff surfaces ~300 phantom-changed lines in `trigger.go` and flags pre-existing `QF1003` (staticcheck) findings as "new" — even on PRs that never touch any Go file.

This blocked PR #2222 (engine-only change) with a lint error in `trigger.go`.

Since `plateau5` is maintained as a fixed compatibility branch, hardcoding `origin/plateau5` keeps the lint baseline correct regardless of how `main` advances.

## Change

- `git fetch origin main` → `git fetch origin plateau5`
- `--new-from-rev=origin/main` → `--new-from-rev=origin/plateau5`
- dropped the duplicated `--timeout=10m`