### PR TITLE
fix(websocket-go): set GOWORK=off in the Go deploy build job

### DIFF
--- a/.github/workflows/build_deploy_websocket_go.yml
+++ b/.github/workflows/build_deploy_websocket_go.yml
@@ -20,6 +20,10 @@ jobs:
   build-websocket-go:
     name: Build Websocket (Go)
     runs-on: ubuntu-latest
+    # The module is intentionally outside the root go.work, so a bare `go build`
+    # picks up the workspace and fails. Match ci_websocket_go.yml and disable it.
+    env:
+      GOWORK: "off"
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1


### PR DESCRIPTION
## Problem

The `build-and-deploy-websocket-go` deploy has been failing at its first job (`Build Websocket (Go)`) on every run since #2148 merged, e.g. on the merge commit:

```
GOWORK='/home/runner/work/reearth-flow/reearth-flow/go.work'
directory cmd/websocket is contained in a module that is not one of the workspace modules listed in go.work
```

`server/websocket-go` is intentionally outside the root `go.work`, so the bare `go build` in the deploy's build job picks up the workspace and fails. Because that job fails, the image build/push and Cloud Run deploy are **skipped**, so the `reearth-flow-websocket-go:nightly` image was never published to the Artifact Registry.

## Fix

Set `GOWORK: "off"` on the build job, matching `ci_websocket_go.yml` (which already does this and passes).

## Note — a second precondition is still required

Even with this fix, the deploy's image push + Cloud Run deploy reference `${{ secrets.WEBSOCKET_GO_IMAGE_GC }}`, which **does not exist** in this repo yet (only the Rust `WEBSOCKET_IMAGE_GC` does). That secret must be created (the Artifact Registry path `us-central1-docker.pkg.dev/reearth-oss/reearth/reearth-flow-websocket-go`) before the deploy can publish the image. Until both are in place, the infra `terraform apply` for `reearth-flow-websocket-go` fails with "image not found".
