### PR TITLE
fix(engine): modification to new geom

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4092,7 +4092,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.62"
+version = "0.2.63"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "futures",
  "once_cell",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "approx",
  "async-trait",
@@ -4694,7 +4694,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "Inflector",
  "approx",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4885,7 +4885,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "bytes",
  "clap",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4979,7 +4979,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "approx",
  "bvh",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5161,7 +5161,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "bytes",
  "futures",
@@ -5207,7 +5207,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "bytes",
  "futures",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "ahash",
  "bytes",
@@ -5310,7 +5310,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.425"
+version = "0.0.426"
 dependencies = [
  "async-trait",
  "axum",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.252"
+version = "0.1.253"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.425"
+version = "0.0.426"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/citygml_parser/resolver.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/resolver.rs
@@ -8,7 +8,7 @@
 use std::collections::{HashMap, HashSet};
 
 use reearth_flow_geometry::collection::Collection3D;
-use reearth_flow_geometry::coordinate::Coordinate;
+use reearth_flow_geometry::coordinate::CoordinateFrame;
 use reearth_flow_geometry::line_string::LineString3D;
 use reearth_flow_geometry::polygon::Polygon3D;
 use reearth_flow_geometry::polygon_mesh::PolygonMesh3D;
@@ -19,7 +19,7 @@ use super::parser::RawNodeKey;
 
 /// The coordinate frame all resolved geometry is expressed in; CityGML `srsName`
 /// / EPSG handling happens downstream.
-pub(super) const FRAME: Coordinate = Coordinate::Euclidean;
+pub(super) const FRAME: CoordinateFrame = CoordinateFrame::Euclidean;
 
 /// A node in a CityGML geometry tree during pass-2 resolution: a geometry already
 /// built in pass 1, a reference still to be looked up, or a container still to be

--- a/engine/runtime/geometry/src/appearance/mod.rs
+++ b/engine/runtime/geometry/src/appearance/mod.rs
@@ -142,11 +142,7 @@ impl Appearance {
         self.themes.iter().flat_map(|theme| theme.uv_sets.iter())
     }
 
-    /// Assemble an appearance from already-validated parts — the multi-theme weld
-    /// path (see [`crate::polygon_mesh`]) and the triangulation expander, which
-    /// build every theme (with its UV) at once rather than appending one at a
-    /// time through [`append_theme`]. The caller guarantees each `UvSet`'s length
-    /// matches the host corner buffer.
+    /// Assemble an appearance from already-validated parts.
     pub(crate) fn from_parts(
         materials: Vec<Material>,
         themes: Vec<ThemeBinding>,
@@ -159,9 +155,7 @@ impl Appearance {
         }
     }
 
-    /// Decompose into `(materials, themes, default_theme)`, the inverse of
-    /// [`from_parts`](Self::from_parts). Lets crate-internal passes that rebuild an
-    /// appearance (e.g. triangulation) move the parts out of the sealed type.
+    /// Decompose into `(materials, themes, default_theme)`.
     pub(crate) fn into_parts(self) -> (Vec<Material>, Vec<ThemeBinding>, ThemeId) {
         (self.materials, self.themes, self.default_theme)
     }
@@ -310,13 +304,7 @@ impl Appearance {
 /// Append one theme's already-validated appearance to a geometry's accumulated
 /// `appearance`. `front` / `back` index `materials` locally; they are offset into
 /// the running palette here. The theme's own `uv_sets` ride inside the appended
-/// [`ThemeBinding`]. Shared by the polygon and triangular-mesh setters so the
-/// palette bookkeeping lives in one place.
-///
-/// Additive and atomic: errors — leaving `appearance` untouched — if `theme` is
-/// already set or a local index overflows the merged palette. The first theme
-/// appended becomes the default. The caller validates the bindings and UV before
-/// calling (the two setters validate in different ways).
+/// [`ThemeBinding`]. 
 pub(crate) fn append_theme(
     appearance: &mut Option<Appearance>,
     theme: ThemeId,
@@ -408,11 +396,7 @@ pub(crate) fn validate_uv_coupling(
 
 /// Strip all back-side appearance from a mesh's `appearance`: drop each theme's
 /// back binding, remove every `Side::Back` UV set from that theme's pool, and
-/// compact the palette so now-orphaned back-only materials are dropped. Shared by
-/// the polygon-mesh and triangular-mesh `make_front_only` shells — a
-/// [`Solid`](crate::solid::Solid)'s back face is its interior (or the inside of a
-/// void), which is never rendered, so back appearance is meaningless there;
-/// `Solid` construction calls this on every shell.
+/// compact the palette so now-orphaned back-only materials are dropped.
 pub(crate) fn make_front_only(appearance: &mut Option<Appearance>) {
     if let Some(app) = appearance {
         for binding in &mut app.themes {

--- a/engine/runtime/geometry/src/appearance/mod.rs
+++ b/engine/runtime/geometry/src/appearance/mod.rs
@@ -1,11 +1,16 @@
 //! Surface appearance: a small graph of types hung off a surface geometry.
 //!
-//! Top-down: a geometry optionally has one `Appearance` and owns a pool of
-//! `UvSet`s; an `Appearance` is a material palette plus, per theme, a per-side
-//! (front / optional back) face-to-material binding; a `Material` is exactly one
-//! of two shading models,
-//! each with a fixed set of texture slots; a `Texture` samples one `UvSet` from
-//! the geometry's pool, and several textures may share the same one.
+//! Top-down: a geometry optionally has one `Appearance`; an `Appearance` is a
+//! material palette plus, per theme, a [`ThemeBinding`] — a per-side (front /
+//! optional back) face-to-material binding together with that theme's own pool of
+//! [`UvSet`]s; a `Material` is exactly one of two shading models, each with a
+//! fixed set of texture slots; a `Texture` samples one `UvSet` from its theme's
+//! pool, and several textures may share the same one.
+//!
+//! `Appearance` is a sealed type: its fields are private and it can only be built
+//! through [`append_theme`] / [`Appearance::from_parts`], both crate-internal and
+//! fed the host geometry's corner count so a `UvSet` can never outlive the
+//! corner-buffer alignment it depends on.
 //!
 //! Appearance attaches to `Polygon`, `PolygonMesh` and `TriangularMesh` as an
 //! `Option<Appearance>`. `Solid` and `Csg` carry none of their own; their meshes
@@ -93,19 +98,78 @@ impl<'de> Deserialize<'de> for MaterialIndex {
     }
 }
 
-/// Materials, themes and per-face bindings for a surface geometry.
+/// Materials, themes, per-face bindings and per-theme UV for a surface geometry.
+///
+/// Sealed: the fields are private and every value is built through
+/// [`append_theme`] or [`Appearance::from_parts`]. A `UvSet` inside a
+/// [`ThemeBinding`] must stay length-matched to the host geometry's corner
+/// buffer — a fact `Appearance` cannot check on its own — so construction is
+/// confined to the geometry crate, where the corner count is in hand. Read
+/// through [`materials`](Self::materials) / [`themes`](Self::themes) /
+/// [`default_theme`](Self::default_theme).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Appearance {
     /// Palette; bindings index into it.
-    pub materials: Vec<Material>,
+    materials: Vec<Material>,
     /// One independent binding per theme; length >= 1.
-    pub themes: Vec<ThemeBinding>,
+    themes: Vec<ThemeBinding>,
     /// Active theme for single-theme sinks (glTF / OBJ / CZML / 3D Tiles).
-    pub default_theme: ThemeId,
+    default_theme: ThemeId,
 }
 
-/// One theme's per-side face-to-material binding.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+impl Appearance {
+    /// The material palette; bindings index into it.
+    #[inline]
+    pub fn materials(&self) -> &[Material] {
+        &self.materials
+    }
+
+    /// The per-theme bindings; length >= 1.
+    #[inline]
+    pub fn themes(&self) -> &[ThemeBinding] {
+        &self.themes
+    }
+
+    /// The active theme for single-theme sinks.
+    #[inline]
+    pub fn default_theme(&self) -> &ThemeId {
+        &self.default_theme
+    }
+
+    /// Every UV set across all themes, in theme then set order. The theme each
+    /// belongs to is lost; use [`themes`](Self::themes) when it matters.
+    pub fn uv_iter(&self) -> impl Iterator<Item = &UvSet> {
+        self.themes.iter().flat_map(|theme| theme.uv_sets.iter())
+    }
+
+    /// Assemble an appearance from already-validated parts — the multi-theme weld
+    /// path (see [`crate::polygon_mesh`]) and the triangulation expander, which
+    /// build every theme (with its UV) at once rather than appending one at a
+    /// time through [`append_theme`]. The caller guarantees each `UvSet`'s length
+    /// matches the host corner buffer.
+    pub(crate) fn from_parts(
+        materials: Vec<Material>,
+        themes: Vec<ThemeBinding>,
+        default_theme: ThemeId,
+    ) -> Self {
+        Appearance {
+            materials,
+            themes,
+            default_theme,
+        }
+    }
+
+    /// Decompose into `(materials, themes, default_theme)`, the inverse of
+    /// [`from_parts`](Self::from_parts). Lets crate-internal passes that rebuild an
+    /// appearance (e.g. triangulation) move the parts out of the sealed type.
+    pub(crate) fn into_parts(self) -> (Vec<Material>, Vec<ThemeBinding>, ThemeId) {
+        (self.materials, self.themes, self.default_theme)
+    }
+}
+
+/// One theme's per-side face-to-material binding together with the UV sets that
+/// theme's textured materials sample.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct ThemeBinding {
     pub theme: ThemeId,
     /// Front-side face-to-material binding.
@@ -114,6 +178,9 @@ pub struct ThemeBinding {
     /// When `Some`, the back side has its own face-to-material mapping: it may
     /// bind different materials, or leave faces unbound.
     pub back: Option<FaceBinding>,
+    /// This theme's UV pool; one set per (side, channel) its materials reference.
+    /// Each `Explicit` array is parallel to the host geometry's corner buffer.
+    pub uv_sets: Vec<UvSet>,
 }
 
 /// Which side of an oriented surface an appearance applies to. The front side
@@ -241,22 +308,22 @@ impl Appearance {
 }
 
 /// Append one theme's already-validated appearance to a geometry's accumulated
-/// `appearance` / `uv_sets`. `front` / `back` index `materials` locally; they are
-/// offset into the running palette here. Shared by the polygon and triangular-mesh
-/// setters so the palette bookkeeping lives in one place.
+/// `appearance`. `front` / `back` index `materials` locally; they are offset into
+/// the running palette here. The theme's own `uv_sets` ride inside the appended
+/// [`ThemeBinding`]. Shared by the polygon and triangular-mesh setters so the
+/// palette bookkeeping lives in one place.
 ///
-/// Additive and atomic: errors — leaving both `appearance` and `uv_sets` untouched
-/// — if `theme` is already set or a local index overflows the merged palette. The
-/// first theme appended becomes the default. The caller validates the bindings and
-/// UV before calling (the two setters validate in different ways).
+/// Additive and atomic: errors — leaving `appearance` untouched — if `theme` is
+/// already set or a local index overflows the merged palette. The first theme
+/// appended becomes the default. The caller validates the bindings and UV before
+/// calling (the two setters validate in different ways).
 pub(crate) fn append_theme(
     appearance: &mut Option<Appearance>,
-    uv_sets: &mut Vec<UvSet>,
     theme: ThemeId,
     materials: Vec<Material>,
     front: FaceBinding,
     back: Option<FaceBinding>,
-    new_uv_sets: Vec<UvSet>,
+    uv_sets: Vec<UvSet>,
 ) -> Result<(), Error> {
     if let Some(app) = appearance.as_ref() {
         if app.themes.iter().any(|b| b.theme == theme) {
@@ -282,8 +349,12 @@ pub(crate) fn append_theme(
         default_theme: theme.clone(),
     });
     app.materials.extend(materials);
-    app.themes.push(ThemeBinding { theme, front, back });
-    uv_sets.extend(new_uv_sets);
+    app.themes.push(ThemeBinding {
+        theme,
+        front,
+        back,
+        uv_sets,
+    });
     Ok(())
 }
 
@@ -335,18 +406,18 @@ pub(crate) fn validate_uv_coupling(
     Ok(())
 }
 
-/// Strip all back-side appearance from a mesh's `(appearance, uv_sets)`: drop each
-/// theme's back binding, remove every `Side::Back` UV set, and compact the palette
-/// so now-orphaned back-only materials are dropped. Shared by the polygon-mesh and
-/// triangular-mesh `make_front_only` shells — a [`Solid`](crate::solid::Solid)'s
-/// back face is its interior (or the inside of a void), which is never rendered, so
-/// back appearance is meaningless there; `Solid` construction calls this on every
-/// shell.
-pub(crate) fn make_front_only(appearance: &mut Option<Appearance>, uv_sets: &mut Vec<UvSet>) {
-    uv_sets.retain(|uv| uv.side != Side::Back);
+/// Strip all back-side appearance from a mesh's `appearance`: drop each theme's
+/// back binding, remove every `Side::Back` UV set from that theme's pool, and
+/// compact the palette so now-orphaned back-only materials are dropped. Shared by
+/// the polygon-mesh and triangular-mesh `make_front_only` shells — a
+/// [`Solid`](crate::solid::Solid)'s back face is its interior (or the inside of a
+/// void), which is never rendered, so back appearance is meaningless there;
+/// `Solid` construction calls this on every shell.
+pub(crate) fn make_front_only(appearance: &mut Option<Appearance>) {
     if let Some(app) = appearance {
         for binding in &mut app.themes {
             binding.back = None;
+            binding.uv_sets.retain(|uv| uv.side != Side::Back);
         }
         app.compact_materials();
     }
@@ -408,6 +479,11 @@ mod tests {
     #[test]
     fn make_front_only_drops_back_and_compacts_palette() {
         let theme = ThemeId(Arc::from("rgb"));
+        let uv = |side| UvSet {
+            side,
+            channel: ChannelId::default(),
+            uv: UvSource::Explicit(Box::new([])),
+        };
         // Material 0 is front-only, material 1 is back-only.
         let mut appearance = Some(Appearance {
             materials: vec![phong(1.0), phong(2.0)],
@@ -415,18 +491,12 @@ mod tests {
                 theme: theme.clone(),
                 front: FaceBinding::Uniform(MaterialIndex::new(0).unwrap()),
                 back: Some(FaceBinding::Uniform(MaterialIndex::new(1).unwrap())),
+                uv_sets: vec![uv(Side::Front), uv(Side::Back)],
             }],
             default_theme: theme.clone(),
         });
-        let uv = |side| UvSet {
-            theme: Some(theme.clone()),
-            side,
-            channel: ChannelId::default(),
-            uv: UvSource::Explicit(Box::new([])),
-        };
-        let mut uv_sets = vec![uv(Side::Front), uv(Side::Back)];
 
-        make_front_only(&mut appearance, &mut uv_sets);
+        make_front_only(&mut appearance);
 
         let app = appearance.unwrap();
         // The back binding is gone and its now-orphaned material dropped, leaving
@@ -435,8 +505,8 @@ mod tests {
         assert!(app.themes[0].back.is_none());
         assert!(matches!(app.themes[0].front, FaceBinding::Uniform(i) if i.get() == 0));
         // The back UV set is stripped; only the front survives.
-        assert_eq!(uv_sets.len(), 1);
-        assert_eq!(uv_sets[0].side, Side::Front);
+        assert_eq!(app.themes[0].uv_sets.len(), 1);
+        assert_eq!(app.themes[0].uv_sets[0].side, Side::Front);
     }
 
     #[test]
@@ -453,6 +523,7 @@ mod tests {
                     Some(MaterialIndex::new(3).unwrap()),
                 ]),
                 back: None,
+                uv_sets: Vec::new(),
             }],
             default_theme: theme,
         };
@@ -491,6 +562,7 @@ mod tests {
                 theme: theme.clone(),
                 front: FaceBinding::Uniform(MaterialIndex::new(5).unwrap()),
                 back: None,
+                uv_sets: Vec::new(),
             }],
             default_theme: theme,
         };

--- a/engine/runtime/geometry/src/appearance/mod.rs
+++ b/engine/runtime/geometry/src/appearance/mod.rs
@@ -304,7 +304,7 @@ impl Appearance {
 /// Append one theme's already-validated appearance to a geometry's accumulated
 /// `appearance`. `front` / `back` index `materials` locally; they are offset into
 /// the running palette here. The theme's own `uv_sets` ride inside the appended
-/// [`ThemeBinding`]. 
+/// [`ThemeBinding`].
 pub(crate) fn append_theme(
     appearance: &mut Option<Appearance>,
     theme: ThemeId,

--- a/engine/runtime/geometry/src/appearance/uv.rs
+++ b/engine/runtime/geometry/src/appearance/uv.rs
@@ -1,9 +1,8 @@
 //! UV sets and their sources.
 //!
 //! UV is geometric: its coordinates run parallel to the geometry's vertex /
-//! corner buffer, not the material. One UV set feeds several maps (base-colour,
-//! normal, occlusion ... all sample it), and a material map references a UV set,
-//! never the reverse.
+//! corner buffer, not the material. One UV set feeds several maps, and 
+//! a material map references a UV set.
 //!
 //! A map's UV is resolved by three coordinates: the theme is the
 //! [`ThemeBinding`](super::ThemeBinding) that owns this set, the side comes from

--- a/engine/runtime/geometry/src/appearance/uv.rs
+++ b/engine/runtime/geometry/src/appearance/uv.rs
@@ -1,7 +1,7 @@
 //! UV sets and their sources.
 //!
-//! UV is geometric: it lives on the mesh leaf, parallel to the vertex / corner
-//! buffer, not on the material. One UV set feeds several maps (base-colour,
+//! UV is geometric: its coordinates run parallel to the geometry's vertex /
+//! corner buffer, not the material. One UV set feeds several maps (base-colour,
 //! normal, occlusion ... all sample it), and a material map references a UV set,
 //! never the reverse.
 //!

--- a/engine/runtime/geometry/src/appearance/uv.rs
+++ b/engine/runtime/geometry/src/appearance/uv.rs
@@ -1,7 +1,7 @@
 //! UV sets and their sources.
 //!
 //! UV is geometric: its coordinates run parallel to the geometry's vertex /
-//! corner buffer, not the material. One UV set feeds several maps, and 
+//! corner buffer, not the material. One UV set feeds several maps, and
 //! a material map references a UV set.
 //!
 //! A map's UV is resolved by three coordinates: the theme is the

--- a/engine/runtime/geometry/src/appearance/uv.rs
+++ b/engine/runtime/geometry/src/appearance/uv.rs
@@ -5,23 +5,22 @@
 //! normal, occlusion ... all sample it), and a material map references a UV set,
 //! never the reverse.
 //!
-//! A map's UV is resolved by three coordinates: the theme and side come from
-//! the per-face binding (face under theme T, on side S -> material), the channel
-//! from the material map's selector. So `channel` carries no global meaning: it
-//! is a material-local index into the UV sets of whatever theme/side the face
-//! resolves to.
+//! A map's UV is resolved by three coordinates: the theme is the
+//! [`ThemeBinding`](super::ThemeBinding) that owns this set, the side comes from
+//! the per-face binding (face under theme T, on side S -> material), and the
+//! channel from the material map's selector. So `channel` carries no global
+//! meaning: it is a material-local index into the UV sets of whatever theme/side
+//! the face resolves to.
 
 use serde::{Deserialize, Serialize};
 
-use super::{ChannelId, Side, ThemeId};
+use super::{ChannelId, Side};
 
-/// One UV set on a mesh leaf. The `Explicit` array is parallel to the host
-/// geometry's corner buffer; the alignment is fixed by the geometry type, not
-/// tagged here.
+/// One UV set, owned by the [`ThemeBinding`](super::ThemeBinding) whose theme it
+/// belongs to. The `Explicit` array is parallel to the host geometry's corner
+/// buffer; the alignment is fixed by the geometry type, not tagged here.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct UvSet {
-    /// Styling variant this UV belongs to; `None` = a single implicit theme.
-    pub theme: Option<ThemeId>,
     /// Which surface side these coordinates parameterise. `Front` for the
     /// common single-sided case.
     pub side: Side,

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -3,7 +3,7 @@
 //! Each embedding's `Collection` holds primitives of the same intrinsic
 //! dimension with no shared vertex topology (equivalent to `Multi*` in
 //! GeoJSON/GML). Members are not required to share a coordinate frame: every
-//! leaf carries its own `coordinate`. Both collections carry per-child
+//! leaf carries its own `frame`. Both collections carry per-child
 //! attributes (`attrs`, parallel to `members`), used to preserve a child's
 //! attributes; they are not exposed as the feature's own attributes.
 
@@ -162,14 +162,14 @@ crate::unsupported!(Collection3D: Triangulate);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::Coordinate;
+    use crate::coordinate::CoordinateFrame;
     use crate::point::{Point2D, Point3D};
 
     #[test]
     fn new_2d_collects_members_without_attrs() {
         let c = Collection2D::new([
-            Euclidean2DGeometry::Point(Point2D::new(Coordinate::Euclidean, [0.0, 0.0])),
-            Euclidean2DGeometry::Point(Point2D::new(Coordinate::Euclidean, [1.0, 1.0])),
+            Euclidean2DGeometry::Point(Point2D::new(CoordinateFrame::Euclidean, [0.0, 0.0])),
+            Euclidean2DGeometry::Point(Point2D::new(CoordinateFrame::Euclidean, [1.0, 1.0])),
         ]);
         assert_eq!(c.members.len(), 2);
         assert!(c.attrs.is_empty());
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn with_attributes_rejects_length_mismatch() {
         let members = vec![Euclidean3DGeometry::Point(Point3D::new(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [0.0, 0.0, 0.0],
         ))];
         assert!(Collection3D::with_attributes(members, vec![Attributes::default(); 2]).is_err());
@@ -187,8 +187,8 @@ mod tests {
     #[test]
     fn collection2d_box_merges_members() {
         let c = Collection2D::new([
-            Euclidean2DGeometry::Point(Point2D::new(Coordinate::Euclidean, [0.0, 3.0])),
-            Euclidean2DGeometry::Point(Point2D::new(Coordinate::Euclidean, [4.0, -1.0])),
+            Euclidean2DGeometry::Point(Point2D::new(CoordinateFrame::Euclidean, [0.0, 3.0])),
+            Euclidean2DGeometry::Point(Point2D::new(CoordinateFrame::Euclidean, [4.0, -1.0])),
         ]);
         assert_eq!(
             c.bounding_box().unwrap(),
@@ -202,8 +202,8 @@ mod tests {
     #[test]
     fn collection3d_box_merges_members() {
         let c = Collection3D::new([
-            Euclidean3DGeometry::Point(Point3D::new(Coordinate::Euclidean, [0.0, 3.0, 1.0])),
-            Euclidean3DGeometry::Point(Point3D::new(Coordinate::Euclidean, [4.0, -1.0, 7.0])),
+            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [0.0, 3.0, 1.0])),
+            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Euclidean, [4.0, -1.0, 7.0])),
         ]);
         assert_eq!(
             c.bounding_box().unwrap(),

--- a/engine/runtime/geometry/src/coordinate.rs
+++ b/engine/runtime/geometry/src/coordinate.rs
@@ -43,11 +43,11 @@ impl From<EpsgCode> for u16 {
 
 /// The coordinate frame a geometry leaf is expressed in.
 ///
-/// Every coordinate-bearing leaf carries its own `coordinate: Coordinate`, so an
+/// Every coordinate-bearing leaf carries its own `frame: CoordinateFrame`, so an
 /// operation reads its source frame from `self` and a collection may hold
 /// members in different frames.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
-pub enum Coordinate {
+pub enum CoordinateFrame {
     /// A geographic / projected CRS identified by its EPSG code.
     Crs(EpsgCode),
     /// Bare Euclidean space with no geo-referencing.
@@ -55,20 +55,20 @@ pub enum Coordinate {
     Euclidean,
     /// A 2D plane embedded in 3D, anchored in a base frame. Boxed: a
     /// `TangentPlane` is ~72 bytes against the 2-byte `EpsgCode`, and `Tangent`
-    /// is the rare frame, so boxing it keeps `Coordinate` — embedded in every
+    /// is the rare frame, so boxing it keeps `CoordinateFrame` — embedded in every
     /// geometry leaf — pointer-sized for the common `Crs` / `Euclidean` cases.
     Tangent(Box<TangentPlane>),
 }
 
-impl Coordinate {
+impl CoordinateFrame {
     /// The EPSG code of this frame, or an error if it is not a CRS frame.
     pub(crate) fn require_crs(&self) -> Result<EpsgCode> {
         match self {
-            Coordinate::Crs(epsg) => Ok(*epsg),
-            Coordinate::Euclidean => Err(Error::projection(
+            CoordinateFrame::Crs(epsg) => Ok(*epsg),
+            CoordinateFrame::Euclidean => Err(Error::projection(
                 "cannot reproject a Euclidean (non-georeferenced) geometry",
             )),
-            Coordinate::Tangent(_) => Err(Error::projection(
+            CoordinateFrame::Tangent(_) => Err(Error::projection(
                 "cannot reproject a Tangent-plane geometry",
             )),
         }
@@ -76,7 +76,7 @@ impl Coordinate {
 }
 
 /// The absolute frame a [`TangentPlane`] is anchored in: exactly the non-tangent
-/// [`Coordinate`] frames, so a tangent plane cannot be anchored in another
+/// [`CoordinateFrame`] frames, so a tangent plane cannot be anchored in another
 /// tangent plane.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum BaseFrame {
@@ -88,7 +88,7 @@ pub enum BaseFrame {
 
 /// A 2D Euclidean plane embedded in 3D space.
 ///
-/// A [`Coordinate::Tangent`] geometry stores in-plane `(x, y)` whose 3D position
+/// A [`CoordinateFrame::Tangent`] geometry stores in-plane `(x, y)` whose 3D position
 /// is `origin + x * u + y * v`. When `base` is a geographic CRS this is the
 /// local tangent (ENU) frame at `origin`, with in-plane coordinates in metres.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/engine/runtime/geometry/src/csg/constructor.rs
+++ b/engine/runtime/geometry/src/csg/constructor.rs
@@ -46,7 +46,7 @@ impl Csg {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::Coordinate;
+    use crate::coordinate::CoordinateFrame;
     use crate::triangular_mesh::TriangularMesh3DData;
 
     fn solid() -> Solid {
@@ -55,7 +55,7 @@ mod tests {
             [0u32, 1, 2],
         )
         .unwrap();
-        Solid::from_exterior(Coordinate::Euclidean, shell)
+        Solid::from_exterior(CoordinateFrame::Euclidean, shell)
     }
 
     #[test]

--- a/engine/runtime/geometry/src/csg/ops.rs
+++ b/engine/runtime/geometry/src/csg/ops.rs
@@ -24,7 +24,7 @@ fn operand_box(operand: &ThreeDimensional) -> Result<Aabb, UnsupportedOperation>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::Coordinate;
+    use crate::coordinate::CoordinateFrame;
     use crate::solid::Solid;
     use crate::triangular_mesh::TriangularMesh3DData;
 
@@ -35,7 +35,7 @@ mod tests {
             [0u32, 1, 2],
         )
         .unwrap();
-        Solid::from_exterior(Coordinate::Euclidean, shell)
+        Solid::from_exterior(CoordinateFrame::Euclidean, shell)
     }
 
     #[test]

--- a/engine/runtime/geometry/src/index.rs
+++ b/engine/runtime/geometry/src/index.rs
@@ -174,6 +174,17 @@ impl<const N: usize> IndexBuffer<N> {
         }
     }
 
+    /// Iterate the elements as `[u32; N]`, widening each stored index from its
+    /// concrete width. Lets callers read the indices without depending on the
+    /// stored width.
+    pub(crate) fn iter_u32(&self) -> impl Iterator<Item = [u32; N]> + '_ {
+        (0..self.len()).map(move |i| match self {
+            IndexBuffer::U8(v) => v[i].map(|x| x as u32),
+            IndexBuffer::U16(v) => v[i].map(|x| x as u32),
+            IndexBuffer::U32(v) => v[i],
+        })
+    }
+
     /// Build from index elements, choosing the narrowest width that fits them all.
     ///
     /// Width-agnostic: storage starts at `u8` and fattens to `u16` then `u32` only

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -260,14 +260,14 @@ impl Reproject for GeometryCollection {
 #[cfg(test)]
 mod bounding_box_tests {
     use super::*;
-    use coordinate::Coordinate;
+    use coordinate::CoordinateFrame;
     use point::{Point2D, Point3D};
     use polygon::Polygon2D;
 
     #[test]
     fn dispatch_reaches_inline_leaf_through_dimension_enum() {
         let g = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [1.0, 2.0, 3.0],
         )));
         assert_eq!(
@@ -283,7 +283,7 @@ mod bounding_box_tests {
     fn dispatch_reaches_boxed_leaf_through_dimension_enum() {
         // The `Box<Polygon2D>` variant exercises the `Box<T>` blanket impl.
         let p = Polygon2D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 0.0]],
             Vec::<Vec<[f64; 2]>>::new(),
         );
@@ -305,11 +305,11 @@ mod bounding_box_tests {
     #[test]
     fn geometry_collection_mixing_2d_and_3d_promotes_to_3d() {
         let p2 = Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [0.0, 0.0],
         )));
         let p3 = Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [4.0, 4.0, 9.0],
         )));
         let gc = Geometry::GeometryCollection(GeometryCollection::new([p2, p3]));
@@ -334,7 +334,7 @@ mod bounding_box_tests {
 #[cfg(test)]
 mod triangulate_tests {
     use super::*;
-    use coordinate::Coordinate;
+    use coordinate::CoordinateFrame;
     use point::Point2D;
     use polygon::{Polygon2D, Polygon3D};
     use polygon_mesh::{PolygonMesh2D, PolygonMesh3D, PolygonMesh3DData};
@@ -344,7 +344,7 @@ mod triangulate_tests {
     /// A spread of supported inputs covering both embeddings, holes, elevation,
     /// multi-face meshes, and a degenerate face.
     fn sample_geometries() -> Vec<Geometry> {
-        let e = Coordinate::Euclidean;
+        let e = CoordinateFrame::Euclidean;
         let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
         let hole = vec![[1.0, 1.0], [3.0, 1.0], [3.0, 3.0], [1.0, 3.0], [1.0, 1.0]];
 
@@ -477,7 +477,11 @@ mod triangulate_tests {
     #[test]
     fn triangulate_dispatches_through_geometry_to_polygon() {
         let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
-        let p = Polygon2D::from_rings(Coordinate::Euclidean, square, Vec::<Vec<[f64; 2]>>::new());
+        let p = Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            square,
+            Vec::<Vec<[f64; 2]>>::new(),
+        );
         let mut g = Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(p)));
         let out = g.triangulate(&mut Cache::new()).unwrap();
         match out {
@@ -491,7 +495,7 @@ mod triangulate_tests {
     #[test]
     fn triangulate_is_unsupported_for_non_polygonal_types() {
         let mut point = Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [0.0, 0.0],
         )));
         assert!(point.triangulate(&mut Cache::new()).is_err());

--- a/engine/runtime/geometry/src/line_string/constructor.rs
+++ b/engine/runtime/geometry/src/line_string/constructor.rs
@@ -7,7 +7,7 @@
 //! (2.5D), split out of `[x, y, z]` input. Lines are stored as given (not closed)
 //! and carry no appearance.
 
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 use crate::error::Error;
 
 use super::{LineString2D, LineString3D};
@@ -16,9 +16,9 @@ impl LineString2D {
     /// Build a 2D polyline from `[x, y]` coordinates. The result is pure 2D (no
     /// elevation); for per-vertex elevation use
     /// [`LineString2D::from_coords_with_elevation`].
-    pub fn from_coords(coordinate: Coordinate, coords: impl IntoIterator<Item = [f64; 2]>) -> Self {
+    pub fn from_coords(frame: CoordinateFrame, coords: impl IntoIterator<Item = [f64; 2]>) -> Self {
         Self {
-            coordinate,
+            frame,
             coords: coords.into_iter().collect(),
             z: None,
         }
@@ -27,7 +27,7 @@ impl LineString2D {
     /// Build a 2.5D polyline from `[x, y, z]` coordinates: the `(x, y)` populate
     /// `coords` and the `z` the parallel elevation buffer.
     pub fn from_coords_with_elevation(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         coords: impl IntoIterator<Item = [f64; 3]>,
     ) -> Self {
         let coords = coords.into_iter();
@@ -39,7 +39,7 @@ impl LineString2D {
             z.push(elevation);
         }
         Self {
-            coordinate,
+            frame,
             coords: xy.into_boxed_slice(),
             z: Some(z.into_boxed_slice()),
         }
@@ -48,7 +48,7 @@ impl LineString2D {
     /// Build from an already-built coordinate buffer and optional parallel
     /// elevation. Errors if `z` is present and not the same length as `coords`.
     pub fn from_raw_parts(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         coords: Box<[[f64; 2]]>,
         z: Option<Box<[f64]>>,
     ) -> Result<Self, Error> {
@@ -61,26 +61,22 @@ impl LineString2D {
                 )));
             }
         }
-        Ok(Self {
-            coordinate,
-            coords,
-            z,
-        })
+        Ok(Self { frame, coords, z })
     }
 }
 
 impl LineString3D {
     /// Build a 3D polyline from `[x, y, z]` coordinates.
-    pub fn from_coords(coordinate: Coordinate, coords: impl IntoIterator<Item = [f64; 3]>) -> Self {
+    pub fn from_coords(frame: CoordinateFrame, coords: impl IntoIterator<Item = [f64; 3]>) -> Self {
         Self {
-            coordinate,
+            frame,
             coords: coords.into_iter().collect(),
         }
     }
 
     /// Build from an already-built coordinate buffer.
-    pub fn from_raw_parts(coordinate: Coordinate, coords: Box<[[f64; 3]]>) -> Self {
-        Self { coordinate, coords }
+    pub fn from_raw_parts(frame: CoordinateFrame, coords: Box<[[f64; 3]]>) -> Self {
+        Self { frame, coords }
     }
 }
 
@@ -90,19 +86,21 @@ mod tests {
 
     #[test]
     fn from_coords_2d_is_open_and_pure() {
-        let l =
-            LineString2D::from_coords(Coordinate::Euclidean, [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]);
+        let l = LineString2D::from_coords(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]],
+        );
         // Stored as given: no closing vertex appended.
         assert_eq!(l.coords.len(), 3);
         assert_eq!(l.coords[0], [0.0, 0.0]);
         assert!(l.z.is_none());
-        assert_eq!(l.coordinate, Coordinate::Euclidean);
+        assert_eq!(l.frame, CoordinateFrame::Euclidean);
     }
 
     #[test]
     fn from_coords_with_elevation_splits_z() {
         let l = LineString2D::from_coords_with_elevation(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0, 10.0], [1.0, 0.0, 11.0]],
         );
         assert_eq!(l.coords, vec![[0.0, 0.0], [1.0, 0.0]].into_boxed_slice());
@@ -113,7 +111,7 @@ mod tests {
     fn from_raw_parts_2d_rejects_unparallel_z() {
         let coords: Box<[[f64; 2]]> = vec![[0.0, 0.0], [1.0, 0.0]].into_boxed_slice();
         let err = LineString2D::from_raw_parts(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             coords,
             Some(vec![0.0].into_boxed_slice()),
         )
@@ -125,7 +123,7 @@ mod tests {
     fn from_raw_parts_2d_accepts_parallel_z() {
         let coords: Box<[[f64; 2]]> = vec![[0.0, 0.0], [1.0, 0.0]].into_boxed_slice();
         let l = LineString2D::from_raw_parts(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             coords,
             Some(vec![3.0, 4.0].into_boxed_slice()),
         )
@@ -135,8 +133,10 @@ mod tests {
 
     #[test]
     fn from_coords_3d() {
-        let l =
-            LineString3D::from_coords(Coordinate::Euclidean, [[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]]);
+        let l = LineString3D::from_coords(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0, 0.0], [1.0, 2.0, 3.0]],
+        );
         assert_eq!(l.coords.len(), 2);
         assert_eq!(l.coords[1], [1.0, 2.0, 3.0]);
     }

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -8,7 +8,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 
 mod constructor;
 mod ops;
@@ -17,7 +17,7 @@ mod ops;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct LineString2D {
     /// Coordinate frame these coords are expressed in.
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     coords: Box<[[f64; 2]]>,
     /// Optional per-vertex elevation, parallel to `coords`.
     /// INVARIANT: when `Some`, `z.len() == coords.len()`. `None` = pure 2D.
@@ -28,7 +28,7 @@ pub struct LineString2D {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct LineString3D {
     /// Coordinate frame these coords are expressed in.
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     coords: Box<[[f64; 3]]>,
 }
 

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -1,5 +1,5 @@
 use super::{LineString2D, LineString3D};
-use crate::coordinate::{Coordinate, EpsgCode};
+use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::ops::reproject::{transform_coords_2d, transform_coords_3d};
 use crate::ops::{Aabb, BoundingBox, Reproject, ReprojectionCache, UnsupportedOperation};
 
@@ -28,10 +28,10 @@ impl Reproject for LineString2D {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
-        let from = self.coordinate.require_crs()?;
+        let from = self.frame.require_crs()?;
         if from != target {
             transform_coords_2d(cache, from, target, &mut self.coords, self.z.as_deref_mut())?;
-            self.coordinate = Coordinate::Crs(target);
+            self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
     }
@@ -43,10 +43,10 @@ impl Reproject for LineString3D {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
-        let from = self.coordinate.require_crs()?;
+        let from = self.frame.require_crs()?;
         if from != target {
             transform_coords_3d(cache, from, target, &mut self.coords)?;
-            self.coordinate = Coordinate::Crs(target);
+            self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
     }
@@ -55,12 +55,14 @@ impl Reproject for LineString3D {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::Coordinate;
+    use crate::coordinate::CoordinateFrame;
 
     #[test]
     fn linestring2d_box_spans_all_coords() {
-        let ls =
-            LineString2D::from_coords(Coordinate::Euclidean, [[0.0, 0.0], [2.0, 1.0], [1.0, 3.0]]);
+        let ls = LineString2D::from_coords(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0], [2.0, 1.0], [1.0, 3.0]],
+        );
         assert_eq!(
             ls.bounding_box().unwrap(),
             Aabb::D2 {
@@ -73,7 +75,7 @@ mod tests {
     #[test]
     fn linestring2d_box_ignores_elevation() {
         let ls = LineString2D::from_coords_with_elevation(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0, 99.0], [2.0, 1.0, -99.0]],
         );
         // 2.5D elevation does not widen the 2D box.
@@ -88,14 +90,16 @@ mod tests {
 
     #[test]
     fn empty_linestring_has_no_box() {
-        let ls = LineString2D::from_coords(Coordinate::Euclidean, Vec::<[f64; 2]>::new());
+        let ls = LineString2D::from_coords(CoordinateFrame::Euclidean, Vec::<[f64; 2]>::new());
         assert!(ls.bounding_box().is_err());
     }
 
     #[test]
     fn linestring3d_box_spans_all_coords() {
-        let ls =
-            LineString3D::from_coords(Coordinate::Euclidean, [[0.0, 0.0, 0.0], [2.0, 1.0, -1.0]]);
+        let ls = LineString3D::from_coords(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0, 0.0], [2.0, 1.0, -1.0]],
+        );
         assert_eq!(
             ls.bounding_box().unwrap(),
             Aabb::D3 {

--- a/engine/runtime/geometry/src/ops/reproject/mod.rs
+++ b/engine/runtime/geometry/src/ops/reproject/mod.rs
@@ -83,7 +83,7 @@ mod tests {
 
     use super::*;
     use crate::collection::Collection3D;
-    use crate::coordinate::Coordinate;
+    use crate::coordinate::CoordinateFrame;
     use crate::line_string::LineString2D;
     use crate::point::{Point2D, Point3D};
     use crate::point_cloud::PointCloud;
@@ -136,11 +136,11 @@ mod tests {
             .transform(EpsgCode::new(4979), EpsgCode::new(4978), start)
             .unwrap();
 
-        let mut p = Point3D::new(Coordinate::Crs(EpsgCode::new(4979)), start);
+        let mut p = Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), start);
         p.reproject(EpsgCode::new(4978), &mut cache).unwrap();
         assert_eq!(
             p,
-            Point3D::new(Coordinate::Crs(EpsgCode::new(4978)), expected)
+            Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4978)), expected)
         );
     }
 
@@ -155,11 +155,11 @@ mod tests {
             )
             .unwrap();
 
-        let mut p = Point2D::new(Coordinate::Crs(EpsgCode::new(4326)), [139.767, 35.681]);
+        let mut p = Point2D::new(CoordinateFrame::Crs(EpsgCode::new(4326)), [139.767, 35.681]);
         p.reproject(EpsgCode::new(3857), &mut cache).unwrap();
         assert_eq!(
             p,
-            Point2D::new(Coordinate::Crs(EpsgCode::new(3857)), [x, y])
+            Point2D::new(CoordinateFrame::Crs(EpsgCode::new(3857)), [x, y])
         );
     }
 
@@ -176,13 +176,15 @@ mod tests {
             })
             .collect();
 
-        let mut ls =
-            LineString2D::from_coords_with_elevation(Coordinate::Crs(EpsgCode::new(4326)), raw);
+        let mut ls = LineString2D::from_coords_with_elevation(
+            CoordinateFrame::Crs(EpsgCode::new(4326)),
+            raw,
+        );
         ls.reproject(EpsgCode::new(3857), &mut cache).unwrap();
         assert_eq!(
             ls,
             LineString2D::from_coords_with_elevation(
-                Coordinate::Crs(EpsgCode::new(3857)),
+                CoordinateFrame::Crs(EpsgCode::new(3857)),
                 expected
             )
         );
@@ -201,15 +203,21 @@ mod tests {
             .unwrap();
 
         let mut col = Collection3D::new([
-            Euclidean3DGeometry::Point(Point3D::new(Coordinate::Crs(EpsgCode::new(4979)), a)),
-            Euclidean3DGeometry::Point(Point3D::new(Coordinate::Crs(EpsgCode::new(4979)), b)),
+            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), a)),
+            Euclidean3DGeometry::Point(Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), b)),
         ]);
         col.reproject(EpsgCode::new(4978), &mut cache).unwrap();
         assert_eq!(
             col,
             Collection3D::new([
-                Euclidean3DGeometry::Point(Point3D::new(Coordinate::Crs(EpsgCode::new(4978)), ea)),
-                Euclidean3DGeometry::Point(Point3D::new(Coordinate::Crs(EpsgCode::new(4978)), eb)),
+                Euclidean3DGeometry::Point(Point3D::new(
+                    CoordinateFrame::Crs(EpsgCode::new(4978)),
+                    ea
+                )),
+                Euclidean3DGeometry::Point(Point3D::new(
+                    CoordinateFrame::Crs(EpsgCode::new(4978)),
+                    eb
+                )),
             ])
         );
     }
@@ -234,18 +242,24 @@ mod tests {
     #[test]
     fn reproject_same_crs_is_noop() {
         let mut cache = ReprojectionCache::new();
-        let mut p = Point3D::new(Coordinate::Crs(EpsgCode::new(4979)), [139.7, 35.6, 50.0]);
+        let mut p = Point3D::new(
+            CoordinateFrame::Crs(EpsgCode::new(4979)),
+            [139.7, 35.6, 50.0],
+        );
         p.reproject(EpsgCode::new(4979), &mut cache).unwrap();
         assert_eq!(
             p,
-            Point3D::new(Coordinate::Crs(EpsgCode::new(4979)), [139.7, 35.6, 50.0])
+            Point3D::new(
+                CoordinateFrame::Crs(EpsgCode::new(4979)),
+                [139.7, 35.6, 50.0]
+            )
         );
     }
 
     #[test]
     fn non_crs_frame_is_error() {
         let mut cache = ReprojectionCache::new();
-        let mut p = Point3D::new(Coordinate::Euclidean, [1.0, 2.0, 3.0]);
+        let mut p = Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0]);
         assert!(matches!(
             p.reproject(EpsgCode::new(4326), &mut cache),
             Err(Error::Projection(_))
@@ -255,8 +269,10 @@ mod tests {
     #[test]
     fn unsupported_leaf_is_error() {
         let mut cache = ReprojectionCache::new();
-        let pc =
-            PointCloud::from_positions(Coordinate::Crs(EpsgCode::new(4979)), [[139.7, 35.6, 1.0]]);
+        let pc = PointCloud::from_positions(
+            CoordinateFrame::Crs(EpsgCode::new(4979)),
+            [[139.7, 35.6, 1.0]],
+        );
         let mut geom = Euclidean3DGeometry::PointCloud(Box::new(pc));
         assert!(matches!(
             geom.reproject(EpsgCode::new(4978), &mut cache),

--- a/engine/runtime/geometry/src/ops/triangulation.rs
+++ b/engine/runtime/geometry/src/ops/triangulation.rs
@@ -85,24 +85,32 @@ pub(crate) fn triangulate_3d(
 }
 
 /// Expand a source geometry's appearance onto its triangulated mesh, consuming it.
-/// `face_tris[i]` is the triangle count of source face `i`. Only the per-face
-/// bindings are expanded (see [`expand_binding`]); palette and themes are unchanged.
+/// `face_tris[i]` is the triangle count of source face `i`; `src_corner[j]` is the
+/// source corner-buffer position output triangle-corner `j` draws from. Per-face
+/// bindings are expanded (see [`expand_binding`]) and each theme's UV sets
+/// re-targeted onto the triangulated corner buffer (see [`retarget_uv`]); palette
+/// and themes are otherwise unchanged.
 pub(crate) fn expand_appearance(
     appearance: Option<Appearance>,
     face_tris: &[u32],
+    src_corner: &[u32],
 ) -> Option<Appearance> {
-    appearance.map(|app| Appearance {
-        materials: app.materials,
-        default_theme: app.default_theme,
-        themes: app
-            .themes
+    appearance.map(|app| {
+        let (materials, themes, default_theme) = app.into_parts();
+        let themes = themes
             .into_iter()
             .map(|theme| ThemeBinding {
                 theme: theme.theme,
                 front: expand_binding(theme.front, face_tris),
                 back: theme.back.map(|back| expand_binding(back, face_tris)),
+                uv_sets: theme
+                    .uv_sets
+                    .into_iter()
+                    .map(|uv| retarget_uv(uv, src_corner))
+                    .collect(),
             })
-            .collect(),
+            .collect();
+        Appearance::from_parts(materials, themes, default_theme)
     })
 }
 
@@ -130,7 +138,7 @@ fn expand_binding(binding: FaceBinding, face_tris: &[u32]) -> FaceBinding {
 /// `PolygonMesh` face. An `Explicit` set is re-gathered into a fresh
 /// `3 * triangle_count`-long array; a `WorldToTexture` matrix is *positional*,
 /// so it moves over verbatim (triangulation preserves world positions).
-/// Only the `uv` payload changes; `theme` / `side` / `channel` carry through.
+/// Only the `uv` payload changes; `side` / `channel` carry through.
 pub(crate) fn retarget_uv(uv: UvSet, src_corner: &[u32]) -> UvSet {
     let mapped = match uv.uv {
         UvSource::Explicit(coords) => {

--- a/engine/runtime/geometry/src/ops/triangulation.rs
+++ b/engine/runtime/geometry/src/ops/triangulation.rs
@@ -28,8 +28,11 @@ impl Cache {
 pub(crate) struct Buffers {
     /// Polygon ring vertex positions into the source `coords`.
     pub(crate) positions: Vec<u32>,
-    /// Hole-ring start offsets (polygon: into the ring list; mesh: per face).
+    /// Hole-ring start offsets (polygon: into the ring list; mesh: into `open_src`).
     pub(crate) holes: Vec<u32>,
+    /// Face-local positions of a mesh face's open-ring corners, closing duplicates
+    /// dropped; parallel to the gathered `verts2` / `verts3`.
+    pub(crate) open_src: Vec<u32>,
     /// One earcut output (one polygon, or one mesh face).
     pub(crate) out: Vec<u32>,
     /// Accumulated global triangle indices (mesh).

--- a/engine/runtime/geometry/src/point/constructor.rs
+++ b/engine/runtime/geometry/src/point/constructor.rs
@@ -4,27 +4,21 @@
 //! vertices, 2D/3D point features) hand over exactly that, so construction just
 //! pairs the position with its coordinate frame.
 
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 
 use super::{Point2D, Point3D};
 
 impl Point2D {
-    /// A 2D point at `position`, in `coordinate`.
-    pub fn new(coordinate: Coordinate, position: [f64; 2]) -> Self {
-        Self {
-            coordinate,
-            position,
-        }
+    /// A 2D point at `position`, in `frame`.
+    pub fn new(frame: CoordinateFrame, position: [f64; 2]) -> Self {
+        Self { frame, position }
     }
 }
 
 impl Point3D {
-    /// A 3D point at `position`, in `coordinate`.
-    pub fn new(coordinate: Coordinate, position: [f64; 3]) -> Self {
-        Self {
-            coordinate,
-            position,
-        }
+    /// A 3D point at `position`, in `frame`.
+    pub fn new(frame: CoordinateFrame, position: [f64; 3]) -> Self {
+        Self { frame, position }
     }
 }
 
@@ -35,12 +29,12 @@ mod tests {
 
     #[test]
     fn new_stores_position_and_frame() {
-        let p = Point2D::new(Coordinate::Euclidean, [1.0, 2.0]);
+        let p = Point2D::new(CoordinateFrame::Euclidean, [1.0, 2.0]);
         assert_eq!(p.position, [1.0, 2.0]);
-        assert_eq!(p.coordinate, Coordinate::Euclidean);
+        assert_eq!(p.frame, CoordinateFrame::Euclidean);
 
-        let q = Point3D::new(Coordinate::Crs(EpsgCode::new(4326)), [1.0, 2.0, 3.0]);
+        let q = Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4326)), [1.0, 2.0, 3.0]);
         assert_eq!(q.position, [1.0, 2.0, 3.0]);
-        assert_eq!(q.coordinate, Coordinate::Crs(EpsgCode::new(4326)));
+        assert_eq!(q.frame, CoordinateFrame::Crs(EpsgCode::new(4326)));
     }
 }

--- a/engine/runtime/geometry/src/point/mod.rs
+++ b/engine/runtime/geometry/src/point/mod.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::coordinate::Coordinate;
+use super::coordinate::CoordinateFrame;
 
 mod constructor;
 mod ops;
@@ -12,7 +12,7 @@ mod ops;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Point2D {
     /// Coordinate frame this position is expressed in.
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     position: [f64; 2],
 }
 
@@ -21,7 +21,7 @@ pub struct Point2D {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Point3D {
     /// Coordinate frame this position is expressed in.
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     position: [f64; 3],
 }
 

--- a/engine/runtime/geometry/src/point/ops.rs
+++ b/engine/runtime/geometry/src/point/ops.rs
@@ -1,5 +1,5 @@
 use super::{Point2D, Point3D};
-use crate::coordinate::{Coordinate, EpsgCode};
+use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::ops::{Aabb, BoundingBox, Reproject, ReprojectionCache, UnsupportedOperation};
 
 impl BoundingBox for Point2D {
@@ -20,12 +20,12 @@ impl Reproject for Point2D {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
-        let from = self.coordinate.require_crs()?;
+        let from = self.frame.require_crs()?;
         if from != target {
             let [x, y] = self.position;
             let [nx, ny, _] = cache.transform(from, target, [x, y, 0.0])?;
             self.position = [nx, ny];
-            self.coordinate = Coordinate::Crs(target);
+            self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
     }
@@ -37,10 +37,10 @@ impl Reproject for Point3D {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
-        let from = self.coordinate.require_crs()?;
+        let from = self.frame.require_crs()?;
         if from != target {
             self.position = cache.transform(from, target, self.position)?;
-            self.coordinate = Coordinate::Crs(target);
+            self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
     }
@@ -49,11 +49,11 @@ impl Reproject for Point3D {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::Coordinate;
+    use crate::coordinate::CoordinateFrame;
 
     #[test]
     fn point2d_box_is_degenerate_d2() {
-        let p = Point2D::new(Coordinate::Euclidean, [1.0, 2.0]);
+        let p = Point2D::new(CoordinateFrame::Euclidean, [1.0, 2.0]);
         assert_eq!(
             p.bounding_box().unwrap(),
             Aabb::D2 {
@@ -65,7 +65,7 @@ mod tests {
 
     #[test]
     fn point3d_box_is_degenerate_d3() {
-        let p = Point3D::new(Coordinate::Euclidean, [1.0, 2.0, 3.0]);
+        let p = Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0]);
         assert_eq!(
             p.bounding_box().unwrap(),
             Aabb::D3 {

--- a/engine/runtime/geometry/src/point_cloud/constructor.rs
+++ b/engine/runtime/geometry/src/point_cloud/constructor.rs
@@ -11,7 +11,7 @@ use std::sync::OnceLock;
 use indexmap::IndexMap;
 use smallvec::SmallVec;
 
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 
 use super::{PointCloud, PositionEncoding, Segment};
 
@@ -22,7 +22,7 @@ impl PointCloud {
     /// Build a point cloud from bare XYZ positions: one `f64`-encoded segment with
     /// no optional fields or attributes.
     pub fn from_positions(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         positions: impl IntoIterator<Item = [f64; 3]>,
     ) -> Self {
         let positions = positions.into_iter();
@@ -46,7 +46,7 @@ impl PointCloud {
             attributes: IndexMap::new(),
         });
         Self {
-            coordinate,
+            frame,
             segments,
             kdtree: OnceLock::new(),
         }
@@ -60,7 +60,7 @@ mod tests {
     #[test]
     fn from_positions_packs_one_f64_segment() {
         let pc = PointCloud::from_positions(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0, 0.0], [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
         );
         assert_eq!(pc.segments.len(), 1);

--- a/engine/runtime/geometry/src/point_cloud/mod.rs
+++ b/engine/runtime/geometry/src/point_cloud/mod.rs
@@ -18,7 +18,7 @@ use kiddo::ImmutableKdTree;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 
 mod constructor;
 mod ops;
@@ -109,7 +109,7 @@ struct Segment {
 #[derive(Serialize, Deserialize)]
 pub struct PointCloud {
     /// Coordinate frame all segments are expressed in.
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     /// One segment inline (no heap allocation) is the common case.
     segments: SmallVec<[Segment; 1]>,
     /// Built lazily on first spatial query, or pre-built explicitly. Not part of
@@ -124,7 +124,7 @@ impl Clone for PointCloud {
     fn clone(&self) -> Self {
         // The KD-tree is a derived cache, rebuilt lazily; a clone starts fresh.
         PointCloud {
-            coordinate: self.coordinate.clone(),
+            frame: self.frame.clone(),
             segments: self.segments.clone(),
             kdtree: OnceLock::new(),
         }
@@ -134,14 +134,14 @@ impl Clone for PointCloud {
 impl PartialEq for PointCloud {
     fn eq(&self, other: &Self) -> bool {
         // The KD-tree cache is not part of the value.
-        self.coordinate == other.coordinate && self.segments == other.segments
+        self.frame == other.frame && self.segments == other.segments
     }
 }
 
 impl fmt::Debug for PointCloud {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PointCloud")
-            .field("coordinate", &self.coordinate)
+            .field("frame", &self.frame)
             .field("segments", &self.segments)
             .field("kdtree", &self.kdtree.get().map(|_| "<built>"))
             .finish()

--- a/engine/runtime/geometry/src/point_cloud/ops.rs
+++ b/engine/runtime/geometry/src/point_cloud/ops.rs
@@ -49,12 +49,12 @@ fn segment_positions(seg: &Segment) -> impl Iterator<Item = [f64; 3]> + '_ {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::Coordinate;
+    use crate::coordinate::CoordinateFrame;
 
     #[test]
     fn point_cloud_box_spans_all_points() {
         let pc = PointCloud::from_positions(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 1.0, 2.0], [4.0, -1.0, 2.0], [1.0, 0.0, 9.0]],
         );
         assert_eq!(
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn empty_point_cloud_has_no_box() {
-        let pc = PointCloud::from_positions(Coordinate::Euclidean, Vec::<[f64; 3]>::new());
+        let pc = PointCloud::from_positions(CoordinateFrame::Euclidean, Vec::<[f64; 3]>::new());
         assert!(pc.bounding_box().is_err());
     }
 }

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -100,7 +100,6 @@ impl Polygon2D {
             coords: coords.into_boxed_slice(),
             interior_offsets: interior_offsets.into_boxed_slice(),
             z: None,
-            uv_sets: Vec::new(),
             appearance: None,
         }
     }
@@ -131,7 +130,6 @@ impl Polygon2D {
             coords: coords.into_boxed_slice(),
             interior_offsets: interior_offsets.into_boxed_slice(),
             z: Some(z.into_boxed_slice()),
-            uv_sets: Vec::new(),
             appearance: None,
         }
     }
@@ -164,7 +162,6 @@ impl Polygon2D {
             coords,
             interior_offsets,
             z,
-            uv_sets: Vec::new(),
             appearance: None,
         })
     }
@@ -188,7 +185,6 @@ impl Polygon3D {
             frame,
             coords: coords.into_boxed_slice(),
             interior_offsets: interior_offsets.into_boxed_slice(),
-            uv_sets: Vec::new(),
             appearance: None,
         }
     }
@@ -206,7 +202,6 @@ impl Polygon3D {
             frame,
             coords,
             interior_offsets,
-            uv_sets: Vec::new(),
             appearance: None,
         })
     }
@@ -456,7 +451,6 @@ impl Polygon2D {
         add_polygon_theme(
             self.coords.len(),
             &mut self.appearance,
-            &mut self.uv_sets,
             theme,
             PolygonFace::single(material, uv),
             None,
@@ -475,7 +469,6 @@ impl Polygon2D {
         add_polygon_theme(
             self.coords.len(),
             &mut self.appearance,
-            &mut self.uv_sets,
             theme,
             front,
             Some(back),
@@ -495,7 +488,6 @@ impl Polygon3D {
         add_polygon_theme(
             self.coords.len(),
             &mut self.appearance,
-            &mut self.uv_sets,
             theme,
             PolygonFace::single(material, uv),
             None,
@@ -513,7 +505,6 @@ impl Polygon3D {
         add_polygon_theme(
             self.coords.len(),
             &mut self.appearance,
-            &mut self.uv_sets,
             theme,
             front,
             Some(back),
@@ -532,7 +523,6 @@ impl Polygon3D {
 fn add_polygon_theme(
     corner_count: usize,
     appearance: &mut Option<Appearance>,
-    uv_sets: &mut Vec<UvSet>,
     theme: ThemeId,
     front: PolygonFace,
     back: Option<PolygonFace>,
@@ -545,7 +535,6 @@ fn add_polygon_theme(
         &mut materials,
         &mut new_uv_sets,
         corner_count,
-        theme.clone(),
         Side::Front,
         front,
     )?;
@@ -554,7 +543,6 @@ fn add_polygon_theme(
             &mut materials,
             &mut new_uv_sets,
             corner_count,
-            theme.clone(),
             Side::Back,
             face,
         )?),
@@ -563,7 +551,6 @@ fn add_polygon_theme(
 
     append_theme(
         appearance,
-        uv_sets,
         theme,
         materials,
         front_binding,
@@ -578,19 +565,13 @@ fn push_face(
     materials: &mut Vec<Material>,
     uv_sets: &mut Vec<UvSet>,
     corner_count: usize,
-    theme: ThemeId,
     side: Side,
     face: PolygonFace,
 ) -> Result<FaceBinding, Error> {
     validate_uv_coupling(&face.material.referenced_channels(), &face.uv, corner_count)?;
 
     for (channel, uv) in face.uv {
-        uv_sets.push(UvSet {
-            theme: Some(theme.clone()),
-            side,
-            channel,
-            uv,
-        });
+        uv_sets.push(UvSet { side, channel, uv });
     }
 
     let index = u32::try_from(materials.len())
@@ -712,7 +693,6 @@ mod tests {
         assert_eq!(p.coords, coords);
         assert!(p.interior_offsets.is_empty());
         assert!(p.z.is_none());
-        assert!(p.uv_sets.is_empty());
         assert!(p.appearance.is_none());
     }
 
@@ -810,22 +790,23 @@ mod tests {
             .unwrap();
 
         let app = p.appearance().as_ref().unwrap();
-        assert_eq!(app.materials.len(), 1);
-        assert_eq!(app.themes.len(), 1);
-        assert_eq!(app.default_theme, theme("rgb"));
-        assert!(matches!(app.themes[0].front, FaceBinding::Uniform(_)));
-        assert!(app.themes[0].back.is_none());
-        assert_eq!(p.uv_sets.len(), 1);
-        assert_eq!(p.uv_sets[0].theme.as_ref(), Some(&theme("rgb")));
-        assert_eq!(p.uv_sets[0].side, Side::Front);
+        assert_eq!(app.materials().len(), 1);
+        assert_eq!(app.themes().len(), 1);
+        assert_eq!(*app.default_theme(), theme("rgb"));
+        assert!(matches!(app.themes()[0].front, FaceBinding::Uniform(_)));
+        assert!(app.themes()[0].back.is_none());
+        assert_eq!(app.themes()[0].theme, theme("rgb"));
+        assert_eq!(app.themes()[0].uv_sets.len(), 1);
+        assert_eq!(app.themes()[0].uv_sets[0].side, Side::Front);
     }
 
     #[test]
     fn bare_material_with_no_uv_is_accepted() {
         let mut p = triangle();
         p.set_appearance(theme("rgb"), bare(), None).unwrap();
-        assert_eq!(p.appearance().as_ref().unwrap().materials.len(), 1);
-        assert!(p.uv_sets.is_empty());
+        let app = p.appearance().as_ref().unwrap();
+        assert_eq!(app.materials().len(), 1);
+        assert!(app.themes()[0].uv_sets.is_empty());
     }
 
     #[test]
@@ -863,7 +844,10 @@ mod tests {
         let mut p = triangle();
         let m = UvSource::WorldToTexture(TexMatrix([[0.0; 4]; 3]));
         p.set_appearance(theme("rgb"), textured(), Some(m)).unwrap();
-        assert_eq!(p.uv_sets.len(), 1);
+        assert_eq!(
+            p.appearance().as_ref().unwrap().themes()[0].uv_sets.len(),
+            1
+        );
     }
 
     #[test]
@@ -873,8 +857,8 @@ mod tests {
         p.set_appearance(theme("rgb"), bare(), None).unwrap();
 
         let app = p.appearance().as_ref().unwrap();
-        assert_eq!(app.default_theme, theme("infrared"));
-        assert_eq!(app.themes.len(), 2);
+        assert_eq!(*app.default_theme(), theme("infrared"));
+        assert_eq!(app.themes().len(), 2);
     }
 
     #[test]
@@ -893,11 +877,12 @@ mod tests {
         p.set_appearance(theme("infrared"), bare(), None).unwrap();
 
         let app = p.appearance().as_ref().unwrap();
-        assert_eq!(app.materials.len(), 2);
-        assert_eq!(app.themes.len(), 2);
-        // Only the textured theme contributes a UV set.
-        assert_eq!(p.uv_sets.len(), 1);
-        assert_eq!(p.uv_sets[0].theme.as_ref(), Some(&theme("rgb")));
+        assert_eq!(app.materials().len(), 2);
+        assert_eq!(app.themes().len(), 2);
+        // Only the textured theme (added first, so index 0) contributes a UV set.
+        assert_eq!(app.themes()[0].theme, theme("rgb"));
+        assert_eq!(app.themes()[0].uv_sets.len(), 1);
+        assert!(app.themes()[1].uv_sets.is_empty());
     }
 
     #[test]
@@ -908,10 +893,10 @@ mod tests {
             .unwrap();
 
         let app = p.appearance().as_ref().unwrap();
-        assert_eq!(app.materials.len(), 2);
-        assert!(app.themes[0].back.is_some());
-        assert_eq!(p.uv_sets.len(), 2);
-        let sides: Vec<Side> = p.uv_sets.iter().map(|u| u.side).collect();
+        assert_eq!(app.materials().len(), 2);
+        assert!(app.themes()[0].back.is_some());
+        assert_eq!(app.themes()[0].uv_sets.len(), 2);
+        let sides: Vec<Side> = app.themes()[0].uv_sets.iter().map(|u| u.side).collect();
         assert!(sides.contains(&Side::Front) && sides.contains(&Side::Back));
     }
 }

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -37,7 +37,7 @@
 //! CSR buffers directly and validate the layout invariants, returning [`Error`] on
 //! violation rather than panicking.
 //!
-//! Constructed polygons are *bare*: no UV sets and no appearance. Appearance is
+//! Constructed polygons are *bare*: no appearance. Appearance is
 //! attached afterwards (CityGML binds it by `gml:id` in a later pass than the
 //! geometry) via the validated [`Polygon2D::set_appearance`] /
 //! [`Polygon2D::set_two_sided_appearance`] setters below — or the raw
@@ -512,7 +512,7 @@ impl Polygon3D {
     }
 }
 
-/// Add one theme's appearance to a single-face polygon's `appearance` / `uv_sets`.
+/// Add one theme's appearance to a single-face polygon's `appearance`.
 /// `corner_count` is the polygon's coordinate count. The `front` face is required;
 /// `back` adds a distinct back-side material/UV. Shared by the 2D and 3D setters
 /// so the invariants live in one place.

--- a/engine/runtime/geometry/src/polygon/constructor.rs
+++ b/engine/runtime/geometry/src/polygon/constructor.rs
@@ -51,7 +51,7 @@ use crate::appearance::{
     append_theme, single_channel_uv, validate_uv_coupling, Appearance, ChannelId, FaceBinding,
     Material, MaterialIndex, Side, ThemeId, UvSet, UvSource,
 };
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 use crate::error::Error;
 
 use super::{Polygon2D, Polygon3D};
@@ -88,7 +88,7 @@ impl Polygon2D {
     /// Rings are concatenated exterior-first and stored verbatim — *not* closed, so
     /// an open ring (first != last) is left as-is for later validation; empty
     /// interior rings are dropped.
-    pub fn from_rings<E, I, R>(coordinate: Coordinate, exterior: E, interiors: I) -> Self
+    pub fn from_rings<E, I, R>(frame: CoordinateFrame, exterior: E, interiors: I) -> Self
     where
         E: IntoIterator<Item = [f64; 2]>,
         I: IntoIterator<Item = R>,
@@ -96,7 +96,7 @@ impl Polygon2D {
     {
         let (coords, interior_offsets) = flatten_rings::<2, _, _, _>(exterior, interiors);
         Self {
-            coordinate,
+            frame,
             coords: coords.into_boxed_slice(),
             interior_offsets: interior_offsets.into_boxed_slice(),
             z: None,
@@ -110,7 +110,7 @@ impl Polygon2D {
     /// that carry elevation on an otherwise 2D footprint (e.g. a height-tagged
     /// shapefile or GeoPackage layer).
     pub fn from_rings_with_elevation<E, I, R>(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         exterior: E,
         interiors: I,
     ) -> Self
@@ -127,7 +127,7 @@ impl Polygon2D {
             z.push(zz);
         }
         Self {
-            coordinate,
+            frame,
             coords: coords.into_boxed_slice(),
             interior_offsets: interior_offsets.into_boxed_slice(),
             z: Some(z.into_boxed_slice()),
@@ -144,7 +144,7 @@ impl Polygon2D {
     /// offset in `1..coords.len()` (every ring non-empty, exterior included).
     /// Violations return [`Error::InvalidGeometry`].
     pub fn from_raw_parts(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         coords: Box<[[f64; 2]]>,
         interior_offsets: Box<[u32]>,
         z: Option<Box<[f64]>>,
@@ -160,7 +160,7 @@ impl Polygon2D {
         }
         check_offsets(&interior_offsets, coords.len())?;
         Ok(Self {
-            coordinate,
+            frame,
             coords,
             interior_offsets,
             z,
@@ -177,7 +177,7 @@ impl Polygon3D {
     /// Rings are concatenated exterior-first and stored verbatim — *not* closed, so
     /// an open ring (first != last) is left as-is for later validation; empty
     /// interior rings are dropped.
-    pub fn from_rings<E, I, R>(coordinate: Coordinate, exterior: E, interiors: I) -> Self
+    pub fn from_rings<E, I, R>(frame: CoordinateFrame, exterior: E, interiors: I) -> Self
     where
         E: IntoIterator<Item = [f64; 3]>,
         I: IntoIterator<Item = R>,
@@ -185,7 +185,7 @@ impl Polygon3D {
     {
         let (coords, interior_offsets) = flatten_rings::<3, _, _, _>(exterior, interiors);
         Self {
-            coordinate,
+            frame,
             coords: coords.into_boxed_slice(),
             interior_offsets: interior_offsets.into_boxed_slice(),
             uv_sets: Vec::new(),
@@ -197,13 +197,13 @@ impl Polygon3D {
     /// be strictly increasing with each offset in `1..coords.len()`; violations
     /// return [`Error::InvalidGeometry`].
     pub fn from_raw_parts(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         coords: Box<[[f64; 3]]>,
         interior_offsets: Box<[u32]>,
     ) -> Result<Self, Error> {
         check_offsets(&interior_offsets, coords.len())?;
         Ok(Self {
-            coordinate,
+            frame,
             coords,
             interior_offsets,
             uv_sets: Vec::new(),
@@ -226,33 +226,33 @@ impl Polygon3D {
 /// compile:
 ///
 /// ```compile_fail
-/// use reearth_flow_geometry::coordinate::Coordinate;
+/// use reearth_flow_geometry::coordinate::CoordinateFrame;
 /// use reearth_flow_geometry::polygon::PolygonBuilder2D;
 /// // No `build` on the `Empty` state.
-/// let _ = PolygonBuilder2D::new(Coordinate::Euclidean).build();
+/// let _ = PolygonBuilder2D::new(CoordinateFrame::Euclidean).build();
 /// ```
 ///
 /// ```compile_fail
-/// use reearth_flow_geometry::coordinate::Coordinate;
+/// use reearth_flow_geometry::coordinate::CoordinateFrame;
 /// use reearth_flow_geometry::polygon::PolygonBuilder2D;
 /// // No `push_interior` before `set_exterior`.
-/// let _ = PolygonBuilder2D::new(Coordinate::Euclidean).push_interior([[0.0, 0.0]]);
+/// let _ = PolygonBuilder2D::new(CoordinateFrame::Euclidean).push_interior([[0.0, 0.0]]);
 /// ```
 ///
 /// Produces a pure-2D polygon (no elevation).
 #[derive(Debug, Clone)]
 pub struct PolygonBuilder2D<S: BuilderState = Empty> {
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     coords: Vec<[f64; 2]>,
     interior_offsets: Vec<u32>,
     _state: PhantomData<S>,
 }
 
 impl PolygonBuilder2D<Empty> {
-    /// Start an empty builder in `coordinate`, awaiting an exterior ring.
-    pub fn new(coordinate: Coordinate) -> Self {
+    /// Start an empty builder in `frame`, awaiting an exterior ring.
+    pub fn new(frame: CoordinateFrame) -> Self {
         Self {
-            coordinate,
+            frame,
             coords: Vec::new(),
             interior_offsets: Vec::new(),
             _state: PhantomData,
@@ -266,7 +266,7 @@ impl PolygonBuilder2D<Empty> {
         R: IntoIterator<Item = [f64; 2]>,
     {
         PolygonBuilder2D {
-            coordinate: self.coordinate,
+            frame: self.frame,
             coords: ring.into_iter().collect(),
             interior_offsets: Vec::new(),
             _state: PhantomData,
@@ -295,7 +295,7 @@ impl PolygonBuilder2D<HasExterior> {
     /// exterior ring (see [`Polygon2D::from_raw_parts`]).
     pub fn build(self) -> Result<Polygon2D, Error> {
         Polygon2D::from_raw_parts(
-            self.coordinate,
+            self.frame,
             self.coords.into_boxed_slice(),
             self.interior_offsets.into_boxed_slice(),
             None,
@@ -307,17 +307,17 @@ impl PolygonBuilder2D<HasExterior> {
 /// [`PolygonBuilder2D`], with rings of `[x, y, z]` and the same typestate machine.
 #[derive(Debug, Clone)]
 pub struct PolygonBuilder3D<S: BuilderState = Empty> {
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     coords: Vec<[f64; 3]>,
     interior_offsets: Vec<u32>,
     _state: PhantomData<S>,
 }
 
 impl PolygonBuilder3D<Empty> {
-    /// Start an empty builder in `coordinate`, awaiting an exterior ring.
-    pub fn new(coordinate: Coordinate) -> Self {
+    /// Start an empty builder in `frame`, awaiting an exterior ring.
+    pub fn new(frame: CoordinateFrame) -> Self {
         Self {
-            coordinate,
+            frame,
             coords: Vec::new(),
             interior_offsets: Vec::new(),
             _state: PhantomData,
@@ -331,7 +331,7 @@ impl PolygonBuilder3D<Empty> {
         R: IntoIterator<Item = [f64; 3]>,
     {
         PolygonBuilder3D {
-            coordinate: self.coordinate,
+            frame: self.frame,
             coords: ring.into_iter().collect(),
             interior_offsets: Vec::new(),
             _state: PhantomData,
@@ -359,7 +359,7 @@ impl PolygonBuilder3D<HasExterior> {
     /// problem the type system cannot rule out (see [`Polygon3D::from_raw_parts`]).
     pub fn build(self) -> Result<Polygon3D, Error> {
         Polygon3D::from_raw_parts(
-            self.coordinate,
+            self.frame,
             self.coords.into_boxed_slice(),
             self.interior_offsets.into_boxed_slice(),
         )
@@ -611,7 +611,7 @@ mod tests {
     #[test]
     fn from_rings_stores_exterior_verbatim() {
         let p = Polygon2D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
             Vec::<Vec<[f64; 2]>>::new(),
         );
@@ -619,7 +619,7 @@ mod tests {
         assert_ne!(p.coords[0], p.coords[p.coords.len() - 1]);
         assert!(p.interior_offsets.is_empty());
         assert!(p.z.is_none());
-        assert_eq!(p.coordinate, Coordinate::Euclidean);
+        assert_eq!(p.frame, CoordinateFrame::Euclidean);
     }
 
     // An empty exterior yields an empty polygon with its holes dropped — never an
@@ -627,7 +627,7 @@ mod tests {
     #[test]
     fn from_rings_empty_exterior_drops_holes() {
         let p = Polygon3D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             Vec::<[f64; 3]>::new(),
             vec![vec![[1.0, 1.0, 0.0], [2.0, 1.0, 0.0], [2.0, 2.0, 0.0]]],
         );
@@ -638,7 +638,7 @@ mod tests {
     #[test]
     fn from_rings_keeps_closed_exterior() {
         let p = Polygon2D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
             Vec::<Vec<[f64; 2]>>::new(),
         );
@@ -648,7 +648,7 @@ mod tests {
     #[test]
     fn from_rings_with_one_hole() {
         let p = Polygon2D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]],
             vec![vec![[1.0, 1.0], [2.0, 1.0], [2.0, 2.0]]],
         );
@@ -664,7 +664,7 @@ mod tests {
     #[test]
     fn from_rings_drops_empty_interior() {
         let p = Polygon2D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
             vec![Vec::<[f64; 2]>::new()],
         );
@@ -675,7 +675,7 @@ mod tests {
     #[test]
     fn from_rings_with_elevation_splits_z() {
         let p = Polygon2D::from_rings_with_elevation(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0, 10.0], [1.0, 0.0, 11.0], [0.0, 1.0, 12.0]],
             Vec::<Vec<[f64; 3]>>::new(),
         );
@@ -689,7 +689,7 @@ mod tests {
     #[test]
     fn from_rings_3d() {
         let p = Polygon3D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 1.0]],
             Vec::<Vec<[f64; 3]>>::new(),
         );
@@ -702,9 +702,13 @@ mod tests {
     fn from_raw_parts_stores_buffers() {
         let coords: Box<[[f64; 2]]> =
             vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 0.0]].into_boxed_slice();
-        let p =
-            Polygon2D::from_raw_parts(Coordinate::Euclidean, coords.clone(), Box::new([]), None)
-                .expect("valid layout");
+        let p = Polygon2D::from_raw_parts(
+            CoordinateFrame::Euclidean,
+            coords.clone(),
+            Box::new([]),
+            None,
+        )
+        .expect("valid layout");
         assert_eq!(p.coords, coords);
         assert!(p.interior_offsets.is_empty());
         assert!(p.z.is_none());
@@ -716,7 +720,7 @@ mod tests {
     fn from_raw_parts_rejects_unparallel_z() {
         let coords: Box<[[f64; 2]]> = vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]].into_boxed_slice();
         let err = Polygon2D::from_raw_parts(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             coords,
             Box::new([]),
             Some(vec![0.0, 0.0].into_boxed_slice()),
@@ -735,18 +739,23 @@ mod tests {
         ]
         .into_boxed_slice();
         // Offset 0 would leave the exterior empty.
-        assert!(
-            Polygon3D::from_raw_parts(Coordinate::Euclidean, coords.clone(), Box::new([0]))
-                .is_err()
-        );
+        assert!(Polygon3D::from_raw_parts(
+            CoordinateFrame::Euclidean,
+            coords.clone(),
+            Box::new([0])
+        )
+        .is_err());
         // Offset == coords.len() leaves a zero-length interior.
-        assert!(
-            Polygon3D::from_raw_parts(Coordinate::Euclidean, coords.clone(), Box::new([4]))
-                .is_err()
-        );
+        assert!(Polygon3D::from_raw_parts(
+            CoordinateFrame::Euclidean,
+            coords.clone(),
+            Box::new([4])
+        )
+        .is_err());
         // Non-increasing offsets.
         assert!(
-            Polygon3D::from_raw_parts(Coordinate::Euclidean, coords, Box::new([2, 2])).is_err()
+            Polygon3D::from_raw_parts(CoordinateFrame::Euclidean, coords, Box::new([2, 2]))
+                .is_err()
         );
     }
 
@@ -754,14 +763,14 @@ mod tests {
     // runtime-rejection tests; see the `compile_fail` doctests on `PolygonBuilder2D`.
     #[test]
     fn builder_streams_rings() {
-        let built = PolygonBuilder2D::new(Coordinate::Euclidean)
+        let built = PolygonBuilder2D::new(CoordinateFrame::Euclidean)
             .set_exterior([[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]])
             .push_interior([[1.0, 1.0], [2.0, 1.0], [2.0, 2.0]])
             .build()
             .unwrap();
 
         let batch = Polygon2D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0]],
             vec![vec![[1.0, 1.0], [2.0, 1.0], [2.0, 2.0]]],
         );
@@ -770,13 +779,13 @@ mod tests {
 
     #[test]
     fn builder_streams_rings_3d() {
-        let built = PolygonBuilder3D::new(Coordinate::Euclidean)
+        let built = PolygonBuilder3D::new(CoordinateFrame::Euclidean)
             .set_exterior([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 1.0]])
             .build()
             .unwrap();
 
         let batch = Polygon3D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 1.0]],
             Vec::<Vec<[f64; 3]>>::new(),
         );
@@ -788,7 +797,7 @@ mod tests {
     /// A 3-corner triangle polygon (open ring), so `coords.len() == 3`.
     fn triangle() -> Polygon3D {
         Polygon3D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
             Vec::<Vec<[f64; 3]>>::new(),
         )

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -24,8 +24,8 @@ pub use constructor::{state, PolygonBuilder2D, PolygonBuilder3D, PolygonFace};
 pub struct Polygon2D {
     /// Coordinate frame these coords are expressed in.
     frame: CoordinateFrame,
-    /// Exterior ring, then all interior rings (holes), concatenated; each ring
-    /// closed (first == last).
+    /// Exterior ring, then all interior rings (holes), concatenated. A valid polygon
+    /// has each ring closed (first == last).
     coords: Box<[[f64; 2]]>,
     /// Start index in `coords` of each interior ring; empty when there are no
     /// holes. exterior = `coords[0 .. first interior start (or end)]`;
@@ -45,8 +45,8 @@ pub struct Polygon2D {
 pub struct Polygon3D {
     /// Coordinate frame these coords are expressed in.
     frame: CoordinateFrame,
-    /// Exterior ring, then all interior rings (holes), concatenated; each ring
-    /// closed (first == last).
+    /// Exterior ring, then all interior rings (holes), concatenated. A valid polygon
+    /// has each ring closed (first == last).
     coords: Box<[[f64; 3]]>,
     /// Start index in `coords` of each interior ring; empty when there are no holes.
     interior_offsets: Box<[u32]>,

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -12,7 +12,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::appearance::{Appearance, UvSet};
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 
 mod constructor;
 mod ops;
@@ -23,7 +23,7 @@ pub use constructor::{state, PolygonBuilder2D, PolygonBuilder3D, PolygonFace};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Polygon2D {
     /// Coordinate frame these coords are expressed in.
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     /// Exterior ring, then all interior rings (holes), concatenated; each ring
     /// closed (first == last).
     coords: Box<[[f64; 2]]>,
@@ -46,7 +46,7 @@ pub struct Polygon2D {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Polygon3D {
     /// Coordinate frame these coords are expressed in.
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     /// Exterior ring, then all interior rings (holes), concatenated; each ring
     /// closed (first == last).
     coords: Box<[[f64; 3]]>,
@@ -61,8 +61,8 @@ pub struct Polygon3D {
 impl Polygon2D {
     /// The coordinate frame these coords are expressed in.
     #[inline]
-    pub fn coordinate(&self) -> &Coordinate {
-        &self.coordinate
+    pub fn frame(&self) -> &CoordinateFrame {
+        &self.frame
     }
 
     /// The exterior ring, as stored verbatim — a well-formed ring is closed
@@ -110,8 +110,8 @@ impl Polygon2D {
 impl Polygon3D {
     /// The coordinate frame these coords are expressed in.
     #[inline]
-    pub fn coordinate(&self) -> &Coordinate {
-        &self.coordinate
+    pub fn frame(&self) -> &CoordinateFrame {
+        &self.frame
     }
 
     /// The exterior ring, as stored verbatim — a well-formed ring is closed

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -11,7 +11,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::appearance::{Appearance, UvSet};
+use crate::appearance::Appearance;
 use crate::coordinate::CoordinateFrame;
 
 mod constructor;
@@ -35,10 +35,8 @@ pub struct Polygon2D {
     /// concatenation). INVARIANT: when `Some`, `z.len() == coords.len()`.
     /// `None` = pure 2D (no allocation).
     z: Option<Box<[f64]>>,
-    /// UV parallel to `coords` (same ring concatenation); one set per
-    /// (theme, side, channel).
-    uv_sets: Vec<UvSet>,
-    /// Materials / themes / single-face binding; `None` = bare geometry.
+    /// Materials / themes / single-face binding, incl. per-theme UV parallel to
+    /// `coords`; `None` = bare geometry.
     appearance: Option<Appearance>,
 }
 
@@ -52,9 +50,8 @@ pub struct Polygon3D {
     coords: Box<[[f64; 3]]>,
     /// Start index in `coords` of each interior ring; empty when there are no holes.
     interior_offsets: Box<[u32]>,
-    /// UV parallel to `coords`; one set per (theme, side, channel).
-    uv_sets: Vec<UvSet>,
-    /// Materials / themes / single-face binding; `None` = bare geometry.
+    /// Materials / themes / single-face binding, incl. per-theme UV parallel to
+    /// `coords`; `None` = bare geometry.
     appearance: Option<Appearance>,
 }
 
@@ -98,13 +95,6 @@ impl Polygon2D {
     pub fn appearance_mut(&mut self) -> &mut Option<Appearance> {
         &mut self.appearance
     }
-
-    /// The UV sets, one per (theme, side, channel); each `Explicit` array is
-    /// parallel to `coords` (exterior then interiors, closed).
-    #[inline]
-    pub fn uv_sets(&self) -> &[UvSet] {
-        &self.uv_sets
-    }
 }
 
 impl Polygon3D {
@@ -146,12 +136,5 @@ impl Polygon3D {
     #[inline]
     pub fn appearance_mut(&mut self) -> &mut Option<Appearance> {
         &mut self.appearance
-    }
-
-    /// The UV sets, one per (theme, side, channel); each `Explicit` array is
-    /// parallel to `coords` (exterior then interiors, closed).
-    #[inline]
-    pub fn uv_sets(&self) -> &[UvSet] {
-        &self.uv_sets
     }
 }

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -1,5 +1,5 @@
 use super::{Polygon2D, Polygon3D};
-use crate::coordinate::{Coordinate, EpsgCode};
+use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::ops::reproject::{transform_coords_2d, transform_coords_3d};
 use crate::ops::triangulation::{
     expand_appearance, retarget_uv, triangulate_2d, triangulate_3d, Cache,
@@ -37,10 +37,10 @@ impl Reproject for Polygon2D {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
-        let from = self.coordinate.require_crs()?;
+        let from = self.frame.require_crs()?;
         if from != target {
             transform_coords_2d(cache, from, target, &mut self.coords, self.z.as_deref_mut())?;
-            self.coordinate = Coordinate::Crs(target);
+            self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
     }
@@ -52,10 +52,10 @@ impl Reproject for Polygon3D {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
-        let from = self.coordinate.require_crs()?;
+        let from = self.frame.require_crs()?;
         if from != target {
             transform_coords_3d(cache, from, target, &mut self.coords)?;
-            self.coordinate = Coordinate::Crs(target);
+            self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
     }
@@ -91,7 +91,7 @@ impl Triangulate for Polygon2D {
                 // SAFETY: every earcut index is `< verts.len()`; count is a multiple of 3.
                 unsafe {
                     TriangularMesh2D::from_parts_unchecked(
-                        self.coordinate.clone(),
+                        self.frame.clone(),
                         verts,
                         buffers.out.len() / 3,
                         buffers.out.iter().copied(),
@@ -115,7 +115,7 @@ impl Triangulate for Polygon2D {
                 // SAFETY: every earcut index is `< verts.len()`; count is a multiple of 3.
                 unsafe {
                     TriangularMesh2D::from_parts_with_elevation_unchecked(
-                        self.coordinate.clone(),
+                        self.frame.clone(),
                         verts,
                         buffers.out.len() / 3,
                         buffers.out.iter().copied(),
@@ -166,7 +166,7 @@ impl Triangulate for Polygon3D {
         // SAFETY: every earcut index is `< verts.len()`; count is a multiple of 3.
         let mut mesh = unsafe {
             TriangularMesh3D::from_parts_unchecked(
-                self.coordinate.clone(),
+                self.frame.clone(),
                 verts,
                 buffers.out.len() / 3,
                 buffers.out.iter().copied(),
@@ -238,7 +238,7 @@ fn open_ring_positions<const N: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::Coordinate;
+    use crate::coordinate::CoordinateFrame;
 
     #[test]
     fn polygon2d_box_is_the_exterior_extent() {
@@ -246,7 +246,7 @@ mod tests {
         // box is the exterior's.
         let exterior = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
         let hole = vec![[1.0, 1.0], [2.0, 1.0], [2.0, 2.0], [1.0, 1.0]];
-        let p = Polygon2D::from_rings(Coordinate::Euclidean, exterior, vec![hole]);
+        let p = Polygon2D::from_rings(CoordinateFrame::Euclidean, exterior, vec![hole]);
         assert_eq!(
             p.bounding_box().unwrap(),
             Aabb::D2 {
@@ -273,8 +273,11 @@ mod tests {
     #[test]
     fn polygon2d_square_triangulates_to_two_triangles() {
         let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
-        let mut p =
-            Polygon2D::from_rings(Coordinate::Euclidean, square, Vec::<Vec<[f64; 2]>>::new());
+        let mut p = Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            square,
+            Vec::<Vec<[f64; 2]>>::new(),
+        );
         let g = p.triangulate(&mut Cache::new()).unwrap();
         let m = tri_mesh_2d(&g);
         assert_eq!(m.num_triangles(), 2);
@@ -287,7 +290,7 @@ mod tests {
         // A 4-vertex square with a 4-vertex square hole: earcut yields 8 triangles.
         let exterior = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
         let hole = vec![[1.0, 1.0], [3.0, 1.0], [3.0, 3.0], [1.0, 3.0], [1.0, 1.0]];
-        let mut p = Polygon2D::from_rings(Coordinate::Euclidean, exterior, vec![hole]);
+        let mut p = Polygon2D::from_rings(CoordinateFrame::Euclidean, exterior, vec![hole]);
         let g = p.triangulate(&mut Cache::new()).unwrap();
         let m = tri_mesh_2d(&g);
         assert_eq!(m.num_triangles(), 8);
@@ -296,7 +299,7 @@ mod tests {
     #[test]
     fn polygon2d_preserves_elevation() {
         let g = Polygon2D::from_rings_with_elevation(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [
                 [0.0, 0.0, 10.0],
                 [4.0, 0.0, 11.0],
@@ -322,8 +325,11 @@ mod tests {
             [0.0, 0.0, 4.0],
             [0.0, 0.0, 0.0],
         ];
-        let mut p =
-            Polygon3D::from_rings(Coordinate::Euclidean, square, Vec::<Vec<[f64; 3]>>::new());
+        let mut p = Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            square,
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
         let g = p.triangulate(&mut Cache::new()).unwrap();
         let m = tri_mesh_3d(&g);
         assert_eq!(m.num_triangles(), 2);
@@ -337,13 +343,17 @@ mod tests {
         let mut cache = Cache::new();
         let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
 
-        let a = Polygon2D::from_rings(Coordinate::Euclidean, square, Vec::<Vec<[f64; 2]>>::new())
-            .triangulate(&mut cache)
-            .unwrap();
+        let a = Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            square,
+            Vec::<Vec<[f64; 2]>>::new(),
+        )
+        .triangulate(&mut cache)
+        .unwrap();
         assert_eq!(tri_mesh_2d(&a).num_triangles(), 2);
 
         let hole = vec![[1.0, 1.0], [3.0, 1.0], [3.0, 3.0], [1.0, 3.0], [1.0, 1.0]];
-        let b = Polygon2D::from_rings(Coordinate::Euclidean, square, vec![hole])
+        let b = Polygon2D::from_rings(CoordinateFrame::Euclidean, square, vec![hole])
             .triangulate(&mut cache)
             .unwrap();
         assert_eq!(tri_mesh_2d(&b).num_triangles(), 8);
@@ -355,9 +365,13 @@ mod tests {
             [0.0, 0.0, 4.0],
             [0.0, 0.0, 0.0],
         ];
-        let c = Polygon3D::from_rings(Coordinate::Euclidean, face3d, Vec::<Vec<[f64; 3]>>::new())
-            .triangulate(&mut cache)
-            .unwrap();
+        let c = Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            face3d,
+            Vec::<Vec<[f64; 3]>>::new(),
+        )
+        .triangulate(&mut cache)
+        .unwrap();
         assert_eq!(tri_mesh_3d(&c).num_triangles(), 2);
     }
 
@@ -370,7 +384,11 @@ mod tests {
             [2.0, 2.0, 2.0],
             [0.0, 0.0, 0.0],
         ];
-        let mut p = Polygon3D::from_rings(Coordinate::Euclidean, line, Vec::<Vec<[f64; 3]>>::new());
+        let mut p = Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            line,
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
         let g = p.triangulate(&mut Cache::new()).unwrap();
         assert_eq!(tri_mesh_3d(&g).num_triangles(), 0);
     }
@@ -383,8 +401,11 @@ mod tests {
         // UV is parallel to `coords` (5 entries, last = closing dup), distinct per
         // real corner so the gather is checkable.
         let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
-        let mut p =
-            Polygon2D::from_rings(Coordinate::Euclidean, square, Vec::<Vec<[f64; 2]>>::new());
+        let mut p = Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            square,
+            Vec::<Vec<[f64; 2]>>::new(),
+        );
         let src_uv = UvSource::Explicit(Box::new([
             [0.0, 0.0],
             [1.0, 0.0],
@@ -420,8 +441,11 @@ mod tests {
         use crate::test_support::{textured, theme};
 
         let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
-        let mut p =
-            Polygon2D::from_rings(Coordinate::Euclidean, square, Vec::<Vec<[f64; 2]>>::new());
+        let mut p = Polygon2D::from_rings(
+            CoordinateFrame::Euclidean,
+            square,
+            Vec::<Vec<[f64; 2]>>::new(),
+        );
         let matrix = TexMatrix([
             [0.25, 0.0, 0.0, 0.0],
             [0.0, 0.25, 0.0, 0.0],
@@ -450,7 +474,11 @@ mod tests {
             [4.0, 4.0, 2.0],
             [0.0, 0.0, 1.0],
         ];
-        let p = Polygon3D::from_rings(Coordinate::Euclidean, exterior, Vec::<Vec<[f64; 3]>>::new());
+        let p = Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            exterior,
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
         assert_eq!(
             p.bounding_box().unwrap(),
             Aabb::D3 {

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -1,9 +1,7 @@
 use super::{Polygon2D, Polygon3D};
 use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::ops::reproject::{transform_coords_2d, transform_coords_3d};
-use crate::ops::triangulation::{
-    expand_appearance, retarget_uv, triangulate_2d, triangulate_3d, Cache,
-};
+use crate::ops::triangulation::{expand_appearance, triangulate_2d, triangulate_3d, Cache};
 use crate::ops::{
     Aabb, BoundingBox, Reproject, ReprojectionCache, Triangulate, UnsupportedOperation,
 };
@@ -128,15 +126,12 @@ impl Triangulate for Polygon2D {
             .iter()
             .map(|&c| buffers.positions[c as usize])
             .collect();
-        let uv_sets = std::mem::take(&mut self.uv_sets)
-            .into_iter()
-            .map(|uv| retarget_uv(uv, &src_corner))
-            .collect();
         let appearance = expand_appearance(
             std::mem::take(&mut self.appearance),
             &[(buffers.out.len() / 3) as u32],
+            &src_corner,
         );
-        mesh.set_raw_appearance(uv_sets, appearance);
+        mesh.set_raw_appearance(appearance);
         Ok(Geometry::Euclidean2D(Euclidean2DGeometry::TriangularMesh(
             Box::new(mesh),
         )))
@@ -177,15 +172,12 @@ impl Triangulate for Polygon3D {
             .iter()
             .map(|&c| buffers.positions[c as usize])
             .collect();
-        let uv_sets = std::mem::take(&mut self.uv_sets)
-            .into_iter()
-            .map(|uv| retarget_uv(uv, &src_corner))
-            .collect();
         let appearance = expand_appearance(
             std::mem::take(&mut self.appearance),
             &[(buffers.out.len() / 3) as u32],
+            &src_corner,
         );
-        mesh.set_raw_appearance(uv_sets, appearance);
+        mesh.set_raw_appearance(appearance);
         Ok(Geometry::Euclidean3D(Euclidean3DGeometry::TriangularMesh(
             Box::new(mesh),
         )))
@@ -421,13 +413,13 @@ mod tests {
         assert_eq!(m.num_triangles(), 2);
 
         let app = m.appearance().as_ref().expect("appearance carried over");
-        assert_eq!(app.materials.len(), 1);
-        assert_eq!(app.default_theme, theme("rgb"));
-        assert!(matches!(app.themes[0].front, FaceBinding::Uniform(_)));
+        assert_eq!(app.materials().len(), 1);
+        assert_eq!(*app.default_theme(), theme("rgb"));
+        assert!(matches!(app.themes()[0].front, FaceBinding::Uniform(_)));
 
         // Every output UV is one of the real source-corner UVs (gathered, not
         // interpolated; the closing-duplicate slot is never referenced).
-        let UvSource::Explicit(out_uv) = &m.uv_sets()[0].uv else {
+        let UvSource::Explicit(out_uv) = &app.themes()[0].uv_sets[0].uv else {
             panic!("expected an explicit output UV set");
         };
         assert_eq!(out_uv.len(), 6);
@@ -460,8 +452,9 @@ mod tests {
 
         let g = p.triangulate(&mut Cache::new()).unwrap();
         let m = tri_mesh_2d(&g);
+        let app = m.appearance().as_ref().unwrap();
         assert!(matches!(
-            m.uv_sets()[0].uv,
+            app.themes()[0].uv_sets[0].uv,
             UvSource::WorldToTexture(out) if out == matrix
         ));
     }

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -34,7 +34,7 @@ use crate::appearance::{
     Appearance, ChannelId, FaceBinding, Material, MaterialIndex, Side, TexMatrix, ThemeBinding,
     ThemeId, UvSet, UvSource,
 };
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 use crate::error::Error;
 use crate::index::{IndexBuffer, IndexWidth};
 use crate::polygon::Polygon3D;
@@ -137,37 +137,37 @@ impl PolygonMesh3DData {
 
 impl PolygonMesh3D {
     /// Pair coordinate-free mesh data with the frame it is expressed in.
-    pub fn new(coordinate: Coordinate, data: PolygonMesh3DData) -> Self {
-        Self { coordinate, data }
+    pub fn new(frame: CoordinateFrame, data: PolygonMesh3DData) -> Self {
+        Self { frame, data }
     }
 
     /// Build from independent face polygons; see [`PolygonMesh3DData::from_polygons`].
-    /// Errors if any polygon's frame differs from `coordinate`.
+    /// Errors if any polygon's frame differs from `frame`.
     pub fn from_polygons<'a>(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         polygons: impl IntoIterator<Item = &'a Polygon3D>,
     ) -> Result<Self, Error> {
-        Self::from_polygons_with_default_theme(coordinate, polygons, None)
+        Self::from_polygons_with_default_theme(frame, polygons, None)
     }
 
     /// As [`from_polygons`](Self::from_polygons), but pins the merged mesh's active
     /// default theme; see
     /// [`PolygonMesh3DData::from_polygons_with_default_theme`].
     pub fn from_polygons_with_default_theme<'a>(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         polygons: impl IntoIterator<Item = &'a Polygon3D>,
         default_theme: Option<ThemeId>,
     ) -> Result<Self, Error> {
         let polygons: Vec<&Polygon3D> = polygons.into_iter().collect();
         for p in &polygons {
-            if p.coordinate() != &coordinate {
+            if p.frame() != &frame {
                 return Err(Error::invalid_geometry(
                     "polygon coordinate frame differs from the mesh frame",
                 ));
             }
         }
         Ok(Self::new(
-            coordinate,
+            frame,
             PolygonMesh3DData::from_polygons_with_default_theme(polygons, default_theme),
         ))
     }
@@ -175,26 +175,26 @@ impl PolygonMesh3D {
     /// Build from a vertex pool and index-list faces; see
     /// [`PolygonMesh3DData::from_parts`].
     pub fn from_parts(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         vertices: Vec<[f64; 3]>,
         faces: impl IntoIterator<Item = impl IntoIterator<Item = u32>>,
     ) -> Result<Self, Error> {
         Ok(Self::new(
-            coordinate,
+            frame,
             PolygonMesh3DData::from_parts(vertices, faces)?,
         ))
     }
 
     /// Build from flat CSR buffers; see [`PolygonMesh3DData::from_raw_parts`].
     pub fn from_raw_parts(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         vertices: Vec<[f64; 3]>,
         face_indices: Vec<u32>,
         face_offsets: Vec<u32>,
         interior_offsets: Vec<u32>,
     ) -> Result<Self, Error> {
         Ok(Self::new(
-            coordinate,
+            frame,
             PolygonMesh3DData::from_raw_parts(
                 vertices,
                 face_indices,
@@ -208,7 +208,7 @@ impl PolygonMesh3D {
 impl PolygonMesh2D {
     /// Build a pure-2D mesh from a vertex pool and index-list faces (no holes).
     pub fn from_parts(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         vertices: Vec<[f64; 2]>,
         faces: impl IntoIterator<Item = impl IntoIterator<Item = u32>>,
     ) -> Result<Self, Error> {
@@ -216,7 +216,7 @@ impl PolygonMesh2D {
         let (face_indices, face_offsets, interior_offsets) =
             pack_csr(vertices.len(), face_indices, face_offsets, Vec::new());
         Ok(Self {
-            coordinate,
+            frame,
             vertices,
             z: None,
             face_indices,
@@ -230,7 +230,7 @@ impl PolygonMesh2D {
     /// Build a 2.5D mesh from `[x, y, z]` vertices (the `(x, y)` populate the pool,
     /// the `z` a parallel elevation buffer) and index-list faces (no holes).
     pub fn from_parts_with_elevation(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         vertices: Vec<[f64; 3]>,
         faces: impl IntoIterator<Item = impl IntoIterator<Item = u32>>,
     ) -> Result<Self, Error> {
@@ -246,7 +246,7 @@ impl PolygonMesh2D {
         let (face_indices, face_offsets, interior_offsets) =
             pack_csr(xy.len(), face_indices, face_offsets, Vec::new());
         Ok(Self {
-            coordinate,
+            frame,
             vertices: xy,
             z: Some(z),
             face_indices,
@@ -259,7 +259,7 @@ impl PolygonMesh2D {
 
     /// Build a pure-2D mesh from flat CSR buffers.
     pub fn from_raw_parts(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         vertices: Vec<[f64; 2]>,
         face_indices: Vec<u32>,
         face_offsets: Vec<u32>,
@@ -274,7 +274,7 @@ impl PolygonMesh2D {
         let (face_indices, face_offsets, interior_offsets) =
             pack_csr(vertices.len(), face_indices, face_offsets, interior_offsets);
         Ok(Self {
-            coordinate,
+            frame,
             vertices,
             z: None,
             face_indices,
@@ -685,7 +685,11 @@ mod tests {
     }
 
     fn quad(corners: [[f64; 3]; 4]) -> Polygon3D {
-        Polygon3D::from_rings(Coordinate::Euclidean, corners, Vec::<Vec<[f64; 3]>>::new())
+        Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            corners,
+            Vec::<Vec<[f64; 3]>>::new(),
+        )
     }
 
     #[test]
@@ -693,7 +697,7 @@ mod tests {
         // Two unit quads sharing the edge (1,0,0)-(1,1,0): 6 unique vertices.
         let a = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
         let b = quad([[1., 0., 0.], [2., 0., 0.], [2., 1., 0.], [1., 1., 0.]]);
-        let m = PolygonMesh3D::from_polygons(Coordinate::Euclidean, [&a, &b]).unwrap();
+        let m = PolygonMesh3D::from_polygons(CoordinateFrame::Euclidean, [&a, &b]).unwrap();
         assert_eq!(
             m.data.vertices,
             vec![
@@ -716,7 +720,7 @@ mod tests {
     fn from_polygons_preserves_a_hole() {
         let outer = [[0., 0., 0.], [4., 0., 0.], [4., 4., 0.], [0., 4., 0.]];
         let hole = vec![[1., 1., 0.], [2., 1., 0.], [2., 2., 0.], [1., 2., 0.]];
-        let p = Polygon3D::from_rings(Coordinate::Euclidean, outer, vec![hole]);
+        let p = Polygon3D::from_rings(CoordinateFrame::Euclidean, outer, vec![hole]);
         let m = PolygonMesh3DData::from_polygons([&p]);
         assert_eq!(m.vertices.len(), 8);
         assert_eq!(ones(&m.face_indices), vec![0, 1, 2, 3, 4, 5, 6, 7]);
@@ -728,8 +732,8 @@ mod tests {
     #[test]
     fn from_polygons_rejects_frame_mismatch() {
         let a = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
-        let err =
-            PolygonMesh3D::from_polygons(Coordinate::Crs(EpsgCode::new(4326)), [&a]).unwrap_err();
+        let err = PolygonMesh3D::from_polygons(CoordinateFrame::Crs(EpsgCode::new(4326)), [&a])
+            .unwrap_err();
         assert!(matches!(err, Error::InvalidGeometry(_)));
     }
 
@@ -737,7 +741,7 @@ mod tests {
     fn from_parts_builds_faces() {
         let verts = vec![[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]];
         let faces = vec![vec![0u32, 1, 2], vec![0u32, 2, 3]];
-        let m = PolygonMesh3D::from_parts(Coordinate::Euclidean, verts, faces).unwrap();
+        let m = PolygonMesh3D::from_parts(CoordinateFrame::Euclidean, verts, faces).unwrap();
         assert_eq!(ones(&m.data.face_indices), vec![0, 1, 2, 0, 2, 3]);
         // Two faces -> a single internal boundary at 3.
         assert_eq!(ones(&m.data.face_offsets), vec![3]);
@@ -756,7 +760,7 @@ mod tests {
     fn from_polygons_skips_empty_face() {
         let a = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
         let empty = Polygon3D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             Vec::<[f64; 3]>::new(),
             Vec::<Vec<[f64; 3]>>::new(),
         );
@@ -771,7 +775,7 @@ mod tests {
     fn from_parts_skips_empty_face() {
         let verts = vec![[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]];
         let faces: Vec<Vec<u32>> = vec![vec![0, 1, 2], vec![], vec![0, 2, 3]];
-        let m = PolygonMesh3D::from_parts(Coordinate::Euclidean, verts, faces).unwrap();
+        let m = PolygonMesh3D::from_parts(CoordinateFrame::Euclidean, verts, faces).unwrap();
         assert_eq!(ones(&m.data.face_indices), vec![0, 1, 2, 0, 2, 3]);
         assert_eq!(ones(&m.data.face_offsets), vec![3]);
     }
@@ -780,7 +784,7 @@ mod tests {
     fn from_parts_with_elevation_splits_z() {
         let verts = vec![[0., 0., 10.], [1., 0., 11.], [0., 1., 12.]];
         let m = PolygonMesh2D::from_parts_with_elevation(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             verts,
             vec![vec![0u32, 1, 2]],
         )
@@ -937,7 +941,7 @@ mod tests {
     fn from_polygons_drops_closing_uv() {
         // Closed triangle: coords [a, b, c, a] (4); the mesh keeps 3 open corners.
         let mut p = Polygon3D::from_rings(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 0.]],
             Vec::<Vec<[f64; 3]>>::new(),
         );

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -48,8 +48,8 @@ impl PolygonMesh3DData {
     ///
     /// Appearance and UV are merged across the faces (see [`merge_appearance`]):
     /// material palettes concatenate, themes union, each face gets a `PerFace`
-    /// binding, and every per-face UV is welded into one mesh-wide array per
-    /// `(theme, side, channel)` — dropping each ring's closing duplicate to match
+    /// binding, and every per-face UV is welded — per theme — into one mesh-wide
+    /// array per `(side, channel)` — dropping each ring's closing duplicate to match
     /// the open corner buffer, baking any `WorldToTexture` matrix to explicit
     /// corners, and zero-filling faces a theme does not cover (their binding is
     /// `None`, so the filler is never sampled). Bare input (no appearance on any
@@ -76,7 +76,7 @@ impl PolygonMesh3DData {
             .iter()
             .map(|p| std::iter::once(p.exterior()).chain(p.interiors()));
         let (vertices, face_indices, face_offsets, interior_offsets) = dedup_faces(faces);
-        let (uv_sets, appearance) = merge_appearance(&polygons, default_theme);
+        let appearance = merge_appearance(&polygons, default_theme);
         let (face_indices, face_offsets, interior_offsets) =
             pack_csr(vertices.len(), face_indices, face_offsets, interior_offsets);
         Self {
@@ -84,7 +84,6 @@ impl PolygonMesh3DData {
             face_indices,
             face_offsets,
             interior_offsets,
-            uv_sets,
             appearance,
         }
     }
@@ -103,7 +102,6 @@ impl PolygonMesh3DData {
             face_indices,
             face_offsets,
             interior_offsets,
-            uv_sets: Vec::new(),
             appearance: None,
         })
     }
@@ -129,7 +127,6 @@ impl PolygonMesh3DData {
             face_indices,
             face_offsets,
             interior_offsets,
-            uv_sets: Vec::new(),
             appearance: None,
         })
     }
@@ -222,7 +219,6 @@ impl PolygonMesh2D {
             face_indices,
             face_offsets,
             interior_offsets,
-            uv_sets: Vec::new(),
             appearance: None,
         })
     }
@@ -252,7 +248,6 @@ impl PolygonMesh2D {
             face_indices,
             face_offsets,
             interior_offsets,
-            uv_sets: Vec::new(),
             appearance: None,
         })
     }
@@ -280,7 +275,6 @@ impl PolygonMesh2D {
             face_indices,
             face_offsets,
             interior_offsets,
-            uv_sets: Vec::new(),
             appearance: None,
         })
     }
@@ -511,7 +505,7 @@ fn has_back(polygon: &Polygon3D, theme: &ThemeId) -> bool {
     polygon
         .appearance()
         .as_ref()
-        .and_then(|app| app.themes.iter().find(|binding| &binding.theme == theme))
+        .and_then(|app| app.themes().iter().find(|binding| &binding.theme == theme))
         .is_some_and(|binding| binding.back.is_some())
 }
 
@@ -528,7 +522,7 @@ fn build_binding(
         .enumerate()
         .map(|(i, polygon)| -> Option<MaterialIndex> {
             let app = polygon.appearance().as_ref()?;
-            let binding = app.themes.iter().find(|b| &b.theme == theme)?;
+            let binding = app.themes().iter().find(|b| &b.theme == theme)?;
             let face = match side {
                 Side::Front => &binding.front,
                 Side::Back => binding.back.as_ref()?,
@@ -542,8 +536,12 @@ fn build_binding(
     FaceBinding::PerFace(per_face)
 }
 
-/// Weld the per-polygon appearance and UV of the kept faces into the mesh-wide
-/// `(uv_sets, appearance)`. Returns `(empty, None)` if no face carries appearance.
+/// Weld the per-polygon appearance and UV of the kept faces into one mesh-wide
+/// `Appearance`. Returns `None` if no face carries appearance.
+///
+/// Each theme's UV pool is rebuilt per (side, channel): one mesh-wide `Explicit`
+/// array whose corners concatenate each face's contribution (zero-filled where a
+/// face lacks that key, whose binding is then `None` so the filler is unsampled).
 ///
 /// `default_override` pins the merged mesh's active default theme; `None` keeps
 /// the auto rule (the shared default when every appearance-carrying face agrees,
@@ -551,7 +549,7 @@ fn build_binding(
 fn merge_appearance(
     polygons: &[&Polygon3D],
     default_override: Option<ThemeId>,
-) -> (Vec<UvSet>, Option<Appearance>) {
+) -> Option<Appearance> {
     let kept: Vec<&Polygon3D> = polygons
         .iter()
         .copied()
@@ -559,7 +557,7 @@ fn merge_appearance(
         .collect();
 
     if kept.iter().all(|p| p.appearance().is_none()) {
-        return (Vec::new(), None);
+        return None;
     }
 
     // Concatenate the material palettes, recording each face's offset for index
@@ -569,7 +567,7 @@ fn merge_appearance(
     for polygon in &kept {
         offset.push(materials.len());
         if let Some(app) = polygon.appearance() {
-            materials.extend(app.materials.iter().cloned());
+            materials.extend(app.materials().iter().cloned());
         }
     }
 
@@ -577,7 +575,7 @@ fn merge_appearance(
     let mut theme_order: Vec<ThemeId> = Vec::new();
     for polygon in &kept {
         if let Some(app) = polygon.appearance() {
-            for binding in &app.themes {
+            for binding in app.themes() {
                 if !theme_order.contains(&binding.theme) {
                     theme_order.push(binding.theme.clone());
                 }
@@ -589,9 +587,46 @@ fn merge_appearance(
     // is the documented fallback when they diverge (rule 2).
     let default_theme = default_override.unwrap_or_else(|| {
         kept.iter()
-            .find_map(|p| p.appearance().as_ref().map(|app| app.default_theme.clone()))
+            .find_map(|p| {
+                p.appearance()
+                    .as_ref()
+                    .map(|app| app.default_theme().clone())
+            })
             .expect("a kept face carries appearance")
     });
+
+    // Index each face's UV by (theme, side, channel) once (so the per-key build is a
+    // map lookup, not a linear scan) and precompute each face's corner count.
+    type UvKey = (ThemeId, Side, ChannelId);
+    let corner_counts: Vec<usize> = kept.iter().map(|p| corner_count(p)).collect();
+    let total_corners: usize = corner_counts.iter().sum();
+    let per_face_uv: Vec<HashMap<UvKey, &UvSource>> = kept
+        .iter()
+        .map(|polygon| {
+            let mut map = HashMap::new();
+            if let Some(app) = polygon.appearance() {
+                for binding in app.themes() {
+                    for set in &binding.uv_sets {
+                        map.insert((binding.theme.clone(), set.side, set.channel), &set.uv);
+                    }
+                }
+            }
+            map
+        })
+        .collect();
+
+    // One mesh-wide UV array for a given (theme, side, channel): each face
+    // contributes its corners, or a zero-filled run where it lacks that key.
+    let build_uv = |key: &UvKey| -> UvSource {
+        let mut data: Vec<[f64; 2]> = Vec::with_capacity(total_corners);
+        for (i, polygon) in kept.iter().enumerate() {
+            match per_face_uv[i].get(key).copied() {
+                Some(uv) => extend_polygon_uv(&mut data, polygon, uv),
+                None => data.resize(data.len() + corner_counts[i], [0.0, 0.0]),
+            }
+        }
+        UvSource::Explicit(data.into_boxed_slice())
+    };
 
     let themes: Vec<ThemeBinding> = theme_order
         .iter()
@@ -601,73 +636,42 @@ fn merge_appearance(
                 .iter()
                 .any(|p| has_back(p, theme))
                 .then(|| build_binding(&kept, &offset, theme, Side::Back));
+
+            // This theme's (side, channel) union across faces, first-seen.
+            let mut uv_keys: Vec<(Side, ChannelId)> = Vec::new();
+            let mut seen: HashSet<(Side, ChannelId)> = HashSet::new();
+            for polygon in &kept {
+                let Some(app) = polygon.appearance() else {
+                    continue;
+                };
+                let Some(binding) = app.themes().iter().find(|b| &b.theme == theme) else {
+                    continue;
+                };
+                for set in &binding.uv_sets {
+                    if seen.insert((set.side, set.channel)) {
+                        uv_keys.push((set.side, set.channel));
+                    }
+                }
+            }
+            let uv_sets = uv_keys
+                .into_iter()
+                .map(|(side, channel)| UvSet {
+                    side,
+                    channel,
+                    uv: build_uv(&(theme.clone(), side, channel)),
+                })
+                .collect();
+
             ThemeBinding {
                 theme: theme.clone(),
                 front,
                 back,
+                uv_sets,
             }
         })
         .collect();
 
-    // Index each face's UV sets by key once (so the per-key build is a map lookup,
-    // not a linear scan) and precompute each face's corner count (recomputing it
-    // per key would re-walk every ring).
-    type UvKey = (Option<ThemeId>, Side, ChannelId);
-    let corner_counts: Vec<usize> = kept.iter().map(|p| corner_count(p)).collect();
-    let total_corners: usize = corner_counts.iter().sum();
-    let per_face_uv: Vec<HashMap<UvKey, &UvSource>> = kept
-        .iter()
-        .map(|polygon| {
-            polygon
-                .uv_sets()
-                .iter()
-                .map(|set| ((set.theme.clone(), set.side, set.channel), &set.uv))
-                .collect()
-        })
-        .collect();
-
-    // UV-set key union, in first-seen order.
-    let mut keys: Vec<UvKey> = Vec::new();
-    let mut seen: HashSet<UvKey> = HashSet::new();
-    for polygon in &kept {
-        for set in polygon.uv_sets() {
-            let key = (set.theme.clone(), set.side, set.channel);
-            if seen.insert(key.clone()) {
-                keys.push(key);
-            }
-        }
-    }
-
-    // One mesh-wide UV array per key: each face contributes its corners, or a
-    // zero-filled run where it lacks that key. Reserved to the total up front.
-    let uv_sets = keys
-        .into_iter()
-        .map(|key| {
-            let mut data: Vec<[f64; 2]> = Vec::with_capacity(total_corners);
-            for (i, polygon) in kept.iter().enumerate() {
-                match per_face_uv[i].get(&key).copied() {
-                    Some(uv) => extend_polygon_uv(&mut data, polygon, uv),
-                    None => data.resize(data.len() + corner_counts[i], [0.0, 0.0]),
-                }
-            }
-            let (theme, side, channel) = key;
-            UvSet {
-                theme,
-                side,
-                channel,
-                uv: UvSource::Explicit(data.into_boxed_slice()),
-            }
-        })
-        .collect();
-
-    (
-        uv_sets,
-        Some(Appearance {
-            materials,
-            themes,
-            default_theme,
-        }),
-    )
+    Some(Appearance::from_parts(materials, themes, default_theme))
 }
 
 #[cfg(test)]
@@ -845,14 +849,15 @@ mod tests {
 
         let m = PolygonMesh3DData::from_polygons([&p]);
         let app = m.appearance.as_ref().unwrap();
-        assert_eq!(app.materials.len(), 1);
-        assert_eq!(app.default_theme, theme("rgb"));
-        let FaceBinding::PerFace(front) = &app.themes[0].front else {
+        assert_eq!(app.materials().len(), 1);
+        assert_eq!(*app.default_theme(), theme("rgb"));
+        let FaceBinding::PerFace(front) = &app.themes()[0].front else {
             panic!("expected PerFace");
         };
         assert_eq!(front, &[MaterialIndex::new(0)]);
-        assert!(app.themes[0].back.is_none());
-        let UvSource::Explicit(uv) = &m.uv_sets[0].uv else {
+        assert!(app.themes()[0].back.is_none());
+        let UvSource::Explicit(uv) = &m.appearance.as_ref().unwrap().themes()[0].uv_sets[0].uv
+        else {
             panic!("expected Explicit");
         };
         assert_eq!(uv.len(), 4);
@@ -869,12 +874,13 @@ mod tests {
 
         let m = PolygonMesh3DData::from_polygons([&a, &b]);
         let app = m.appearance.as_ref().unwrap();
-        assert_eq!(app.materials.len(), 2);
-        let FaceBinding::PerFace(front) = &app.themes[0].front else {
+        assert_eq!(app.materials().len(), 2);
+        let FaceBinding::PerFace(front) = &app.themes()[0].front else {
             panic!("expected PerFace");
         };
         assert_eq!(front, &[MaterialIndex::new(0), MaterialIndex::new(1)]);
-        let UvSource::Explicit(uv) = &m.uv_sets[0].uv else {
+        let UvSource::Explicit(uv) = &m.appearance.as_ref().unwrap().themes()[0].uv_sets[0].uv
+        else {
             panic!("expected Explicit");
         };
         assert_eq!(uv.len(), 8);
@@ -890,17 +896,23 @@ mod tests {
 
         // Auto, diverging: falls back to the first kept face's default (rule 2).
         let m = PolygonMesh3DData::from_polygons([&a, &b]);
-        assert_eq!(m.appearance.as_ref().unwrap().default_theme, theme("rgb"));
+        assert_eq!(
+            *m.appearance.as_ref().unwrap().default_theme(),
+            theme("rgb")
+        );
 
         // Auto, uniform: every face agrees, so that shared default is chosen (rule 1).
         let m = PolygonMesh3DData::from_polygons([&a, &a]);
-        assert_eq!(m.appearance.as_ref().unwrap().default_theme, theme("rgb"));
+        assert_eq!(
+            *m.appearance.as_ref().unwrap().default_theme(),
+            theme("rgb")
+        );
 
         // Explicit override pins the active theme regardless of the faces.
         let m =
             PolygonMesh3DData::from_polygons_with_default_theme([&a, &b], Some(theme("infrared")));
         assert_eq!(
-            m.appearance.as_ref().unwrap().default_theme,
+            *m.appearance.as_ref().unwrap().default_theme(),
             theme("infrared")
         );
     }
@@ -924,12 +936,17 @@ mod tests {
 
         let m = PolygonMesh3DData::from_polygons([&a, &b]);
         let app = m.appearance.as_ref().unwrap();
-        assert_eq!(app.materials.len(), 1, "only the textured face contributes");
-        let FaceBinding::PerFace(front) = &app.themes[0].front else {
+        assert_eq!(
+            app.materials().len(),
+            1,
+            "only the textured face contributes"
+        );
+        let FaceBinding::PerFace(front) = &app.themes()[0].front else {
             panic!("expected PerFace");
         };
         assert_eq!(front, &[MaterialIndex::new(0), None]);
-        let UvSource::Explicit(uv) = &m.uv_sets[0].uv else {
+        let UvSource::Explicit(uv) = &m.appearance.as_ref().unwrap().themes()[0].uv_sets[0].uv
+        else {
             panic!("expected Explicit");
         };
         assert_eq!(uv.len(), 8);
@@ -953,7 +970,8 @@ mod tests {
         .unwrap();
 
         let m = PolygonMesh3DData::from_polygons([&p]);
-        let UvSource::Explicit(uv) = &m.uv_sets[0].uv else {
+        let UvSource::Explicit(uv) = &m.appearance.as_ref().unwrap().themes()[0].uv_sets[0].uv
+        else {
             panic!("expected Explicit");
         };
         assert_eq!(uv.len(), 3);
@@ -973,7 +991,8 @@ mod tests {
         .unwrap();
 
         let m = PolygonMesh3DData::from_polygons([&p]);
-        let UvSource::Explicit(uv) = &m.uv_sets[0].uv else {
+        let UvSource::Explicit(uv) = &m.appearance.as_ref().unwrap().themes()[0].uv_sets[0].uv
+        else {
             panic!("expected baked Explicit");
         };
         assert_eq!(&uv[..], &[[0., 0.], [2., 0.], [2., 3.], [0., 3.]]);
@@ -984,6 +1003,5 @@ mod tests {
         let a = quad([[0., 0., 0.], [1., 0., 0.], [1., 1., 0.], [0., 1., 0.]]);
         let m = PolygonMesh3DData::from_polygons([&a]);
         assert!(m.appearance.is_none());
-        assert!(m.uv_sets.is_empty());
     }
 }

--- a/engine/runtime/geometry/src/polygon_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/constructor.rs
@@ -16,11 +16,12 @@
 //!
 //! * `from_raw_parts` — the flat CSR buffers in hand, validated for consistency.
 //!
-//! Rings are stored **open**: the closing vertex is implied by the face / hole
-//! boundary, so `from_polygons` drops the closing duplicate that a `Polygon`
-//! carries, and `from_parts` expects the open faces OBJ provides. The index widths
-//! follow the type's contract: `face_indices` from the (dedup-discovered) vertex
-//! count, `face_offsets` / `interior_offsets` from `face_indices.len()`.
+//! Polygon-sourced rings are stored closed (last index equals first):
+//! `from_polygons` keeps the closing vertex a valid `Polygon` ring carries and
+//! appends one to an open input ring. `from_parts` / `from_raw_parts` store their
+//! vertex-index faces verbatim. The index widths follow the type's contract:
+//! `face_indices` from the vertex count, `face_offsets` / `interior_offsets` from
+//! `face_indices.len()`.
 //!
 //! 3D constructors build the coordinate-free [`PolygonMesh3DData`] a
 //! [`Solid`](crate::solid::Solid) shell also stores, so the frame-carrying
@@ -44,21 +45,19 @@ use super::{PolygonMesh2D, PolygonMesh3D, PolygonMesh3DData};
 impl PolygonMesh3DData {
     /// Build coordinate-free mesh data from independent face polygons, deduplicating
     /// their corners into a shared vertex pool. Each polygon becomes one face
-    /// (exterior then holes), stored open.
+    /// (exterior then holes), each ring stored closed.
     ///
     /// Appearance and UV are merged across the faces (see [`merge_appearance`]):
     /// material palettes concatenate, themes union, each face gets a `PerFace`
-    /// binding, and every per-face UV is welded — per theme — into one mesh-wide
-    /// array per `(side, channel)` — dropping each ring's closing duplicate to match
-    /// the open corner buffer, baking any `WorldToTexture` matrix to explicit
-    /// corners, and zero-filling faces a theme does not cover (their binding is
-    /// `None`, so the filler is never sampled). Bare input (no appearance on any
-    /// polygon) yields a bare mesh.
+    /// binding, and every per-face UV is welded, per theme, into one mesh-wide
+    /// array per `(side, channel)`, matching the closed corner buffer, baking any
+    /// `WorldToTexture` matrix to explicit corners, and zero-filling faces a theme
+    /// does not cover (their binding is `None`, so the filler is never sampled).
+    /// Bare input (no appearance on any polygon) yields a bare mesh.
     ///
-    /// A welded multi-face mesh's faces carry *different* `WorldToTexture` matrices
-    /// and cannot share one, so any matrix UV is baked to per-corner `Explicit` here
-    /// (a single-surface triangulation keeps its one matrix instead — see
-    /// [`UvSource`]).
+    /// A welded multi-face mesh's faces carry different `WorldToTexture` matrices
+    /// and cannot share one, so any matrix UV is baked to per-corner `Explicit`
+    /// here.
     pub fn from_polygons<'a>(polygons: impl IntoIterator<Item = &'a Polygon3D>) -> Self {
         Self::from_polygons_with_default_theme(polygons, None)
     }
@@ -280,14 +279,10 @@ impl PolygonMesh2D {
     }
 }
 
-/// Drop a ring's closing vertex when it duplicates the first, yielding the open
-/// ring (closure is implied by the face / hole boundary in the mesh).
-fn open_ring<const N: usize>(ring: &[[f64; N]]) -> &[[f64; N]] {
-    if ring.len() > 1 && ring.first() == ring.last() {
-        &ring[..ring.len() - 1]
-    } else {
-        ring
-    }
+/// Whether a ring needs its first vertex appended to be stored closed: it has at
+/// least two vertices and its last does not already equal its first.
+fn needs_closing<const N: usize>(ring: &[[f64; N]]) -> bool {
+    ring.len() >= 2 && ring.first() != ring.last()
 }
 
 /// Deduplicate the corners of a sequence of faces (each a sequence of rings,
@@ -313,9 +308,8 @@ where
                 interior_offsets.push(face_indices.len() as u32);
             }
             is_exterior = false;
-            for &coord in open_ring(ring) {
-                // Index of `coord` in the pool, inserting it on first sight; dedup
-                // is on exact `f64` bits.
+            let closing = needs_closing(ring).then(|| &ring[0]);
+            for &coord in ring.iter().chain(closing) {
                 let index = *seen.entry(coord.map(f64::to_bits)).or_insert_with(|| {
                     let next = vertices.len() as u32;
                     vertices.push(coord);
@@ -444,29 +438,35 @@ fn pack_csr(
     )
 }
 
-/// The number of mesh corners a polygon contributes — its rings with each
-/// closing duplicate dropped, matching `dedup_faces` / [`open_ring`]. A face
-/// with zero corners is skipped by `dedup_faces`, so it is dropped here too.
+/// The number of mesh corners a polygon contributes: its rings stored closed,
+/// matching `dedup_faces`.
 fn corner_count(polygon: &Polygon3D) -> usize {
     std::iter::once(polygon.exterior())
         .chain(polygon.interiors())
-        .map(|ring| open_ring(ring).len())
+        .map(|ring| ring.len() + usize::from(needs_closing(ring)))
         .sum()
 }
 
 /// Append one polygon's UV in mesh-corner order for a single `UvSource` directly
-/// onto `out`: rings concatenated (exterior then interiors), each closing
-/// duplicate dropped. `Explicit` slices the parallel array; `WorldToTexture` bakes
-/// the matrix at each corner vertex. Writes straight into the caller's reserved
-/// buffer — no per-face temporary.
+/// onto `out`: rings concatenated (exterior then interiors), each stored closed to
+/// match `dedup_faces`. `Explicit` slices the parallel array; `WorldToTexture` bakes
+/// the matrix at each corner vertex.
 fn extend_polygon_uv(out: &mut Vec<[f64; 2]>, polygon: &Polygon3D, source: &UvSource) {
     let mut pos = 0usize;
     for ring in std::iter::once(polygon.exterior()).chain(polygon.interiors()) {
-        let open = open_ring(ring);
+        let closing = needs_closing(ring);
         match source {
-            UvSource::Explicit(uv) => out.extend_from_slice(&uv[pos..pos + open.len()]),
+            UvSource::Explicit(uv) => {
+                out.extend_from_slice(&uv[pos..pos + ring.len()]);
+                if closing {
+                    out.push(uv[pos]);
+                }
+            }
             UvSource::WorldToTexture(matrix) => {
-                out.extend(open.iter().map(|&vertex| bake(matrix, vertex)));
+                out.extend(ring.iter().map(|&vertex| bake(matrix, vertex)));
+                if closing {
+                    out.push(bake(matrix, ring[0]));
+                }
             }
         }
         pos += ring.len();
@@ -713,10 +713,13 @@ mod tests {
                 [2., 1., 0.],
             ]
         );
-        // Rings stored open (the closing duplicate is dropped).
-        assert_eq!(ones(&m.data.face_indices), vec![0, 1, 2, 3, 1, 4, 5, 2]);
-        // Internal boundary only: face 0 ends / face 1 begins at 4.
-        assert_eq!(ones(&m.data.face_offsets), vec![4]);
+        // Rings stored closed (each ends where it began).
+        assert_eq!(
+            ones(&m.data.face_indices),
+            vec![0, 1, 2, 3, 0, 1, 4, 5, 2, 1]
+        );
+        // Internal boundary only: face 0 ends / face 1 begins at 5.
+        assert_eq!(ones(&m.data.face_offsets), vec![5]);
         assert!(ones(&m.data.interior_offsets).is_empty());
     }
 
@@ -727,10 +730,10 @@ mod tests {
         let p = Polygon3D::from_rings(CoordinateFrame::Euclidean, outer, vec![hole]);
         let m = PolygonMesh3DData::from_polygons([&p]);
         assert_eq!(m.vertices.len(), 8);
-        assert_eq!(ones(&m.face_indices), vec![0, 1, 2, 3, 4, 5, 6, 7]);
-        // Single face -> no internal boundaries; the hole starts at index 4.
+        assert_eq!(ones(&m.face_indices), vec![0, 1, 2, 3, 0, 4, 5, 6, 7, 4]);
+        // Single face -> no internal boundaries; the hole starts at index 5.
         assert!(ones(&m.face_offsets).is_empty());
-        assert_eq!(ones(&m.interior_offsets), vec![4]);
+        assert_eq!(ones(&m.interior_offsets), vec![5]);
     }
 
     #[test]
@@ -772,7 +775,7 @@ mod tests {
         let m = PolygonMesh3DData::from_polygons([&a, &empty, &b]);
         assert_eq!(m.vertices.len(), 6);
         // Two real faces -> one internal boundary, no duplicate from the empty face.
-        assert_eq!(ones(&m.face_offsets), vec![4]);
+        assert_eq!(ones(&m.face_offsets), vec![5]);
     }
 
     #[test]
@@ -860,7 +863,7 @@ mod tests {
         else {
             panic!("expected Explicit");
         };
-        assert_eq!(uv.len(), 4);
+        assert_eq!(uv.len(), 5);
     }
 
     #[test]
@@ -883,7 +886,7 @@ mod tests {
         else {
             panic!("expected Explicit");
         };
-        assert_eq!(uv.len(), 8);
+        assert_eq!(uv.len(), 10);
     }
 
     #[test]
@@ -949,14 +952,17 @@ mod tests {
         else {
             panic!("expected Explicit");
         };
-        assert_eq!(uv.len(), 8);
-        assert_eq!(&uv[0..4], &[[0.2, 0.2], [0.4, 0.2], [0.4, 0.4], [0.2, 0.4]]);
-        assert_eq!(&uv[4..8], &[[0., 0.], [0., 0.], [0., 0.], [0., 0.]]);
+        assert_eq!(uv.len(), 10);
+        assert_eq!(
+            &uv[0..5],
+            &[[0.2, 0.2], [0.4, 0.2], [0.4, 0.4], [0.2, 0.4], [0.2, 0.2]]
+        );
+        assert_eq!(&uv[5..10], &[[0., 0.]; 5]);
     }
 
     #[test]
-    fn from_polygons_drops_closing_uv() {
-        // Closed triangle: coords [a, b, c, a] (4); the mesh keeps 3 open corners.
+    fn from_polygons_keeps_closing_uv() {
+        // Closed triangle: coords [a, b, c, a] (4); the mesh keeps all 4 corners.
         let mut p = Polygon3D::from_rings(
             CoordinateFrame::Euclidean,
             [[0., 0., 0.], [1., 0., 0.], [0., 1., 0.], [0., 0., 0.]],
@@ -974,8 +980,8 @@ mod tests {
         else {
             panic!("expected Explicit");
         };
-        assert_eq!(uv.len(), 3);
-        assert_eq!(&uv[..], &[[0., 0.], [1., 0.], [0., 1.]]);
+        assert_eq!(uv.len(), 4);
+        assert_eq!(&uv[..], &[[0., 0.], [1., 0.], [0., 1.], [0., 0.]]);
     }
 
     #[test]
@@ -995,7 +1001,7 @@ mod tests {
         else {
             panic!("expected baked Explicit");
         };
-        assert_eq!(&uv[..], &[[0., 0.], [2., 0.], [2., 3.], [0., 3.]]);
+        assert_eq!(&uv[..], &[[0., 0.], [2., 0.], [2., 3.], [0., 3.], [0., 0.]]);
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -13,7 +13,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::appearance::{Appearance, UvSet};
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 use crate::index::IndexBuffer;
 
 mod constructor;
@@ -24,7 +24,7 @@ mod ops;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct PolygonMesh2D {
     /// Coordinate frame these vertices are expressed in.
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     vertices: Vec<[f64; 2]>,
     /// Optional per-vertex elevation, parallel to `vertices`. INVARIANT: when
     /// `Some`, `z.len() == vertices.len()`. `None` = pure 2D.
@@ -51,7 +51,7 @@ pub struct PolygonMesh2D {
 /// topology, UV and appearance, with no frame of its own.
 ///
 /// Shared by two hosts that each supply the frame: the standalone
-/// [`PolygonMesh3D`] leaf pairs this with its own [`Coordinate`], while a
+/// [`PolygonMesh3D`] leaf pairs this with its own [`CoordinateFrame`], while a
 /// [`Solid`](crate::solid::Solid) shell stores it directly and takes the one
 /// frame from the enclosing `Solid` — so a solid and its boundaries cannot
 /// disagree on a frame. Mirrors the [`Raster`](crate::appearance::Raster) /
@@ -82,8 +82,8 @@ pub struct PolygonMesh3DData {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct PolygonMesh3D {
     /// Coordinate frame the mesh data is expressed in.
-    coordinate: Coordinate,
-    /// Coordinate-free mesh data; the same form a [`Solid`](crate::solid::Solid)
+    frame: CoordinateFrame,
+    /// coordinate-free mesh data; the same form a [`Solid`](crate::solid::Solid)
     /// shell stores directly.
     data: PolygonMesh3DData,
 }

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -12,7 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::appearance::{Appearance, UvSet};
+use crate::appearance::Appearance;
 use crate::coordinate::CoordinateFrame;
 use crate::index::IndexBuffer;
 
@@ -41,9 +41,8 @@ pub struct PolygonMesh2D {
     /// Start in `face_indices` of each hole ring, across all faces; empty when
     /// no face has holes. Width from `face_indices.len() - 1`.
     interior_offsets: IndexBuffer<1>,
-    /// Geometric UV, parallel to the corner buffers; empty = no UV.
-    uv_sets: Vec<UvSet>,
-    /// Optional materials / themes / per-face binding; `None` = bare.
+    /// Optional materials / themes / per-face binding, incl. per-theme UV parallel
+    /// to the corner buffers; `None` = bare.
     appearance: Option<Appearance>,
 }
 
@@ -71,9 +70,8 @@ pub struct PolygonMesh3DData {
     /// Start in `face_indices` of each hole ring, across all faces; empty when
     /// no face has holes. Width from `face_indices.len() - 1`.
     interior_offsets: IndexBuffer<1>,
-    /// Geometric UV, parallel to the corner buffers; empty = no UV.
-    uv_sets: Vec<UvSet>,
-    /// Optional materials / themes / per-face binding; `None` = bare.
+    /// Optional materials / themes / per-face binding, incl. per-theme UV parallel
+    /// to the corner buffers; `None` = bare.
     appearance: Option<Appearance>,
 }
 
@@ -167,7 +165,7 @@ impl PolygonMesh3DData {
     /// Drop all back-side appearance, keeping only the front; see
     /// [`crate::appearance::make_front_only`].
     pub(crate) fn make_front_only(&mut self) {
-        crate::appearance::make_front_only(&mut self.appearance, &mut self.uv_sets);
+        crate::appearance::make_front_only(&mut self.appearance);
     }
 }
 
@@ -177,13 +175,12 @@ mod tests {
 
     use super::*;
     use crate::appearance::{
-        ChannelId, FaceBinding, MaterialIndex, Side, ThemeBinding, ThemeId, UvSource,
+        ChannelId, FaceBinding, MaterialIndex, Side, ThemeBinding, ThemeId, UvSet, UvSource,
     };
     use crate::test_support::bare;
 
     fn uv(side: Side) -> UvSet {
         UvSet {
-            theme: Some(ThemeId(Arc::from("t"))),
             side,
             channel: ChannelId::default(),
             uv: UvSource::Explicit(Box::new([])),
@@ -197,34 +194,50 @@ mod tests {
             [[0u32, 1, 2]],
         )
         .unwrap();
-        m.appearance = Some(Appearance {
-            materials: vec![bare(), bare()],
-            themes: vec![ThemeBinding {
-                theme: ThemeId(Arc::from("t")),
+        let theme = ThemeId(Arc::from("t"));
+        m.appearance = Some(Appearance::from_parts(
+            vec![bare(), bare()],
+            vec![ThemeBinding {
+                theme: theme.clone(),
                 front: FaceBinding::Uniform(MaterialIndex::new(0).unwrap()),
                 back: Some(FaceBinding::Uniform(MaterialIndex::new(1).unwrap())),
+                uv_sets: vec![uv(Side::Front), uv(Side::Back)],
             }],
-            default_theme: ThemeId(Arc::from("t")),
-        });
-        m.uv_sets = vec![uv(Side::Front), uv(Side::Back)];
+            theme,
+        ));
 
         m.make_front_only();
 
-        assert!(m.appearance.as_ref().unwrap().themes[0].back.is_none());
-        assert_eq!(m.uv_sets.len(), 1);
-        assert_eq!(m.uv_sets[0].side, Side::Front);
+        let app = m.appearance.as_ref().unwrap();
+        assert!(app.themes()[0].back.is_none());
+        assert_eq!(app.themes()[0].uv_sets.len(), 1);
+        assert_eq!(app.themes()[0].uv_sets[0].side, Side::Front);
     }
 
     #[test]
-    fn make_front_only_is_a_noop_when_already_front() {
+    fn make_front_only_leaves_a_front_only_appearance_intact() {
         let mut m = PolygonMesh3DData::from_parts(
             vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
             [[0u32, 1, 2]],
         )
         .unwrap();
-        m.uv_sets = vec![uv(Side::Front)];
+        let theme = ThemeId(Arc::from("t"));
+        m.appearance = Some(Appearance::from_parts(
+            vec![bare()],
+            vec![ThemeBinding {
+                theme: theme.clone(),
+                front: FaceBinding::Uniform(MaterialIndex::new(0).unwrap()),
+                back: None,
+                uv_sets: vec![uv(Side::Front)],
+            }],
+            theme,
+        ));
+
         m.make_front_only();
-        assert_eq!(m.uv_sets.len(), 1);
-        assert!(m.appearance.is_none());
+
+        let app = m.appearance.as_ref().unwrap();
+        assert!(app.themes()[0].back.is_none());
+        assert_eq!(app.themes()[0].uv_sets.len(), 1);
+        assert_eq!(app.themes()[0].uv_sets[0].side, Side::Front);
     }
 }

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -47,7 +47,7 @@ pub struct PolygonMesh2D {
 }
 
 /// The coordinate-free data of a 3D polygon mesh: the vertex pool, CSR face
-/// topology, UV and appearance, with no frame of its own.
+/// topology and appearance, with no frame of its own.
 ///
 /// Shared by two hosts that each supply the frame: the standalone
 /// [`PolygonMesh3D`] leaf pairs this with its own [`CoordinateFrame`], while a

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -81,29 +81,39 @@ impl Triangulate for PolygonMesh2D {
             let mut start = 0usize;
             for fi in 0..n_faces {
                 let end = buffers.face_offsets.get(fi).map_or(n, |&o| o as usize);
-                face_holes(&buffers.interior_offsets, start, end, &mut buffers.holes);
+                build_open_rings(
+                    &buffers.face_indices,
+                    &buffers.interior_offsets,
+                    start,
+                    end,
+                    &mut buffers.open_src,
+                    &mut buffers.holes,
+                );
                 let face = &buffers.face_indices[start..end];
                 buffers.verts2.clear();
                 // SAFETY: face indices are validated `< vertices.len()` at construction.
-                buffers.verts2.extend(
-                    face.iter()
-                        .map(|&gi| unsafe { *self.vertices.get_unchecked(gi as usize) }),
-                );
+                buffers
+                    .verts2
+                    .extend(buffers.open_src.iter().map(|&p| unsafe {
+                        *self
+                            .vertices
+                            .get_unchecked(*face.get_unchecked(p as usize) as usize)
+                    }));
                 // earcut clears `out` itself, but reset explicitly so the per-face
                 // count below stays correct without relying on that internal.
                 buffers.out.clear();
                 triangulate_2d(earcut, &buffers.verts2, &buffers.holes, &mut buffers.out);
                 // Map face-local corner indices back to the shared vertex pool.
-                // SAFETY: each earcut index is `< face.len()`.
-                buffers.tris.extend(
+                // SAFETY: each earcut index is `< open_src.len()`.
+                buffers.tris.extend(buffers.out.iter().map(|&l| unsafe {
+                    *face.get_unchecked(*buffers.open_src.get_unchecked(l as usize) as usize)
+                }));
+                buffers.corner_src.extend(
                     buffers
                         .out
                         .iter()
-                        .map(|&l| unsafe { *face.get_unchecked(l as usize) }),
+                        .map(|&l| start as u32 + buffers.open_src[l as usize]),
                 );
-                buffers
-                    .corner_src
-                    .extend(buffers.out.iter().map(|&l| start as u32 + l));
                 buffers.face_tris.push((buffers.out.len() / 3) as u32);
                 start = end;
             }
@@ -170,15 +180,28 @@ impl PolygonMesh3DData {
             let mut start = 0usize;
             for fi in 0..n_faces {
                 let end = buffers.face_offsets.get(fi).map_or(n, |&o| o as usize);
-                face_holes(&buffers.interior_offsets, start, end, &mut buffers.holes);
+                build_open_rings(
+                    &buffers.face_indices,
+                    &buffers.interior_offsets,
+                    start,
+                    end,
+                    &mut buffers.open_src,
+                    &mut buffers.holes,
+                );
                 let face = &buffers.face_indices[start..end];
-                let num_outer = buffers.holes.first().map_or(face.len(), |&h| h as usize);
+                let num_outer = buffers
+                    .holes
+                    .first()
+                    .map_or(buffers.open_src.len(), |&h| h as usize);
                 buffers.verts3.clear();
                 // SAFETY: face indices are validated `< vertices.len()` at construction.
-                buffers.verts3.extend(
-                    face.iter()
-                        .map(|&gi| unsafe { *self.vertices.get_unchecked(gi as usize) }),
-                );
+                buffers
+                    .verts3
+                    .extend(buffers.open_src.iter().map(|&p| unsafe {
+                        *self
+                            .vertices
+                            .get_unchecked(*face.get_unchecked(p as usize) as usize)
+                    }));
                 // `triangulate_3d` clears `out` on its degenerate paths and earcut
                 // clears it on success; reset explicitly so the per-face count
                 // below holds without relying on either internal.
@@ -190,16 +213,16 @@ impl PolygonMesh3DData {
                     &buffers.holes,
                     &mut buffers.out,
                 ) {
-                    // SAFETY: each earcut index is `< face.len()`.
-                    buffers.tris.extend(
+                    // SAFETY: each earcut index is `< open_src.len()`.
+                    buffers.tris.extend(buffers.out.iter().map(|&l| unsafe {
+                        *face.get_unchecked(*buffers.open_src.get_unchecked(l as usize) as usize)
+                    }));
+                    buffers.corner_src.extend(
                         buffers
                             .out
                             .iter()
-                            .map(|&l| unsafe { *face.get_unchecked(l as usize) }),
+                            .map(|&l| start as u32 + buffers.open_src[l as usize]),
                     );
-                    buffers
-                        .corner_src
-                        .extend(buffers.out.iter().map(|&l| start as u32 + l));
                 }
                 // Outside the `if`: a degenerate face records 0 (its `out` is empty).
                 buffers.face_tris.push((buffers.out.len() / 3) as u32);
@@ -246,17 +269,49 @@ fn decode_into(buf: &IndexBuffer<1>, out: &mut Vec<u32>) {
     }
 }
 
-/// Collect, into the reused `out` buffer, the face-local start offsets of the
-/// hole rings that fall strictly inside the face spanning `[start, end)` of
-/// `face_indices`.
-fn face_holes(interior_offsets: &[u32], start: usize, end: usize, out: &mut Vec<u32>) {
-    out.clear();
-    out.extend(
-        interior_offsets
-            .iter()
-            .filter(|&&o| (o as usize) > start && (o as usize) < end)
-            .map(|&o| o - start as u32),
-    );
+/// Build the open-ring layout of the face spanning `[start, end)` of
+/// `face_indices` for triangulation. Fills `open_src` with the face-local position
+/// of each corner (each ring's closing duplicate dropped) and `holes` with the
+/// start offset of each hole ring into `open_src`.
+fn build_open_rings(
+    face_indices: &[u32],
+    interior_offsets: &[u32],
+    start: usize,
+    end: usize,
+    open_src: &mut Vec<u32>,
+    holes: &mut Vec<u32>,
+) {
+    open_src.clear();
+    holes.clear();
+    let mut ring_start = start;
+    for &offset in interior_offsets {
+        let boundary = offset as usize;
+        if boundary <= start || boundary >= end {
+            continue;
+        }
+        push_open_ring(face_indices, start, ring_start, boundary, open_src);
+        holes.push(open_src.len() as u32);
+        ring_start = boundary;
+    }
+    push_open_ring(face_indices, start, ring_start, end, open_src);
+}
+
+/// Append the face-local positions of ring `[ring_start, ring_end)` to `open_src`,
+/// dropping the ring's closing vertex when it duplicates the first.
+fn push_open_ring(
+    face_indices: &[u32],
+    start: usize,
+    ring_start: usize,
+    ring_end: usize,
+    open_src: &mut Vec<u32>,
+) {
+    let open_end =
+        if ring_end - ring_start >= 2 && face_indices[ring_start] == face_indices[ring_end - 1] {
+            ring_end - 1
+        } else {
+            ring_end
+        };
+    open_src.extend((ring_start..open_end).map(|p| (p - start) as u32));
 }
 
 #[cfg(test)]
@@ -376,6 +431,36 @@ mod tests {
             _ => panic!("expected a 3D triangular mesh"),
         };
         // A square ring with a square hole tessellates into 8 triangles.
+        assert_eq!(tm.num_triangles(), 8);
+    }
+
+    #[test]
+    fn polygon_mesh3d_triangulates_holed_polygon_with_closed_rings() {
+        // Built via `from_polygons`, so the exterior and hole rings are stored
+        // closed; triangulation must drop each closing vertex before earcut.
+        use crate::polygon::Polygon3D;
+
+        let exterior = [
+            [0.0, 0.0, 0.0],
+            [4.0, 0.0, 0.0],
+            [4.0, 4.0, 0.0],
+            [0.0, 4.0, 0.0],
+            [0.0, 0.0, 0.0],
+        ];
+        let hole = vec![
+            [1.0, 1.0, 0.0],
+            [3.0, 1.0, 0.0],
+            [3.0, 3.0, 0.0],
+            [1.0, 3.0, 0.0],
+            [1.0, 1.0, 0.0],
+        ];
+        let p = Polygon3D::from_rings(CoordinateFrame::Euclidean, exterior, vec![hole]);
+        let mut mesh = PolygonMesh3D::from_polygons(CoordinateFrame::Euclidean, [&p]).unwrap();
+        let g = mesh.triangulate(&mut Cache::new()).unwrap();
+        let tm = match &g {
+            Geometry::Euclidean3D(Euclidean3DGeometry::TriangularMesh(m)) => m,
+            _ => panic!("expected a 3D triangular mesh"),
+        };
         assert_eq!(tm.num_triangles(), 8);
     }
 

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -2,9 +2,7 @@ use super::{PolygonMesh2D, PolygonMesh3D, PolygonMesh3DData};
 use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::index::IndexBuffer;
 use crate::ops::reproject::{transform_coords_2d, transform_coords_3d};
-use crate::ops::triangulation::{
-    expand_appearance, retarget_uv, triangulate_2d, triangulate_3d, Cache,
-};
+use crate::ops::triangulation::{expand_appearance, triangulate_2d, triangulate_3d, Cache};
 use crate::ops::{
     Aabb, BoundingBox, Reproject, ReprojectionCache, Triangulate, UnsupportedOperation,
 };
@@ -111,12 +109,11 @@ impl Triangulate for PolygonMesh2D {
             }
         }
 
-        let uv_sets = std::mem::take(&mut self.uv_sets)
-            .into_iter()
-            .map(|uv| retarget_uv(uv, &buffers.corner_src))
-            .collect();
-        let appearance =
-            expand_appearance(std::mem::take(&mut self.appearance), &buffers.face_tris);
+        let appearance = expand_appearance(
+            std::mem::take(&mut self.appearance),
+            &buffers.face_tris,
+            &buffers.corner_src,
+        );
         let triangle_count = buffers.tris.len() / 3;
         // `tris` index the existing pool (each `< vertices.len()`) in triples.
         let mut mesh = match std::mem::take(&mut self.z) {
@@ -146,7 +143,7 @@ impl Triangulate for PolygonMesh2D {
                 )
             },
         };
-        mesh.set_raw_appearance(uv_sets, appearance);
+        mesh.set_raw_appearance(appearance);
         Ok(Geometry::Euclidean2D(Euclidean2DGeometry::TriangularMesh(
             Box::new(mesh),
         )))
@@ -210,12 +207,11 @@ impl PolygonMesh3DData {
             }
         }
 
-        let uv_sets = std::mem::take(&mut self.uv_sets)
-            .into_iter()
-            .map(|uv| retarget_uv(uv, &buffers.corner_src))
-            .collect();
-        let appearance =
-            expand_appearance(std::mem::take(&mut self.appearance), &buffers.face_tris);
+        let appearance = expand_appearance(
+            std::mem::take(&mut self.appearance),
+            &buffers.face_tris,
+            &buffers.corner_src,
+        );
         // SAFETY: `tris` index `self.vertices` (`< len`); count is a multiple of 3.
         let mut data = unsafe {
             TriangularMesh3DData::from_parts_unchecked(
@@ -224,7 +220,7 @@ impl PolygonMesh3DData {
                 buffers.tris.iter().copied(),
             )
         };
-        data.set_raw_appearance(uv_sets, appearance);
+        data.set_raw_appearance(appearance);
         data
     }
 }
@@ -420,7 +416,7 @@ mod tests {
 
         let mut mesh = PolygonMesh3D::from_polygons(CoordinateFrame::Euclidean, [&a, &b]).unwrap();
         assert!(matches!(
-            mesh.appearance().as_ref().unwrap().themes[0].front,
+            mesh.appearance().as_ref().unwrap().themes()[0].front,
             FaceBinding::PerFace(_)
         ));
 
@@ -431,7 +427,8 @@ mod tests {
         };
         // Each quad -> 2 triangles; the per-face binding expands to one entry per triangle.
         assert_eq!(tm.num_triangles(), 4);
-        let FaceBinding::PerFace(front) = &tm.appearance().as_ref().unwrap().themes[0].front else {
+        let FaceBinding::PerFace(front) = &tm.appearance().as_ref().unwrap().themes()[0].front
+        else {
             panic!("expected PerFace");
         };
         assert_eq!(
@@ -465,33 +462,33 @@ mod tests {
         )
         .unwrap();
         let src = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
-        data.uv_sets = vec![UvSet {
-            theme: Some(theme("rgb")),
-            side: Side::Front,
-            channel: Default::default(),
-            uv: UvSource::Explicit(Box::new(src)),
-        }];
-        data.appearance = Some(Appearance {
-            materials: vec![textured()],
-            themes: vec![ThemeBinding {
+        data.appearance = Some(Appearance::from_parts(
+            vec![textured()],
+            vec![ThemeBinding {
                 theme: theme("rgb"),
                 front: FaceBinding::Uniform(MaterialIndex::new(0).unwrap()),
                 back: None,
+                uv_sets: vec![UvSet {
+                    side: Side::Front,
+                    channel: Default::default(),
+                    uv: UvSource::Explicit(Box::new(src)),
+                }],
             }],
-            default_theme: theme("rgb"),
-        });
+            theme("rgb"),
+        ));
 
         let out = data.triangulate(&mut Cache::new());
         let mesh = TriangularMesh3D::new(CoordinateFrame::Euclidean, out);
         assert_eq!(mesh.num_triangles(), 2);
 
-        let UvSource::Explicit(out_uv) = &mesh.uv_sets()[0].uv else {
+        let app = mesh.appearance().as_ref().unwrap();
+        let UvSource::Explicit(out_uv) = &app.themes()[0].uv_sets[0].uv else {
             panic!("expected an explicit output UV set");
         };
         assert_eq!(out_uv.len(), 6);
         assert!(out_uv.iter().all(|uv| src.contains(uv)));
         assert!(matches!(
-            mesh.appearance().as_ref().unwrap().themes[0].front,
+            mesh.appearance().as_ref().unwrap().themes()[0].front,
             FaceBinding::Uniform(_)
         ));
     }

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -1,5 +1,5 @@
 use super::{PolygonMesh2D, PolygonMesh3D, PolygonMesh3DData};
-use crate::coordinate::{Coordinate, EpsgCode};
+use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::index::IndexBuffer;
 use crate::ops::reproject::{transform_coords_2d, transform_coords_3d};
 use crate::ops::triangulation::{
@@ -35,7 +35,7 @@ impl Reproject for PolygonMesh2D {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
-        let from = self.coordinate.require_crs()?;
+        let from = self.frame.require_crs()?;
         if from != target {
             transform_coords_2d(
                 cache,
@@ -44,7 +44,7 @@ impl Reproject for PolygonMesh2D {
                 &mut self.vertices,
                 self.z.as_deref_mut(),
             )?;
-            self.coordinate = Coordinate::Crs(target);
+            self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
     }
@@ -56,10 +56,10 @@ impl Reproject for PolygonMesh3D {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
-        let from = self.coordinate.require_crs()?;
+        let from = self.frame.require_crs()?;
         if from != target {
             transform_coords_3d(cache, from, target, self.data.vertices_mut())?;
-            self.coordinate = Coordinate::Crs(target);
+            self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
     }
@@ -129,7 +129,7 @@ impl Triangulate for PolygonMesh2D {
                 // SAFETY: every index is `< verts3.len()`; count is a multiple of 3.
                 unsafe {
                     TriangularMesh2D::from_parts_with_elevation_unchecked(
-                        self.coordinate.clone(),
+                        self.frame.clone(),
                         verts3,
                         triangle_count,
                         buffers.tris.iter().copied(),
@@ -139,7 +139,7 @@ impl Triangulate for PolygonMesh2D {
             // SAFETY: every index is `< vertices.len()`; count is a multiple of 3.
             None => unsafe {
                 TriangularMesh2D::from_parts_unchecked(
-                    self.coordinate.clone(),
+                    self.frame.clone(),
                     std::mem::take(&mut self.vertices),
                     triangle_count,
                     buffers.tris.iter().copied(),
@@ -232,7 +232,7 @@ impl PolygonMesh3DData {
 impl Triangulate for PolygonMesh3D {
     fn triangulate(&mut self, cache: &mut Cache) -> Result<Geometry, UnsupportedOperation> {
         let data = self.data.triangulate(cache);
-        let mesh = TriangularMesh3D::new(self.coordinate.clone(), data);
+        let mesh = TriangularMesh3D::new(self.frame.clone(), data);
         Ok(Geometry::Euclidean3D(Euclidean3DGeometry::TriangularMesh(
             Box::new(mesh),
         )))
@@ -266,12 +266,12 @@ fn face_holes(interior_offsets: &[u32], start: usize, end: usize, out: &mut Vec<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::Coordinate;
+    use crate::coordinate::CoordinateFrame;
 
     #[test]
     fn polygon_mesh2d_box_spans_vertex_pool() {
         let m = PolygonMesh2D::from_parts(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             vec![[0.0, 0.0], [3.0, 0.0], [3.0, 2.0]],
             vec![vec![0u32, 1, 2]],
         )
@@ -288,7 +288,7 @@ mod tests {
     #[test]
     fn polygon_mesh3d_box_spans_vertex_pool() {
         let m = PolygonMesh3D::from_parts(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             vec![[0.0, 0.0, 0.0], [3.0, 0.0, 1.0], [3.0, 2.0, -1.0]],
             vec![vec![0u32, 1, 2]],
         )
@@ -314,7 +314,7 @@ mod tests {
             [4.0, 2.0],
         ];
         let mut mesh = PolygonMesh2D::from_parts(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             vertices,
             vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
         )
@@ -332,7 +332,7 @@ mod tests {
     #[test]
     fn polygon_mesh3d_triangulates_quad_in_plane() {
         let mut mesh = PolygonMesh3D::from_parts(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             vec![
                 [0.0, 0.0, 0.0],
                 [2.0, 0.0, 0.0],
@@ -367,7 +367,7 @@ mod tests {
             [1.0, 3.0, 0.0],
         ];
         let mut mesh = PolygonMesh3D::from_raw_parts(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             vertices,
             vec![0, 1, 2, 3, 4, 5, 6, 7], // face_indices: exterior then hole
             vec![],                       // one face
@@ -403,16 +403,22 @@ mod tests {
             [2.0, 1.0, 0.0],
             [2.0, 0.0, 0.0],
         ];
-        let mut a =
-            Polygon3D::from_rings(Coordinate::Euclidean, ring_a, Vec::<Vec<[f64; 3]>>::new());
+        let mut a = Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            ring_a,
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
         a.set_appearance(theme("rgb"), textured(), Some(uv(5)))
             .unwrap();
-        let mut b =
-            Polygon3D::from_rings(Coordinate::Euclidean, ring_b, Vec::<Vec<[f64; 3]>>::new());
+        let mut b = Polygon3D::from_rings(
+            CoordinateFrame::Euclidean,
+            ring_b,
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
         b.set_appearance(theme("rgb"), textured(), Some(uv(5)))
             .unwrap();
 
-        let mut mesh = PolygonMesh3D::from_polygons(Coordinate::Euclidean, [&a, &b]).unwrap();
+        let mut mesh = PolygonMesh3D::from_polygons(CoordinateFrame::Euclidean, [&a, &b]).unwrap();
         assert!(matches!(
             mesh.appearance().as_ref().unwrap().themes[0].front,
             FaceBinding::PerFace(_)
@@ -476,7 +482,7 @@ mod tests {
         });
 
         let out = data.triangulate(&mut Cache::new());
-        let mesh = TriangularMesh3D::new(Coordinate::Euclidean, out);
+        let mesh = TriangularMesh3D::new(CoordinateFrame::Euclidean, out);
         assert_eq!(mesh.num_triangles(), 2);
 
         let UvSource::Explicit(out_uv) = &mesh.uv_sets()[0].uv else {

--- a/engine/runtime/geometry/src/solid/constructor.rs
+++ b/engine/runtime/geometry/src/solid/constructor.rs
@@ -6,7 +6,7 @@
 //! expressed in. The `From` impls let a mesh be passed where a [`Shell`] is
 //! expected.
 
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 use crate::polygon_mesh::PolygonMesh3DData;
 use crate::triangular_mesh::TriangularMesh3DData;
 
@@ -38,14 +38,14 @@ impl Shell {
 
 impl Solid {
     /// A solid bounded by `exterior` with the given interior (void) shells, in
-    /// `coordinate`.
+    /// `frame`.
     ///
     /// Every shell — exterior and interiors — is normalised to **front-side only**:
     /// a solid's boundary faces are oriented outward (or inward for voids), so the
     /// back of any boundary is the solid's interior and is never rendered. Any
     /// back-side appearance a shell mesh carried is dropped here.
     pub fn new(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         exterior: impl Into<Shell>,
         mut interiors: Vec<Shell>,
     ) -> Self {
@@ -55,15 +55,15 @@ impl Solid {
             shell.make_front_only();
         }
         Self {
-            coordinate,
+            frame,
             exterior,
             interiors,
         }
     }
 
     /// A solid bounded by a single exterior shell, with no voids.
-    pub fn from_exterior(coordinate: Coordinate, exterior: impl Into<Shell>) -> Self {
-        Self::new(coordinate, exterior, Vec::new())
+    pub fn from_exterior(frame: CoordinateFrame, exterior: impl Into<Shell>) -> Self {
+        Self::new(frame, exterior, Vec::new())
     }
 }
 
@@ -82,16 +82,16 @@ mod tests {
 
     #[test]
     fn from_exterior_has_no_voids() {
-        let s = Solid::from_exterior(Coordinate::Euclidean, cube_shell());
+        let s = Solid::from_exterior(CoordinateFrame::Euclidean, cube_shell());
         assert!(matches!(s.exterior, Shell::TriangularMesh(_)));
         assert!(s.interiors.is_empty());
-        assert_eq!(s.coordinate, Coordinate::Euclidean);
+        assert_eq!(s.frame, CoordinateFrame::Euclidean);
     }
 
     #[test]
     fn new_carries_void_shells() {
         let s = Solid::new(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             cube_shell(),
             vec![Shell::from(cube_shell())],
         );

--- a/engine/runtime/geometry/src/solid/mod.rs
+++ b/engine/runtime/geometry/src/solid/mod.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 use crate::polygon_mesh::PolygonMesh3DData;
 use crate::triangular_mesh::TriangularMesh3DData;
 
@@ -52,7 +52,7 @@ impl Shell {
 pub struct Solid {
     /// Coordinate frame this solid's shells are expressed in; the shells
     /// themselves are coordless raw meshes.
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     exterior: Shell,
     /// Hollow voids.
     interiors: Vec<Shell>,

--- a/engine/runtime/geometry/src/solid/ops.rs
+++ b/engine/runtime/geometry/src/solid/ops.rs
@@ -1,5 +1,5 @@
 use super::{Shell, Solid};
-use crate::coordinate::{Coordinate, EpsgCode};
+use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::ops::reproject::transform_coords_3d;
 use crate::ops::triangulation::Cache;
 use crate::ops::{
@@ -31,7 +31,7 @@ impl Triangulate for Solid {
             .iter_mut()
             .map(|shell| shell.triangulated(cache))
             .collect();
-        let solid = Solid::new(self.coordinate.clone(), exterior, interiors);
+        let solid = Solid::new(self.frame.clone(), exterior, interiors);
         Ok(Geometry::Euclidean3D(Euclidean3DGeometry::Solid(Box::new(
             solid,
         ))))
@@ -56,13 +56,13 @@ impl Reproject for Solid {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
-        let from = self.coordinate.require_crs()?;
+        let from = self.frame.require_crs()?;
         if from != target {
             reproject_shell(&mut self.exterior, from, target, cache)?;
             for shell in &mut self.interiors {
                 reproject_shell(shell, from, target, cache)?;
             }
-            self.coordinate = Coordinate::Crs(target);
+            self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
     }
@@ -85,7 +85,7 @@ fn reproject_shell(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::Coordinate;
+    use crate::coordinate::CoordinateFrame;
     use crate::solid::Shell;
     use crate::triangular_mesh::TriangularMesh3DData;
 
@@ -96,7 +96,7 @@ mod tests {
     #[test]
     fn solid_box_spans_exterior_shell() {
         let s = Solid::from_exterior(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             shell(vec![[0.0, 0.0, 0.0], [2.0, 0.0, 0.0], [0.0, 2.0, 3.0]]),
         );
         assert_eq!(
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn solid_box_includes_interior_shells() {
         let s = Solid::new(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             shell(vec![[0.0, 0.0, 0.0], [2.0, 0.0, 0.0], [0.0, 2.0, 0.0]]),
             vec![Shell::from(shell(vec![
                 [5.0, 5.0, 5.0],
@@ -146,7 +146,7 @@ mod tests {
         .unwrap();
         // Interior void: already a triangle-mesh shell -> passes through unchanged.
         let void = shell(vec![[5.0, 5.0, 5.0], [6.0, 5.0, 5.0], [5.0, 6.0, 5.0]]);
-        let mut solid = Solid::new(Coordinate::Euclidean, quad, vec![Shell::from(void)]);
+        let mut solid = Solid::new(CoordinateFrame::Euclidean, quad, vec![Shell::from(void)]);
 
         let out = match solid.triangulate(&mut Cache::new()).unwrap() {
             // The output is a Solid, not a bare mesh.
@@ -156,7 +156,7 @@ mod tests {
         // The polygon-mesh exterior is now a 2-triangle triangular-mesh shell.
         match &out.exterior {
             Shell::TriangularMesh(d) => {
-                let tris = TriangularMesh3D::new(Coordinate::Euclidean, d.clone());
+                let tris = TriangularMesh3D::new(CoordinateFrame::Euclidean, d.clone());
                 assert_eq!(tris.num_triangles(), 2);
             }
             Shell::PolygonMesh(_) => panic!("exterior polygon-mesh shell should be triangulated"),

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -20,7 +20,7 @@
 //!
 //! 3D constructors build the coordinate-free [`TriangularMesh3DData`] that a
 //! [`Solid`](crate::solid::Solid) shell also stores, so the frame-carrying
-//! [`TriangularMesh3D`] is a thin wrapper. All meshes are built bare (no UV, no
+//! [`TriangularMesh3D`] is a thin wrapper. All meshes are built bare (no
 //! appearance); attach an appearance afterwards via `appearance_mut`.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -29,7 +29,7 @@ use crate::appearance::{
     append_theme, single_channel_uv, validate_uv_coupling, Appearance, ChannelId, FaceBinding,
     Material, MaterialIndex, Side, ThemeId, UvSet, UvSource,
 };
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 use crate::error::Error;
 use crate::index::{IndexBuffer, IndexWidth};
 
@@ -147,19 +147,19 @@ impl TriangularMesh3DData {
 
 impl TriangularMesh3D {
     /// Pair coordinate-free mesh data with the frame it is expressed in.
-    pub fn new(coordinate: Coordinate, data: TriangularMesh3DData) -> Self {
-        Self { coordinate, data }
+    pub fn new(frame: CoordinateFrame, data: TriangularMesh3DData) -> Self {
+        Self { frame, data }
     }
 
     /// Build from a vertex pool and a flat `u32` index stream; see
     /// [`TriangularMesh3DData::from_parts`].
     pub fn from_parts(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         vertices: Vec<[f64; 3]>,
         indices: impl IntoIterator<Item = u32>,
     ) -> Result<Self, Error> {
         Ok(Self::new(
-            coordinate,
+            frame,
             TriangularMesh3DData::from_parts(vertices, indices)?,
         ))
     }
@@ -171,20 +171,20 @@ impl TriangularMesh3D {
     /// Same contract as [`TriangularMesh3DData::from_parts_unchecked`].
     #[allow(unused)] // TODO: remove this after the migration is complete at which point this will be used.
     pub unsafe fn from_parts_unchecked(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         vertices: Vec<[f64; 3]>,
         triangle_count: usize,
         indices: impl IntoIterator<Item = u32>,
     ) -> Self {
         Self::new(
-            coordinate,
+            frame,
             TriangularMesh3DData::from_parts_unchecked(vertices, triangle_count, indices),
         )
     }
 
     /// Build from a triangle soup; see [`TriangularMesh3DData::from_soup`].
-    pub fn from_soup(coordinate: Coordinate, iter: impl IntoIterator<Item = [f64; 3]>) -> Self {
-        Self::new(coordinate, TriangularMesh3DData::from_soup(iter))
+    pub fn from_soup(frame: CoordinateFrame, iter: impl IntoIterator<Item = [f64; 3]>) -> Self {
+        Self::new(frame, TriangularMesh3DData::from_soup(iter))
     }
 
     /// Install raw `appearance` / `uv_sets`; see
@@ -227,14 +227,14 @@ impl TriangularMesh2D {
     /// Validates the index count and range; the width is taken from the vertex
     /// count.
     pub fn from_parts(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         vertices: Vec<[f64; 2]>,
         indices: impl IntoIterator<Item = u32>,
     ) -> Result<Self, Error> {
         let width = index_width_for(vertices.len());
         let triangles = triangles_checked(indices, vertices.len())?;
         Ok(Self {
-            coordinate,
+            frame,
             vertices,
             z: None,
             indices: pack_checked(width, triangles),
@@ -246,7 +246,7 @@ impl TriangularMesh2D {
     /// Build a 2.5D mesh from `[x, y, z]` vertices: the `(x, y)` populate the
     /// vertex pool and the `z` the parallel elevation buffer.
     pub fn from_parts_with_elevation(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         vertices: Vec<[f64; 3]>,
         indices: impl IntoIterator<Item = u32>,
     ) -> Result<Self, Error> {
@@ -260,7 +260,7 @@ impl TriangularMesh2D {
             z.push(elevation);
         }
         Ok(Self {
-            coordinate,
+            frame,
             vertices: xy,
             z: Some(z.into_boxed_slice()),
             indices: pack_checked(width, triangles),
@@ -274,7 +274,7 @@ impl TriangularMesh2D {
     /// # Safety
     /// Same contract as [`TriangularMesh3DData::from_parts_unchecked`].
     pub unsafe fn from_parts_with_elevation_unchecked(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         vertices: Vec<[f64; 3]>,
         triangle_count: usize,
         indices: impl IntoIterator<Item = u32>,
@@ -288,7 +288,7 @@ impl TriangularMesh2D {
             z.push(elevation);
         }
         Self {
-            coordinate,
+            frame,
             indices: IndexBuffer::from_exact_unchecked(
                 width,
                 triangle_count,
@@ -306,14 +306,14 @@ impl TriangularMesh2D {
     /// # Safety
     /// Same contract as [`TriangularMesh3DData::from_parts_unchecked`].
     pub unsafe fn from_parts_unchecked(
-        coordinate: Coordinate,
+        frame: CoordinateFrame,
         vertices: Vec<[f64; 2]>,
         triangle_count: usize,
         indices: impl IntoIterator<Item = u32>,
     ) -> Self {
         let width = index_width_for(vertices.len());
         Self {
-            coordinate,
+            frame,
             indices: IndexBuffer::from_exact_unchecked(
                 width,
                 triangle_count,
@@ -338,10 +338,10 @@ impl TriangularMesh2D {
     }
 
     /// Build a pure-2D mesh from a triangle soup of `[x, y]` corners.
-    pub fn from_soup(coordinate: Coordinate, iter: impl IntoIterator<Item = [f64; 2]>) -> Self {
+    pub fn from_soup(frame: CoordinateFrame, iter: impl IntoIterator<Item = [f64; 2]>) -> Self {
         let (vertices, indices) = soup_buffers::<2>(iter);
         Self {
-            coordinate,
+            frame,
             vertices,
             z: None,
             indices,
@@ -566,7 +566,8 @@ mod tests {
     #[test]
     fn from_parts_builds_validated_mesh() {
         let verts = vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
-        let m = TriangularMesh3D::from_parts(Coordinate::Euclidean, verts, [0u32, 1, 2]).unwrap();
+        let m =
+            TriangularMesh3D::from_parts(CoordinateFrame::Euclidean, verts, [0u32, 1, 2]).unwrap();
         assert_eq!(m.data.vertices.len(), 3);
         assert_eq!(m.data.indices.width(), IndexWidth::U8);
         assert_eq!(triples(&m.data.indices), vec![[0, 1, 2]]);
@@ -623,9 +624,12 @@ mod tests {
     #[test]
     fn from_parts_with_elevation_splits_z() {
         let verts = vec![[0.0, 0.0, 10.0], [1.0, 0.0, 11.0], [0.0, 1.0, 12.0]];
-        let m =
-            TriangularMesh2D::from_parts_with_elevation(Coordinate::Euclidean, verts, [0u32, 1, 2])
-                .unwrap();
+        let m = TriangularMesh2D::from_parts_with_elevation(
+            CoordinateFrame::Euclidean,
+            verts,
+            [0u32, 1, 2],
+        )
+        .unwrap();
         assert_eq!(m.vertices, vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]);
         assert_eq!(m.z.as_deref(), Some(&[10.0, 11.0, 12.0][..]));
     }

--- a/engine/runtime/geometry/src/triangular_mesh/constructor.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/constructor.rs
@@ -48,7 +48,6 @@ impl TriangularMesh3DData {
         Ok(Self {
             vertices,
             indices: pack_checked(width, triangles),
-            uv_sets: Vec::new(),
             appearance: None,
         })
     }
@@ -74,20 +73,14 @@ impl TriangularMesh3DData {
                 group_triples(indices),
             ),
             vertices,
-            uv_sets: Vec::new(),
             appearance: None,
         }
     }
 
-    /// Install an already-built `appearance` and `uv_sets` directly, **unvalidated**
-    /// (the caller owns the invariants). Used by tessellation, whose appearance is
-    /// consistent by construction.
-    pub(crate) fn set_raw_appearance(
-        &mut self,
-        uv_sets: Vec<UvSet>,
-        appearance: Option<Appearance>,
-    ) {
-        self.uv_sets = uv_sets;
+    /// Install an already-built `appearance` (with its per-theme UV) directly,
+    /// **unvalidated** (the caller owns the invariants). Used by tessellation, whose
+    /// appearance is consistent by construction.
+    pub(crate) fn set_raw_appearance(&mut self, appearance: Option<Appearance>) {
         self.appearance = appearance;
     }
 
@@ -98,7 +91,6 @@ impl TriangularMesh3DData {
         Self {
             vertices,
             indices,
-            uv_sets: Vec::new(),
             appearance: None,
         }
     }
@@ -122,7 +114,7 @@ impl TriangularMesh3DData {
 
     /// Add a multi-material, front-side appearance for one theme with an explicit
     /// per-triangle `binding`. `binding` indexes `materials` locally
-    /// (`0..materials.len()`); those indices are offset into the accumulated
+    /// (`0..materials().len()`); those indices are offset into the accumulated
     /// palette. A `PerFace` binding's length must equal the triangle count. `uvs`
     /// supplies one UV set per channel the bound materials' maps sample.
     /// Additive and validated like [`set_appearance`](Self::set_appearance).
@@ -136,7 +128,6 @@ impl TriangularMesh3DData {
         add_theme(
             self.indices.len(),
             &mut self.appearance,
-            &mut self.uv_sets,
             theme,
             materials,
             binding,
@@ -187,14 +178,10 @@ impl TriangularMesh3D {
         Self::new(frame, TriangularMesh3DData::from_soup(iter))
     }
 
-    /// Install raw `appearance` / `uv_sets`; see
+    /// Install a raw `appearance`; see
     /// [`TriangularMesh3DData::set_raw_appearance`].
-    pub(crate) fn set_raw_appearance(
-        &mut self,
-        uv_sets: Vec<UvSet>,
-        appearance: Option<Appearance>,
-    ) {
-        self.data.set_raw_appearance(uv_sets, appearance);
+    pub(crate) fn set_raw_appearance(&mut self, appearance: Option<Appearance>) {
+        self.data.set_raw_appearance(appearance);
     }
 
     /// Add a single-material appearance for one theme; see
@@ -238,7 +225,6 @@ impl TriangularMesh2D {
             vertices,
             z: None,
             indices: pack_checked(width, triangles),
-            uv_sets: Vec::new(),
             appearance: None,
         })
     }
@@ -264,7 +250,6 @@ impl TriangularMesh2D {
             vertices: xy,
             z: Some(z.into_boxed_slice()),
             indices: pack_checked(width, triangles),
-            uv_sets: Vec::new(),
             appearance: None,
         })
     }
@@ -296,7 +281,6 @@ impl TriangularMesh2D {
             ),
             vertices: xy,
             z: Some(z.into_boxed_slice()),
-            uv_sets: Vec::new(),
             appearance: None,
         }
     }
@@ -321,19 +305,13 @@ impl TriangularMesh2D {
             ),
             vertices,
             z: None,
-            uv_sets: Vec::new(),
             appearance: None,
         }
     }
 
-    /// Install raw `appearance` / `uv_sets`; see
+    /// Install a raw `appearance`; see
     /// [`TriangularMesh3DData::set_raw_appearance`].
-    pub(crate) fn set_raw_appearance(
-        &mut self,
-        uv_sets: Vec<UvSet>,
-        appearance: Option<Appearance>,
-    ) {
-        self.uv_sets = uv_sets;
+    pub(crate) fn set_raw_appearance(&mut self, appearance: Option<Appearance>) {
         self.appearance = appearance;
     }
 
@@ -345,7 +323,6 @@ impl TriangularMesh2D {
             vertices,
             z: None,
             indices,
-            uv_sets: Vec::new(),
             appearance: None,
         }
     }
@@ -374,7 +351,6 @@ impl TriangularMesh2D {
         add_theme(
             self.indices.len(),
             &mut self.appearance,
-            &mut self.uv_sets,
             theme,
             materials,
             binding,
@@ -383,15 +359,14 @@ impl TriangularMesh2D {
     }
 }
 
-/// Add one theme's appearance to a triangle mesh's `appearance` / `uv_sets`.
-/// `binding` indexes `materials` locally; its indices are offset into the
-/// accumulated palette. Validates the binding shape, the material/UV coupling and
-/// (for `Explicit`) the UV length against `3 * triangle_count`. On any error the
+/// Add one theme's appearance (with its front-side UV) to a triangle mesh's
+/// `appearance`. `binding` indexes `materials` locally; its indices are offset into
+/// the accumulated palette. Validates the binding shape, the material/UV coupling
+/// and (for `Explicit`) the UV length against `3 * triangle_count`. On any error the
 /// mesh is left unchanged; on success the first theme added becomes the default.
 fn add_theme(
     triangle_count: usize,
     appearance: &mut Option<Appearance>,
-    uv_sets: &mut Vec<UvSet>,
     theme: ThemeId,
     materials: Vec<Material>,
     binding: FaceBinding,
@@ -407,21 +382,12 @@ fn add_theme(
     let new_uv_sets = uvs
         .into_iter()
         .map(|(channel, uv)| UvSet {
-            theme: Some(theme.clone()),
             side: Side::Front,
             channel,
             uv,
         })
         .collect();
-    append_theme(
-        appearance,
-        uv_sets,
-        theme,
-        materials,
-        binding,
-        None,
-        new_uv_sets,
-    )
+    append_theme(appearance, theme, materials, binding, None, new_uv_sets)
 }
 
 /// Check a binding references only `0..palette_len` and, when `PerFace`, has one
@@ -674,20 +640,21 @@ mod tests {
         m.set_appearance(theme("rgb"), textured(), Some(uv(3)))
             .unwrap();
         let app = m.appearance.as_ref().unwrap();
-        assert_eq!(app.materials.len(), 1);
-        assert_eq!(app.default_theme, theme("rgb"));
-        assert!(matches!(app.themes[0].front, FaceBinding::Uniform(_)));
-        assert!(app.themes[0].back.is_none());
-        assert_eq!(m.uv_sets.len(), 1);
-        assert_eq!(m.uv_sets[0].side, Side::Front);
+        assert_eq!(app.materials().len(), 1);
+        assert_eq!(*app.default_theme(), theme("rgb"));
+        assert!(matches!(app.themes()[0].front, FaceBinding::Uniform(_)));
+        assert!(app.themes()[0].back.is_none());
+        assert_eq!(app.themes()[0].uv_sets.len(), 1);
+        assert_eq!(app.themes()[0].uv_sets[0].side, Side::Front);
     }
 
     #[test]
     fn set_appearance_uniform_bare_has_no_uv() {
         let mut m = one_triangle();
         m.set_appearance(theme("rgb"), bare(), None).unwrap();
-        assert_eq!(m.appearance.as_ref().unwrap().materials.len(), 1);
-        assert!(m.uv_sets.is_empty());
+        let app = m.appearance.as_ref().unwrap();
+        assert_eq!(app.materials().len(), 1);
+        assert!(app.themes()[0].uv_sets.is_empty());
     }
 
     #[test]
@@ -722,12 +689,12 @@ mod tests {
         )
         .unwrap();
         let app = m.appearance.as_ref().unwrap();
-        assert_eq!(app.materials.len(), 2);
-        let FaceBinding::PerFace(faces) = &app.themes[0].front else {
+        assert_eq!(app.materials().len(), 2);
+        let FaceBinding::PerFace(faces) = &app.themes()[0].front else {
             panic!("expected PerFace");
         };
         assert_eq!(faces, &[MaterialIndex::new(0), MaterialIndex::new(1)]);
-        let UvSource::Explicit(coords) = &m.uv_sets[0].uv else {
+        let UvSource::Explicit(coords) = &app.themes()[0].uv_sets[0].uv else {
             panic!("expected Explicit");
         };
         assert_eq!(coords.len(), 6);
@@ -742,8 +709,9 @@ mod tests {
             .unwrap();
 
         // One UV set per referenced channel, each tagged with its channel.
-        assert_eq!(m.uv_sets.len(), 2);
-        let mut channels: Vec<_> = m.uv_sets.iter().map(|s| s.channel).collect();
+        let app = m.appearance.as_ref().unwrap();
+        assert_eq!(app.themes()[0].uv_sets.len(), 2);
+        let mut channels: Vec<_> = app.themes()[0].uv_sets.iter().map(|s| s.channel).collect();
         channels.sort();
         assert_eq!(channels, vec![ChannelId(0), ChannelId(1)]);
     }
@@ -814,25 +782,26 @@ mod tests {
         m.set_appearance(theme("infrared"), bare(), None).unwrap();
 
         let app = m.appearance.as_ref().unwrap();
-        assert_eq!(app.themes.len(), 2);
+        assert_eq!(app.themes().len(), 2);
         assert_eq!(
-            app.default_theme,
+            *app.default_theme(),
             theme("rgb"),
             "first theme is the default"
         );
-        assert_eq!(app.materials.len(), 2);
+        assert_eq!(app.materials().len(), 2);
         // The second theme's local index 0 is offset to palette slot 1.
-        let FaceBinding::Uniform(rgb) = app.themes[0].front else {
+        let FaceBinding::Uniform(rgb) = app.themes()[0].front else {
             panic!();
         };
-        let FaceBinding::Uniform(infrared) = app.themes[1].front else {
+        let FaceBinding::Uniform(infrared) = app.themes()[1].front else {
             panic!();
         };
         assert_eq!(rgb.get(), 0);
         assert_eq!(infrared.get(), 1);
         // Only the textured theme contributes a UV set.
-        assert_eq!(m.uv_sets.len(), 1);
-        assert_eq!(m.uv_sets[0].theme.as_ref(), Some(&theme("rgb")));
+        assert_eq!(app.themes()[0].uv_sets.len(), 1);
+        assert_eq!(app.themes()[0].theme, theme("rgb"));
+        assert!(app.themes()[1].uv_sets.is_empty());
     }
 
     #[test]

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -11,7 +11,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::appearance::{Appearance, UvSet};
-use crate::coordinate::Coordinate;
+use crate::coordinate::CoordinateFrame;
 use crate::index::IndexBuffer;
 
 mod constructor;
@@ -21,7 +21,7 @@ mod ops;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct TriangularMesh2D {
     /// Coordinate frame these vertices are expressed in.
-    coordinate: Coordinate,
+    frame: CoordinateFrame,
     vertices: Vec<[f64; 2]>,
     /// Optional per-vertex elevation, parallel to `vertices`. INVARIANT: when
     /// `Some`, `z.len() == vertices.len()`. `None` = pure 2D.
@@ -38,7 +38,7 @@ pub struct TriangularMesh2D {
 /// index list, UV and appearance, with no frame of its own.
 ///
 /// Shared by two hosts that each supply the frame: the standalone
-/// [`TriangularMesh3D`] leaf pairs this with its own [`Coordinate`], while a
+/// [`TriangularMesh3D`] leaf pairs this with its own [`CoordinateFrame`], while a
 /// [`Solid`](crate::solid::Solid) shell stores it directly and takes the one
 /// frame from the enclosing `Solid` — so a solid and its boundaries cannot
 /// disagree on a frame. Mirrors the [`Raster`](crate::appearance::Raster) /
@@ -59,8 +59,8 @@ pub struct TriangularMesh3DData {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct TriangularMesh3D {
     /// Coordinate frame the mesh data is expressed in.
-    coordinate: Coordinate,
-    /// Coordinate-free mesh data; the same form a [`Solid`](crate::solid::Solid)
+    frame: CoordinateFrame,
+    /// coordinate-free mesh data; the same form a [`Solid`](crate::solid::Solid)
     /// shell stores directly.
     data: TriangularMesh3DData,
 }

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -34,7 +34,7 @@ pub struct TriangularMesh2D {
 }
 
 /// The coordinate-free data of a 3D triangle mesh: the vertex pool, triangle
-/// index list, UV and appearance, with no frame of its own.
+/// index list and appearance, with no frame of its own.
 ///
 /// Shared by two hosts that each supply the frame: the standalone
 /// [`TriangularMesh3D`] leaf pairs this with its own [`CoordinateFrame`], while a

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::appearance::{Appearance, UvSet};
+use crate::appearance::Appearance;
 use crate::coordinate::CoordinateFrame;
 use crate::index::IndexBuffer;
 
@@ -28,9 +28,8 @@ pub struct TriangularMesh2D {
     z: Option<Box<[f64]>>,
     /// Flat triangle index list; width from `vertices.len() - 1`.
     indices: IndexBuffer<3>,
-    /// Geometric UV, parallel to the corner buffers; empty = no UV.
-    uv_sets: Vec<UvSet>,
-    /// Optional materials / themes / per-face binding; `None` = bare.
+    /// Optional materials / themes / per-face binding, incl. per-theme UV parallel
+    /// to the corner buffers; `None` = bare.
     appearance: Option<Appearance>,
 }
 
@@ -48,9 +47,8 @@ pub struct TriangularMesh3DData {
     vertices: Vec<[f64; 3]>,
     /// Flat triangle index list; width from `vertices.len() - 1`.
     indices: IndexBuffer<3>,
-    /// Geometric UV, parallel to the corner buffers; empty = no UV.
-    uv_sets: Vec<UvSet>,
-    /// Optional materials / themes / per-face binding; `None` = bare.
+    /// Optional materials / themes / per-face binding, incl. per-theme UV parallel
+    /// to the corner buffers; `None` = bare.
     appearance: Option<Appearance>,
 }
 
@@ -92,13 +90,6 @@ impl TriangularMesh2D {
     pub fn appearance_mut(&mut self) -> &mut Option<Appearance> {
         &mut self.appearance
     }
-
-    /// The UV sets, one per (theme, side, channel); each `Explicit` array is
-    /// parallel to the corner buffer (`3 * num_triangles`).
-    #[inline]
-    pub fn uv_sets(&self) -> &[UvSet] {
-        &self.uv_sets
-    }
 }
 
 impl TriangularMesh3DData {
@@ -127,13 +118,6 @@ impl TriangularMesh3D {
         &mut self.data.appearance
     }
 
-    /// The UV sets, one per (theme, side, channel); each `Explicit` array is
-    /// parallel to the corner buffer (`3 * num_triangles`).
-    #[inline]
-    pub fn uv_sets(&self) -> &[UvSet] {
-        &self.data.uv_sets
-    }
-
     /// Consume the mesh, yielding its coordinate-free data for use as a
     /// [`Solid`](crate::solid::Solid) shell.
     #[inline]
@@ -158,7 +142,7 @@ impl TriangularMesh3DData {
     /// Drop all back-side appearance, keeping only the front; see
     /// [`crate::appearance::make_front_only`].
     pub(crate) fn make_front_only(&mut self) {
-        crate::appearance::make_front_only(&mut self.appearance, &mut self.uv_sets);
+        crate::appearance::make_front_only(&mut self.appearance);
     }
 }
 
@@ -172,13 +156,12 @@ mod tests {
 
     use super::*;
     use crate::appearance::{
-        ChannelId, FaceBinding, MaterialIndex, Side, ThemeBinding, ThemeId, UvSource,
+        ChannelId, FaceBinding, MaterialIndex, Side, ThemeBinding, ThemeId, UvSet, UvSource,
     };
     use crate::test_support::bare;
 
     fn uv(side: Side) -> UvSet {
         UvSet {
-            theme: Some(ThemeId(Arc::from("t"))),
             side,
             channel: ChannelId::default(),
             uv: UvSource::Explicit(Box::new([])),
@@ -192,21 +175,23 @@ mod tests {
             [0u32, 1, 2],
         )
         .unwrap();
-        m.appearance = Some(Appearance {
-            materials: vec![bare(), bare()],
-            themes: vec![ThemeBinding {
-                theme: ThemeId(Arc::from("t")),
+        let theme = ThemeId(Arc::from("t"));
+        m.appearance = Some(Appearance::from_parts(
+            vec![bare(), bare()],
+            vec![ThemeBinding {
+                theme: theme.clone(),
                 front: FaceBinding::Uniform(MaterialIndex::new(0).unwrap()),
                 back: Some(FaceBinding::Uniform(MaterialIndex::new(1).unwrap())),
+                uv_sets: vec![uv(Side::Front), uv(Side::Back)],
             }],
-            default_theme: ThemeId(Arc::from("t")),
-        });
-        m.uv_sets = vec![uv(Side::Front), uv(Side::Back)];
+            theme,
+        ));
 
         m.make_front_only();
 
-        assert!(m.appearance.as_ref().unwrap().themes[0].back.is_none());
-        assert_eq!(m.uv_sets.len(), 1);
-        assert_eq!(m.uv_sets[0].side, Side::Front);
+        let app = m.appearance.as_ref().unwrap();
+        assert!(app.themes()[0].back.is_none());
+        assert_eq!(app.themes()[0].uv_sets.len(), 1);
+        assert_eq!(app.themes()[0].uv_sets[0].side, Side::Front);
     }
 }

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -79,6 +79,13 @@ impl TriangularMesh2D {
         self.indices.len()
     }
 
+    /// The triangles, each as its three vertex indices into the shared vertex
+    /// pool, widened from the internal index width.
+    #[inline]
+    pub fn triangles(&self) -> impl Iterator<Item = [u32; 3]> + '_ {
+        self.indices.iter_u32()
+    }
+
     /// Borrow the appearance, if any.
     #[inline]
     pub fn appearance(&self) -> &Option<Appearance> {
@@ -104,6 +111,13 @@ impl TriangularMesh3D {
     #[inline]
     pub fn num_triangles(&self) -> usize {
         self.data.indices.len()
+    }
+
+    /// The triangles, each as its three vertex indices into the shared vertex
+    /// pool, widened from the internal index width.
+    #[inline]
+    pub fn triangles(&self) -> impl Iterator<Item = [u32; 3]> + '_ {
+        self.data.triangles()
     }
 
     /// Borrow the appearance, if any.
@@ -139,6 +153,13 @@ impl TriangularMesh3DData {
         self.indices.len()
     }
 
+    /// The triangles, each as its three vertex indices into the shared vertex
+    /// pool, widened from the internal index width.
+    #[inline]
+    pub fn triangles(&self) -> impl Iterator<Item = [u32; 3]> + '_ {
+        self.indices.iter_u32()
+    }
+
     /// Drop all back-side appearance, keeping only the front; see
     /// [`crate::appearance::make_front_only`].
     pub(crate) fn make_front_only(&mut self) {
@@ -166,6 +187,22 @@ mod tests {
             channel: ChannelId::default(),
             uv: UvSource::Explicit(Box::new([])),
         }
+    }
+
+    #[test]
+    fn triangles_yields_widened_index_triples() {
+        let m = TriangularMesh3DData::from_parts(
+            vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 1.0, 0.0],
+            ],
+            [0u32, 1, 2, 1, 3, 2],
+        )
+        .unwrap();
+        let tris: Vec<[u32; 3]> = m.triangles().collect();
+        assert_eq!(tris, vec![[0, 1, 2], [1, 3, 2]]);
     }
 
     #[test]

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -1,5 +1,5 @@
 use super::{TriangularMesh2D, TriangularMesh3D};
-use crate::coordinate::{Coordinate, EpsgCode};
+use crate::coordinate::{CoordinateFrame, EpsgCode};
 use crate::ops::reproject::{transform_coords_2d, transform_coords_3d};
 use crate::ops::{Aabb, BoundingBox, Reproject, ReprojectionCache, UnsupportedOperation};
 
@@ -27,7 +27,7 @@ impl Reproject for TriangularMesh2D {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
-        let from = self.coordinate.require_crs()?;
+        let from = self.frame.require_crs()?;
         if from != target {
             transform_coords_2d(
                 cache,
@@ -36,7 +36,7 @@ impl Reproject for TriangularMesh2D {
                 &mut self.vertices,
                 self.z.as_deref_mut(),
             )?;
-            self.coordinate = Coordinate::Crs(target);
+            self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
     }
@@ -48,10 +48,10 @@ impl Reproject for TriangularMesh3D {
         target: EpsgCode,
         cache: &mut ReprojectionCache,
     ) -> crate::error::Result<()> {
-        let from = self.coordinate.require_crs()?;
+        let from = self.frame.require_crs()?;
         if from != target {
             transform_coords_3d(cache, from, target, self.data.vertices_mut())?;
-            self.coordinate = Coordinate::Crs(target);
+            self.frame = CoordinateFrame::Crs(target);
         }
         Ok(())
     }
@@ -60,12 +60,12 @@ impl Reproject for TriangularMesh3D {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::Coordinate;
+    use crate::coordinate::CoordinateFrame;
 
     #[test]
     fn triangular_mesh2d_box() {
         let m = TriangularMesh2D::from_soup(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0], [3.0, 0.0], [3.0, 2.0]],
         );
         assert_eq!(
@@ -80,7 +80,7 @@ mod tests {
     #[test]
     fn triangular_mesh3d_box() {
         let m = TriangularMesh3D::from_soup(
-            Coordinate::Euclidean,
+            CoordinateFrame::Euclidean,
             [[0.0, 0.0, 0.0], [3.0, 0.0, 1.0], [3.0, 2.0, -1.0]],
         );
         assert_eq!(

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.62"
+version = "0.2.63"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.252"
+version = "0.1.253"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR makes the following design revisions on the new geometry types:
## Changes
### `Coordinate` → `CoordinateFrame` rename (field `coordinate` → `frame`)
The name `Coordinate` is ambiguous for what it represents (epsg, etc), and it's now changed to `CoordinateFrame`. The field name is also changed from `coordinate` to `frame`.

### UV sets moved to live inside `Appearance`
Until this PR, the UV sets were living directly inside geometry types because the structure of UV sets are parallel to that of geometry and `Appearance` by itself is agnostic about the structure. However, UV sets are still part of appearance data, and thus we moved .

The issue that "the standalone `Appearance` can't possibly know about the structure of UV" is addressed by not exposing the appearance constructor API outside the `geometry` crate. `Appearance` is thus a read-only object inside geometry that cannot be manually constructed and set to the geometry.

### Mesh rings changed from stored-open to stored-closed
Valid mesh rings are now closed in the internal polygon mesh representation, making it possible for the users to explicitly validate rings being closed inside their workflow.

### Indices accessor API for `TriangularMesh`
`TriangularMesh` now exposes a function that returns an iterator of its triangle indices.