### PR TITLE
ci: publish latest allure report to bucket root

### DIFF
--- a/.github/workflows/e2e_ui.yml
+++ b/.github/workflows/e2e_ui.yml
@@ -163,9 +163,6 @@ jobs:
 
       - name: Publish latest report to bucket root
         if: ${{ !cancelled() && steps.check-results.outputs.has_results == 'true' }}
-        # The report is a single self-contained HTML file (allurerc.mjs sets
-        # singleFile: true), so publishing "latest" is one object copy. Never
-        # rsync -d at the bucket root; it would delete runs/ and index.json.
         run: |
           gsutil -h "Cache-Control:no-cache" cp ./allure-report/index.html "gs://$BUCKET/index.html"
 

--- a/.github/workflows/e2e_ui.yml
+++ b/.github/workflows/e2e_ui.yml
@@ -161,6 +161,14 @@ jobs:
             gsutil cp ./allure-report/widgets/summary.json "gs://$BUCKET/runs/$RUN_ID/summary.json"
           fi
 
+      - name: Publish latest report to bucket root
+        if: ${{ !cancelled() && steps.check-results.outputs.has_results == 'true' }}
+        # The report is a single self-contained HTML file (allurerc.mjs sets
+        # singleFile: true), so publishing "latest" is one object copy. Never
+        # rsync -d at the bucket root; it would delete runs/ and index.json.
+        run: |
+          gsutil -h "Cache-Control:no-cache" cp ./allure-report/index.html "gs://$BUCKET/index.html"
+
       - name: Update dashboard index.json
         if: ${{ !cancelled() && steps.check-results.outputs.has_results == 'true' }}
         env:


### PR DESCRIPTION
# Overview

## What I've done
This PR updates the UI E2E GitHub Actions workflow to additionally publish the most recent generated Allure report as a stable “latest” entrypoint at the GCS bucket root, alongside the existing per-run report upload and dashboard index update.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
