### PR TITLE
feat(engine): new geometry path for citygml

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4092,7 +4092,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.60"
+version = "0.2.61"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "futures",
  "once_cell",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "approx",
  "async-trait",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "Inflector",
  "approx",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "bytes",
  "clap",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "approx",
  "bvh",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5161,7 +5161,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "bytes",
  "futures",
@@ -5207,7 +5207,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "bytes",
  "futures",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "ahash",
  "bytes",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.423"
+version = "0.0.424"
 dependencies = [
  "async-trait",
  "axum",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.250"
+version = "0.1.251"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.423"
+version = "0.0.424"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/citygml_parser/GEOMETRY_MAPPING.md
+++ b/engine/runtime/action-processor/src/citygml_parser/GEOMETRY_MAPPING.md
@@ -1,0 +1,288 @@
+# GML geometry Mapping
+
+This document is the reference for how GML geometry types map onto Flow's geometry
+model (`reearth_flow_geometry`), and how the two passes of the reader work.
+
+The geometry model is shared across GML 3.1 and GML 3.2. The geometry types, their
+composition, and their `gml:id` / `xlink:href` behaviour are the same for every type
+below. The type mapping and graphs therefore apply to all three CityGML versions.
+
+## How it reads
+
+The reader runs in two passes so it can resolve references that point forward or
+across files:
+
+1. **Streaming pass** (`process`, one call per file): the document is streamed and
+   each geometry is examined. A geometry that is guaranteed to be fully self
+   contained is parsed immediately into a Flow geometry. A geometry that can carry
+   an `xlink:href`, or that contains one, is kept as a small unresolved node.
+   Geometry is carved out of the feature's attribute tree at this point, so
+   coordinate text is never retained as feature attributes. Every geometry that
+   carries a `gml:id` is registered so it can be found by reference.
+2. **Assembly pass** (`finish`, after all files): `xlink:href` and `gml:id`
+   references are resolved (across files), unresolved container nodes are assembled
+   from their resolved members, and each feature is emitted.
+
+A feature's geometry is always a `GeometryCollection`, one member per geometry
+property the feature carried. A CityGML feature can hold several
+geometries at different levels of detail, and Flow's `Feature` has a single
+geometry slot, so the collection is the container that holds them together.
+
+When `extractTags` is set, boundary sub-features (for example `WallSurface`,
+`RoofSurface`) are hoisted into their own features. Each carved geometry is
+attached to the nearest enclosing feature that is actually emitted.
+
+## The two geometry models as coupled type trees
+
+The rest of this document describes two directed trees whose nodes are geometry
+types and whose edges are the "can consist of" relation. The trees are coupled:
+every CityGML node carries the Flow geometry type it becomes (`→ Flow::…`). That
+projection is what the reader produces for a top-level geometry.
+
+### Which CityGML types are nodes
+
+A GML geometry type (3.1 or 3.2) is a node when it can carry a `gml:id`, i.e. it
+derives from `gml:AbstractGML`. That is exactly the set of types that can be the
+target of an `xlink:href`, and must therefore be individually registrable and
+resolvable. In conformant GML 3.1 and 3.2 data every geometry object carries a
+`gml:id`, so "can be a node" and "is a geometry object" describe the same set.
+
+Types that derive from `AbstractSurfacePatch` / `AbstractCurveSegment` rather than
+`AbstractGML` are never nodes. They cannot carry a `gml:id`, are never reference
+targets, and are always parsed inline inside their owning object:
+
+- Surface patches: `PolygonPatch`, `Triangle`, `Rectangle`
+- Curve segments: `LineStringSegment`, `Arc`, and so on
+
+`LinearRing` and `Ring` do derive from `AbstractGML`, so they are nodes. Flow has
+no standalone ring type: a ring is a closed area boundary, so a standalone or
+referenced ring becomes a `Flow::Polygon` with no interiors (its closed chain
+becomes the single exterior ring). As a `Polygon`'s ring it is absorbed into that
+`Polygon`.
+
+### Inline vs reference-bearing
+
+The graphs distinguish two kinds of type, which correspond to the two passes:
+
+- **Inline** (green node the in graph): always fully self-contained, so it is parsed in
+  the streaming pass. A type is inline when every one of its child properties is
+  by-value only (no `xlink:href`) and every child type is itself inline.
+  `TriangulatedSurface` is the clearest case: its only children are `Triangle`
+  patches, which cannot be referenced, so it can be built end to end while
+  streaming.
+- **Reference-bearing** (blue node the in graph): may arrive by reference, or may contain a
+  reference, so it is assembled in the second pass. In the edge coloring, a blue
+  edge marks a property that can carry an `xlink:href`, or that points to a type
+  that is not itself inline; a green edge marks by-value-only containment. Grey
+  dotted nodes are the inline-only patches and segments that are not their own
+  nodes.
+
+## Graph 1: CityGML geometry composition (GML 3.1 / 3.2)
+
+Split by dimensional family for legibility. Solid arrows `==>` are "can consist
+of", labelled with the GML property and cardinality. Where a property formally
+accepts a whole substitution group, edges go directly to the concrete types that
+occur in practice, with the group named in the label.
+
+### Points
+
+```mermaid
+flowchart TD
+    Point["Point<br/>→ Flow::Point"]:::p1
+    MultiPoint["MultiPoint<br/>→ Flow::Collection"]:::df
+
+    MultiPoint ==>|"pointMember 0..*"| Point
+
+    linkStyle 0 stroke:#1a73e8,stroke-width:2px;
+    classDef p1 fill:#e6f4ea,stroke:#34a853,color:#111;
+    classDef df fill:#e8f0fe,stroke:#1a73e8,color:#111;
+```
+
+### Curves and rings
+
+```mermaid
+flowchart TD
+    LineString["LineString<br/>→ Flow::LineString"]:::p1
+    LinearRing["LinearRing<br/>→ Flow::Polygon (no interiors)"]:::p1
+    MultiCurve["MultiCurve<br/>→ Flow::Collection"]:::df
+    Curve["Curve<br/>→ Flow::LineString"]:::p1
+    OrientableCurve["OrientableCurve<br/>→ Flow::LineString"]:::df
+    CompositeCurve["CompositeCurve<br/>→ Flow::Collection"]:::df
+    Ring["Ring<br/>→ Flow::Polygon (no interiors)"]:::df
+    seg(["segments: LineStringSegment / Arc<br/>no gml:id, inline"]):::inl
+
+    MultiCurve ==>|"curveMember 0..* (any AbstractCurve; commonly LineString)"| LineString
+    CompositeCurve ==>|"curveMember 1..*"| LineString
+    OrientableCurve ==>|"baseCurve 1"| LineString
+    Ring ==>|"curveMember 1..*"| LineString
+    Curve ==>|"segments 1..*"| seg
+
+    linkStyle 0,1,2,3 stroke:#1a73e8,stroke-width:2px;
+    linkStyle 4 stroke:#34a853,stroke-width:2px;
+    classDef p1 fill:#e6f4ea,stroke:#34a853,color:#111;
+    classDef df fill:#e8f0fe,stroke:#1a73e8,color:#111;
+    classDef inl fill:#f0f0f0,stroke:#bbb,stroke-dasharray:2 2,color:#888;
+```
+
+### Surfaces
+
+```mermaid
+flowchart TD
+    LinearRing["LinearRing<br/>→ Flow::Polygon (no interiors)"]:::p1
+    Polygon["Polygon<br/>→ Flow::Polygon"]:::p1
+    TriangulatedSurface["TriangulatedSurface<br/>→ Flow::TriangularMesh"]:::p1
+    MultiSurface["MultiSurface<br/>→ Flow::Collection"]:::df
+    CompositeSurface["CompositeSurface<br/>→ Flow::PolygonMesh"]:::df
+    OrientableSurface["OrientableSurface<br/>→ Flow::PolygonMesh"]:::df
+    Surface["Surface<br/>→ Flow::PolygonMesh"]:::p1
+    PolyhedralSurface["PolyhedralSurface<br/>→ Flow::PolygonMesh"]:::p1
+    Tin["Tin<br/>→ Flow::TriangularMesh"]:::p1
+    patch(["patches: PolygonPatch / Rectangle<br/>no gml:id, inline"]):::inl
+    triangle(["Triangle (patch): exterior LinearRing<br/>no gml:id, inline"]):::inl
+
+    MultiSurface ==>|"surfaceMember 0..* (any AbstractSurface)"| Polygon
+    MultiSurface ==>|"surfaceMember 0..*"| OrientableSurface
+    CompositeSurface ==>|"surfaceMember 1..*"| Polygon
+    OrientableSurface ==>|"baseSurface 1"| Polygon
+    Polygon ==>|"exterior 0..1"| LinearRing
+    Polygon ==>|"interior 0..*"| LinearRing
+    TriangulatedSurface ==>|"trianglePatches 1..*"| triangle
+    Surface ==>|"patches 1..*"| patch
+    PolyhedralSurface ==>|"polygonPatches 1..*"| patch
+    Tin ==>|"trianglePatches 1..* (+ control points)"| triangle
+
+    linkStyle 0,1,2,3 stroke:#1a73e8,stroke-width:2px;
+    linkStyle 4,5,6,7,8,9 stroke:#34a853,stroke-width:2px;
+    classDef p1 fill:#e6f4ea,stroke:#34a853,color:#111;
+    classDef df fill:#e8f0fe,stroke:#1a73e8,color:#111;
+    classDef inl fill:#f0f0f0,stroke:#bbb,stroke-dasharray:2 2,color:#888;
+```
+
+### Solids
+
+```mermaid
+flowchart TD
+    Solid["Solid<br/>→ Flow::Solid"]:::df
+    Shell["Shell<br/>→ Flow::Solid shell"]:::df
+    CompositeSurface2["CompositeSurface (alt shell body)<br/>→ Flow::Solid shell"]:::df
+    CompositeSolid["CompositeSolid<br/>→ Flow::Collection (of Solid)"]:::df
+    MultiSolid["MultiSolid<br/>→ Flow::Collection (of Solid)"]:::df
+    surfaces(["Polygon / OrientableSurface<br/>(see Surfaces graph)"]):::ref
+
+    Solid ==>|"exterior 0..1"| Shell
+    Solid ==>|"interior 0..*"| Shell
+    Solid ==>|"exterior/interior (GML 3.1 style; some datasets)"| CompositeSurface2
+    Shell ==>|"surfaceMember 1..*"| surfaces
+    CompositeSurface2 ==>|"surfaceMember 1..*"| surfaces
+    CompositeSolid ==>|"solidMember 1..*"| Solid
+    MultiSolid ==>|"solidMember 0..*"| Solid
+
+    linkStyle 0,1,2,3,4,5,6 stroke:#1a73e8,stroke-width:2px;
+    classDef df fill:#e8f0fe,stroke:#1a73e8,color:#111;
+    classDef ref fill:#fff,stroke:#999,stroke-dasharray:4 3,color:#555;
+```
+
+`Solid`'s `exterior` / `interior` are by-value (`ShellPropertyType` has no
+`xlink`), yet the edges are drawn as reference-bearing because the child `Shell` is
+not itself inline (its `surfaceMember`s can be references).
+
+### Heterogeneous aggregates (rare)
+
+```mermaid
+flowchart TD
+    MultiGeometry["MultiGeometry<br/>→ Flow::Collection"]:::df
+    GeometricComplex["GeometricComplex<br/>→ Flow::Collection"]:::df
+    any(["any geometry / primitive<br/>(see other graphs)"]):::ref
+
+    MultiGeometry ==>|"geometryMember 0..* (any AbstractGeometry)"| any
+    GeometricComplex ==>|"element 1..* (any AbstractGeometricPrimitive)"| any
+
+    linkStyle 0,1 stroke:#1a73e8,stroke-width:2px;
+    classDef df fill:#e8f0fe,stroke:#1a73e8,color:#111;
+    classDef ref fill:#fff,stroke:#999,stroke-dasharray:4 3,color:#555;
+```
+
+### Inline nodes
+
+`Point`, `LineString`, `LinearRing`, `Polygon`, `Curve`, `Surface`,
+`PolyhedralSurface`, `TriangulatedSurface`, and `Tin` are inline: the reader builds
+them while streaming, with an eager constructor (`from_rings`, `from_polygons`,
+`from_coords`, `from_soup`).
+
+Every other type is reference-bearing and is assembled from its resolved members
+in the second pass. These map to the Flow constructors that take members:
+`Collection` (from the `Multi*` aggregates, `CompositeCurve` / `CompositeSolid`,
+and `GeometricComplex`), `PolygonMesh` (`from_polygons`, welding a
+`CompositeSurface`'s or `Shell`'s `surfaceMember`s into one surface), `Polygon`
+(`from_rings` with an empty interior list, for a standalone or referenced ring),
+and `Solid` (`from_exterior` over resolved shells).
+
+## Graph 2: Flow geometry composition
+
+Flow's model (the `reearth_flow_geometry` crate). Solid arrows `==>` are "can
+consist of" with cardinality; dotted arrows `-.->` are enum-variant membership.
+The `==>` edges are the member-taking constructors that the reference-bearing
+CityGML types feed into.
+
+```mermaid
+flowchart TD
+    Geometry(["Geometry (top-level enum)"]):::hub
+    GeometryCollection["GeometryCollection<br/>per-feature container"]:::node
+    E3D(["Euclidean3DGeometry (variant)"]):::hub
+    None["None: no geometry"]:::node
+
+    Point["Point"]:::node
+    LineString["LineString"]:::node
+    Polygon["Polygon<br/>exterior ring + hole rings"]:::node
+    PolygonMesh["PolygonMesh<br/>CSR faces, variable valence, holes"]:::node
+    TriangularMesh["TriangularMesh<br/>fixed 3-index faces"]:::node
+    Solid["Solid"]:::node
+    PointCloud["PointCloud"]:::node
+    Csg["Csg: boolean tree over Solids"]:::node
+    Collection3D["Collection3D: Multi* of 3D geometries"]:::node
+    Shell(["Shell (internal: PolygonMesh | TriangularMesh data)"]):::hub
+
+    Geometry -.->|"None"| None
+    Geometry -.->|"Euclidean3D"| E3D
+    Geometry -.->|"GeometryCollection"| GeometryCollection
+    GeometryCollection ==>|"members 0..* (+ parallel attrs)"| Geometry
+
+    E3D -.-> Point
+    E3D -.-> LineString
+    E3D -.-> Polygon
+    E3D -.-> PolygonMesh
+    E3D -.-> TriangularMesh
+    E3D -.-> Solid
+    E3D -.-> PointCloud
+    E3D -.-> Csg
+    E3D -.-> Collection3D
+
+    Collection3D ==>|"members 0..*"| E3D
+    Solid ==>|"exterior 1"| Shell
+    Solid ==>|"interiors 0..*"| Shell
+    Shell -.->|"PolygonMesh data"| PolygonMesh
+    Shell -.->|"TriangularMesh data"| TriangularMesh
+    Csg ==>|"operands"| Solid
+    PolygonMesh ==>|"faces 1..* (each: 1 exterior ring + 0..* hole rings)"| Polygon
+
+    classDef node fill:#e6f4ea,stroke:#34a853,color:#111;
+    classDef hub fill:#fff,stroke:#999,stroke-dasharray:4 3,color:#555;
+```
+
+The `faces → Polygon` edge is conceptual: a `PolygonMesh` face has the same ring
+structure as a `Polygon` but is stored in the mesh's shared CSR buffers, not as
+separate `Polygon` values.
+
+## Coordinate order
+
+GML `posList` / `pos` for the geographic CRSs used by CityGML are in
+latitude, longitude, height order. The reader stores coordinates in `x, y, z`
+order, so the leading latitude/longitude pair is swapped to `x = longitude`,
+`y = latitude`. Reprojection to other CRSs happens in later workflow steps.
+
+## Note on representation
+
+Abstract substitution-group hubs are not drawn: aggregate members are almost
+always `Polygon` in practice, so edges go directly to the concrete types that
+occur, with the formal substitution group named in the edge label. The full set of
+`gml:id`-bearing types is listed in the mapping table.

--- a/engine/runtime/action-processor/src/citygml_parser/GEOMETRY_MAPPING.md
+++ b/engine/runtime/action-processor/src/citygml_parser/GEOMETRY_MAPPING.md
@@ -1,7 +1,7 @@
-# GML geometry Mapping
+# GML Geometry Mapping
 
 This document is the reference for how GML geometry types map onto Flow's geometry
-model (`reearth_flow_geometry`), and how the two passes of the reader work.
+model (`reearth_flow_geometry`).
 
 The geometry model is shared across GML 3.1 and GML 3.2. The geometry types, their
 composition, and their `gml:id` / `xlink:href` behaviour are the same for every type

--- a/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
@@ -1,4 +1,4 @@
-//! Pass-1 geometry extraction for the CityGML 3.0 reader.
+//! Pass-1 geometry extraction for the CityGML reader.
 //!
 //! Splits geometry out of a feature's attribute tree while streaming: each
 //! `lod<N>…` / `tin` property is converted into a [`GeomNode`] and removed from
@@ -177,7 +177,7 @@ fn geometry_node(node: &RawNode, registry: &mut GeomRegistry) -> Option<GeomNode
     let Some(ty) = geometry_type(local_name(&node.name.0)) else {
         tracing::warn!(
             element = local_name(&node.name.0),
-            "citygml3 geometry: unrecognized element, skipped"
+            "citygml geometry: unrecognized element, skipped"
         );
         return None;
     };
@@ -242,7 +242,7 @@ fn build_leaf(node: &RawNode, ty: &GmlGeometryType) -> Option<Euclidean3DGeometr
         // TODO: gml:Curve support is deferred. Its segments may be arcs or splines,
         // which cannot be handled by sweeping control points into a straight chain.
         GmlGeometryType::Curve => {
-            tracing::warn!("citygml3 geometry: gml:Curve is not supported yet, skipped");
+            tracing::warn!("citygml geometry: gml:Curve is not supported yet, skipped");
             None
         }
         GmlGeometryType::LinearRing => build_ring_polygon(node),
@@ -390,11 +390,11 @@ fn parse_ordinates(text: &str) -> Option<Vec<f64>> {
 /// producing misaligned coordinates.
 fn parse_pos_list(text: &str) -> Vec<[f64; 3]> {
     let Some(values) = parse_ordinates(text) else {
-        tracing::warn!("citygml3 geometry: invalid gml:posList content, skipped");
+        tracing::warn!("citygml geometry: invalid gml:posList content, skipped");
         return Vec::new();
     };
     if !values.len().is_multiple_of(3) {
-        tracing::warn!("citygml3 geometry: gml:posList length not a multiple of 3, skipped");
+        tracing::warn!("citygml geometry: gml:posList length not a multiple of 3, skipped");
         return Vec::new();
     }
     values.chunks_exact(3).map(|c| [c[1], c[0], c[2]]).collect()
@@ -403,7 +403,7 @@ fn parse_pos_list(text: &str) -> Vec<[f64; 3]> {
 /// Parse a single `gml:pos` into one `[x, y, z]`, swapping latitude/longitude.
 fn parse_pos(text: &str) -> Option<[f64; 3]> {
     let Some(values) = parse_ordinates(text) else {
-        tracing::warn!("citygml3 geometry: invalid gml:pos content, skipped");
+        tracing::warn!("citygml geometry: invalid gml:pos content, skipped");
         return None;
     };
     if values.len() != 3 {
@@ -604,18 +604,18 @@ mod tests {
         assert_eq!(collection_len(&geometry), 2);
     }
 
-    // ── Trimmed cases from the Takeshiba CityGML 3.0 sample (Layer A: one geometry
-    //    via resolve_root). Meshes are two faces sharing edge B–C. ──
+    // Single-geometry cases resolved via resolve_root. The two-face meshes are
+    // built from TA and TB, two triangles sharing edge B–C.
 
-    /// Two polygons sharing edge B–C.
-    const TA: &str = "<gml:Polygon><gml:exterior><gml:LinearRing><gml:posList>35.6000 139.8000 10.0 35.6001 139.8000 10.0 35.6000 139.8001 12.0 35.6000 139.8000 10.0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>";
-    const TB: &str = "<gml:Polygon><gml:exterior><gml:LinearRing><gml:posList>35.6001 139.8000 10.0 35.6001 139.8001 12.0 35.6000 139.8001 12.0 35.6001 139.8000 10.0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>";
+    /// Two triangles sharing edge B–C.
+    const TA: &str = "<gml:Polygon><gml:exterior><gml:LinearRing><gml:posList>1 2 0 3 2 0 1 4 5 1 2 0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>";
+    const TB: &str = "<gml:Polygon><gml:exterior><gml:LinearRing><gml:posList>3 2 0 3 4 5 1 4 5 3 2 0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>";
 
     #[test]
     fn case01_multicurve_linestring() {
         let (geoms, registry) = parse_one(
             r#"<core:lod0MultiCurve><gml:MultiCurve><gml:curveMember><gml:LineString>
-                 <gml:posList>35.6007 139.8340 0.0 35.6033 139.8321 0.0 35.6042 139.8314 0.0</gml:posList>
+                 <gml:posList>0 1 0 2 3 0 4 5 0</gml:posList>
                </gml:LineString></gml:curveMember></gml:MultiCurve></core:lod0MultiCurve>"#,
         );
         assert_eq!(geoms.len(), 1);
@@ -625,7 +625,7 @@ mod tests {
             Euclidean3DGeometry::LineString(ls) => {
                 assert_eq!(ls.coords().len(), 3);
                 // posList is lat/lon; stored x/y, so the pair is swapped.
-                assert_eq!(ls.coords()[0], [139.8340, 35.6007, 0.0]);
+                assert_eq!(ls.coords()[0], [1.0, 0.0, 0.0]);
             }
             other => panic!("expected LineString, got {other:?}"),
         }
@@ -642,7 +642,7 @@ mod tests {
         match only_member(&geometry) {
             Euclidean3DGeometry::Polygon(p) => {
                 assert_eq!(p.exterior().len(), 4);
-                assert_eq!(p.exterior()[0], [139.8000, 35.6000, 10.0]); // swapped
+                assert_eq!(p.exterior()[0], [2.0, 1.0, 0.0]); // swapped
                 assert_eq!(p.interiors().count(), 0);
             }
             other => panic!("expected Polygon, got {other:?}"),
@@ -654,8 +654,8 @@ mod tests {
         let (geoms, registry) = parse_one(
             r#"<core:lod2MultiSurface><gml:MultiSurface><gml:surfaceMember>
                  <gml:Polygon>
-                   <gml:exterior><gml:LinearRing><gml:posList>35.6000 139.8000 0.0 35.6010 139.8000 0.0 35.6010 139.8010 0.0 35.6000 139.8010 0.0 35.6000 139.8000 0.0</gml:posList></gml:LinearRing></gml:exterior>
-                   <gml:interior><gml:LinearRing><gml:posList>35.6003 139.8003 0.0 35.6007 139.8003 0.0 35.6007 139.8007 0.0 35.6003 139.8003 0.0</gml:posList></gml:LinearRing></gml:interior>
+                   <gml:exterior><gml:LinearRing><gml:posList>0 0 0 4 0 0 4 4 0 0 4 0 0 0 0</gml:posList></gml:LinearRing></gml:exterior>
+                   <gml:interior><gml:LinearRing><gml:posList>1 1 0 3 1 0 3 3 0 1 1 0</gml:posList></gml:LinearRing></gml:interior>
                  </gml:Polygon>
                </gml:surfaceMember></gml:MultiSurface></core:lod2MultiSurface>"#,
         );
@@ -758,8 +758,8 @@ mod tests {
     fn case08_triangulated_surface() {
         let (geoms, registry) = parse_one(
             r#"<dem:tin><gml:TriangulatedSurface><gml:patches>
-                 <gml:Triangle><gml:exterior><gml:LinearRing><gml:posList>35.6000 139.8000 10.0 35.6001 139.8000 10.0 35.6000 139.8001 12.0 35.6000 139.8000 10.0</gml:posList></gml:LinearRing></gml:exterior></gml:Triangle>
-                 <gml:Triangle><gml:exterior><gml:LinearRing><gml:posList>35.6001 139.8000 10.0 35.6001 139.8001 12.0 35.6000 139.8001 12.0 35.6001 139.8000 10.0</gml:posList></gml:LinearRing></gml:exterior></gml:Triangle>
+                 <gml:Triangle><gml:exterior><gml:LinearRing><gml:posList>1 2 0 3 2 0 1 4 5 1 2 0</gml:posList></gml:LinearRing></gml:exterior></gml:Triangle>
+                 <gml:Triangle><gml:exterior><gml:LinearRing><gml:posList>3 2 0 3 4 5 1 4 5 3 2 0</gml:posList></gml:LinearRing></gml:exterior></gml:Triangle>
                </gml:patches></gml:TriangulatedSurface></dem:tin>"#,
         );
         assert_eq!(geoms.len(), 1);
@@ -777,12 +777,12 @@ mod tests {
     #[test]
     fn case09_point() {
         let (geoms, registry) = parse_one(
-            r#"<urc:lod0Geometry><gml:Point><gml:pos>35.6536 139.7632 5.0</gml:pos></gml:Point></urc:lod0Geometry>"#,
+            r#"<urc:lod0Geometry><gml:Point><gml:pos>1 2 5</gml:pos></gml:Point></urc:lod0Geometry>"#,
         );
         assert_eq!(geoms.len(), 1);
         assert_eq!(geoms[0].lod, Some(0));
         match resolve_root(&geoms[0].node, &registry).unwrap() {
-            Euclidean3DGeometry::Point(p) => assert_eq!(p.position(), [139.7632, 35.6536, 5.0]),
+            Euclidean3DGeometry::Point(p) => assert_eq!(p.position(), [2.0, 1.0, 5.0]),
             other => panic!("expected Point, got {other:?}"),
         }
     }
@@ -830,7 +830,7 @@ mod tests {
         // The bad pos yields no coordinate, so the Point is dropped at parse time
         // and no geometry is carved from the feature.
         let (geoms, _registry) = parse_one(
-            r#"<urc:lod0Geometry><gml:Point><gml:pos>35.6536 x 5.0</gml:pos></gml:Point></urc:lod0Geometry>"#,
+            r#"<urc:lod0Geometry><gml:Point><gml:pos>1 x 5</gml:pos></gml:Point></urc:lod0Geometry>"#,
         );
         assert!(geoms.is_empty());
     }

--- a/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
@@ -1,0 +1,869 @@
+//! Pass-1 geometry extraction for the CityGML 3.0 reader.
+//!
+//! Splits geometry out of a feature's attribute tree while streaming: each
+//! `lod<N>…` / `tin` property is converted into a [`GeomNode`] and removed from
+//! the tree, so coordinate text is never carried into the feature's attributes.
+//! Fully-inline geometry is parsed to [`Euclidean3DGeometry`] here; containers are
+//! left as [`Unresolved`] nodes and any `xlink:href` as a [`GeomNode::Ref`], both
+//! assembled in pass 2. See `GEOMETRY_MAPPING.md` for the type mapping.
+
+use std::sync::Arc;
+
+use reearth_flow_geometry::line_string::LineString3D;
+use reearth_flow_geometry::point::Point3D;
+use reearth_flow_geometry::polygon::Polygon3D;
+use reearth_flow_geometry::polygon_mesh::PolygonMesh3D;
+use reearth_flow_geometry::triangular_mesh::TriangularMesh3D;
+use reearth_flow_geometry::Euclidean3DGeometry;
+
+use super::parser::{raw_gml_id, RawChild, RawNode};
+use super::resolver::{GeomNode, GeomRegistry, GmlGeometryType, Role, Unresolved, FRAME};
+use super::utils::{local_name, GML_NS_ID};
+
+/// A geometry carved from a feature, tagged with the LOD of the property it came
+/// from (`None` for `tin`) and the `gml:id`s of its enclosing elements (nearest
+/// first), used to attach it to the right feature when `flatten` hoists children.
+pub(super) struct PendingGeom {
+    pub(super) lod: Option<u8>,
+    pub(super) node: GeomNode,
+    pub(super) owner_ids: Vec<String>,
+}
+
+/// A `gml:id`-bearing ancestor, chained on the stack so the enclosing-id list is
+/// materialized only where a geometry is actually found.
+struct Owner<'a> {
+    id: &'a str,
+    parent: Option<&'a Owner<'a>>,
+}
+
+/// The enclosing `gml:id`s, nearest first.
+fn owner_chain(mut owner: Option<&Owner>) -> Vec<String> {
+    let mut ids = Vec::new();
+    while let Some(o) = owner {
+        ids.push(o.id.to_string());
+        owner = o.parent;
+    }
+    ids
+}
+
+/// Strip every geometry property from `node`, returning the geometry-free
+/// attribute tree and the geometries carved out of it. Geometries carrying a
+/// `gml:id` are registered in `registry` as reference targets. `track_owners`
+/// records each geometry's enclosing `gml:id`s, needed only when children will be
+/// hoisted.
+pub(super) fn split_geometry(
+    node: &Arc<RawNode>,
+    registry: &mut GeomRegistry,
+    track_owners: bool,
+) -> (Arc<RawNode>, Vec<PendingGeom>) {
+    let mut geoms = Vec::new();
+    let stripped = strip(node, None, registry, &mut geoms, track_owners);
+    (stripped, geoms)
+}
+
+/// Recursively rebuild `node` without its geometry-property children, collecting
+/// the parsed geometries into `geoms`. `owner` is the chain of enclosing
+/// `gml:id`s above `node`.
+fn strip(
+    node: &Arc<RawNode>,
+    owner: Option<&Owner>,
+    registry: &mut GeomRegistry,
+    geoms: &mut Vec<PendingGeom>,
+    track_owners: bool,
+) -> Arc<RawNode> {
+    let here = gml_id_ref(node).map(|id| Owner { id, parent: owner });
+    let owner = here.as_ref().or(owner);
+    let mut new_children: Option<Vec<RawChild>> = None;
+
+    for (i, child) in node.children.iter().enumerate() {
+        let RawChild::Element(e) = child else {
+            if let Some(ref mut nc) = new_children {
+                nc.push(child.clone());
+            }
+            continue;
+        };
+
+        let ln = local_name(&e.name.0);
+        let lod = if ln == "tin" {
+            Some(None)
+        } else {
+            extract_lod(ln).map(Some)
+        };
+        // A name match alone is not enough: keep an element that merely shares the
+        // `lod<N>…` / `tin` naming but wraps no geometry, rather than stripping it.
+        let lod = lod.filter(|_| is_geometry_property(e));
+
+        if let Some(lod) = lod {
+            if let Some(gnode) = property_geometry(e, registry) {
+                let owner_ids = if track_owners {
+                    owner_chain(owner)
+                } else {
+                    Vec::new()
+                };
+                geoms.push(PendingGeom {
+                    lod,
+                    node: gnode,
+                    owner_ids,
+                });
+            }
+            if new_children.is_none() {
+                new_children = Some(node.children[..i].to_vec());
+            }
+        } else {
+            let stripped_child = strip(e, owner, registry, geoms, track_owners);
+            match new_children {
+                None => {
+                    if !Arc::ptr_eq(&stripped_child, e) {
+                        let mut nc = node.children[..i].to_vec();
+                        nc.push(RawChild::Element(stripped_child));
+                        new_children = Some(nc);
+                    }
+                }
+                Some(ref mut nc) => nc.push(RawChild::Element(stripped_child)),
+            }
+        }
+    }
+
+    match new_children {
+        None => Arc::clone(node),
+        Some(children) => Arc::new(RawNode {
+            name: node.name.clone(),
+            attrs: node.attrs.clone(),
+            children,
+            source_url: Arc::clone(&node.source_url),
+        }),
+    }
+}
+
+/// Borrow a node's `gml:id`, if any.
+fn gml_id_ref(node: &RawNode) -> Option<&str> {
+    node.attrs
+        .iter()
+        .find(|((q, ns), _)| local_name(q) == "id" && *ns == GML_NS_ID)
+        .map(|(_, v)| v.as_str())
+}
+
+/// Whether a `lod<N>…` / `tin`-named element actually wraps a geometry: its first
+/// non-text child is a recognized GML geometry element or an `xlink:href`
+/// reference. Mirrors [`property_geometry`]'s child selection.
+fn is_geometry_property(prop: &RawNode) -> bool {
+    for child in &prop.children {
+        match child {
+            RawChild::Ref(_) => return true,
+            RawChild::Element(e) => return geometry_type(local_name(&e.name.0)).is_some(),
+            RawChild::Text(_) => {}
+        }
+    }
+    false
+}
+
+/// Parse the single geometry element (or `xlink:href`) inside a `lod<N>…` / `tin`
+/// property into a [`GeomNode`].
+fn property_geometry(prop: &RawNode, registry: &mut GeomRegistry) -> Option<GeomNode> {
+    for child in &prop.children {
+        match child {
+            RawChild::Ref(key) => return Some(GeomNode::Ref(key.clone())),
+            RawChild::Element(e) => return geometry_node(e, registry),
+            RawChild::Text(_) => {}
+        }
+    }
+    None
+}
+
+/// Convert a geometry element into a [`GeomNode`]: an inline leaf is parsed to a
+/// concrete geometry, a container is left [`Unresolved`]. A node with a `gml:id`
+/// is moved into `registry` and replaced by a [`GeomNode::Ref`].
+fn geometry_node(node: &RawNode, registry: &mut GeomRegistry) -> Option<GeomNode> {
+    let Some(ty) = geometry_type(local_name(&node.name.0)) else {
+        tracing::warn!(
+            element = local_name(&node.name.0),
+            "citygml3 geometry: unrecognized element, skipped"
+        );
+        return None;
+    };
+    let id = raw_gml_id(node);
+    let geom = if ty.is_inline() {
+        GeomNode::Resolved(build_leaf(node, &ty)?)
+    } else {
+        GeomNode::Unresolved(Unresolved {
+            ty,
+            id: id.clone(),
+            members: collect_members(node, registry),
+        })
+    };
+    Some(register(node, id, geom, registry))
+}
+
+/// Register a geometry as an `xlink` target if it has a `gml:id`, returning a
+/// [`GeomNode::Ref`] in its place; otherwise return it unchanged.
+fn register(
+    node: &RawNode,
+    id: Option<String>,
+    geom: GeomNode,
+    registry: &mut GeomRegistry,
+) -> GeomNode {
+    match id {
+        Some(id) => {
+            let key = (node.source_url.as_str().to_string(), id);
+            registry.insert(key.clone(), geom);
+            GeomNode::Ref(key)
+        }
+        None => geom,
+    }
+}
+
+/// Collect a container's members, tagging each with the role of the property that
+/// owns it.
+fn collect_members(node: &RawNode, registry: &mut GeomRegistry) -> Vec<(Role, GeomNode)> {
+    let mut members = Vec::new();
+    for prop in element_children(node) {
+        let role = property_role(local_name(&prop.name.0));
+        for child in &prop.children {
+            match child {
+                RawChild::Ref(key) => members.push((role, GeomNode::Ref(key.clone()))),
+                RawChild::Element(inner) => {
+                    if let Some(g) = geometry_node(inner, registry) {
+                        members.push((role, g));
+                    }
+                }
+                RawChild::Text(_) => {}
+            }
+        }
+    }
+    members
+}
+
+/// Parse an inline geometry leaf into a concrete geometry, dispatching on its
+/// type. Container types and unsupported leaves yield `None`.
+fn build_leaf(node: &RawNode, ty: &GmlGeometryType) -> Option<Euclidean3DGeometry> {
+    match ty {
+        GmlGeometryType::Point => build_point(node),
+        GmlGeometryType::LineString => build_line_string(node),
+        // TODO: gml:Curve support is deferred. Its segments may be arcs or splines,
+        // which cannot be handled by sweeping control points into a straight chain.
+        GmlGeometryType::Curve => {
+            tracing::warn!("citygml3 geometry: gml:Curve is not supported yet, skipped");
+            None
+        }
+        GmlGeometryType::LinearRing => build_ring_polygon(node),
+        GmlGeometryType::Polygon => build_polygon(node),
+        GmlGeometryType::Surface | GmlGeometryType::PolyhedralSurface => build_surface(node),
+        GmlGeometryType::TriangulatedSurface | GmlGeometryType::Tin => build_triangulated(node),
+        _ => None,
+    }
+}
+
+/// Build a `Point` from the element's first coordinate; `None` if it carries none.
+fn build_point(node: &RawNode) -> Option<Euclidean3DGeometry> {
+    let coords = gather_coords(node);
+    coords
+        .first()
+        .map(|&c| Euclidean3DGeometry::Point(Point3D::new(FRAME, c)))
+}
+
+/// Build a `LineString` from the element's coordinates; `None` if it carries none.
+fn build_line_string(node: &RawNode) -> Option<Euclidean3DGeometry> {
+    let coords = gather_coords(node);
+    if coords.is_empty() {
+        return None;
+    }
+    Some(Euclidean3DGeometry::LineString(LineString3D::from_coords(
+        FRAME, coords,
+    )))
+}
+
+/// Build a single-ring `Polygon` from a `LinearRing`'s coordinates; `None` if it
+/// carries none.
+fn build_ring_polygon(node: &RawNode) -> Option<Euclidean3DGeometry> {
+    let exterior = gather_coords(node);
+    if exterior.is_empty() {
+        return None;
+    }
+    Some(Euclidean3DGeometry::Polygon(Box::new(
+        Polygon3D::from_rings(FRAME, exterior, Vec::<Vec<[f64; 3]>>::new()),
+    )))
+}
+
+/// Build a `Polygon` from an element's exterior and interior ring properties.
+fn build_polygon(node: &RawNode) -> Option<Euclidean3DGeometry> {
+    polygon_from_rings(node).map(|p| Euclidean3DGeometry::Polygon(Box::new(p)))
+}
+
+/// Build a `PolygonMesh` by welding a `Surface`/`PolyhedralSurface`'s polygon
+/// patches into one mesh; `None` if it has no patches.
+fn build_surface(node: &RawNode) -> Option<Euclidean3DGeometry> {
+    let mut faces: Vec<Polygon3D> = Vec::new();
+    for prop in element_children(node) {
+        if matches!(local_name(&prop.name.0), "patches" | "polygonPatches") {
+            for patch in element_children(prop) {
+                if let Some(p) = polygon_from_rings(patch) {
+                    faces.push(p);
+                }
+            }
+        }
+    }
+    if faces.is_empty() {
+        return None;
+    }
+    PolygonMesh3D::from_polygons(FRAME, &faces)
+        .ok()
+        .map(|m| Euclidean3DGeometry::PolygonMesh(Box::new(m)))
+}
+
+/// Build a `TriangularMesh` from a `TriangulatedSurface`/`Tin`'s triangle patches,
+/// taking the first three coordinates of each; `None` if it has no patches.
+fn build_triangulated(node: &RawNode) -> Option<Euclidean3DGeometry> {
+    let mut soup: Vec<[f64; 3]> = Vec::new();
+    for prop in element_children(node) {
+        if matches!(local_name(&prop.name.0), "trianglePatches" | "patches") {
+            for triangle in element_children(prop) {
+                let ring = gather_coords(triangle);
+                if ring.len() >= 3 {
+                    soup.extend_from_slice(&ring[..3]);
+                }
+            }
+        }
+    }
+    if soup.is_empty() {
+        return None;
+    }
+    Some(Euclidean3DGeometry::TriangularMesh(Box::new(
+        TriangularMesh3D::from_soup(FRAME, soup),
+    )))
+}
+
+/// Build a polygon from an element's `exterior` / `interior` ring properties.
+fn polygon_from_rings(node: &RawNode) -> Option<Polygon3D> {
+    let mut exterior: Option<Vec<[f64; 3]>> = None;
+    let mut interiors: Vec<Vec<[f64; 3]>> = Vec::new();
+    for prop in element_children(node) {
+        match local_name(&prop.name.0) {
+            "exterior" => {
+                let ring = gather_coords(prop);
+                if !ring.is_empty() {
+                    exterior = Some(ring);
+                }
+            }
+            "interior" => {
+                let ring = gather_coords(prop);
+                if !ring.is_empty() {
+                    interiors.push(ring);
+                }
+            }
+            _ => {}
+        }
+    }
+    exterior.map(|ext| Polygon3D::from_rings(FRAME, ext, interiors))
+}
+
+/// Collect every coordinate under `node`, descending through property and ring
+/// wrappers to the `posList` / `pos` leaves.
+fn gather_coords(node: &RawNode) -> Vec<[f64; 3]> {
+    let mut out = Vec::new();
+    gather_coords_into(node, &mut out);
+    out
+}
+
+/// Collect every coordinate under `node` into `out`, descending through wrappers
+/// to the `posList` / `pos` leaves.
+fn gather_coords_into(node: &RawNode, out: &mut Vec<[f64; 3]>) {
+    for child in element_children(node) {
+        match local_name(&child.name.0) {
+            "posList" => out.extend(parse_pos_list(text_content(child))),
+            "pos" => out.extend(parse_pos(text_content(child))),
+            _ => gather_coords_into(child, out),
+        }
+    }
+}
+
+/// Parse whitespace-separated ordinates, returning `None` if any token is not a
+/// valid number.
+fn parse_ordinates(text: &str) -> Option<Vec<f64>> {
+    text.split_whitespace()
+        .map(|s| s.parse::<f64>().ok())
+        .collect()
+}
+
+/// Parse a `gml:posList` into `[x, y, z]` triples, swapping the leading
+/// latitude/longitude pair into `x, y` order. A list with any unparseable token,
+/// or whose ordinate count is not a multiple of 3, is skipped whole rather than
+/// producing misaligned coordinates.
+fn parse_pos_list(text: &str) -> Vec<[f64; 3]> {
+    let Some(values) = parse_ordinates(text) else {
+        tracing::warn!("citygml3 geometry: invalid gml:posList content, skipped");
+        return Vec::new();
+    };
+    if !values.len().is_multiple_of(3) {
+        tracing::warn!("citygml3 geometry: gml:posList length not a multiple of 3, skipped");
+        return Vec::new();
+    }
+    values.chunks_exact(3).map(|c| [c[1], c[0], c[2]]).collect()
+}
+
+/// Parse a single `gml:pos` into one `[x, y, z]`, swapping latitude/longitude.
+fn parse_pos(text: &str) -> Option<[f64; 3]> {
+    let Some(values) = parse_ordinates(text) else {
+        tracing::warn!("citygml3 geometry: invalid gml:pos content, skipped");
+        return None;
+    };
+    if values.len() != 3 {
+        return None;
+    }
+    Some([values[1], values[0], values[2]])
+}
+
+/// Extract the LOD digit from a `lod<N>…` property name.
+fn extract_lod(local: &str) -> Option<u8> {
+    if local.len() >= 4 && local.starts_with("lod") {
+        local.chars().nth(3)?.to_digit(10).map(|d| d as u8)
+    } else {
+        None
+    }
+}
+
+/// The GML property a member fills within its parent.
+fn property_role(local: &str) -> Role {
+    match local {
+        "exterior" => Role::Exterior,
+        "interior" => Role::Interior,
+        _ => Role::Member,
+    }
+}
+
+/// Map a geometry element's local name to its type.
+fn geometry_type(local: &str) -> Option<GmlGeometryType> {
+    Some(match local {
+        "Point" => GmlGeometryType::Point,
+        "LineString" => GmlGeometryType::LineString,
+        "Curve" => GmlGeometryType::Curve,
+        "LinearRing" => GmlGeometryType::LinearRing,
+        "Polygon" => GmlGeometryType::Polygon,
+        "Surface" => GmlGeometryType::Surface,
+        "PolyhedralSurface" => GmlGeometryType::PolyhedralSurface,
+        "TriangulatedSurface" => GmlGeometryType::TriangulatedSurface,
+        "Tin" => GmlGeometryType::Tin,
+        "MultiPoint" => GmlGeometryType::MultiPoint,
+        "OrientableCurve" => GmlGeometryType::OrientableCurve,
+        "CompositeCurve" => GmlGeometryType::CompositeCurve,
+        "MultiCurve" => GmlGeometryType::MultiCurve,
+        "Ring" => GmlGeometryType::Ring,
+        "OrientableSurface" => GmlGeometryType::OrientableSurface,
+        "CompositeSurface" => GmlGeometryType::CompositeSurface,
+        "MultiSurface" => GmlGeometryType::MultiSurface,
+        "Shell" => GmlGeometryType::Shell,
+        "Solid" => GmlGeometryType::Solid,
+        "CompositeSolid" => GmlGeometryType::CompositeSolid,
+        "MultiSolid" => GmlGeometryType::MultiSolid,
+        "MultiGeometry" => GmlGeometryType::MultiGeometry,
+        "GeometricComplex" => GmlGeometryType::GeometricComplex,
+        // TODO: ImplicitGeometry support is deferred. Placing it correctly needs
+        // its transformationMatrix/referencePoint applied to the relativeGeometry
+        // prototype; emitting the untransformed prototype puts geometry at the
+        // wrong position, so it is dropped rather than mis-placed for now.
+        _ => return None,
+    })
+}
+
+/// Iterate a node's element children.
+fn element_children(node: &RawNode) -> impl Iterator<Item = &RawNode> {
+    node.children.iter().filter_map(|c| match c {
+        RawChild::Element(e) => Some(e.as_ref()),
+        _ => None,
+    })
+}
+
+/// The first text child of a node, or the empty string.
+fn text_content(node: &RawNode) -> &str {
+    node.children
+        .iter()
+        .find_map(|c| match c {
+            RawChild::Text(t) => Some(t.as_str()),
+            _ => None,
+        })
+        .unwrap_or("")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::citygml_parser::parser::Parser;
+    use crate::citygml_parser::resolver::resolve_root;
+    use url::Url;
+
+    /// Parse one CityGML feature wrapping `inner`, returning its stripped attribute
+    /// tree, its carved geometries, and the geometry registry.
+    fn parse_one_feature(inner: &str) -> (Arc<RawNode>, Vec<PendingGeom>, GeomRegistry) {
+        let xml = format!(
+            r#"<core:CityModel
+                 xmlns:core="http://www.opengis.net/citygml/3.0"
+                 xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
+                 xmlns:con="http://www.opengis.net/citygml/construction/3.0"
+                 xmlns:dem="http://www.opengis.net/citygml/relief/3.0"
+                 xmlns:urc="https://www.geospatial.jp/iur/urc/4.0"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:xlink="http://www.w3.org/1999/xlink">
+               <core:cityObjectMember><bldg:Building gml:id="b1">{inner}</bldg:Building></core:cityObjectMember>
+             </core:CityModel>"#
+        );
+        let url = Url::parse("file:///test.gml").unwrap();
+        let mut parser = Parser::new();
+        parser.parse(xml.as_bytes(), &url).unwrap();
+        let (pending, _raw, geom_registry, _ns) = parser.finish();
+        let feature = pending.into_iter().next().expect("one feature");
+        (feature.root, feature.geoms, geom_registry)
+    }
+
+    /// Parse one CityGML feature wrapping `inner`, returning its carved geometries
+    /// and the geometry registry.
+    fn parse_one(inner: &str) -> (Vec<PendingGeom>, GeomRegistry) {
+        let (_root, geoms, registry) = parse_one_feature(inner);
+        (geoms, registry)
+    }
+
+    const POLYGON: &str = r#"<gml:Polygon><gml:exterior><gml:LinearRing>
+        <gml:posList>0 0 0 1 0 0 0 1 0 0 0 0</gml:posList>
+      </gml:LinearRing></gml:exterior></gml:Polygon>"#;
+
+    fn collection_len(geometry: &Euclidean3DGeometry) -> usize {
+        match geometry {
+            Euclidean3DGeometry::Collection(c) => c.len(),
+            other => panic!("expected a collection, got {other:?}"),
+        }
+    }
+
+    /// The sole member of a one-member collection.
+    fn only_member(geometry: &Euclidean3DGeometry) -> &Euclidean3DGeometry {
+        match geometry {
+            Euclidean3DGeometry::Collection(c) => {
+                assert_eq!(c.len(), 1, "expected exactly one member");
+                &c.members()[0]
+            }
+            other => panic!("expected a collection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inline_multisurface_resolves_to_collection() {
+        let (geoms, registry) = parse_one(&format!(
+            "<bldg:lod2MultiSurface><gml:MultiSurface><gml:surfaceMember>{POLYGON}</gml:surfaceMember></gml:MultiSurface></bldg:lod2MultiSurface>"
+        ));
+        assert_eq!(geoms.len(), 1);
+        assert_eq!(geoms[0].lod, Some(2));
+        let geometry = resolve_root(&geoms[0].node, &registry).unwrap();
+        assert_eq!(collection_len(&geometry), 1);
+    }
+
+    #[test]
+    fn inline_solid_resolves_to_solid() {
+        let (geoms, registry) = parse_one(&format!(
+            "<bldg:lod2Solid><gml:Solid><gml:exterior><gml:Shell><gml:surfaceMember>{POLYGON}</gml:surfaceMember></gml:Shell></gml:exterior></gml:Solid></bldg:lod2Solid>"
+        ));
+        let geometry = resolve_root(&geoms[0].node, &registry).unwrap();
+        assert!(matches!(geometry, Euclidean3DGeometry::Solid(_)));
+    }
+
+    #[test]
+    fn triangulated_surface_resolves_to_triangular_mesh() {
+        let (geoms, registry) = parse_one(
+            r#"<bldg:lod1MultiSurface><gml:TriangulatedSurface><gml:trianglePatches>
+                 <gml:Triangle><gml:exterior><gml:LinearRing>
+                   <gml:posList>0 0 0 1 0 0 0 1 0 0 0 0</gml:posList>
+                 </gml:LinearRing></gml:exterior></gml:Triangle>
+               </gml:trianglePatches></gml:TriangulatedSurface></bldg:lod1MultiSurface>"#,
+        );
+        let geometry = resolve_root(&geoms[0].node, &registry).unwrap();
+        assert!(matches!(geometry, Euclidean3DGeometry::TriangularMesh(_)));
+    }
+
+    #[test]
+    fn geometry_tagged_with_enclosing_gml_ids() {
+        // The wrapping feature is `b1`; a nested WallSurface `wall1` owns the geometry.
+        let (geoms, _) = parse_one(&format!(
+            r#"<core:boundary><con:WallSurface gml:id="wall1">
+                 <core:lod2MultiSurface><gml:MultiSurface><gml:surfaceMember>{POLYGON}</gml:surfaceMember></gml:MultiSurface></core:lod2MultiSurface>
+               </con:WallSurface></core:boundary>"#
+        ));
+        assert_eq!(geoms.len(), 1);
+        assert_eq!(
+            geoms[0].owner_ids,
+            vec!["wall1".to_string(), "b1".to_string()]
+        );
+    }
+
+    #[test]
+    fn gml_id_geometry_registers_and_xlink_resolves() {
+        let inline = POLYGON.replacen("<gml:Polygon>", r#"<gml:Polygon gml:id="p1">"#, 1);
+        let (geoms, registry) = parse_one(&format!(
+            r##"<bldg:lod2MultiSurface><gml:MultiSurface>
+                 <gml:surfaceMember>{inline}</gml:surfaceMember>
+                 <gml:surfaceMember xlink:href="#p1"/>
+               </gml:MultiSurface></bldg:lod2MultiSurface>"##
+        ));
+        assert!(registry.contains_key(&("file:///test.gml".to_string(), "p1".to_string())));
+        let geometry = resolve_root(&geoms[0].node, &registry).unwrap();
+        assert_eq!(collection_len(&geometry), 2);
+    }
+
+    // ── Trimmed cases from the Takeshiba CityGML 3.0 sample (Layer A: one geometry
+    //    via resolve_root). Meshes are two faces sharing edge B–C. ──
+
+    /// Two polygons sharing edge B–C.
+    const TA: &str = "<gml:Polygon><gml:exterior><gml:LinearRing><gml:posList>35.6000 139.8000 10.0 35.6001 139.8000 10.0 35.6000 139.8001 12.0 35.6000 139.8000 10.0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>";
+    const TB: &str = "<gml:Polygon><gml:exterior><gml:LinearRing><gml:posList>35.6001 139.8000 10.0 35.6001 139.8001 12.0 35.6000 139.8001 12.0 35.6001 139.8000 10.0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>";
+
+    #[test]
+    fn case01_multicurve_linestring() {
+        let (geoms, registry) = parse_one(
+            r#"<core:lod0MultiCurve><gml:MultiCurve><gml:curveMember><gml:LineString>
+                 <gml:posList>35.6007 139.8340 0.0 35.6033 139.8321 0.0 35.6042 139.8314 0.0</gml:posList>
+               </gml:LineString></gml:curveMember></gml:MultiCurve></core:lod0MultiCurve>"#,
+        );
+        assert_eq!(geoms.len(), 1);
+        assert_eq!(geoms[0].lod, Some(0));
+        let geometry = resolve_root(&geoms[0].node, &registry).unwrap();
+        match only_member(&geometry) {
+            Euclidean3DGeometry::LineString(ls) => {
+                assert_eq!(ls.coords().len(), 3);
+                // posList is lat/lon; stored x/y, so the pair is swapped.
+                assert_eq!(ls.coords()[0], [139.8340, 35.6007, 0.0]);
+            }
+            other => panic!("expected LineString, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case02_multisurface_polygon() {
+        let (geoms, registry) = parse_one(&format!(
+            "<core:lod2MultiSurface><gml:MultiSurface><gml:surfaceMember>{TA}</gml:surfaceMember></gml:MultiSurface></core:lod2MultiSurface>"
+        ));
+        assert_eq!(geoms.len(), 1);
+        assert_eq!(geoms[0].lod, Some(2));
+        let geometry = resolve_root(&geoms[0].node, &registry).unwrap();
+        match only_member(&geometry) {
+            Euclidean3DGeometry::Polygon(p) => {
+                assert_eq!(p.exterior().len(), 4);
+                assert_eq!(p.exterior()[0], [139.8000, 35.6000, 10.0]); // swapped
+                assert_eq!(p.interiors().count(), 0);
+            }
+            other => panic!("expected Polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case03_polygon_with_hole() {
+        let (geoms, registry) = parse_one(
+            r#"<core:lod2MultiSurface><gml:MultiSurface><gml:surfaceMember>
+                 <gml:Polygon>
+                   <gml:exterior><gml:LinearRing><gml:posList>35.6000 139.8000 0.0 35.6010 139.8000 0.0 35.6010 139.8010 0.0 35.6000 139.8010 0.0 35.6000 139.8000 0.0</gml:posList></gml:LinearRing></gml:exterior>
+                   <gml:interior><gml:LinearRing><gml:posList>35.6003 139.8003 0.0 35.6007 139.8003 0.0 35.6007 139.8007 0.0 35.6003 139.8003 0.0</gml:posList></gml:LinearRing></gml:interior>
+                 </gml:Polygon>
+               </gml:surfaceMember></gml:MultiSurface></core:lod2MultiSurface>"#,
+        );
+        let geometry = resolve_root(&geoms[0].node, &registry).unwrap();
+        match only_member(&geometry) {
+            Euclidean3DGeometry::Polygon(p) => {
+                assert_eq!(p.exterior().len(), 5);
+                let holes: Vec<_> = p.interiors().collect();
+                assert_eq!(holes.len(), 1);
+                assert_eq!(holes[0].len(), 4);
+            }
+            other => panic!("expected Polygon, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case04_multisurface_compositesurface_xlink() {
+        let (geoms, registry) = parse_one(&format!(
+            r##"<core:lod2MultiSurface><gml:MultiSurface><gml:surfaceMember>
+                  <gml:CompositeSurface>
+                    <gml:surfaceMember xlink:href="#cp1"/>
+                    <gml:surfaceMember xlink:href="#cp2"/>
+                  </gml:CompositeSurface>
+                </gml:surfaceMember></gml:MultiSurface></core:lod2MultiSurface>
+                <core:lod2MultiSurface><gml:MultiSurface>
+                  <gml:surfaceMember>{cp1}</gml:surfaceMember>
+                  <gml:surfaceMember>{cp2}</gml:surfaceMember>
+                </gml:MultiSurface></core:lod2MultiSurface>"##,
+            cp1 = TA.replacen("<gml:Polygon>", r#"<gml:Polygon gml:id="cp1">"#, 1),
+            cp2 = TB.replacen("<gml:Polygon>", r#"<gml:Polygon gml:id="cp2">"#, 1),
+        ));
+        assert_eq!(geoms.len(), 2);
+        // geoms[0] is the CompositeSurface-in-MultiSurface: the two xlinked polygons
+        // resolved and welded into one two-face mesh.
+        let geometry = resolve_root(&geoms[0].node, &registry).unwrap();
+        match only_member(&geometry) {
+            Euclidean3DGeometry::PolygonMesh(m) => assert_eq!(m.num_faces(), 2),
+            other => panic!("expected PolygonMesh, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case05_multisurface_surfacemember_xlink() {
+        let (geoms, registry) = parse_one(&format!(
+            r##"<core:lod2MultiSurface><gml:MultiSurface>
+                  <gml:surfaceMember xlink:href="#tp1"/>
+                </gml:MultiSurface></core:lod2MultiSurface>
+                <core:lod2MultiSurface><gml:MultiSurface>
+                  <gml:surfaceMember>{tp1}</gml:surfaceMember>
+                </gml:MultiSurface></core:lod2MultiSurface>"##,
+            tp1 = TA.replacen("<gml:Polygon>", r#"<gml:Polygon gml:id="tp1">"#, 1),
+        ));
+        assert_eq!(geoms.len(), 2);
+        let geometry = resolve_root(&geoms[0].node, &registry).unwrap();
+        match only_member(&geometry) {
+            Euclidean3DGeometry::Polygon(p) => assert_eq!(p.exterior().len(), 4),
+            other => panic!("expected Polygon (xlink resolved), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case06_solid_shell_polygons() {
+        let (geoms, registry) = parse_one(&format!(
+            "<core:lod1Solid><gml:Solid><gml:exterior><gml:Shell>
+               <gml:surfaceMember>{TA}</gml:surfaceMember>
+               <gml:surfaceMember>{TB}</gml:surfaceMember>
+             </gml:Shell></gml:exterior></gml:Solid></core:lod1Solid>"
+        ));
+        assert_eq!(geoms.len(), 1);
+        assert_eq!(geoms[0].lod, Some(1));
+        match resolve_root(&geoms[0].node, &registry).unwrap() {
+            Euclidean3DGeometry::Solid(s) => {
+                assert_eq!(s.exterior().num_faces(), 2);
+                assert!(s.interiors().is_empty());
+            }
+            other => panic!("expected Solid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case07_solid_shell_compositesurface() {
+        let (geoms, registry) = parse_one(&format!(
+            "<core:lod2Solid><gml:Solid><gml:exterior><gml:Shell><gml:surfaceMember>
+               <gml:CompositeSurface>
+                 <gml:surfaceMember>{TA}</gml:surfaceMember>
+                 <gml:surfaceMember>{TB}</gml:surfaceMember>
+               </gml:CompositeSurface>
+             </gml:surfaceMember></gml:Shell></gml:exterior></gml:Solid></core:lod2Solid>"
+        ));
+        assert_eq!(geoms[0].lod, Some(2));
+        // The CompositeSurface shell body welds its two polygons into the solid's
+        // one exterior shell.
+        match resolve_root(&geoms[0].node, &registry).unwrap() {
+            Euclidean3DGeometry::Solid(s) => assert_eq!(s.exterior().num_faces(), 2),
+            other => panic!("expected Solid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case08_triangulated_surface() {
+        let (geoms, registry) = parse_one(
+            r#"<dem:tin><gml:TriangulatedSurface><gml:patches>
+                 <gml:Triangle><gml:exterior><gml:LinearRing><gml:posList>35.6000 139.8000 10.0 35.6001 139.8000 10.0 35.6000 139.8001 12.0 35.6000 139.8000 10.0</gml:posList></gml:LinearRing></gml:exterior></gml:Triangle>
+                 <gml:Triangle><gml:exterior><gml:LinearRing><gml:posList>35.6001 139.8000 10.0 35.6001 139.8001 12.0 35.6000 139.8001 12.0 35.6001 139.8000 10.0</gml:posList></gml:LinearRing></gml:exterior></gml:Triangle>
+               </gml:patches></gml:TriangulatedSurface></dem:tin>"#,
+        );
+        assert_eq!(geoms.len(), 1);
+        assert_eq!(geoms[0].lod, None);
+        match resolve_root(&geoms[0].node, &registry).unwrap() {
+            Euclidean3DGeometry::TriangularMesh(m) => {
+                assert_eq!(m.num_triangles(), 2);
+                // Edge B–C is shared, so the two triangles dedup to four vertices.
+                assert_eq!(m.vertices().len(), 4);
+            }
+            other => panic!("expected TriangularMesh, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case09_point() {
+        let (geoms, registry) = parse_one(
+            r#"<urc:lod0Geometry><gml:Point><gml:pos>35.6536 139.7632 5.0</gml:pos></gml:Point></urc:lod0Geometry>"#,
+        );
+        assert_eq!(geoms.len(), 1);
+        assert_eq!(geoms[0].lod, Some(0));
+        match resolve_root(&geoms[0].node, &registry).unwrap() {
+            Euclidean3DGeometry::Point(p) => assert_eq!(p.position(), [139.7632, 35.6536, 5.0]),
+            other => panic!("expected Point, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn poslist_with_invalid_token_is_dropped_whole_not_shifted() {
+        // A malformed ordinate must reject its whole ring rather than dropping the
+        // token and misaligning every following coordinate. The valid member
+        // survives; the one with a bad token is dropped entirely.
+        let (geoms, registry) = parse_one(&format!(
+            "<bldg:lod2MultiSurface><gml:MultiSurface>\
+               <gml:surfaceMember>{POLYGON}</gml:surfaceMember>\
+               <gml:surfaceMember><gml:Polygon><gml:exterior><gml:LinearRing>\
+                 <gml:posList>0 0 0 1 0 0 0 1 bad 0 0 0</gml:posList>\
+               </gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember>\
+             </gml:MultiSurface></bldg:lod2MultiSurface>"
+        ));
+        assert_eq!(
+            collection_len(&resolve_root(&geoms[0].node, &registry).unwrap()),
+            1
+        );
+    }
+
+    #[test]
+    fn poslist_length_not_multiple_of_three_is_dropped_whole() {
+        // An 8-ordinate list (e.g. a 2D posList, or a data error) is not a multiple
+        // of 3; it must drop the whole ring rather than truncate into misaligned
+        // coordinates. The valid member survives; the malformed one is dropped.
+        let (geoms, registry) = parse_one(&format!(
+            "<bldg:lod2MultiSurface><gml:MultiSurface>\
+               <gml:surfaceMember>{POLYGON}</gml:surfaceMember>\
+               <gml:surfaceMember><gml:Polygon><gml:exterior><gml:LinearRing>\
+                 <gml:posList>0 0 1 0 1 1 0 0</gml:posList>\
+               </gml:LinearRing></gml:exterior></gml:Polygon></gml:surfaceMember>\
+             </gml:MultiSurface></bldg:lod2MultiSurface>"
+        ));
+        assert_eq!(
+            collection_len(&resolve_root(&geoms[0].node, &registry).unwrap()),
+            1
+        );
+    }
+
+    #[test]
+    fn pos_with_invalid_token_is_skipped() {
+        // The bad pos yields no coordinate, so the Point is dropped at parse time
+        // and no geometry is carved from the feature.
+        let (geoms, _registry) = parse_one(
+            r#"<urc:lod0Geometry><gml:Point><gml:pos>35.6536 x 5.0</gml:pos></gml:Point></urc:lod0Geometry>"#,
+        );
+        assert!(geoms.is_empty());
+    }
+
+    #[test]
+    fn lod_named_non_geometry_element_is_kept_as_attribute() {
+        // An element whose name matches the lod<N> pattern but wraps no geometry
+        // must stay in the attribute tree, not be stripped and silently lost.
+        let (root, geoms, _registry) = parse_one_feature("<bldg:lod1Note>keep me</bldg:lod1Note>");
+        assert!(geoms.is_empty(), "no geometry should be carved");
+        assert!(
+            root.children.iter().any(|c| matches!(
+                c,
+                RawChild::Element(e) if local_name(&e.name.0) == "lod1Note"
+            )),
+            "the lod-named non-geometry element should be preserved"
+        );
+    }
+
+    #[test]
+    fn curve_is_deferred_and_skipped() {
+        let (geoms, registry) = parse_one(
+            r#"<bldg:lod0MultiSurface><gml:MultiCurve><gml:curveMember>
+                 <gml:Curve><gml:segments><gml:LineStringSegment>
+                   <gml:posList>0 0 0 1 0 0</gml:posList>
+                 </gml:LineStringSegment></gml:segments></gml:Curve>
+               </gml:curveMember></gml:MultiCurve></bldg:lod0MultiSurface>"#,
+        );
+        // The MultiCurve survives but its sole Curve member is dropped, leaving an
+        // empty collection.
+        assert_eq!(
+            collection_len(&resolve_root(&geoms[0].node, &registry).unwrap()),
+            0
+        );
+    }
+}

--- a/engine/runtime/action-processor/src/citygml_parser/mod.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/mod.rs
@@ -1,7 +1,17 @@
 pub(crate) mod codespace;
 pub(crate) mod flatten;
+#[cfg(not(feature = "new-geometry"))]
 pub(crate) mod geometry;
+#[cfg(feature = "new-geometry")]
+#[path = "geometry_next.rs"]
+pub(crate) mod geometry;
+#[cfg(not(feature = "new-geometry"))]
+pub mod parser;
+#[cfg(feature = "new-geometry")]
+#[path = "parser_next.rs"]
 pub mod parser;
 pub mod pipeline;
+#[cfg(feature = "new-geometry")]
+pub(crate) mod resolver;
 pub(crate) mod utils;
 pub(crate) mod xlink;

--- a/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
@@ -1,0 +1,818 @@
+use std::collections::{hash_map::Entry, HashMap};
+use std::io::BufRead;
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+use quick_xml::events::Event;
+use quick_xml::name::ResolveResult;
+use quick_xml::NsReader;
+use reearth_flow_types::{Attribute, AttributeValue, Attributes, CitygmlFeatureExt, Feature};
+use url::Url;
+
+use super::geometry;
+use super::resolver::GeomRegistry;
+use super::utils::{
+    gml_id_attr, local_name as utils_local_name, xlink_href_attr, NamespaceRegistry, NsId, QName,
+    XmlChild, XmlNode, EMPTY_NS_ID, GML_NS_ID, XLINK_NS_ID,
+};
+
+pub(super) type RawNodeKey = (String, String); // (file_url, gml_id)
+
+pub(crate) struct RawNode {
+    pub(crate) name: QName,
+    pub(crate) attrs: Vec<(QName, String)>,
+    pub(crate) children: Vec<RawChild>,
+    pub(crate) source_url: Arc<Url>,
+}
+
+#[derive(Clone)]
+pub(crate) enum RawChild {
+    Element(Arc<RawNode>),
+    Text(String),
+    Ref(RawNodeKey),
+}
+
+pub(crate) type RawRegistry = HashMap<RawNodeKey, Arc<RawNode>>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("XML error: {0}")]
+    Xml(#[from] quick_xml::Error),
+    #[error("Encoding error: {0}")]
+    Encoding(String),
+    #[error("Malformed XML: {0}")]
+    Malformed(String),
+    #[error("No CityModel root element found")]
+    NoCityModel,
+    #[error("Unexpected end of file inside CityModel")]
+    UnexpectedEof,
+}
+
+/// First pass parser: streams each file, parsing geometry eagerly into
+/// [`GeomNode`](super::resolver::GeomNode)s and leaving the attribute tree as
+/// stripped `RawNode`s. Call `parse()` once per file, then `finish()` to hand off
+/// the state for pass-2 reference resolution.
+pub struct Parser {
+    raw_registry: RawRegistry,
+    geom_registry: GeomRegistry,
+    pub(super) ns_registry: NamespaceRegistry,
+    pending: Vec<PendingFeature>,
+    /// Whether to record each geometry's enclosing `gml:id`s, needed only when
+    /// `flatten` will hoist children into separate features.
+    track_owners: bool,
+}
+
+impl Default for Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for Parser {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Parser")
+            .field("pending", &self.pending.len())
+            .field("raw_registry", &self.raw_registry.len())
+            .field("geom_registry", &self.geom_registry.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Parser {
+    pub fn new() -> Self {
+        Self::with_owner_tracking(true)
+    }
+
+    /// A parser that records geometry owner `gml:id`s only when `track_owners` is
+    /// set; leave it off unless `flatten` will hoist children.
+    pub(super) fn with_owner_tracking(track_owners: bool) -> Self {
+        Self {
+            raw_registry: RawRegistry::new(),
+            geom_registry: GeomRegistry::new(),
+            ns_registry: NamespaceRegistry::new(),
+            pending: Vec::new(),
+            track_owners,
+        }
+    }
+
+    pub fn parse(&mut self, source: &[u8], source_url: &Url) -> Result<(), ParseError> {
+        let src = std::str::from_utf8(source)
+            .map_err(|e| ParseError::Encoding(format!("Non-UTF-8 content: {e}")))?;
+        let mut reader = NsReader::from_str(src);
+        let mut buf = Vec::new();
+        let source_url_arc = Arc::new(source_url.clone());
+
+        loop {
+            match next_event(&mut reader, &mut buf, &mut self.ns_registry)? {
+                OwnedEvent::Start { name, .. } if local_name(&name.0) == "CityModel" => break,
+                OwnedEvent::Eof => return Err(ParseError::NoCityModel),
+                _ => {}
+            }
+        }
+
+        loop {
+            match next_event(&mut reader, &mut buf, &mut self.ns_registry)? {
+                OwnedEvent::Start { name, attrs } => {
+                    let ln = local_name(&name.0);
+                    if ln == "cityObjectMember" || ln == "featureMember" {
+                        let member = parse_element(
+                            &mut reader,
+                            &mut buf,
+                            name,
+                            attrs,
+                            &source_url_arc,
+                            &mut self.ns_registry,
+                        )?;
+                        if let Some(feature_node) =
+                            member.children.iter().find_map(|child| match child {
+                                RawChild::Element(node) => Some(Arc::clone(node)),
+                                _ => None,
+                            })
+                        {
+                            let (stripped, geoms) = geometry::split_geometry(
+                                &feature_node,
+                                &mut self.geom_registry,
+                                self.track_owners,
+                            );
+                            collect_ids(&stripped, source_url_arc.as_str(), &mut self.raw_registry);
+                            self.pending.push(PendingFeature {
+                                root: stripped,
+                                geoms,
+                            });
+                        } else {
+                            tracing::warn!(
+                                "citygml3: empty cityObjectMember/featureMember, skipped"
+                            );
+                        }
+                    } else {
+                        skip_element(&mut reader, &mut buf, &mut self.ns_registry)?;
+                    }
+                }
+                OwnedEvent::End => break,
+                OwnedEvent::Eof => return Err(ParseError::UnexpectedEof),
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Consume the parser and return the pending features, the attribute and
+    /// geometry registries, and the namespace registry for pass-2 resolution.
+    pub(super) fn finish(
+        self,
+    ) -> (
+        Vec<PendingFeature>,
+        RawRegistry,
+        GeomRegistry,
+        NamespaceRegistry,
+    ) {
+        (
+            self.pending,
+            self.raw_registry,
+            self.geom_registry,
+            self.ns_registry,
+        )
+    }
+}
+
+/// A top-level city object awaiting pass-2 resolution: its attribute tree, with
+/// geometry stripped out, plus the geometries carved from it.
+pub(super) struct PendingFeature {
+    pub(super) root: Arc<RawNode>,
+    pub(super) geoms: Vec<geometry::PendingGeom>,
+}
+
+pub fn to_feature(node: &XmlNode) -> Feature {
+    let content = node_to_attribute_value(node);
+    build_feature(&node.name.0, gml_id_attr(&node.attrs).as_deref(), content)
+}
+
+pub fn node_to_attribute_value(node: &XmlNode) -> AttributeValue {
+    let mut elem_groups: IndexMap<String, Vec<AttributeValue>> = IndexMap::new();
+    let mut text_parts: Vec<String> = Vec::new();
+
+    for child in &node.children {
+        match child {
+            XmlChild::Element(e) => {
+                elem_groups
+                    .entry(e.name.0.clone())
+                    .or_default()
+                    .push(node_to_attribute_value(e));
+            }
+            XmlChild::Text(t) => text_parts.push(t.clone()),
+        }
+    }
+
+    if node.attrs.is_empty() && elem_groups.is_empty() {
+        return AttributeValue::String(text_parts.join(""));
+    }
+
+    // currently unordered because AttributeValue::Map is unordered
+    let mut map: HashMap<String, AttributeValue> = HashMap::new();
+
+    for ((qname, _), v) in &node.attrs {
+        map.insert(format!("@{qname}"), AttributeValue::String(v.clone()));
+    }
+    if !text_parts.is_empty() {
+        map.insert("$".into(), AttributeValue::String(text_parts.join("")));
+    }
+    for (name, mut values) in elem_groups {
+        let av = if values.len() == 1 {
+            values.pop().unwrap()
+        } else {
+            AttributeValue::Array(values)
+        };
+        map.insert(name, av);
+    }
+
+    AttributeValue::Map(map)
+}
+
+pub(super) fn raw_gml_id(node: &RawNode) -> Option<String> {
+    node.attrs
+        .iter()
+        .find(|((q, ns), _)| local_name(q) == "id" && *ns == GML_NS_ID)
+        .map(|(_, v)| v.clone())
+}
+
+fn collect_ids(node: &Arc<RawNode>, source_url: &str, registry: &mut RawRegistry) {
+    if let Some(id) = raw_gml_id(node) {
+        let key = (source_url.to_string(), id.clone());
+        if let Entry::Vacant(entry) = registry.entry(key) {
+            entry.insert(Arc::clone(node));
+        } else {
+            tracing::error!(
+                id,
+                source_url,
+                "citygml3: duplicate gml:id encountered; keeping first definition and skipping duplicate"
+            );
+        }
+    }
+    for child in &node.children {
+        if let RawChild::Element(e) = child {
+            collect_ids(e, source_url, registry);
+        }
+    }
+}
+
+fn href_to_key(href: &str, base: &Url) -> Option<RawNodeKey> {
+    if let Some(frag) = href.strip_prefix('#') {
+        Some((base.as_str().to_string(), frag.to_string()))
+    } else if let Some((file, frag)) = href.split_once('#') {
+        base.join(file)
+            .ok()
+            .map(|u| (u.to_string(), frag.to_string()))
+    } else {
+        tracing::warn!(href, "citygml3: unsupported xlink:href format, skipped");
+        None
+    }
+}
+
+enum OwnedEvent {
+    Start {
+        name: QName,
+        attrs: Vec<(QName, String)>,
+    },
+    End,
+    Empty {
+        name: QName,
+        attrs: Vec<(QName, String)>,
+    },
+    Text(String),
+    Eof,
+    Other,
+}
+
+fn next_event<R: BufRead>(
+    reader: &mut NsReader<R>,
+    buf: &mut Vec<u8>,
+    ns_reg: &mut NamespaceRegistry,
+) -> Result<OwnedEvent, ParseError> {
+    buf.clear();
+    let (ns_result, event) = reader
+        .read_resolved_event_into(buf)
+        .map_err(ParseError::Xml)?;
+    let elem_ns_id = match ns_result {
+        ResolveResult::Bound(ns) => intern_ns(ns.into_inner(), ns_reg)?,
+        _ => EMPTY_NS_ID,
+    };
+    match event {
+        Event::Start(e) => Ok(OwnedEvent::Start {
+            name: (decode_utf8(e.name().as_ref(), "element name")?, elem_ns_id),
+            attrs: extract_attrs(&e, reader, ns_reg)?,
+        }),
+        Event::End(_) => Ok(OwnedEvent::End),
+        Event::Empty(e) => Ok(OwnedEvent::Empty {
+            name: (decode_utf8(e.name().as_ref(), "element name")?, elem_ns_id),
+            attrs: extract_attrs(&e, reader, ns_reg)?,
+        }),
+        Event::Text(t) => Ok(OwnedEvent::Text(
+            t.unescape().map_err(ParseError::Xml)?.to_string(),
+        )),
+        Event::CData(c) => Ok(OwnedEvent::Text(decode_utf8(&c, "CDATA content")?)),
+        Event::Eof => Ok(OwnedEvent::Eof),
+        _ => Ok(OwnedEvent::Other),
+    }
+}
+
+fn parse_element<R: BufRead>(
+    reader: &mut NsReader<R>,
+    buf: &mut Vec<u8>,
+    name: QName,
+    attrs: Vec<(QName, String)>,
+    source_url_arc: &Arc<Url>,
+    ns_reg: &mut NamespaceRegistry,
+) -> Result<RawNode, ParseError> {
+    let href = xlink_href_attr(&attrs)
+        .and_then(|href| href_to_key(href, source_url_arc.as_ref()))
+        .map(|key| {
+            let filtered = attrs
+                .iter()
+                .filter(|((q, ns), _)| !(local_name(q) == "href" && *ns == XLINK_NS_ID))
+                .cloned()
+                .collect::<Vec<_>>();
+            (key, filtered)
+        });
+    let mut children = Vec::new();
+
+    loop {
+        match next_event(reader, buf, ns_reg)? {
+            OwnedEvent::Start {
+                name: cn,
+                attrs: ca,
+            } => {
+                let child = parse_element(reader, buf, cn, ca, source_url_arc, ns_reg)?;
+                children.push(RawChild::Element(Arc::new(child)));
+            }
+            OwnedEvent::Empty {
+                name: cn,
+                attrs: ca,
+            } => {
+                if let Some(href) = xlink_href_attr(&ca) {
+                    if let Some(key) = href_to_key(href, source_url_arc.as_ref()) {
+                        let filtered: Vec<(QName, String)> = ca
+                            .into_iter()
+                            .filter(|((q, ns), _)| !(local_name(q) == "href" && *ns == XLINK_NS_ID))
+                            .collect();
+                        children.push(RawChild::Element(Arc::new(RawNode {
+                            name: cn,
+                            attrs: filtered,
+                            children: vec![RawChild::Ref(key)],
+                            source_url: Arc::clone(source_url_arc),
+                        })));
+                    } else {
+                        children.push(RawChild::Element(Arc::new(RawNode {
+                            name: cn,
+                            attrs: ca,
+                            children: Vec::new(),
+                            source_url: Arc::clone(source_url_arc),
+                        })));
+                    }
+                } else {
+                    children.push(RawChild::Element(Arc::new(RawNode {
+                        name: cn,
+                        attrs: ca,
+                        children: Vec::new(),
+                        source_url: Arc::clone(source_url_arc),
+                    })));
+                }
+            }
+            OwnedEvent::End => break,
+            OwnedEvent::Eof => return Err(ParseError::UnexpectedEof),
+            OwnedEvent::Text(t) if !t.trim().is_empty() => {
+                children.push(RawChild::Text(t));
+            }
+            _ => {}
+        }
+    }
+
+    if let Some((key, filtered_attrs)) = href {
+        if !children.is_empty() {
+            tracing::warn!(
+                element = name.0,
+                id = key.1,
+                "citygml3: xlink:href element had inline content; inline content ignored"
+            );
+        }
+        return Ok(RawNode {
+            name,
+            attrs: filtered_attrs,
+            children: vec![RawChild::Ref(key)],
+            source_url: Arc::clone(source_url_arc),
+        });
+    }
+
+    Ok(RawNode {
+        name,
+        attrs,
+        children,
+        source_url: Arc::clone(source_url_arc),
+    })
+}
+
+fn skip_element<R: BufRead>(
+    reader: &mut NsReader<R>,
+    buf: &mut Vec<u8>,
+    ns_reg: &mut NamespaceRegistry,
+) -> Result<(), ParseError> {
+    let mut depth: usize = 1;
+    loop {
+        match next_event(reader, buf, ns_reg)? {
+            OwnedEvent::Start { .. } => depth += 1,
+            OwnedEvent::End => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            OwnedEvent::Eof => return Err(ParseError::UnexpectedEof),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn extract_attrs<R: BufRead>(
+    e: &quick_xml::events::BytesStart<'_>,
+    reader: &NsReader<R>,
+    ns_reg: &mut NamespaceRegistry,
+) -> Result<Vec<(QName, String)>, ParseError> {
+    e.attributes()
+        .map(|a| {
+            let a = a.map_err(|err| ParseError::Malformed(format!("invalid attribute: {err}")))?;
+            let qname_str = decode_utf8(a.key.as_ref(), "attribute name")?;
+            let ns_id = match reader.resolve_attribute(a.key).0 {
+                ResolveResult::Bound(ns) => intern_ns(ns.into_inner(), ns_reg)?,
+                _ => EMPTY_NS_ID,
+            };
+            let v = a
+                .unescape_value()
+                .map_err(|err| ParseError::Malformed(format!("invalid attribute value: {err}")))?
+                .to_string();
+            Ok(((qname_str, ns_id), v))
+        })
+        .collect()
+}
+
+fn intern_ns(bytes: &[u8], ns_reg: &mut NamespaceRegistry) -> Result<NsId, ParseError> {
+    let s = std::str::from_utf8(bytes)
+        .map_err(|e| ParseError::Encoding(format!("invalid UTF-8 in namespace URI: {e}")))?;
+    Ok(ns_reg.intern(s))
+}
+
+fn decode_utf8(bytes: &[u8], context: &str) -> Result<String, ParseError> {
+    std::str::from_utf8(bytes)
+        .map(|s| s.to_string())
+        .map_err(|err| ParseError::Encoding(format!("invalid UTF-8 in {context}: {err}")))
+}
+
+fn build_feature(feature_type: &str, gml_id: Option<&str>, content: AttributeValue) -> Feature {
+    let mut attrs = Attributes::new();
+
+    if let AttributeValue::Map(map) = content {
+        for (k, v) in map {
+            attrs.insert(Attribute::new(k), v);
+        }
+    }
+
+    let mut feature = Feature::new_with_attributes(attrs);
+    feature.update_feature_type(feature_type.to_string());
+    if let Some(id) = gml_id {
+        feature.update_feature_id(id.to_string());
+    }
+    feature
+}
+
+fn local_name(name: &str) -> &str {
+    utils_local_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reearth_flow_types::CitygmlFeatureExt;
+    use url::Url;
+
+    use crate::citygml_parser::utils::{test_url, XmlChild, XmlNode, EMPTY_NS_ID, GML_NS_ID};
+
+    fn dummy_url() -> Url {
+        Url::parse("file:///test.gml").unwrap()
+    }
+
+    fn make_node(
+        name: &str,
+        ns: NsId,
+        attrs: Vec<(&str, NsId, &str)>,
+        children: Vec<XmlChild>,
+    ) -> XmlNode {
+        XmlNode {
+            name: (name.to_string(), ns),
+            attrs: attrs
+                .into_iter()
+                .map(|(q, ns, v)| ((q.to_string(), ns), v.to_string()))
+                .collect(),
+            children,
+            source_url: test_url(),
+        }
+    }
+
+    fn text(s: &str) -> XmlChild {
+        XmlChild::Text(s.to_string())
+    }
+
+    fn elem(node: XmlNode) -> XmlChild {
+        XmlChild::Element(Arc::new(node))
+    }
+
+    fn parse_test(xml: &[u8]) -> Result<(), ParseError> {
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url())
+    }
+
+    #[test]
+    fn parse_errors_for_non_citygml() {
+        assert!(matches!(
+            parse_test(b"<Foo/>"),
+            Err(ParseError::NoCityModel)
+        ));
+    }
+
+    #[test]
+    fn parse_extracts_top_level_features() {
+        let xml = br#"
+<core:CityModel
+  xmlns:core="http://www.opengis.net/citygml/3.0"
+  xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2">
+  <core:cityObjectMember>
+    <bldg:Building gml:id="bldg001">
+      <bldg:lod1Solid/>
+    </bldg:Building>
+  </core:cityObjectMember>
+  <core:cityObjectMember>
+    <bldg:Building gml:id="bldg002"/>
+  </core:cityObjectMember>
+</core:CityModel>"#;
+
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (pending, _, _, _) = parser.finish();
+
+        assert_eq!(pending.len(), 2);
+        assert_eq!(raw_gml_id(&pending[0].root), Some("bldg001".to_string()));
+        assert_eq!(raw_gml_id(&pending[1].root), Some("bldg002".to_string()));
+        assert_eq!(pending[0].root.name.0, "bldg:Building");
+    }
+
+    #[test]
+    fn parse_non_standard_gml_prefix() {
+        let xml = br#"
+<core:CityModel
+  xmlns:core="http://www.opengis.net/citygml/3.0"
+  xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
+  xmlns:g="http://www.opengis.net/gml/3.2">
+  <core:cityObjectMember>
+    <bldg:Building g:id="bldg001"/>
+  </core:cityObjectMember>
+</core:CityModel>"#;
+
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (pending, raw_reg, _, _) = parser.finish();
+        assert_eq!(raw_gml_id(&pending[0].root), Some("bldg001".to_string()));
+        assert!(raw_reg.contains_key(&(dummy_url().to_string(), "bldg001".to_string())));
+    }
+
+    #[test]
+    fn parse_registers_ids_in_registry() {
+        let xml = br#"
+<core:CityModel
+  xmlns:core="http://www.opengis.net/citygml/3.0"
+  xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2">
+  <core:cityObjectMember>
+    <bldg:Building gml:id="bldg001">
+      <bldg:part gml:id="part001"/>
+    </bldg:Building>
+  </core:cityObjectMember>
+</core:CityModel>"#;
+
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (_, raw_reg, _, _) = parser.finish();
+
+        let url = dummy_url().to_string();
+        assert!(raw_reg.contains_key(&(url.clone(), "bldg001".to_string())));
+        assert!(raw_reg.contains_key(&(url, "part001".to_string())));
+    }
+
+    #[test]
+    fn parse_cross_file_gml_id_collision() {
+        let xml = br#"
+<core:CityModel
+  xmlns:core="http://www.opengis.net/citygml/3.0"
+  xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2">
+  <core:cityObjectMember>
+    <bldg:Building gml:id="shared001"/>
+  </core:cityObjectMember>
+</core:CityModel>"#;
+
+        let url_a = Url::parse("file:///a.gml").unwrap();
+        let url_b = Url::parse("file:///b.gml").unwrap();
+
+        let mut parser = Parser::new();
+        parser.parse(xml, &url_a).unwrap();
+        parser.parse(xml, &url_b).unwrap();
+        let (_, raw_reg, _, _) = parser.finish();
+
+        assert_eq!(raw_reg.len(), 2);
+        assert!(raw_reg.contains_key(&(url_a.to_string(), "shared001".to_string())));
+        assert!(raw_reg.contains_key(&(url_b.to_string(), "shared001".to_string())));
+        let node_a = raw_reg
+            .get(&(url_a.to_string(), "shared001".to_string()))
+            .unwrap();
+        let node_b = raw_reg
+            .get(&(url_b.to_string(), "shared001".to_string()))
+            .unwrap();
+        assert!(!Arc::ptr_eq(node_a, node_b));
+    }
+
+    #[test]
+    fn parse_skips_non_member_children() {
+        let xml = br#"
+<core:CityModel
+  xmlns:core="http://www.opengis.net/citygml/3.0"
+  xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy><gml:Envelope/></gml:boundedBy>
+  <core:cityObjectMember>
+    <bldg:Building gml:id="bldg001"/>
+  </core:cityObjectMember>
+</core:CityModel>"#;
+
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (pending, _, _, _) = parser.finish();
+        assert_eq!(pending.len(), 1);
+    }
+
+    #[test]
+    fn parse_errors_on_truncated_citygml() {
+        let xml = br#"
+<core:CityModel
+  xmlns:core="http://www.opengis.net/citygml/3.0"
+  xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2">
+  <core:cityObjectMember>
+    <bldg:Building gml:id="bldg001"/>
+  </core:cityObjectMember>"#;
+
+        assert!(matches!(parse_test(xml), Err(ParseError::UnexpectedEof)));
+    }
+
+    #[test]
+    fn parse_skips_empty_member_without_panic() {
+        let xml = br#"
+<core:CityModel
+  xmlns:core="http://www.opengis.net/citygml/3.0"
+  xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2">
+  <core:cityObjectMember/>
+  <core:cityObjectMember>
+    <bldg:Building gml:id="bldg001"/>
+  </core:cityObjectMember>
+</core:CityModel>"#;
+
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (pending, _, _, _) = parser.finish();
+        assert_eq!(pending.len(), 1);
+    }
+
+    #[test]
+    fn node_to_attribute_value_pure_text() {
+        let node = make_node("gml:name", GML_NS_ID, vec![], vec![text("Building A")]);
+        let av = node_to_attribute_value(&node);
+        assert_eq!(av, AttributeValue::String("Building A".to_string()));
+    }
+
+    #[test]
+    fn node_to_attribute_value_attrs_become_map() {
+        let node = make_node(
+            "gml:name",
+            GML_NS_ID,
+            vec![("gml:id", GML_NS_ID, "n1")],
+            vec![text("foo")],
+        );
+        let av = node_to_attribute_value(&node);
+        let AttributeValue::Map(map) = av else {
+            panic!("expected Map");
+        };
+        assert_eq!(
+            map.get("@gml:id"),
+            Some(&AttributeValue::String("n1".to_string()))
+        );
+        assert_eq!(
+            map.get("$"),
+            Some(&AttributeValue::String("foo".to_string()))
+        );
+    }
+
+    #[test]
+    fn node_to_attribute_value_non_standard_prefix_preserves_qname() {
+        let node = make_node(
+            "bldg:Building",
+            EMPTY_NS_ID,
+            vec![("g:id", GML_NS_ID, "bldg001")],
+            vec![],
+        );
+        let AttributeValue::Map(map) = node_to_attribute_value(&node) else {
+            panic!("expected Map");
+        };
+        assert_eq!(
+            map.get("@g:id"),
+            Some(&AttributeValue::String("bldg001".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_unescapes_attribute_values() {
+        let xml = br#"
+<core:CityModel
+  xmlns:core="http://www.opengis.net/citygml/3.0"
+  xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2">
+  <core:cityObjectMember>
+    <bldg:Building gml:id="bldg001" codeSpace="A &amp; B &lt;test&gt;"/>
+  </core:cityObjectMember>
+</core:CityModel>"#;
+
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let (pending, _, _, _) = parser.finish();
+
+        assert_eq!(
+            pending[0]
+                .root
+                .attrs
+                .iter()
+                .find(|((q, _), _)| q == "codeSpace")
+                .map(|(_, v)| v.as_str()),
+            Some("A & B <test>")
+        );
+    }
+
+    #[test]
+    fn node_to_attribute_value_repeated_children_become_array() {
+        let node = make_node(
+            "parent",
+            EMPTY_NS_ID,
+            vec![],
+            vec![
+                elem(make_node("item", EMPTY_NS_ID, vec![], vec![text("a")])),
+                elem(make_node("item", EMPTY_NS_ID, vec![], vec![text("b")])),
+            ],
+        );
+        let AttributeValue::Map(map) = node_to_attribute_value(&node) else {
+            panic!("expected Map");
+        };
+        let AttributeValue::Array(arr) = map.get("item").unwrap() else {
+            panic!("expected Array");
+        };
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn node_to_attribute_value_single_child_not_wrapped_in_array() {
+        let node = make_node(
+            "parent",
+            EMPTY_NS_ID,
+            vec![],
+            vec![elem(make_node(
+                "item",
+                EMPTY_NS_ID,
+                vec![],
+                vec![text("only")],
+            ))],
+        );
+        let AttributeValue::Map(map) = node_to_attribute_value(&node) else {
+            panic!("expected Map");
+        };
+        assert!(matches!(map.get("item"), Some(AttributeValue::String(_))));
+    }
+
+    #[test]
+    fn to_feature_sets_feature_type_and_id() {
+        let node = make_node(
+            "bldg:Building",
+            EMPTY_NS_ID,
+            vec![("gml:id", GML_NS_ID, "bldg001")],
+            vec![],
+        );
+        let feature = to_feature(&node);
+        assert_eq!(feature.feature_type(), Some("bldg:Building".to_string()));
+        assert_eq!(feature.feature_id(), Some("bldg001".to_string()));
+    }
+}

--- a/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
@@ -141,7 +141,7 @@ impl Parser {
                             });
                         } else {
                             tracing::warn!(
-                                "citygml3: empty cityObjectMember/featureMember, skipped"
+                                "citygml: empty cityObjectMember/featureMember, skipped"
                             );
                         }
                     } else {
@@ -245,7 +245,7 @@ fn collect_ids(node: &Arc<RawNode>, source_url: &str, registry: &mut RawRegistry
             tracing::error!(
                 id,
                 source_url,
-                "citygml3: duplicate gml:id encountered; keeping first definition and skipping duplicate"
+                "citygml: duplicate gml:id encountered; keeping first definition and skipping duplicate"
             );
         }
     }
@@ -264,7 +264,7 @@ fn href_to_key(href: &str, base: &Url) -> Option<RawNodeKey> {
             .ok()
             .map(|u| (u.to_string(), frag.to_string()))
     } else {
-        tracing::warn!(href, "citygml3: unsupported xlink:href format, skipped");
+        tracing::warn!(href, "citygml: unsupported xlink:href format, skipped");
         None
     }
 }
@@ -392,7 +392,7 @@ fn parse_element<R: BufRead>(
             tracing::warn!(
                 element = name.0,
                 id = key.1,
-                "citygml3: xlink:href element had inline content; inline content ignored"
+                "citygml: xlink:href element had inline content; inline content ignored"
             );
         }
         return Ok(RawNode {

--- a/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
@@ -144,3 +144,283 @@ fn neutral_uv_polygon(poly: &Polygon3D<f64>) -> Polygon2D<f64> {
         .collect();
     Polygon2D::new(ext, ints)
 }
+
+#[cfg(feature = "new-geometry")]
+pub use build_next::build_features;
+
+/// New-geometry feature building: resolves each parsed city object's references
+/// and attaches its geometry as a [`GeometryCollection`], one member per `lodN`
+/// property. Kept in its own module so its geometry imports do not collide with
+/// the legacy path's.
+#[cfg(feature = "new-geometry")]
+mod build_next {
+    use std::collections::{HashMap, HashSet};
+
+    use reearth_flow_geometry::{Geometry, GeometryCollection};
+    use reearth_flow_types::{
+        AttributeValue, Attributes, Feature, CITYGML_PARENT_GML_ID_KEY, CITYGML_ROOT_GML_ID_KEY,
+    };
+
+    use crate::citygml_parser::{
+        codespace, flatten, geometry,
+        parser::{self, Parser, RawRegistry},
+        resolver::{self, GeomRegistry},
+        utils::{gml_id_attr, NamespaceRegistry},
+        xlink,
+    };
+
+    /// Resolves the parsed document and returns one feature per top-level city object, or — when
+    /// `extract_tags` is non-empty — one feature per matching flattened node, each with its
+    /// geometry attached. Signature mirrors the legacy `build_features` so the readers share one
+    /// `finish` across geometry worlds.
+    // TODO: honor `base_attributes` and the keep/flatten options in the new-geometry path.
+    pub fn build_features(
+        parser: Parser,
+        extract_tags: &HashSet<String>,
+        _base_attributes: &HashMap<String, Attributes>,
+        _citygml_attribute_key: Option<&str>,
+        _keep_attributes: bool,
+        _flatten_single_child_objects: bool,
+        _flatten_measure_types: bool,
+    ) -> Vec<Feature> {
+        let (pending, raw_registry, geom_registry, ns_registry) = parser.finish();
+        assemble_features(
+            pending,
+            &raw_registry,
+            &geom_registry,
+            &ns_registry,
+            extract_tags,
+        )
+    }
+
+    /// Resolve every pending feature into emitted `Feature`s: one per top-level city object when
+    /// `extract_tags` is empty, or the hoisted sub-features otherwise, each with its geometry
+    /// attached.
+    fn assemble_features(
+        pending: Vec<parser::PendingFeature>,
+        raw_registry: &RawRegistry,
+        geom_registry: &GeomRegistry,
+        ns_registry: &NamespaceRegistry,
+        extract_tags: &HashSet<String>,
+    ) -> Vec<Feature> {
+        let mut out = Vec::new();
+        let mut codelist_resolver = codespace::CodelistResolver::new();
+        let mut xlink_cache = xlink::ResolveCache::new();
+
+        for parser::PendingFeature { root, geoms } in pending {
+            let Some(resolved_root) = xlink::resolve_one(&root, raw_registry, &mut xlink_cache)
+            else {
+                continue;
+            };
+            let resolved = codespace::resolve(vec![resolved_root], &mut codelist_resolver);
+            let Some(feature_root) = resolved.into_iter().next() else {
+                continue;
+            };
+
+            if extract_tags.is_empty() {
+                let mut feature = parser::to_feature(&feature_root);
+                attach_geometry(&mut feature, &geoms, geom_registry);
+                out.push(feature);
+            } else {
+                let root_gml_id = gml_id_attr(&feature_root.attrs);
+                let extracted = flatten::extract(&feature_root, extract_tags, ns_registry);
+                let emitted_ids: HashSet<String> = extracted
+                    .iter()
+                    .filter_map(|(n, _)| gml_id_attr(&n.attrs))
+                    .collect();
+                // Attach each carved geometry to its nearest emitted (hoisted) ancestor.
+                let mut by_owner: HashMap<&str, Vec<&geometry::PendingGeom>> = HashMap::new();
+                for g in &geoms {
+                    if let Some(target) = g
+                        .owner_ids
+                        .iter()
+                        .find(|id| emitted_ids.contains(id.as_str()))
+                    {
+                        by_owner.entry(target.as_str()).or_default().push(g);
+                    }
+                }
+                for (node, parent_id) in &extracted {
+                    let mut feature = parser::to_feature(node);
+                    if let Some(id) = parent_id {
+                        feature.insert(
+                            CITYGML_PARENT_GML_ID_KEY,
+                            AttributeValue::String(id.clone()),
+                        );
+                    }
+                    if let Some(ref id) = root_gml_id {
+                        feature.insert(CITYGML_ROOT_GML_ID_KEY, AttributeValue::String(id.clone()));
+                    }
+                    if let Some(gs) =
+                        gml_id_attr(&node.attrs).and_then(|id| by_owner.get(id.as_str()))
+                    {
+                        attach_geometry(&mut feature, gs.iter().copied(), geom_registry);
+                    }
+                    out.push(feature);
+                }
+            }
+        }
+        out
+    }
+
+    /// Resolve each carved geometry and set the feature's geometry to a collection of the results,
+    /// one member per geometry. Leaves the geometry unset when none resolve.
+    fn attach_geometry<'a>(
+        feature: &mut Feature,
+        geoms: impl IntoIterator<Item = &'a geometry::PendingGeom>,
+        registry: &GeomRegistry,
+    ) {
+        // TODO: carry each geometry's LOD and gml:id in the collection's per-member attributes.
+        let members: Vec<Geometry> = geoms
+            .into_iter()
+            .filter_map(|pending| {
+                resolver::resolve_root(&pending.node, registry).map(Geometry::Euclidean3D)
+            })
+            .collect();
+        if !members.is_empty() {
+            *feature.geometry_mut() =
+                Geometry::GeometryCollection(GeometryCollection::new(members));
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use reearth_flow_geometry::Euclidean3DGeometry;
+        use reearth_flow_types::CitygmlFeatureExt;
+        use url::Url;
+
+        const TA: &str = "<gml:Polygon><gml:exterior><gml:LinearRing><gml:posList>35.6000 139.8000 10.0 35.6001 139.8000 10.0 35.6000 139.8001 12.0 35.6000 139.8000 10.0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>";
+        const TB: &str = "<gml:Polygon><gml:exterior><gml:LinearRing><gml:posList>35.6001 139.8000 10.0 35.6001 139.8001 12.0 35.6000 139.8001 12.0 35.6001 139.8000 10.0</gml:posList></gml:LinearRing></gml:exterior></gml:Polygon>";
+
+        /// Parse one CityModel wrapping `members`, then assemble features under
+        /// `extract_tags` (the full pass-2 pipeline, minus forwarding).
+        fn run(members: &str, extract_tags: &[&str]) -> Vec<Feature> {
+            let xml = format!(
+                r#"<core:CityModel
+                     xmlns:core="http://www.opengis.net/citygml/3.0"
+                     xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
+                     xmlns:con="http://www.opengis.net/citygml/construction/3.0"
+                     xmlns:gml="http://www.opengis.net/gml/3.2"
+                     xmlns:xlink="http://www.w3.org/1999/xlink">{members}</core:CityModel>"#
+            );
+            let mut parser = Parser::new();
+            parser
+                .parse(xml.as_bytes(), &Url::parse("file:///test.gml").unwrap())
+                .unwrap();
+            let (pending, raw_registry, geom_registry, ns_registry) = parser.finish();
+            let tags: HashSet<String> = extract_tags.iter().map(|s| s.to_string()).collect();
+            assemble_features(pending, &raw_registry, &geom_registry, &ns_registry, &tags)
+        }
+
+        /// The single `Euclidean3D` geometry of a feature whose `GeometryCollection`
+        /// has exactly one member.
+        fn only_e3d(feature: &Feature) -> &Euclidean3DGeometry {
+            match &*feature.geometry {
+                Geometry::GeometryCollection(gc) => {
+                    assert_eq!(gc.len(), 1, "expected exactly one geometry");
+                    match &gc.members()[0] {
+                        Geometry::Euclidean3D(e) => e,
+                        other => panic!("expected a Euclidean3D member, got {other:?}"),
+                    }
+                }
+                other => panic!("expected GeometryCollection, got {other:?}"),
+            }
+        }
+
+        fn by_type<'a>(features: &'a [Feature], ty: &str) -> &'a Feature {
+            features
+                .iter()
+                .find(|f| f.feature_type().as_deref() == Some(ty))
+                .unwrap_or_else(|| panic!("no feature of type {ty}"))
+        }
+
+        fn assert_single_polygon_surface(feature: &Feature) {
+            match only_e3d(feature) {
+                Euclidean3DGeometry::Collection(c) => {
+                    assert_eq!(c.len(), 1);
+                    assert!(matches!(c.members()[0], Euclidean3DGeometry::Polygon(_)));
+                }
+                other => panic!("expected Collection[Polygon], got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn case10_feature_with_multiple_geometries() {
+            let solid = format!("<gml:Solid><gml:exterior><gml:Shell><gml:surfaceMember>{TA}</gml:surfaceMember><gml:surfaceMember>{TB}</gml:surfaceMember></gml:Shell></gml:exterior></gml:Solid>");
+            let features = run(
+                &format!(
+                    "<core:cityObjectMember><bldg:Building gml:id=\"b_multi\">\
+                       <core:lod0MultiSurface><gml:MultiSurface><gml:surfaceMember>{TA}</gml:surfaceMember></gml:MultiSurface></core:lod0MultiSurface>\
+                       <core:lod1Solid>{solid}</core:lod1Solid>\
+                       <core:lod2Solid>{solid}</core:lod2Solid>\
+                     </bldg:Building></core:cityObjectMember>"
+                ),
+                &[],
+            );
+            assert_eq!(features.len(), 1);
+            assert_eq!(
+                features[0].feature_type(),
+                Some("bldg:Building".to_string())
+            );
+            // One member per lodN property, in document order: MultiSurface, Solid, Solid.
+            match &*features[0].geometry {
+                Geometry::GeometryCollection(gc) => {
+                    let m = gc.members();
+                    assert_eq!(m.len(), 3);
+                    assert!(matches!(
+                        m[0],
+                        Geometry::Euclidean3D(Euclidean3DGeometry::Collection(_))
+                    ));
+                    assert!(matches!(
+                        m[1],
+                        Geometry::Euclidean3D(Euclidean3DGeometry::Solid(_))
+                    ));
+                    assert!(matches!(
+                        m[2],
+                        Geometry::Euclidean3D(Euclidean3DGeometry::Solid(_))
+                    ));
+                }
+                other => panic!("expected GeometryCollection, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn case11_flatten_hoists_children() {
+            let members = format!(
+                "<core:cityObjectMember><bldg:Building gml:id=\"b_par\">\
+                   <core:boundary><con:WallSurface gml:id=\"wall1\"><core:lod2MultiSurface><gml:MultiSurface><gml:surfaceMember>{TA}</gml:surfaceMember></gml:MultiSurface></core:lod2MultiSurface></con:WallSurface></core:boundary>\
+                   <core:boundary><con:RoofSurface gml:id=\"roof1\"><core:lod2MultiSurface><gml:MultiSurface><gml:surfaceMember>{TB}</gml:surfaceMember></gml:MultiSurface></core:lod2MultiSurface></con:RoofSurface></core:boundary>\
+                 </bldg:Building></core:cityObjectMember>"
+            );
+            let features = run(&members, &["WallSurface", "RoofSurface"]);
+            // Two children hoisted; the Building itself is dropped (not in the tag set).
+            assert_eq!(features.len(), 2);
+            assert_single_polygon_surface(by_type(&features, "con:WallSurface"));
+            assert_single_polygon_surface(by_type(&features, "con:RoofSurface"));
+            assert_eq!(
+                by_type(&features, "con:WallSurface").feature_id(),
+                Some("wall1".to_string())
+            );
+        }
+
+        #[test]
+        fn case12_flatten_parent_and_child() {
+            let members = format!(
+                "<core:cityObjectMember><bldg:Building gml:id=\"b_par\">\
+                   <core:lod1Solid><gml:Solid><gml:exterior><gml:Shell><gml:surfaceMember>{TA}</gml:surfaceMember><gml:surfaceMember>{TB}</gml:surfaceMember></gml:Shell></gml:exterior></gml:Solid></core:lod1Solid>\
+                   <core:boundary><con:WallSurface gml:id=\"wall1\"><core:lod2MultiSurface><gml:MultiSurface><gml:surfaceMember>{TA}</gml:surfaceMember></gml:MultiSurface></core:lod2MultiSurface></con:WallSurface></core:boundary>\
+                   <core:boundary><con:RoofSurface gml:id=\"roof1\"><core:lod2MultiSurface><gml:MultiSurface><gml:surfaceMember>{TB}</gml:surfaceMember></gml:MultiSurface></core:lod2MultiSurface></con:RoofSurface></core:boundary>\
+                 </bldg:Building></core:cityObjectMember>"
+            );
+            let features = run(&members, &["Building", "WallSurface", "RoofSurface"]);
+            assert_eq!(features.len(), 3);
+            // The Building keeps only its own lod1Solid (its boundary surfaces are hoisted out).
+            match only_e3d(by_type(&features, "bldg:Building")) {
+                Euclidean3DGeometry::Solid(s) => assert_eq!(s.exterior().num_faces(), 2),
+                other => panic!("expected Solid, got {other:?}"),
+            }
+            assert_single_polygon_surface(by_type(&features, "con:WallSurface"));
+            assert_single_polygon_surface(by_type(&features, "con:RoofSurface"));
+        }
+    }
+}

--- a/engine/runtime/action-processor/src/citygml_parser/resolver.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/resolver.rs
@@ -1,4 +1,4 @@
-//! Pass-2 geometry resolution for the CityGML 3.0 reader.
+//! Pass-2 geometry resolution for the CityGML reader.
 //!
 //! Pass 1 parses every geometry that is guaranteed to be fully inline directly
 //! into [`Euclidean3DGeometry`]; the remaining reference-bearing containers are
@@ -65,7 +65,7 @@ pub(super) enum Role {
 /// Registry of geometries reachable by `xlink:href`, keyed by `(file_url, gml:id)`.
 pub(super) type GeomRegistry = HashMap<RawNodeKey, GeomNode>;
 
-/// The CityGML 3.0 / GML 3.2 geometry types the reader recognizes.
+/// The CityGML / GML geometry types the reader recognizes.
 ///
 /// The types split into ones that are always fully inline, parsed whole in pass 1,
 /// and reference-bearing containers assembled in pass 2; see
@@ -172,7 +172,7 @@ fn resolve_ref(
     in_progress: &mut HashSet<RawNodeKey>,
 ) -> Option<Euclidean3DGeometry> {
     if !in_progress.insert(key.clone()) {
-        tracing::warn!(id = key.1, "citygml3 geometry: cyclic xlink:href, skipped");
+        tracing::warn!(id = key.1, "citygml geometry: cyclic xlink:href, skipped");
         return None;
     }
     let resolved = match registry.get(key) {
@@ -180,7 +180,7 @@ fn resolve_ref(
         None => {
             tracing::warn!(
                 id = key.1,
-                "citygml3 geometry: unresolved xlink:href, skipped"
+                "citygml geometry: unresolved xlink:href, skipped"
             );
             None
         }
@@ -221,7 +221,7 @@ fn construct(
         GmlGeometryType::CompositeSurface | GmlGeometryType::Shell => surface_mesh(members),
         GmlGeometryType::Solid => solid(members),
         _ => {
-            tracing::warn!("citygml3 geometry: inline type deferred to pass 2, skipped");
+            tracing::warn!("citygml geometry: inline type deferred to pass 2, skipped");
             None
         }
     }
@@ -241,7 +241,7 @@ fn ring(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometry
     for (_, geometry) in members {
         match into_line_string(geometry) {
             Some(line) => exterior.extend_from_slice(line.coords()),
-            None => tracing::warn!("citygml3 geometry: non-curve ring member, skipped"),
+            None => tracing::warn!("citygml geometry: non-curve ring member, skipped"),
         }
     }
     if exterior.is_empty() {
@@ -253,9 +253,8 @@ fn ring(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometry
 
 /// Assemble surface members into one mesh, for a `CompositeSurface` or a solid's
 /// `Shell`. A single already-built mesh passes through as-is; otherwise bare
-/// polygon members are welded into a mesh and merged with any polygon-mesh
-/// members into one. Triangle-mesh members cannot be merged into a polygon mesh
-/// and are skipped with a warning.
+/// polygon members are welded into a single mesh. Mesh members mixed with other
+/// members are not yet supported and are skipped with a warning.
 fn surface_mesh(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometry> {
     if members.len() == 1
         && matches!(
@@ -267,35 +266,21 @@ fn surface_mesh(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3D
     }
 
     let mut faces: Vec<Polygon3D> = Vec::new();
-    let mut meshes: Vec<PolygonMesh3D> = Vec::new();
     for (_, geometry) in members {
         match geometry {
             Euclidean3DGeometry::Polygon(polygon) => faces.push(*polygon),
-            Euclidean3DGeometry::PolygonMesh(mesh) => meshes.push(*mesh),
-            Euclidean3DGeometry::TriangularMesh(_) => tracing::warn!(
-                "citygml3 geometry: merging a triangle mesh into a composite surface is not supported, member skipped"
-            ),
-            _ => tracing::warn!("citygml3 geometry: expected a surface member, skipped"),
+            Euclidean3DGeometry::PolygonMesh(_) | Euclidean3DGeometry::TriangularMesh(_) => {
+                tracing::warn!(
+                    "citygml geometry: merging a mesh into a composite surface is not yet supported, member skipped"
+                )
+            }
+            _ => tracing::warn!("citygml geometry: expected a surface member, skipped"),
         }
     }
-    if !faces.is_empty() {
-        meshes.extend(build_mesh(faces));
-    }
-    if meshes.len() == 1 {
-        return Some(Euclidean3DGeometry::PolygonMesh(Box::new(
-            meshes.pop().unwrap(),
-        )));
-    }
-    if meshes.is_empty() {
+    if faces.is_empty() {
         return None;
     }
-    match PolygonMesh3D::merge(FRAME, meshes) {
-        Ok(mesh) => Some(Euclidean3DGeometry::PolygonMesh(Box::new(mesh))),
-        Err(e) => {
-            tracing::warn!("citygml3 geometry: failed to merge composite surface: {e}");
-            None
-        }
-    }
+    build_mesh(faces).map(|mesh| Euclidean3DGeometry::PolygonMesh(Box::new(mesh)))
 }
 
 /// Pair an exterior boundary with any interior void boundaries into a `Solid`.
@@ -306,11 +291,11 @@ fn solid(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometr
         match role {
             Role::Exterior if exterior.is_none() => exterior = into_shell(geometry),
             Role::Exterior => {
-                tracing::warn!("citygml3 geometry: solid with multiple exteriors, extra skipped")
+                tracing::warn!("citygml geometry: solid with multiple exteriors, extra skipped")
             }
             Role::Interior => interiors.extend(into_shell(geometry)),
             Role::Member => {
-                tracing::warn!("citygml3 geometry: unexpected solid member role, skipped")
+                tracing::warn!("citygml geometry: unexpected solid member role, skipped")
             }
         }
     }
@@ -325,7 +310,7 @@ fn build_mesh(faces: Vec<Polygon3D>) -> Option<PolygonMesh3D> {
     match PolygonMesh3D::from_polygons(FRAME, &faces) {
         Ok(mesh) => Some(mesh),
         Err(e) => {
-            tracing::warn!("citygml3 geometry: failed to weld mesh: {e}");
+            tracing::warn!("citygml geometry: failed to weld mesh: {e}");
             None
         }
     }
@@ -336,7 +321,7 @@ fn into_line_string(geometry: Euclidean3DGeometry) -> Option<LineString3D> {
     match geometry {
         Euclidean3DGeometry::LineString(line) => Some(line),
         _ => {
-            tracing::warn!("citygml3 geometry: expected a curve, skipped");
+            tracing::warn!("citygml geometry: expected a curve, skipped");
             None
         }
     }
@@ -354,7 +339,7 @@ fn into_shell(geometry: Euclidean3DGeometry) -> Option<Shell> {
             build_mesh(vec![*polygon]).map(|mesh| Shell::PolygonMesh(mesh.into_data()))
         }
         _ => {
-            tracing::warn!("citygml3 geometry: cannot use as a solid boundary, skipped");
+            tracing::warn!("citygml geometry: cannot use as a solid boundary, skipped");
             None
         }
     }
@@ -474,31 +459,17 @@ mod tests {
     }
 
     #[test]
-    fn composite_surface_merges_multiple_mesh_members() {
-        let n = node(
-            GmlGeometryType::CompositeSurface,
-            vec![
-                (Role::Member, resolved(two_face_mesh())),
-                (Role::Member, resolved(two_face_mesh())),
-            ],
-        );
-        match resolve_root(&n, &GeomRegistry::new()).unwrap() {
-            Euclidean3DGeometry::PolygonMesh(mesh) => assert_eq!(mesh.num_faces(), 4),
-            other => panic!("expected PolygonMesh, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn composite_surface_merges_mesh_and_polygon_members() {
+    fn composite_surface_welds_polygons_and_skips_mesh_members() {
         let n = node(
             GmlGeometryType::CompositeSurface,
             vec![
                 (Role::Member, resolved(two_face_mesh())),
                 (Role::Member, resolved(triangle())),
+                (Role::Member, resolved(triangle())),
             ],
         );
         match resolve_root(&n, &GeomRegistry::new()).unwrap() {
-            Euclidean3DGeometry::PolygonMesh(mesh) => assert_eq!(mesh.num_faces(), 3),
+            Euclidean3DGeometry::PolygonMesh(mesh) => assert_eq!(mesh.num_faces(), 2),
             other => panic!("expected PolygonMesh, got {other:?}"),
         }
     }

--- a/engine/runtime/action-processor/src/citygml_parser/resolver.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/resolver.rs
@@ -1,0 +1,566 @@
+//! Pass-2 geometry resolution for the CityGML 3.0 reader.
+//!
+//! Pass 1 parses every geometry that is guaranteed to be fully inline directly
+//! into [`Euclidean3DGeometry`]; the remaining reference-bearing containers are
+//! left as [`Unresolved`] nodes and assembled here once every `gml:id` is known.
+//! See `GEOMETRY_MAPPING.md` for the CityGML-to-Flow type mapping.
+
+use std::collections::{HashMap, HashSet};
+
+use reearth_flow_geometry::collection::Collection3D;
+use reearth_flow_geometry::coordinate::Coordinate;
+use reearth_flow_geometry::line_string::LineString3D;
+use reearth_flow_geometry::polygon::Polygon3D;
+use reearth_flow_geometry::polygon_mesh::PolygonMesh3D;
+use reearth_flow_geometry::solid::{Shell, Solid};
+use reearth_flow_geometry::Euclidean3DGeometry;
+
+use super::parser::RawNodeKey;
+
+/// The coordinate frame all resolved geometry is expressed in; CityGML `srsName`
+/// / EPSG handling happens downstream.
+pub(super) const FRAME: Coordinate = Coordinate::Euclidean;
+
+/// A node in a CityGML geometry tree during pass-2 resolution: a geometry already
+/// built in pass 1, a reference still to be looked up, or a container still to be
+/// assembled from its members.
+pub(super) enum GeomNode {
+    /// A geometry fully parsed in pass 1: an inline leaf, or a container that
+    /// turned out to be reference-free and was assembled eagerly.
+    Resolved(Euclidean3DGeometry),
+    /// An `xlink:href`, resolved against the geometry registry in pass 2.
+    Ref(RawNodeKey),
+    /// A container awaiting assembly from its resolved members.
+    Unresolved(Unresolved),
+}
+
+/// A geometry container held until pass 2, when its members are resolved and
+/// folded into a single [`Euclidean3DGeometry`].
+pub(super) struct Unresolved {
+    /// The CityGML type, selecting which construction site assembles this node.
+    pub(super) ty: GmlGeometryType,
+    /// The `gml:id`, if any, under which this node is registered as a reference
+    /// target.
+    pub(super) id: Option<String>,
+    /// The child geometries, each tagged with the GML property that owns it.
+    pub(super) members: Vec<(Role, GeomNode)>,
+}
+
+/// The GML property a member fills within its parent container.
+///
+/// Only `Solid` distinguishes its roles; every other container has a single member
+/// role, for which [`Role::Member`] stands in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Role {
+    /// The sole member role of aggregates and single-base wrappers (`pointMember`,
+    /// `curveMember`, `surfaceMember`, `solidMember`, `geometryMember`, `element`,
+    /// `baseCurve`, `baseSurface`).
+    Member,
+    /// A `Solid`'s outer boundary shell (`exterior`).
+    Exterior,
+    /// A `Solid`'s inner void boundary shell (`interior`).
+    Interior,
+}
+
+/// Registry of geometries reachable by `xlink:href`, keyed by `(file_url, gml:id)`.
+pub(super) type GeomRegistry = HashMap<RawNodeKey, GeomNode>;
+
+/// The CityGML 3.0 / GML 3.2 geometry types the reader recognizes.
+///
+/// The types split into ones that are always fully inline, parsed whole in pass 1,
+/// and reference-bearing containers assembled in pass 2; see
+/// [`GmlGeometryType::is_inline`].
+pub(super) enum GmlGeometryType {
+    /// A single position. Inline.
+    Point,
+    /// A chain of positions. Inline.
+    LineString,
+    /// A chain of inline curve segments. Inline. Parsing is deferred; see
+    /// `build_leaf`.
+    Curve,
+    /// A single closed ring. Inline.
+    LinearRing,
+    /// An exterior ring with optional interior holes. Inline.
+    Polygon,
+    /// Inline polygon patches. Inline.
+    Surface,
+    /// Inline polygon patches forming a connected surface. Inline.
+    PolyhedralSurface,
+    /// Inline triangle patches. Inline.
+    TriangulatedSurface,
+    /// Inline triangle patches with control points. Inline.
+    Tin,
+    /// A collection of points.
+    MultiPoint,
+    /// A single base curve, possibly reversed.
+    OrientableCurve,
+    /// Curve members forming one connected curve.
+    CompositeCurve,
+    /// A collection of curves.
+    MultiCurve,
+    /// Curve members concatenated into one closed ring.
+    Ring,
+    /// A single base surface, possibly flipped.
+    OrientableSurface,
+    /// Surface members forming one connected surface.
+    CompositeSurface,
+    /// A collection of surfaces.
+    MultiSurface,
+    /// Surface members bounding a solid.
+    Shell,
+    /// An exterior shell with optional interior void shells.
+    Solid,
+    /// Solid members forming one connected solid.
+    CompositeSolid,
+    /// A collection of solids.
+    MultiSolid,
+    /// A heterogeneous collection of geometries.
+    MultiGeometry,
+    /// A heterogeneous collection of geometric primitives.
+    GeometricComplex,
+}
+
+impl GmlGeometryType {
+    /// Whether this type is always fully buildable while streaming, i.e. it can
+    /// carry no `xlink:href` in any child property and every child type is itself
+    /// inline. These are parsed in pass 1; every other type defers to pass 2.
+    pub(super) fn is_inline(&self) -> bool {
+        matches!(
+            self,
+            GmlGeometryType::Point
+                | GmlGeometryType::LineString
+                | GmlGeometryType::Curve
+                | GmlGeometryType::LinearRing
+                | GmlGeometryType::Polygon
+                | GmlGeometryType::Surface
+                | GmlGeometryType::PolyhedralSurface
+                | GmlGeometryType::TriangulatedSurface
+                | GmlGeometryType::Tin
+        )
+    }
+}
+
+/// Resolve a top-level geometry node into a single [`Euclidean3DGeometry`],
+/// following `xlink:href` references through `registry`. Returns `None` when the
+/// node, or every one of its members, cannot be resolved.
+pub(super) fn resolve_root(
+    node: &GeomNode,
+    registry: &GeomRegistry,
+) -> Option<Euclidean3DGeometry> {
+    resolve(node, registry, &mut HashSet::new())
+}
+
+/// Resolve one node. `in_progress` holds the `xlink` keys on the current
+/// resolution path, so a reference cycle is caught instead of recursing forever.
+fn resolve(
+    node: &GeomNode,
+    registry: &GeomRegistry,
+    in_progress: &mut HashSet<RawNodeKey>,
+) -> Option<Euclidean3DGeometry> {
+    match node {
+        GeomNode::Resolved(geometry) => Some(geometry.clone()),
+        GeomNode::Ref(key) => resolve_ref(key, registry, in_progress),
+        GeomNode::Unresolved(unresolved) => construct(unresolved, registry, in_progress),
+    }
+}
+
+/// Resolve an `xlink:href` target through `registry`. `in_progress` holds the keys
+/// on the current path, so a reference cycle is caught instead of recursing forever.
+fn resolve_ref(
+    key: &RawNodeKey,
+    registry: &GeomRegistry,
+    in_progress: &mut HashSet<RawNodeKey>,
+) -> Option<Euclidean3DGeometry> {
+    if !in_progress.insert(key.clone()) {
+        tracing::warn!(id = key.1, "citygml3 geometry: cyclic xlink:href, skipped");
+        return None;
+    }
+    let resolved = match registry.get(key) {
+        Some(target) => resolve(target, registry, in_progress),
+        None => {
+            tracing::warn!(
+                id = key.1,
+                "citygml3 geometry: unresolved xlink:href, skipped"
+            );
+            None
+        }
+    };
+    in_progress.remove(key);
+    resolved
+}
+
+/// Assemble a container from its resolved members, dispatching on its CityGML
+/// type. Members that fail to resolve are dropped, so a container survives with
+/// whatever members did resolve.
+fn construct(
+    node: &Unresolved,
+    registry: &GeomRegistry,
+    in_progress: &mut HashSet<RawNodeKey>,
+) -> Option<Euclidean3DGeometry> {
+    let members: Vec<(Role, Euclidean3DGeometry)> = node
+        .members
+        .iter()
+        .filter_map(|(role, child)| resolve(child, registry, in_progress).map(|g| (*role, g)))
+        .collect();
+
+    match node.ty {
+        GmlGeometryType::MultiPoint
+        | GmlGeometryType::MultiCurve
+        | GmlGeometryType::CompositeCurve
+        | GmlGeometryType::MultiSurface
+        | GmlGeometryType::CompositeSolid
+        | GmlGeometryType::MultiSolid
+        | GmlGeometryType::MultiGeometry
+        | GmlGeometryType::GeometricComplex => Some(collection(members)),
+        // A single base curve/surface passes through unchanged.
+        // TODO: honor orientation="-" (reverse curve / flip surface normals).
+        GmlGeometryType::OrientableCurve | GmlGeometryType::OrientableSurface => {
+            members.into_iter().next().map(|(_, geometry)| geometry)
+        }
+        GmlGeometryType::Ring => ring(members),
+        GmlGeometryType::CompositeSurface | GmlGeometryType::Shell => surface_mesh(members),
+        GmlGeometryType::Solid => solid(members),
+        _ => {
+            tracing::warn!("citygml3 geometry: inline type deferred to pass 2, skipped");
+            None
+        }
+    }
+}
+
+/// Gather members into a `Collection`, discarding their roles.
+fn collection(members: Vec<(Role, Euclidean3DGeometry)>) -> Euclidean3DGeometry {
+    Euclidean3DGeometry::Collection(Collection3D::new(
+        members.into_iter().map(|(_, geometry)| geometry),
+    ))
+}
+
+/// Concatenate curve members into one open exterior ring, yielding a single-ring
+/// `Polygon`.
+fn ring(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometry> {
+    let mut exterior: Vec<[f64; 3]> = Vec::new();
+    for (_, geometry) in members {
+        match into_line_string(geometry) {
+            Some(line) => exterior.extend_from_slice(line.coords()),
+            None => tracing::warn!("citygml3 geometry: non-curve ring member, skipped"),
+        }
+    }
+    if exterior.is_empty() {
+        return None;
+    }
+    let polygon = Polygon3D::from_rings(FRAME, exterior, Vec::<Vec<[f64; 3]>>::new());
+    Some(Euclidean3DGeometry::Polygon(Box::new(polygon)))
+}
+
+/// Assemble surface members into one mesh, for a `CompositeSurface` or a solid's
+/// `Shell`. A single already-built mesh passes through as-is; otherwise bare
+/// polygon members are welded into a mesh and merged with any polygon-mesh
+/// members into one. Triangle-mesh members cannot be merged into a polygon mesh
+/// and are skipped with a warning.
+fn surface_mesh(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometry> {
+    if members.len() == 1
+        && matches!(
+            members[0].1,
+            Euclidean3DGeometry::PolygonMesh(_) | Euclidean3DGeometry::TriangularMesh(_)
+        )
+    {
+        return members.into_iter().next().map(|(_, geometry)| geometry);
+    }
+
+    let mut faces: Vec<Polygon3D> = Vec::new();
+    let mut meshes: Vec<PolygonMesh3D> = Vec::new();
+    for (_, geometry) in members {
+        match geometry {
+            Euclidean3DGeometry::Polygon(polygon) => faces.push(*polygon),
+            Euclidean3DGeometry::PolygonMesh(mesh) => meshes.push(*mesh),
+            Euclidean3DGeometry::TriangularMesh(_) => tracing::warn!(
+                "citygml3 geometry: merging a triangle mesh into a composite surface is not supported, member skipped"
+            ),
+            _ => tracing::warn!("citygml3 geometry: expected a surface member, skipped"),
+        }
+    }
+    if !faces.is_empty() {
+        meshes.extend(build_mesh(faces));
+    }
+    if meshes.len() == 1 {
+        return Some(Euclidean3DGeometry::PolygonMesh(Box::new(
+            meshes.pop().unwrap(),
+        )));
+    }
+    if meshes.is_empty() {
+        return None;
+    }
+    match PolygonMesh3D::merge(FRAME, meshes) {
+        Ok(mesh) => Some(Euclidean3DGeometry::PolygonMesh(Box::new(mesh))),
+        Err(e) => {
+            tracing::warn!("citygml3 geometry: failed to merge composite surface: {e}");
+            None
+        }
+    }
+}
+
+/// Pair an exterior boundary with any interior void boundaries into a `Solid`.
+fn solid(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometry> {
+    let mut exterior: Option<Shell> = None;
+    let mut interiors: Vec<Shell> = Vec::new();
+    for (role, geometry) in members {
+        match role {
+            Role::Exterior if exterior.is_none() => exterior = into_shell(geometry),
+            Role::Exterior => {
+                tracing::warn!("citygml3 geometry: solid with multiple exteriors, extra skipped")
+            }
+            Role::Interior => interiors.extend(into_shell(geometry)),
+            Role::Member => {
+                tracing::warn!("citygml3 geometry: unexpected solid member role, skipped")
+            }
+        }
+    }
+    let exterior = exterior?;
+    Some(Euclidean3DGeometry::Solid(Box::new(Solid::new(
+        FRAME, exterior, interiors,
+    ))))
+}
+
+/// Weld independent faces into one polygon mesh in [`FRAME`].
+fn build_mesh(faces: Vec<Polygon3D>) -> Option<PolygonMesh3D> {
+    match PolygonMesh3D::from_polygons(FRAME, &faces) {
+        Ok(mesh) => Some(mesh),
+        Err(e) => {
+            tracing::warn!("citygml3 geometry: failed to weld mesh: {e}");
+            None
+        }
+    }
+}
+
+/// Coerce a resolved member to a curve.
+fn into_line_string(geometry: Euclidean3DGeometry) -> Option<LineString3D> {
+    match geometry {
+        Euclidean3DGeometry::LineString(line) => Some(line),
+        _ => {
+            tracing::warn!("citygml3 geometry: expected a curve, skipped");
+            None
+        }
+    }
+}
+
+/// Coerce a resolved member to a solid boundary shell. A `CompositeSurface` or
+/// `Shell` boundary has already been assembled into a mesh by [`surface_mesh`], so
+/// this just unwraps it; a bare `Polygon` boundary is welded into a single-face
+/// mesh.
+fn into_shell(geometry: Euclidean3DGeometry) -> Option<Shell> {
+    match geometry {
+        Euclidean3DGeometry::PolygonMesh(mesh) => Some(Shell::PolygonMesh(mesh.into_data())),
+        Euclidean3DGeometry::TriangularMesh(mesh) => Some(Shell::TriangularMesh(mesh.into_data())),
+        Euclidean3DGeometry::Polygon(polygon) => {
+            build_mesh(vec![*polygon]).map(|mesh| Shell::PolygonMesh(mesh.into_data()))
+        }
+        _ => {
+            tracing::warn!("citygml3 geometry: cannot use as a solid boundary, skipped");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reearth_flow_geometry::point::Point3D;
+
+    fn key(id: &str) -> RawNodeKey {
+        ("file:///test.gml".to_string(), id.to_string())
+    }
+
+    fn point() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Point(Point3D::new(FRAME, [1.0, 2.0, 3.0]))
+    }
+
+    fn triangle() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Polygon(Box::new(Polygon3D::from_rings(
+            FRAME,
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            Vec::<Vec<[f64; 3]>>::new(),
+        )))
+    }
+
+    fn line() -> Euclidean3DGeometry {
+        Euclidean3DGeometry::LineString(LineString3D::from_coords(
+            FRAME,
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0]],
+        ))
+    }
+
+    fn resolved(geometry: Euclidean3DGeometry) -> GeomNode {
+        GeomNode::Resolved(geometry)
+    }
+
+    fn node(ty: GmlGeometryType, members: Vec<(Role, GeomNode)>) -> GeomNode {
+        GeomNode::Unresolved(Unresolved {
+            ty,
+            id: None,
+            members,
+        })
+    }
+
+    fn collection_len(geometry: &Euclidean3DGeometry) -> usize {
+        match geometry {
+            Euclidean3DGeometry::Collection(collection) => collection.len(),
+            other => panic!("expected a collection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multipoint_becomes_collection() {
+        let n = node(
+            GmlGeometryType::MultiPoint,
+            vec![
+                (Role::Member, resolved(point())),
+                (Role::Member, resolved(point())),
+            ],
+        );
+        let geometry = resolve_root(&n, &GeomRegistry::new()).unwrap();
+        assert_eq!(collection_len(&geometry), 2);
+    }
+
+    #[test]
+    fn shell_welds_polygons_into_mesh() {
+        let n = node(
+            GmlGeometryType::Shell,
+            vec![
+                (Role::Member, resolved(triangle())),
+                (Role::Member, resolved(triangle())),
+            ],
+        );
+        let geometry = resolve_root(&n, &GeomRegistry::new()).unwrap();
+        assert!(matches!(geometry, Euclidean3DGeometry::PolygonMesh(_)));
+    }
+
+    #[test]
+    fn solid_from_exterior_shell() {
+        let shell = node(
+            GmlGeometryType::Shell,
+            vec![(Role::Member, resolved(triangle()))],
+        );
+        let n = node(GmlGeometryType::Solid, vec![(Role::Exterior, shell)]);
+        let geometry = resolve_root(&n, &GeomRegistry::new()).unwrap();
+        assert!(matches!(geometry, Euclidean3DGeometry::Solid(_)));
+    }
+
+    #[test]
+    fn composite_surface_welds_polygons_into_mesh() {
+        let n = node(
+            GmlGeometryType::CompositeSurface,
+            vec![
+                (Role::Member, resolved(triangle())),
+                (Role::Member, resolved(triangle())),
+            ],
+        );
+        let geometry = resolve_root(&n, &GeomRegistry::new()).unwrap();
+        assert!(matches!(geometry, Euclidean3DGeometry::PolygonMesh(_)));
+    }
+
+    fn two_face_mesh() -> Euclidean3DGeometry {
+        let a = Polygon3D::from_rings(
+            FRAME,
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
+        let b = Polygon3D::from_rings(
+            FRAME,
+            [[1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]],
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
+        Euclidean3DGeometry::PolygonMesh(Box::new(
+            PolygonMesh3D::from_polygons(FRAME, &[a, b]).unwrap(),
+        ))
+    }
+
+    #[test]
+    fn composite_surface_merges_multiple_mesh_members() {
+        let n = node(
+            GmlGeometryType::CompositeSurface,
+            vec![
+                (Role::Member, resolved(two_face_mesh())),
+                (Role::Member, resolved(two_face_mesh())),
+            ],
+        );
+        match resolve_root(&n, &GeomRegistry::new()).unwrap() {
+            Euclidean3DGeometry::PolygonMesh(mesh) => assert_eq!(mesh.num_faces(), 4),
+            other => panic!("expected PolygonMesh, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn composite_surface_merges_mesh_and_polygon_members() {
+        let n = node(
+            GmlGeometryType::CompositeSurface,
+            vec![
+                (Role::Member, resolved(two_face_mesh())),
+                (Role::Member, resolved(triangle())),
+            ],
+        );
+        match resolve_root(&n, &GeomRegistry::new()).unwrap() {
+            Euclidean3DGeometry::PolygonMesh(mesh) => assert_eq!(mesh.num_faces(), 3),
+            other => panic!("expected PolygonMesh, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn solid_from_composite_surface_exterior() {
+        // PLATEAU's common shape: a Solid whose boundary is a CompositeSurface.
+        let boundary = node(
+            GmlGeometryType::CompositeSurface,
+            vec![(Role::Member, resolved(triangle()))],
+        );
+        let n = node(GmlGeometryType::Solid, vec![(Role::Exterior, boundary)]);
+        let geometry = resolve_root(&n, &GeomRegistry::new()).unwrap();
+        assert!(matches!(geometry, Euclidean3DGeometry::Solid(_)));
+    }
+
+    #[test]
+    fn ring_concatenates_curves_into_polygon() {
+        let n = node(
+            GmlGeometryType::Ring,
+            vec![(Role::Member, resolved(line()))],
+        );
+        let geometry = resolve_root(&n, &GeomRegistry::new()).unwrap();
+        assert!(matches!(geometry, Euclidean3DGeometry::Polygon(_)));
+    }
+
+    #[test]
+    fn ref_resolves_via_registry() {
+        let mut registry = GeomRegistry::new();
+        registry.insert(key("p1"), resolved(point()));
+        let n = node(
+            GmlGeometryType::MultiPoint,
+            vec![(Role::Member, GeomNode::Ref(key("p1")))],
+        );
+        let geometry = resolve_root(&n, &registry).unwrap();
+        assert_eq!(collection_len(&geometry), 1);
+    }
+
+    #[test]
+    fn unresolved_ref_is_dropped() {
+        let n = node(
+            GmlGeometryType::MultiPoint,
+            vec![
+                (Role::Member, GeomNode::Ref(key("missing"))),
+                (Role::Member, resolved(point())),
+            ],
+        );
+        let geometry = resolve_root(&n, &GeomRegistry::new()).unwrap();
+        assert_eq!(collection_len(&geometry), 1);
+    }
+
+    #[test]
+    fn cyclic_ref_terminates() {
+        let mut registry = GeomRegistry::new();
+        registry.insert(
+            key("a"),
+            node(
+                GmlGeometryType::MultiGeometry,
+                vec![(Role::Member, GeomNode::Ref(key("a")))],
+            ),
+        );
+        let geometry = resolve_root(&GeomNode::Ref(key("a")), &registry).unwrap();
+        assert_eq!(collection_len(&geometry), 0);
+    }
+}

--- a/engine/runtime/action-processor/src/citygml_parser/xlink.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/xlink.rs
@@ -26,6 +26,30 @@ pub fn resolve(
         .collect()
 }
 
+/// Dedup cache of resolved nodes, keyed by the pointer of a `RawNode` held alive
+/// by the registry or a pending feature. Shared across features in one batch so an
+/// attribute node referenced from several features is converted only once.
+#[cfg(feature = "new-geometry")]
+pub type ResolveCache = HashMap<*const RawNode, Arc<XmlNode>>;
+
+/// Resolve a single feature root, reusing `cache` across calls. Returns `None`
+/// when the root cannot be resolved because of a cyclic `xlink:href`.
+#[cfg(feature = "new-geometry")]
+pub fn resolve_one(
+    raw: &Arc<RawNode>,
+    registry: &RawRegistry,
+    cache: &mut ResolveCache,
+) -> Option<Arc<XmlNode>> {
+    let mut in_progress: HashSet<*const RawNode> = HashSet::new();
+    convert_node(raw, registry, cache, &mut in_progress).or_else(|| {
+        tracing::error!(
+            name = raw.name.0.as_str(),
+            "failed to resolve top-level node due to cyclic xlink reference, skipped"
+        );
+        None
+    })
+}
+
 fn convert_node(
     raw: &Arc<RawNode>,
     registry: &RawRegistry,
@@ -74,7 +98,9 @@ fn convert_node(
     Some(node)
 }
 
-#[cfg(test)]
+// Exercises the shared xlink resolution via the legacy parser's `finish`; the geometry world
+// covers the same code path through the pipeline's assembly tests.
+#[cfg(all(test, not(feature = "new-geometry")))]
 mod tests {
     use std::sync::Arc;
     use url::Url;

--- a/engine/runtime/action-processor/src/feature/reader/citygml2.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml2.rs
@@ -16,7 +16,6 @@ use serde_json::Value;
 use url::Url;
 
 use crate::citygml_parser::parser::Parser;
-#[cfg(not(feature = "new-geometry"))]
 use crate::citygml_parser::pipeline::build_features;
 use crate::feature::errors::FeatureProcessorError;
 
@@ -207,7 +206,6 @@ impl Processor for FeatureCityGml2Reader {
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-processor/src/feature/reader/citygml3.rs
+++ b/engine/runtime/action-processor/src/feature/reader/citygml3.rs
@@ -16,7 +16,6 @@ use serde_json::Value;
 use url::Url;
 
 use crate::citygml_parser::parser::Parser;
-#[cfg(not(feature = "new-geometry"))]
 use crate::citygml_parser::pipeline::build_features;
 use crate::feature::errors::FeatureProcessorError;
 
@@ -207,7 +206,6 @@ impl Processor for FeatureCityGml3Reader {
         Ok(())
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     fn finish(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -94,6 +94,21 @@ impl Collection3D {
     pub(crate) fn members_mut(&mut self) -> &mut [Euclidean3DGeometry] {
         &mut self.members
     }
+
+    /// The number of members.
+    pub fn len(&self) -> usize {
+        self.members.len()
+    }
+
+    /// Whether the collection has no members.
+    pub fn is_empty(&self) -> bool {
+        self.members.is_empty()
+    }
+
+    /// The members, in order.
+    pub fn members(&self) -> &[Euclidean3DGeometry] {
+        &self.members
+    }
 }
 
 impl BoundingBox for Collection2D {

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -114,6 +114,21 @@ impl GeometryCollection {
     pub(crate) fn members_mut(&mut self) -> &mut [Geometry] {
         &mut self.members
     }
+
+    /// The number of members.
+    pub fn len(&self) -> usize {
+        self.members.len()
+    }
+
+    /// Whether the collection has no members.
+    pub fn is_empty(&self) -> bool {
+        self.members.is_empty()
+    }
+
+    /// The members, in order.
+    pub fn members(&self) -> &[Geometry] {
+        &self.members
+    }
 }
 
 /// 2D-embedded geometry. All coordinates are 2D `(x, y)`; some leaves carry an

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -32,5 +32,13 @@ pub struct LineString3D {
     coords: Box<[[f64; 3]]>,
 }
 
+impl LineString3D {
+    /// The chain's vertices in order.
+    #[inline]
+    pub fn coords(&self) -> &[[f64; 3]] {
+        &self.coords
+    }
+}
+
 crate::unsupported!(LineString2D: Triangulate);
 crate::unsupported!(LineString3D: Triangulate);

--- a/engine/runtime/geometry/src/point/mod.rs
+++ b/engine/runtime/geometry/src/point/mod.rs
@@ -25,5 +25,13 @@ pub struct Point3D {
     position: [f64; 3],
 }
 
+impl Point3D {
+    /// The `[x, y, z]` position.
+    #[inline]
+    pub fn position(&self) -> [f64; 3] {
+        self.position
+    }
+}
+
 crate::unsupported!(Point2D: Triangulate);
 crate::unsupported!(Point3D: Triangulate);

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -133,48 +133,6 @@ impl PolygonMesh3DData {
             appearance: None,
         })
     }
-
-    /// Concatenate several meshes into one, offsetting each mesh's face and hole
-    /// indices onto a combined vertex pool; vertices are not deduplicated across
-    /// meshes. Rejects any input carrying appearance or UV, which this does not
-    /// merge.
-    pub fn merge(meshes: impl IntoIterator<Item = PolygonMesh3DData>) -> Result<Self, Error> {
-        let mut vertices: Vec<[f64; 3]> = Vec::new();
-        let mut face_indices: Vec<u32> = Vec::new();
-        let mut face_offsets: Vec<u32> = Vec::new();
-        let mut interior_offsets: Vec<u32> = Vec::new();
-        for mesh in meshes {
-            if !mesh.uv_sets.is_empty() || mesh.appearance.is_some() {
-                return Err(Error::invalid_geometry(
-                    "cannot merge polygon meshes that carry appearance or UV",
-                ));
-            }
-            if mesh.vertices.is_empty() {
-                continue;
-            }
-            let vertex_base = vertices.len() as u32;
-            let index_base = face_indices.len() as u32;
-            // Every face after the first overall is an internal boundary, so this
-            // mesh's first face starts a new boundary once anything precedes it.
-            if !face_indices.is_empty() {
-                face_offsets.push(index_base);
-            }
-            rebase_into(&mesh.face_offsets, index_base, &mut face_offsets);
-            rebase_into(&mesh.interior_offsets, index_base, &mut interior_offsets);
-            rebase_into(&mesh.face_indices, vertex_base, &mut face_indices);
-            vertices.extend_from_slice(&mesh.vertices);
-        }
-        Self::from_raw_parts(vertices, face_indices, face_offsets, interior_offsets)
-    }
-}
-
-/// Decode an index buffer, adding `base` to each value, appending to `out`.
-fn rebase_into(buf: &IndexBuffer<1>, base: u32, out: &mut Vec<u32>) {
-    match buf {
-        IndexBuffer::U8(v) => out.extend(v.iter().map(|&[i]| i as u32 + base)),
-        IndexBuffer::U16(v) => out.extend(v.iter().map(|&[i]| i as u32 + base)),
-        IndexBuffer::U32(v) => out.extend(v.iter().map(|&[i]| i + base)),
-    }
 }
 
 impl PolygonMesh3D {
@@ -244,28 +202,6 @@ impl PolygonMesh3D {
                 interior_offsets,
             )?,
         ))
-    }
-
-    /// Concatenate several meshes sharing `coordinate` into one; see
-    /// [`PolygonMesh3DData::merge`]. Errors if any mesh's frame differs from
-    /// `coordinate`.
-    pub fn merge(
-        coordinate: Coordinate,
-        meshes: impl IntoIterator<Item = PolygonMesh3D>,
-    ) -> Result<Self, Error> {
-        let datas = meshes
-            .into_iter()
-            .map(|mesh| {
-                if mesh.coordinate == coordinate {
-                    Ok(mesh.data)
-                } else {
-                    Err(Error::invalid_geometry(
-                        "polygon mesh coordinate frame differs from the merge frame",
-                    ))
-                }
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok(Self::new(coordinate, PolygonMesh3DData::merge(datas)?))
     }
 }
 
@@ -787,60 +723,6 @@ mod tests {
         // Single face -> no internal boundaries; the hole starts at index 4.
         assert!(ones(&m.face_offsets).is_empty());
         assert_eq!(ones(&m.interior_offsets), vec![4]);
-    }
-
-    #[test]
-    fn merge_concatenates_two_meshes() {
-        let a = PolygonMesh3DData::from_polygons([&quad([
-            [0., 0., 0.],
-            [1., 0., 0.],
-            [1., 1., 0.],
-            [0., 1., 0.],
-        ])]);
-        let b = PolygonMesh3DData::from_polygons([&quad([
-            [2., 0., 0.],
-            [3., 0., 0.],
-            [3., 1., 0.],
-            [2., 1., 0.],
-        ])]);
-        let m = PolygonMesh3DData::merge([a, b]).unwrap();
-        // Vertices are not deduplicated across meshes: 4 + 4.
-        assert_eq!(m.vertices.len(), 8);
-        assert_eq!(m.num_faces(), 2);
-        // Face 1 begins where mesh `a`'s four corners end.
-        assert_eq!(ones(&m.face_offsets), vec![4]);
-        assert_eq!(ones(&m.face_indices), vec![0, 1, 2, 3, 4, 5, 6, 7]);
-    }
-
-    #[test]
-    fn merge_rebases_a_hole_onto_the_combined_pool() {
-        let outer = [[0., 0., 0.], [4., 0., 0.], [4., 4., 0.], [0., 4., 0.]];
-        let hole = vec![[1., 1., 0.], [2., 1., 0.], [2., 2., 0.], [1., 2., 0.]];
-        let holed = PolygonMesh3DData::from_polygons([&Polygon3D::from_rings(
-            Coordinate::Euclidean,
-            outer,
-            vec![hole],
-        )]);
-        let tri = PolygonMesh3DData::from_polygons([&Polygon3D::from_rings(
-            Coordinate::Euclidean,
-            [[5., 0., 0.], [6., 0., 0.], [5., 1., 0.]],
-            Vec::<Vec<[f64; 3]>>::new(),
-        )]);
-        let m = PolygonMesh3DData::merge([holed, tri]).unwrap();
-        assert_eq!(m.num_faces(), 2);
-        // The holed face's 8 corners come first; the triangle's face starts at 8.
-        assert_eq!(ones(&m.face_offsets), vec![8]);
-        // The hole still starts at corner 4, within the first face.
-        assert_eq!(ones(&m.interior_offsets), vec![4]);
-    }
-
-    #[test]
-    fn merge_rejects_appearance_carrying_input() {
-        let mut p = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
-        p.set_appearance(theme("rgb"), textured(), Some(unit_quad_uv()))
-            .unwrap();
-        let textured = PolygonMesh3DData::from_polygons([&p]);
-        assert!(PolygonMesh3DData::merge([textured]).is_err());
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -133,6 +133,48 @@ impl PolygonMesh3DData {
             appearance: None,
         })
     }
+
+    /// Concatenate several meshes into one, offsetting each mesh's face and hole
+    /// indices onto a combined vertex pool; vertices are not deduplicated across
+    /// meshes. Rejects any input carrying appearance or UV, which this does not
+    /// merge.
+    pub fn merge(meshes: impl IntoIterator<Item = PolygonMesh3DData>) -> Result<Self, Error> {
+        let mut vertices: Vec<[f64; 3]> = Vec::new();
+        let mut face_indices: Vec<u32> = Vec::new();
+        let mut face_offsets: Vec<u32> = Vec::new();
+        let mut interior_offsets: Vec<u32> = Vec::new();
+        for mesh in meshes {
+            if !mesh.uv_sets.is_empty() || mesh.appearance.is_some() {
+                return Err(Error::invalid_geometry(
+                    "cannot merge polygon meshes that carry appearance or UV",
+                ));
+            }
+            if mesh.vertices.is_empty() {
+                continue;
+            }
+            let vertex_base = vertices.len() as u32;
+            let index_base = face_indices.len() as u32;
+            // Every face after the first overall is an internal boundary, so this
+            // mesh's first face starts a new boundary once anything precedes it.
+            if !face_indices.is_empty() {
+                face_offsets.push(index_base);
+            }
+            rebase_into(&mesh.face_offsets, index_base, &mut face_offsets);
+            rebase_into(&mesh.interior_offsets, index_base, &mut interior_offsets);
+            rebase_into(&mesh.face_indices, vertex_base, &mut face_indices);
+            vertices.extend_from_slice(&mesh.vertices);
+        }
+        Self::from_raw_parts(vertices, face_indices, face_offsets, interior_offsets)
+    }
+}
+
+/// Decode an index buffer, adding `base` to each value, appending to `out`.
+fn rebase_into(buf: &IndexBuffer<1>, base: u32, out: &mut Vec<u32>) {
+    match buf {
+        IndexBuffer::U8(v) => out.extend(v.iter().map(|&[i]| i as u32 + base)),
+        IndexBuffer::U16(v) => out.extend(v.iter().map(|&[i]| i as u32 + base)),
+        IndexBuffer::U32(v) => out.extend(v.iter().map(|&[i]| i + base)),
+    }
 }
 
 impl PolygonMesh3D {
@@ -202,6 +244,28 @@ impl PolygonMesh3D {
                 interior_offsets,
             )?,
         ))
+    }
+
+    /// Concatenate several meshes sharing `coordinate` into one; see
+    /// [`PolygonMesh3DData::merge`]. Errors if any mesh's frame differs from
+    /// `coordinate`.
+    pub fn merge(
+        coordinate: Coordinate,
+        meshes: impl IntoIterator<Item = PolygonMesh3D>,
+    ) -> Result<Self, Error> {
+        let datas = meshes
+            .into_iter()
+            .map(|mesh| {
+                if mesh.coordinate == coordinate {
+                    Ok(mesh.data)
+                } else {
+                    Err(Error::invalid_geometry(
+                        "polygon mesh coordinate frame differs from the merge frame",
+                    ))
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self::new(coordinate, PolygonMesh3DData::merge(datas)?))
     }
 }
 
@@ -723,6 +787,60 @@ mod tests {
         // Single face -> no internal boundaries; the hole starts at index 4.
         assert!(ones(&m.face_offsets).is_empty());
         assert_eq!(ones(&m.interior_offsets), vec![4]);
+    }
+
+    #[test]
+    fn merge_concatenates_two_meshes() {
+        let a = PolygonMesh3DData::from_polygons([&quad([
+            [0., 0., 0.],
+            [1., 0., 0.],
+            [1., 1., 0.],
+            [0., 1., 0.],
+        ])]);
+        let b = PolygonMesh3DData::from_polygons([&quad([
+            [2., 0., 0.],
+            [3., 0., 0.],
+            [3., 1., 0.],
+            [2., 1., 0.],
+        ])]);
+        let m = PolygonMesh3DData::merge([a, b]).unwrap();
+        // Vertices are not deduplicated across meshes: 4 + 4.
+        assert_eq!(m.vertices.len(), 8);
+        assert_eq!(m.num_faces(), 2);
+        // Face 1 begins where mesh `a`'s four corners end.
+        assert_eq!(ones(&m.face_offsets), vec![4]);
+        assert_eq!(ones(&m.face_indices), vec![0, 1, 2, 3, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn merge_rebases_a_hole_onto_the_combined_pool() {
+        let outer = [[0., 0., 0.], [4., 0., 0.], [4., 4., 0.], [0., 4., 0.]];
+        let hole = vec![[1., 1., 0.], [2., 1., 0.], [2., 2., 0.], [1., 2., 0.]];
+        let holed = PolygonMesh3DData::from_polygons([&Polygon3D::from_rings(
+            Coordinate::Euclidean,
+            outer,
+            vec![hole],
+        )]);
+        let tri = PolygonMesh3DData::from_polygons([&Polygon3D::from_rings(
+            Coordinate::Euclidean,
+            [[5., 0., 0.], [6., 0., 0.], [5., 1., 0.]],
+            Vec::<Vec<[f64; 3]>>::new(),
+        )]);
+        let m = PolygonMesh3DData::merge([holed, tri]).unwrap();
+        assert_eq!(m.num_faces(), 2);
+        // The holed face's 8 corners come first; the triangle's face starts at 8.
+        assert_eq!(ones(&m.face_offsets), vec![8]);
+        // The hole still starts at corner 4, within the first face.
+        assert_eq!(ones(&m.interior_offsets), vec![4]);
+    }
+
+    #[test]
+    fn merge_rejects_appearance_carrying_input() {
+        let mut p = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
+        p.set_appearance(theme("rgb"), textured(), Some(unit_quad_uv()))
+            .unwrap();
+        let textured = PolygonMesh3DData::from_polygons([&p]);
+        assert!(PolygonMesh3DData::merge([textured]).is_err());
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -130,6 +130,37 @@ impl PolygonMesh3D {
     pub fn appearance_mut(&mut self) -> &mut Option<Appearance> {
         &mut self.data.appearance
     }
+
+    /// Consume the mesh, yielding its coordinate-free data for use as a
+    /// [`Solid`](crate::solid::Solid) shell.
+    #[inline]
+    pub fn into_data(self) -> PolygonMesh3DData {
+        self.data
+    }
+
+    /// The number of faces.
+    #[inline]
+    pub fn num_faces(&self) -> usize {
+        self.data.num_faces()
+    }
+
+    /// The shared vertex pool.
+    #[inline]
+    pub fn vertices(&self) -> &[[f64; 3]] {
+        self.data.vertices()
+    }
+}
+
+impl PolygonMesh3DData {
+    /// The number of faces.
+    #[inline]
+    pub fn num_faces(&self) -> usize {
+        if self.face_indices.len() == 0 {
+            0
+        } else {
+            self.face_offsets.len() + 1
+        }
+    }
 }
 
 impl PolygonMesh3DData {

--- a/engine/runtime/geometry/src/solid/mod.rs
+++ b/engine/runtime/geometry/src/solid/mod.rs
@@ -35,6 +35,15 @@ impl Shell {
             Shell::TriangularMesh(d) => d.vertices(),
         }
     }
+
+    /// The number of boundary faces, regardless of mesh kind.
+    #[inline]
+    pub fn num_faces(&self) -> usize {
+        match self {
+            Shell::PolygonMesh(d) => d.num_faces(),
+            Shell::TriangularMesh(d) => d.num_triangles(),
+        }
+    }
 }
 
 /// A volumetric solid bounded by an exterior shell and any number of interior
@@ -47,4 +56,18 @@ pub struct Solid {
     exterior: Shell,
     /// Hollow voids.
     interiors: Vec<Shell>,
+}
+
+impl Solid {
+    /// The exterior boundary shell.
+    #[inline]
+    pub fn exterior(&self) -> &Shell {
+        &self.exterior
+    }
+
+    /// The interior (void) boundary shells.
+    #[inline]
+    pub fn interiors(&self) -> &[Shell] {
+        &self.interiors
+    }
 }

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -133,9 +133,28 @@ impl TriangularMesh3D {
     pub fn uv_sets(&self) -> &[UvSet] {
         &self.data.uv_sets
     }
+
+    /// Consume the mesh, yielding its coordinate-free data for use as a
+    /// [`Solid`](crate::solid::Solid) shell.
+    #[inline]
+    pub fn into_data(self) -> TriangularMesh3DData {
+        self.data
+    }
+
+    /// The shared vertex pool.
+    #[inline]
+    pub fn vertices(&self) -> &[[f64; 3]] {
+        self.data.vertices()
+    }
 }
 
 impl TriangularMesh3DData {
+    /// The number of triangles.
+    #[inline]
+    pub fn num_triangles(&self) -> usize {
+        self.indices.len()
+    }
+
     /// Drop all back-side appearance, keeping only the front; see
     /// [`crate::appearance::make_front_only`].
     pub(crate) fn make_front_only(&mut self) {

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.60"
+version = "0.2.61"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.250"
+version = "0.1.251"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR defines a mapping from GML3.1/3.2 geometry to Flow's new geometry, and adds the `new-geometry` path to the `FeatureCityGmlReader`. There is also another change made to the parser core: Previously, the CityGML reader was materializing everything as a text, all resolved and materialized into geometry at `finish()`, which requires more allocations and clones. Instead, the new approach stream-builds geometry on the first pass (i.e. in `process()`), and it drastically reduced the `finish()` time without compromising `process()` time.

The new geometry is implemented as a complete new path, in order to make it easy to remove old geometry path later. As a consequence, there are a lot of duplicates between the old-geometry path and the new-geometry path (e.g. `parser.rs` and `parser_next.rs`).

## Geometry Mapping
Unlike `CityGmlGeometry`, the Flow's new geometry is not designed solely for parsing CityGML, thus we need to define the mapping between the GML geometry and the new geometry. The following mapping is an exact copy of `GEOMETRY_MAPPING.md`, which is committed for future reference.

### CityGML geometry composition (GML 3.1 / 3.2)

Split by dimensional family for legibility. Solid arrows `==>` are "can consist of", labelled with the GML property and cardinality. Where a property formally accepts a whole substitution group, edges go directly to the concrete types that occur in practice, with the group named in the label.

#### Points

```mermaid
flowchart TD
    Point["Point<br/>→ Flow::Point"]:::p1
    MultiPoint["MultiPoint<br/>→ Flow::Collection"]:::df

    MultiPoint ==>|"pointMember 0..*"| Point

    linkStyle 0 stroke:#1a73e8,stroke-width:2px;
    classDef p1 fill:#e6f4ea,stroke:#34a853,color:#111;
    classDef df fill:#e8f0fe,stroke:#1a73e8,color:#111;
```

#### Curves and rings

```mermaid
flowchart TD
    LineString["LineString<br/>→ Flow::LineString"]:::p1
    LinearRing["LinearRing<br/>→ Flow::Polygon (no interiors)"]:::p1
    MultiCurve["MultiCurve<br/>→ Flow::Collection"]:::df
    Curve["Curve<br/>→ Flow::LineString"]:::p1
    OrientableCurve["OrientableCurve<br/>→ Flow::LineString"]:::df
    CompositeCurve["CompositeCurve<br/>→ Flow::Collection"]:::df
    Ring["Ring<br/>→ Flow::Polygon (no interiors)"]:::df
    seg(["segments: LineStringSegment / Arc<br/>no gml:id, inline"]):::inl

    MultiCurve ==>|"curveMember 0..* (any AbstractCurve; commonly LineString)"| LineString
    CompositeCurve ==>|"curveMember 1..*"| LineString
    OrientableCurve ==>|"baseCurve 1"| LineString
    Ring ==>|"curveMember 1..*"| LineString
    Curve ==>|"segments 1..*"| seg

    linkStyle 0,1,2,3 stroke:#1a73e8,stroke-width:2px;
    linkStyle 4 stroke:#34a853,stroke-width:2px;
    classDef p1 fill:#e6f4ea,stroke:#34a853,color:#111;
    classDef df fill:#e8f0fe,stroke:#1a73e8,color:#111;
    classDef inl fill:#f0f0f0,stroke:#bbb,stroke-dasharray:2 2,color:#888;
```

#### Surfaces

```mermaid
flowchart TD
    LinearRing["LinearRing<br/>→ Flow::Polygon (no interiors)"]:::p1
    Polygon["Polygon<br/>→ Flow::Polygon"]:::p1
    TriangulatedSurface["TriangulatedSurface<br/>→ Flow::TriangularMesh"]:::p1
    MultiSurface["MultiSurface<br/>→ Flow::Collection"]:::df
    CompositeSurface["CompositeSurface<br/>→ Flow::PolygonMesh"]:::df
    OrientableSurface["OrientableSurface<br/>→ Flow::PolygonMesh"]:::df
    Surface["Surface<br/>→ Flow::PolygonMesh"]:::p1
    PolyhedralSurface["PolyhedralSurface<br/>→ Flow::PolygonMesh"]:::p1
    Tin["Tin<br/>→ Flow::TriangularMesh"]:::p1
    patch(["patches: PolygonPatch / Rectangle<br/>no gml:id, inline"]):::inl
    triangle(["Triangle (patch): exterior LinearRing<br/>no gml:id, inline"]):::inl

    MultiSurface ==>|"surfaceMember 0..* (any AbstractSurface)"| Polygon
    MultiSurface ==>|"surfaceMember 0..*"| OrientableSurface
    CompositeSurface ==>|"surfaceMember 1..*"| Polygon
    OrientableSurface ==>|"baseSurface 1"| Polygon
    Polygon ==>|"exterior 0..1"| LinearRing
    Polygon ==>|"interior 0..*"| LinearRing
    TriangulatedSurface ==>|"trianglePatches 1..*"| triangle
    Surface ==>|"patches 1..*"| patch
    PolyhedralSurface ==>|"polygonPatches 1..*"| patch
    Tin ==>|"trianglePatches 1..* (+ control points)"| triangle

    linkStyle 0,1,2,3 stroke:#1a73e8,stroke-width:2px;
    linkStyle 4,5,6,7,8,9 stroke:#34a853,stroke-width:2px;
    classDef p1 fill:#e6f4ea,stroke:#34a853,color:#111;
    classDef df fill:#e8f0fe,stroke:#1a73e8,color:#111;
    classDef inl fill:#f0f0f0,stroke:#bbb,stroke-dasharray:2 2,color:#888;
```

#### Solids

```mermaid
flowchart TD
    Solid["Solid<br/>→ Flow::Solid"]:::df
    Shell["Shell<br/>→ Flow::Solid shell"]:::df
    CompositeSurface2["CompositeSurface (alt shell body)<br/>→ Flow::Solid shell"]:::df
    CompositeSolid["CompositeSolid<br/>→ Flow::Collection (of Solid)"]:::df
    MultiSolid["MultiSolid<br/>→ Flow::Collection (of Solid)"]:::df
    surfaces(["Polygon / OrientableSurface<br/>(see Surfaces graph)"]):::ref

    Solid ==>|"exterior 0..1"| Shell
    Solid ==>|"interior 0..*"| Shell
    Solid ==>|"exterior/interior (GML 3.1 style; some datasets)"| CompositeSurface2
    Shell ==>|"surfaceMember 1..*"| surfaces
    CompositeSurface2 ==>|"surfaceMember 1..*"| surfaces
    CompositeSolid ==>|"solidMember 1..*"| Solid
    MultiSolid ==>|"solidMember 0..*"| Solid

    linkStyle 0,1,2,3,4,5,6 stroke:#1a73e8,stroke-width:2px;
    classDef df fill:#e8f0fe,stroke:#1a73e8,color:#111;
    classDef ref fill:#fff,stroke:#999,stroke-dasharray:4 3,color:#555;
```

#### Heterogeneous aggregates (rare)

```mermaid
flowchart TD
    MultiGeometry["MultiGeometry<br/>→ Flow::Collection"]:::df
    GeometricComplex["GeometricComplex<br/>→ Flow::Collection"]:::df
    any(["any geometry / primitive<br/>(see other graphs)"]):::ref

    MultiGeometry ==>|"geometryMember 0..* (any AbstractGeometry)"| any
    GeometricComplex ==>|"element 1..* (any AbstractGeometricPrimitive)"| any

    linkStyle 0,1 stroke:#1a73e8,stroke-width:2px;
    classDef df fill:#e8f0fe,stroke:#1a73e8,color:#111;
    classDef ref fill:#fff,stroke:#999,stroke-dasharray:4 3,color:#555;
```

#### Inline nodes

`Point`, `LineString`, `LinearRing`, `Polygon`, `Curve`, `Surface`,
`PolyhedralSurface`, `TriangulatedSurface`, and `Tin` are inline: the reader builds
them while streaming, with an eager constructor (`from_rings`, `from_polygons`,
`from_coords`, `from_soup`).

Every other type is reference-bearing and is assembled from its resolved members
in the second pass. These map to the Flow constructors that take members:
`Collection` (from the `Multi*` aggregates, `CompositeCurve` / `CompositeSolid`,
and `GeometricComplex`), `PolygonMesh` (`from_polygons`, welding a
`CompositeSurface`'s or `Shell`'s `surfaceMember`s into one surface), `Polygon`
(`from_rings` with an empty interior list, for a standalone or referenced ring),
and `Solid` (`from_exterior` over resolved shells).

### Flow geometry composition (for reference purpose)

Flow's model (the `reearth_flow_geometry` crate). Solid arrows `==>` are "can
consist of" with cardinality; dotted arrows `-.->` are enum-variant membership.
The `==>` edges are the member-taking constructors that the reference-bearing
CityGML types feed into.

```mermaid
flowchart TD
    Geometry(["Geometry (top-level enum)"]):::hub
    GeometryCollection["GeometryCollection<br/>per-feature container"]:::node
    E3D(["Euclidean3DGeometry (variant)"]):::hub
    None["None: no geometry"]:::node

    Point["Point"]:::node
    LineString["LineString"]:::node
    Polygon["Polygon<br/>exterior ring + hole rings"]:::node
    PolygonMesh["PolygonMesh<br/>CSR faces, variable valence, holes"]:::node
    TriangularMesh["TriangularMesh<br/>fixed 3-index faces"]:::node
    Solid["Solid"]:::node
    PointCloud["PointCloud"]:::node
    Csg["Csg: boolean tree over Solids"]:::node
    Collection3D["Collection3D: Multi* of 3D geometries"]:::node
    Shell(["Shell (internal: PolygonMesh | TriangularMesh data)"]):::hub

    Geometry -.->|"None"| None
    Geometry -.->|"Euclidean3D"| E3D
    Geometry -.->|"GeometryCollection"| GeometryCollection
    GeometryCollection ==>|"members 0..* (+ parallel attrs)"| Geometry

    E3D -.-> Point
    E3D -.-> LineString
    E3D -.-> Polygon
    E3D -.-> PolygonMesh
    E3D -.-> TriangularMesh
    E3D -.-> Solid
    E3D -.-> PointCloud
    E3D -.-> Csg
    E3D -.-> Collection3D

    Collection3D ==>|"members 0..*"| E3D
    Solid ==>|"exterior 1"| Shell
    Solid ==>|"interiors 0..*"| Shell
    Shell -.->|"PolygonMesh data"| PolygonMesh
    Shell -.->|"TriangularMesh data"| TriangularMesh
    Csg ==>|"operands"| Solid
    PolygonMesh ==>|"faces 1..* (each: 1 exterior ring + 0..* hole rings)"| Polygon

    classDef node fill:#e6f4ea,stroke:#34a853,color:#111;
    classDef hub fill:#fff,stroke:#999,stroke-dasharray:4 3,color:#555;
```

## How I tested
Among others, the 12 test cases in `citygml_parser/geometry_next.rs` resemble the actual PLATEAU data.

Alongside the unit tests, the behavior of the new parser is checked on the Takeshiba CityGML 3.0 sample. 
| Reader                      | Data       | `process` | `finish` | total  | MB/s     |
| --------------------------- | ---------- | --------- | -------- | ---------- | -------- |
| HEAD  (new geom) | 2.7 GB CG3 | 24.0 s    | 46.2 s   | 70.2 s | 38.0 |
| main (old geom)              | 2.7 GB CG3 | 25.4 s    | 353.2 s  | 378.6 s    | 7.0      |
| 2.0 nusamai parser (old geom)       | 2.4 GB CG2 | 21.5 s    | 227.8 s  | 249.4 s    | 9.5      |

`process()` takes almost the same amount of time on all three, but `HEAD` is clearly the fastest on `finish` and total. In fact, `HEAD`'s  `finish` is 7 - 8x faster than that of `main` on this data. We sampled some features and verified that the parsed data are equivalent.
Some notes are helpful for a fair comparison: 
1. Though `2.0 nusamai parser (old geom)` doesn't read appearance, it populates zeros on the UV parallel to the geometry, which almost doubles the size, while new geometry simply strips all appearance data.
2. The new geometry needs runtime data conversions on read (merge vertices, constructing indices buffer, etc), while old geometry read the data as is.
3. `2.0 nusamai parser (old geom)` reads appearance data, while the other two don't.
4. `2.0 nusamai parser (old geom)` is Plateau data specific, though the other two are a more general parser.

## What I haven't done
- Some rare geometry construction paths that are not usually used in PLATEAU data, are not implemented in this PR and is explicitly excused as `TODO`. These include `gml:Curve` and `gml:CompositeSurface` built from multiple meshes.
- `ImplicitGeometry` is deferred, even though they **are** used in Plateau. Though it wasn't there in the base branch, that is not the reason we are deferring this; In fact, we are deferring it is because we actually need to think more on how we would handle implicit geometry inside the new geometry in general.
- `Appearance` is not implemented in this PR, as it was not implemented in the base branch. We will handle this in another PR.
- **In this PR, we always assume `gml:Polygon` and `gml:TrianglatedSurface` can always be build in the first pass**. This might not be the case if their `gml:exteior` uses, for example, `gml:Ring` which may not be inline. However, these paths were not covered by the base branch or the nusamai parser either, so this issue is pre-existing, and needs to be addressed in another PR when necessary.

## Other changes
- A few new functions are added to `geometry` crate to increase the publicity of the geometry data.