### PR TITLE
chore(engine): enable schemars preserve_order for declaration-ordered action parameters

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2708,6 +2708,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -5792,6 +5793,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "chrono",
  "dyn-clone",
+ "indexmap 1.9.3",
  "schemars_derive",
  "serde",
  "serde_json",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4093,7 +4093,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.64"
+version = "0.2.65"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "futures",
  "once_cell",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "approx",
  "async-trait",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "Inflector",
  "approx",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "bytes",
  "clap",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4980,7 +4980,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "approx",
  "bvh",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5126,7 +5126,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5191,7 +5191,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "bytes",
  "futures",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "bytes",
  "futures",
@@ -5227,7 +5227,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5241,7 +5241,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5275,7 +5275,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "ahash",
  "bytes",
@@ -5311,7 +5311,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.427"
+version = "0.0.428"
 dependencies = [
  "async-trait",
  "axum",
@@ -8044,7 +8044,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.254"
+version = "0.1.255"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -196,7 +196,7 @@ rmp-serde = "1.3.1"
 robust = "1.2.0"
 rstar = "0.12.2"
 rust_xlsxwriter = "0.93.0"
-schemars = { version = "0.8.22", features = ["chrono", "uuid1"] }
+schemars = { version = "0.8.22", features = ["chrono", "preserve_order", "uuid1"] }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = { version = "1.0.149", features = [
   "arbitrary_precision",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.427"
+version = "0.0.428"
 
 [profile.dev]
 opt-level = 0

--- a/engine/docs/mdbook/src/action.md
+++ b/engine/docs/mdbook/src/action.md
@@ -36,12 +36,6 @@ Calculates the planar or sloped area of polygon geometries and adds the results 
         }
       ]
     },
-    "multiplier": {
-      "description": "Multiplier to scale the area values (default: 1.0)",
-      "default": 1.0,
-      "type": "number",
-      "format": "double"
-    },
     "outputAttribute": {
       "description": "Name of the attribute to store the calculated area (default: \"area\")",
       "default": "area",
@@ -50,6 +44,12 @@ Calculates the planar or sloped area of polygon geometries and adds the results 
           "$ref": "#/definitions/Attribute"
         }
       ]
+    },
+    "multiplier": {
+      "description": "Multiplier to scale the area values (default: 1.0)",
+      "default": 1.0,
+      "type": "number",
+      "format": "double"
     }
   },
   "definitions": {
@@ -86,6 +86,17 @@ Perform Area Overlay Analysis
   "description": "Configure how area overlay analysis is performed",
   "type": "object",
   "properties": {
+    "groupBy": {
+      "title": "Group By Attributes",
+      "description": "Optional attributes to group features by during overlay analysis",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Attribute"
+      }
+    },
     "accumulationMode": {
       "title": "Accumulation Mode",
       "description": "Controls how attributes from input features are handled in output features",
@@ -103,17 +114,6 @@ Perform Area Overlay Analysis
         "string",
         "null"
       ]
-    },
-    "groupBy": {
-      "title": "Group By Attributes",
-      "description": "Optional attributes to group features by during overlay analysis",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/Attribute"
-      }
     },
     "outputAttribute": {
       "title": "Output Attribute",
@@ -134,15 +134,15 @@ Perform Area Overlay Analysis
     }
   },
   "definitions": {
+    "Attribute": {
+      "type": "string"
+    },
     "AccumulationMode": {
       "type": "string",
       "enum": [
         "useAttributesFromOneFeature",
         "dropIncomingAttributes"
       ]
-    },
-    "Attribute": {
-      "type": "string"
     }
   }
 }
@@ -204,14 +204,6 @@ Group and Aggregate Features by Attributes
         }
       }
     },
-    "calculationAttribute": {
-      "title": "Attribute to store calculation result",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        }
-      ]
-    },
     "calculationValue": {
       "title": "Value to use for calculation",
       "type": [
@@ -219,6 +211,14 @@ Group and Aggregate Features by Attributes
         "null"
       ],
       "format": "int64"
+    },
+    "calculationAttribute": {
+      "title": "Attribute to store calculation result",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        }
+      ]
     },
     "method": {
       "title": "Method to use for aggregation",
@@ -236,6 +236,14 @@ Group and Aggregate Features by Attributes
         "newAttribute"
       ],
       "properties": {
+        "newAttribute": {
+          "title": "New attribute to create",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Attribute"
+            }
+          ]
+        },
         "attribute": {
           "title": "Existing attribute to use",
           "anyOf": [
@@ -269,14 +277,6 @@ Group and Aggregate Features by Attributes
               "type": "string"
             }
           }
-        },
-        "newAttribute": {
-          "title": "New attribute to create",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Attribute"
-            }
-          ]
         }
       }
     },
@@ -376,6 +376,14 @@ Transform Feature Attributes Using Lookup Tables
     "rules"
   ],
   "properties": {
+    "rules": {
+      "title": "Conversion Rules",
+      "description": "List of rules defining how to map attributes using the conversion table",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/AttributeConversionTableRule"
+      }
+    },
     "dataset": {
       "title": "Dataset URI",
       "description": "Path or URI to external conversion table file",
@@ -401,15 +409,6 @@ Transform Feature Attributes Using Lookup Tables
         }
       }
     },
-    "format": {
-      "title": "Table Format",
-      "description": "Format of the conversion table (CSV, TSV, or JSON)",
-      "allOf": [
-        {
-          "$ref": "#/definitions/ConversionTableFormat"
-        }
-      ]
-    },
     "inline": {
       "title": "Inline Table Data",
       "description": "Conversion table data provided directly as string content",
@@ -418,19 +417,17 @@ Transform Feature Attributes Using Lookup Tables
         "null"
       ]
     },
-    "rules": {
-      "title": "Conversion Rules",
-      "description": "List of rules defining how to map attributes using the conversion table",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/AttributeConversionTableRule"
-      }
+    "format": {
+      "title": "Table Format",
+      "description": "Format of the conversion table (CSV, TSV, or JSON)",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConversionTableFormat"
+        }
+      ]
     }
   },
   "definitions": {
-    "Attribute": {
-      "type": "string"
-    },
     "AttributeConversionTableRule": {
       "type": "object",
       "required": [
@@ -440,17 +437,6 @@ Transform Feature Attributes Using Lookup Tables
         "featureTo"
       ],
       "properties": {
-        "conversionTableKeys": {
-          "title": "Keys to match in conversion table",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "conversionTableTo": {
-          "title": "Attribute to convert to",
-          "type": "string"
-        },
         "featureFroms": {
           "title": "Attributes to convert from",
           "type": "array",
@@ -465,8 +451,22 @@ Transform Feature Attributes Using Lookup Tables
               "$ref": "#/definitions/Attribute"
             }
           ]
+        },
+        "conversionTableKeys": {
+          "title": "Keys to match in conversion table",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "conversionTableTo": {
+          "title": "Attribute to convert to",
+          "type": "string"
         }
       }
+    },
+    "Attribute": {
+      "type": "string"
     },
     "ConversionTableFormat": {
       "type": "string",
@@ -627,15 +627,6 @@ Create, Convert, Rename, and Remove Feature Attributes
     }
   },
   "definitions": {
-    "Method": {
-      "type": "string",
-      "enum": [
-        "convert",
-        "create",
-        "rename",
-        "remove"
-      ]
-    },
     "Operation": {
       "type": "object",
       "required": [
@@ -681,6 +672,15 @@ Create, Convert, Rename, and Remove Feature Attributes
           }
         }
       }
+    },
+    "Method": {
+      "type": "string",
+      "enum": [
+        "convert",
+        "create",
+        "rename",
+        "remove"
+      ]
     }
   }
 }
@@ -727,13 +727,6 @@ Transform Feature Attributes Using Expressions and Mappings
             "null"
           ]
         },
-        "childAttribute": {
-          "title": "Child attribute name",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "expr": {
           "title": "Expression to evaluate",
           "type": [
@@ -758,6 +751,27 @@ Transform Feature Attributes Using Expressions and Mappings
             }
           }
         },
+        "valueAttribute": {
+          "title": "Attribute name to get value from",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "parentAttribute": {
+          "title": "Parent attribute name",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "childAttribute": {
+          "title": "Child attribute name",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "multipleExpr": {
           "title": "Expression to evaluate multiple attributes",
           "type": [
@@ -780,20 +794,6 @@ Transform Feature Attributes Using Expressions and Mappings
               "type": "string"
             }
           }
-        },
-        "parentAttribute": {
-          "title": "Parent attribute name",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "valueAttribute": {
-          "title": "Attribute name to get value from",
-          "type": [
-            "string",
-            "null"
-          ]
         }
       }
     }
@@ -824,10 +824,6 @@ Map attribute values to ranges and assign corresponding output values
     "rangeTable"
   ],
   "properties": {
-    "defaultValue": {
-      "title": "Default Value",
-      "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
-    },
     "inputAttribute": {
       "title": "Input Attribute",
       "description": "The attribute to evaluate for range mapping",
@@ -845,6 +841,10 @@ Map attribute values to ranges and assign corresponding output values
       "items": {
         "$ref": "#/definitions/RangeEntry"
       }
+    },
+    "defaultValue": {
+      "title": "Default Value",
+      "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
     }
   },
   "definitions": {
@@ -863,15 +863,15 @@ Map attribute values to ranges and assign corresponding output values
           "type": "number",
           "format": "double"
         },
-        "outputValue": {
-          "title": "Output Value",
-          "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
-        },
         "to": {
           "title": "To (Maximum)",
           "description": "The maximum value of the range (exclusive)",
           "type": "number",
           "format": "double"
+        },
+        "outputValue": {
+          "title": "Output Value",
+          "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
         }
       }
     }
@@ -898,13 +898,13 @@ Extracts the boundary of geometries. For solids/meshes returns bounding surfaces
   "description": "Configuration for extracting boundaries from geometries.",
   "type": "object",
   "properties": {
-    "exteriorOnly": {
-      "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
+    "keepEmptyBoundaries": {
+      "description": "Whether to keep features with empty boundaries (default: false)",
       "default": false,
       "type": "boolean"
     },
-    "keepEmptyBoundaries": {
-      "description": "Whether to keep features with empty boundaries (default: false)",
+    "exteriorOnly": {
+      "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
       "default": false,
       "type": "boolean"
     }
@@ -930,18 +930,6 @@ Extract Bounding Box Coordinates from Feature Geometry
   "title": "BoundsExtractor Parameters",
   "type": "object",
   "properties": {
-    "xmax": {
-      "title": "Maximum X Attribute",
-      "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "xmin": {
       "title": "Minimum X Attribute",
       "description": "Attribute name for storing the minimum X coordinate (defaults to \"xmin\")",
@@ -954,9 +942,9 @@ Extract Bounding Box Coordinates from Feature Geometry
         }
       ]
     },
-    "ymax": {
-      "title": "Maximum Y Attribute",
-      "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
+    "xmax": {
+      "title": "Maximum X Attribute",
+      "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
       "anyOf": [
         {
           "$ref": "#/definitions/Attribute"
@@ -978,9 +966,9 @@ Extract Bounding Box Coordinates from Feature Geometry
         }
       ]
     },
-    "zmax": {
-      "title": "Maximum Z Attribute",
-      "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
+    "ymax": {
+      "title": "Maximum Y Attribute",
+      "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
       "anyOf": [
         {
           "$ref": "#/definitions/Attribute"
@@ -993,6 +981,18 @@ Extract Bounding Box Coordinates from Feature Geometry
     "zmin": {
       "title": "Minimum Z Attribute",
       "description": "Attribute name for storing the minimum Z coordinate (defaults to \"zmin\")",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "zmax": {
+      "title": "Maximum Z Attribute",
+      "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
       "anyOf": [
         {
           "$ref": "#/definitions/Attribute"
@@ -1100,6 +1100,15 @@ Rename Feature Attributes in Bulk
     "renameValue"
   ],
   "properties": {
+    "renameType": {
+      "title": "Which Attributes to Rename",
+      "description": "Choose whether to rename all attributes or only selected ones",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RenameType"
+        }
+      ]
+    },
     "renameAction": {
       "title": "Rename Operation",
       "description": "The type of renaming operation to perform on the attribute names",
@@ -1109,13 +1118,12 @@ Rename Feature Attributes in Bulk
         }
       ]
     },
-    "renameType": {
-      "title": "Which Attributes to Rename",
-      "description": "Choose whether to rename all attributes or only selected ones",
-      "allOf": [
-        {
-          "$ref": "#/definitions/RenameType"
-        }
+    "textToFind": {
+      "title": "Text Pattern to Find",
+      "description": "Regular expression pattern to match when using \"Replace Text\" operation",
+      "type": [
+        "string",
+        "null"
       ]
     },
     "renameValue": {
@@ -1133,17 +1141,29 @@ Rename Feature Attributes in Bulk
       "items": {
         "type": "string"
       }
-    },
-    "textToFind": {
-      "title": "Text Pattern to Find",
-      "description": "Regular expression pattern to match when using \"Replace Text\" operation",
-      "type": [
-        "string",
-        "null"
-      ]
     }
   },
   "definitions": {
+    "RenameType": {
+      "oneOf": [
+        {
+          "title": "All Attributes",
+          "description": "Rename all attributes in the feature",
+          "type": "string",
+          "enum": [
+            "All"
+          ]
+        },
+        {
+          "title": "Selected Attributes",
+          "description": "Rename only specific attributes listed below",
+          "type": "string",
+          "enum": [
+            "Selected"
+          ]
+        }
+      ]
+    },
     "RenameAction": {
       "oneOf": [
         {
@@ -1187,26 +1207,6 @@ Rename Feature Attributes in Bulk
           ]
         }
       ]
-    },
-    "RenameType": {
-      "oneOf": [
-        {
-          "title": "All Attributes",
-          "description": "Rename all attributes in the feature",
-          "type": "string",
-          "enum": [
-            "All"
-          ]
-        },
-        {
-          "title": "Selected Attributes",
-          "description": "Rename only specific attributes listed below",
-          "type": "string",
-          "enum": [
-            "Selected"
-          ]
-        }
-      ]
     }
   }
 }
@@ -1231,22 +1231,6 @@ Constructs a Consecutive Solid Geometry (CSG) representation from a pair (Left, 
   "description": "Configure how the CSG builder pairs features from left and right ports",
   "type": "object",
   "properties": {
-    "createList": {
-      "title": "Create List",
-      "description": "When enabled, creates a list of attribute values from both children (left and right)",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "listAttributeName": {
-      "title": "List Attribute Name",
-      "description": "Name of the attribute to create the list from (required when create_list is true)",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "pairIdAttribute": {
       "title": "Pair ID Attribute",
       "description": "Expression to evaluate the pair ID used to match features from left and right ports",
@@ -1270,6 +1254,22 @@ Constructs a Consecutive Solid Geometry (CSG) representation from a pair (Left, 
           "type": "string"
         }
       }
+    },
+    "createList": {
+      "title": "Create List",
+      "description": "When enabled, creates a list of attribute values from both children (left and right)",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "listAttributeName": {
+      "title": "List Attribute Name",
+      "description": "Name of the attribute to create the list from (required when create_list is true)",
+      "type": [
+        "string",
+        "null"
+      ]
     }
   }
 }
@@ -1411,6 +1411,42 @@ Export Features as Cesium 3D Tiles for Web Visualization
     "output"
   ],
   "properties": {
+    "output": {
+      "title": "Output Path",
+      "description": "Directory path where the 3D tiles will be written",
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "minZoom": {
+      "title": "Minimum Zoom Level",
+      "description": "Minimum zoom level for tile generation (0-24)",
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "maxZoom": {
+      "title": "Maximum Zoom Level",
+      "description": "Maximum zoom level for tile generation (0-24)",
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
+    },
     "attachTexture": {
       "title": "Attach Textures",
       "description": "Whether to include texture information in the generated tiles",
@@ -1452,55 +1488,19 @@ Export Features as Cesium 3D Tiles for Web Visualization
         "null"
       ]
     },
-    "maxZoom": {
-      "title": "Maximum Zoom Level",
-      "description": "Maximum zoom level for tile generation (0-24)",
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "minZoom": {
-      "title": "Minimum Zoom Level",
-      "description": "Minimum zoom level for tile generation (0-24)",
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "output": {
-      "title": "Output Path",
-      "description": "Directory path where the 3D tiles will be written",
-      "type": "object",
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr",
-            "string"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
+    "skipUnexposedAttributes": {
+      "title": "Skip unexposed Attributes",
+      "description": "Skip attributes with double underscore prefix",
+      "type": [
+        "boolean",
+        "null"
+      ]
     },
     "schemaKey": {
       "title": "Schema Key",
       "description": "Attribute key whose value identifies the schema type and determines the output filename: all features sharing the same value are written to the same file. This attribute is excluded from output.",
       "type": [
         "string",
-        "null"
-      ]
-    },
-    "skipUnexposedAttributes": {
-      "title": "Skip unexposed Attributes",
-      "description": "Skip attributes with double underscore prefix",
-      "type": [
-        "boolean",
         "null"
       ]
     }
@@ -1552,12 +1552,6 @@ Reads 3D city models from CityGML files.
         }
       }
     },
-    "flatten": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
     "inline": {
       "title": "Inline Content",
       "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -1582,6 +1576,12 @@ Reads 3D city models from CityGML files.
           "type": "string"
         }
       }
+    },
+    "flatten": {
+      "type": [
+        "boolean",
+        "null"
+      ]
     }
   }
 }
@@ -1607,29 +1607,6 @@ Writes features to CityGML 2.0 files
     "output"
   ],
   "properties": {
-    "epsgCode": {
-      "description": "EPSG code for coordinate reference system",
-      "default": null,
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint32",
-      "minimum": 0.0
-    },
-    "lodFilter": {
-      "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-      "default": null,
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "integer",
-        "format": "uint8",
-        "minimum": 0.0
-      }
-    },
     "output": {
       "description": "Output file path expression",
       "type": "object",
@@ -1650,6 +1627,29 @@ Writes features to CityGML 2.0 files
           "type": "string"
         }
       }
+    },
+    "lodFilter": {
+      "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+      "default": null,
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0.0
+      }
+    },
+    "epsgCode": {
+      "description": "EPSG code for coordinate reference system",
+      "default": null,
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint32",
+      "minimum": 0.0
     },
     "prettyPrint": {
       "description": "Whether to format output with indentation (default: true)",
@@ -1755,15 +1755,6 @@ Extracts coordinates from geometry vertices into feature attributes
     "mode"
   ],
   "properties": {
-    "defaultZValue": {
-      "title": "Default Z Value",
-      "description": "Z value to use for 2D geometries that have no Z coordinate.",
-      "type": [
-        "number",
-        "null"
-      ],
-      "format": "double"
-    },
     "mode": {
       "title": "Extraction Mode",
       "description": "How to extract coordinates from geometry vertices.",
@@ -1772,12 +1763,18 @@ Extracts coordinates from geometry vertices into feature attributes
           "$ref": "#/definitions/CoordinateExtractionMode"
         }
       ]
+    },
+    "defaultZValue": {
+      "title": "Default Z Value",
+      "description": "Z value to use for 2D geometries that have no Z coordinate.",
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
     }
   },
   "definitions": {
-    "Attribute": {
-      "type": "string"
-    },
     "CoordinateExtractionMode": {
       "description": "Extraction mode: determines how coordinates are output.",
       "oneOf": [
@@ -1788,6 +1785,12 @@ Extracts coordinates from geometry vertices into feature attributes
             "type"
           ],
           "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "allCoordinates"
+              ]
+            },
             "coordinatesListName": {
               "title": "Coordinates List Name",
               "description": "Name of the list attribute that will store coordinate objects (default: \"_indices\")",
@@ -1796,12 +1799,6 @@ Extracts coordinates from geometry vertices into feature attributes
                 {
                   "$ref": "#/definitions/Attribute"
                 }
-              ]
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "allCoordinates"
               ]
             }
           }
@@ -1814,17 +1811,17 @@ Extracts coordinates from geometry vertices into feature attributes
             "type"
           ],
           "properties": {
-            "coordinateIndex": {
-              "title": "Coordinate Index",
-              "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
-              "type": "integer",
-              "format": "int64"
-            },
             "type": {
               "type": "string",
               "enum": [
                 "specifyCoordinate"
               ]
+            },
+            "coordinateIndex": {
+              "title": "Coordinate Index",
+              "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
+              "type": "integer",
+              "format": "int64"
             },
             "xAttribute": {
               "title": "X Attribute Name",
@@ -1859,6 +1856,9 @@ Extracts coordinates from geometry vertices into feature attributes
           }
         }
       ]
+    },
+    "Attribute": {
+      "type": "string"
     }
   }
 }
@@ -1887,6 +1887,23 @@ Read Features from CSV or TSV File
     "format"
   ],
   "properties": {
+    "format": {
+      "title": "File Format",
+      "description": "Choose the delimiter format for the input file",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CsvFormat"
+        }
+      ]
+    },
+    "encoding": {
+      "title": "Character Encoding",
+      "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -1911,45 +1928,6 @@ Read Features from CSV or TSV File
           "type": "string"
         }
       }
-    },
-    "encoding": {
-      "title": "Character Encoding",
-      "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "format": {
-      "title": "File Format",
-      "description": "Choose the delimiter format for the input file",
-      "allOf": [
-        {
-          "$ref": "#/definitions/CsvFormat"
-        }
-      ]
-    },
-    "geometry": {
-      "title": "Geometry Configuration",
-      "description": "Optional configuration for parsing geometry from CSV columns",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/GeometryConfig"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "headerRows": {
-      "title": "Header Row Count",
-      "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint",
-      "minimum": 0.0
     },
     "inline": {
       "title": "Inline Content",
@@ -1985,6 +1963,28 @@ Read Features from CSV or TSV File
       ],
       "format": "uint",
       "minimum": 0.0
+    },
+    "headerRows": {
+      "title": "Header Row Count",
+      "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint",
+      "minimum": 0.0
+    },
+    "geometry": {
+      "title": "Geometry Configuration",
+      "description": "Optional configuration for parsing geometry from CSV columns",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/GeometryConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {
@@ -2097,26 +2097,6 @@ Writes features to CSV or TSV files.
     "output"
   ],
   "properties": {
-    "format": {
-      "description": "File format: csv (comma) or tsv (tab)",
-      "allOf": [
-        {
-          "$ref": "#/definitions/CsvFormat"
-        }
-      ]
-    },
-    "geometry": {
-      "title": "Geometry Configuration",
-      "description": "Optional configuration for exporting geometry to CSV columns",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/GeometryExportConfig"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "output": {
       "description": "Output path or expression for the CSV/TSV file to create",
       "type": "object",
@@ -2137,6 +2117,26 @@ Writes features to CSV or TSV files.
           "type": "string"
         }
       }
+    },
+    "format": {
+      "description": "File format: csv (comma) or tsv (tab)",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CsvFormat"
+        }
+      ]
+    },
+    "geometry": {
+      "title": "Geometry Configuration",
+      "description": "Optional configuration for exporting geometry to CSV columns",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/GeometryExportConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {
@@ -2233,6 +2233,28 @@ Reads geographic features from CZML (Cesium Language) files for 3D visualization
   "description": "Configuration for reading CZML files as geographic features.",
   "type": "object",
   "properties": {
+    "force2d": {
+      "title": "Force 2D",
+      "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+      "default": false,
+      "type": "boolean"
+    },
+    "skipDocumentPacket": {
+      "title": "Skip Document Packet",
+      "description": "If true, skips the document packet (first packet with version/clock info)",
+      "default": true,
+      "type": "boolean"
+    },
+    "timeSampling": {
+      "title": "Time Sampling Strategy",
+      "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
+      "default": "preserveRaw",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TimeSamplingStrategy"
+        }
+      ]
+    },
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -2258,12 +2280,6 @@ Reads geographic features from CZML (Cesium Language) files for 3D visualization
         }
       }
     },
-    "force2d": {
-      "title": "Force 2D",
-      "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-      "default": false,
-      "type": "boolean"
-    },
     "inline": {
       "title": "Inline Content",
       "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -2288,22 +2304,6 @@ Reads geographic features from CZML (Cesium Language) files for 3D visualization
           "type": "string"
         }
       }
-    },
-    "skipDocumentPacket": {
-      "title": "Skip Document Packet",
-      "description": "If true, skips the document packet (first packet with version/clock info)",
-      "default": true,
-      "type": "boolean"
-    },
-    "timeSampling": {
-      "title": "Time Sampling Strategy",
-      "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
-      "default": "preserveRaw",
-      "allOf": [
-        {
-          "$ref": "#/definitions/TimeSamplingStrategy"
-        }
-      ]
     }
   },
   "definitions": {
@@ -2358,87 +2358,6 @@ Export features as CZML for Cesium visualization. Supports static entities and t
     "output"
   ],
   "properties": {
-    "colorAttribute": {
-      "title": "Color Attribute",
-      "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "epoch": {
-      "title": "Epoch",
-      "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "groupBy": {
-      "title": "Group By Attributes",
-      "description": "Attributes used to group features into separate CZML files",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/Attribute"
-      }
-    },
-    "groupTimeseriesBy": {
-      "title": "Group Timeseries By",
-      "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "heightAttribute": {
-      "title": "Height Attribute",
-      "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "interpolationAlgorithm": {
-      "title": "Interpolation Algorithm",
-      "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
-      "default": "LINEAR",
-      "allOf": [
-        {
-          "$ref": "#/definitions/InterpolationAlgorithm"
-        }
-      ]
-    },
-    "interpolationDegree": {
-      "title": "Interpolation Degree",
-      "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
-      "default": 1,
-      "type": "integer",
-      "format": "uint32",
-      "minimum": 0.0
-    },
-    "opacity": {
-      "title": "Opacity",
-      "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
-      "default": 180,
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
     "output": {
       "title": "Output File Path",
       "description": "Path where the CZML file will be written",
@@ -2461,9 +2380,90 @@ Export features as CZML for Cesium visualization. Supports static entities and t
         }
       }
     },
+    "groupBy": {
+      "title": "Group By Attributes",
+      "description": "Attributes used to group features into separate CZML files",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Attribute"
+      }
+    },
     "timeField": {
       "title": "Time Field",
       "description": "Attribute containing the timestamp for each feature. Supports two formats: - **ISO 8601 strings**: e.g., \"2024-01-01T00:00:00Z\", \"2024-01-01T12:30:45+09:00\" - **Numeric values**: Seconds as offset from epoch (e.g., \"0\", \"60\", \"120.5\")\n\nWhen set together with `groupTimeseriesBy`, features sharing the same group key are combined into a single CZML entity with time-tagged position samples for animation in Cesium.\n\n**Example workflow configuration:** ```yaml - action: CzmlWriter with: output: \"output.czml\" timeField: \"timestamp\" groupTimeseriesBy: \"vehicleId\" epoch: \"2024-01-01T00:00:00Z\"  # Optional for numeric times (auto-defaults to Unix epoch) ```",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "epoch": {
+      "title": "Epoch",
+      "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "interpolationAlgorithm": {
+      "title": "Interpolation Algorithm",
+      "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
+      "default": "LINEAR",
+      "allOf": [
+        {
+          "$ref": "#/definitions/InterpolationAlgorithm"
+        }
+      ]
+    },
+    "interpolationDegree": {
+      "title": "Interpolation Degree",
+      "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
+      "default": 1,
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0.0
+    },
+    "groupTimeseriesBy": {
+      "title": "Group Timeseries By",
+      "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "colorAttribute": {
+      "title": "Color Attribute",
+      "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "opacity": {
+      "title": "Opacity",
+      "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
+      "default": 180,
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "heightAttribute": {
+      "title": "Height Attribute",
+      "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
       "anyOf": [
         {
           "$ref": "#/definitions/Attribute"
@@ -2541,14 +2541,6 @@ Convert datetime values between different formats
         }
       ]
     },
-    "outputAttribute": {
-      "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
-      "default": null,
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "outputFormat": {
       "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode).",
       "default": "auto",
@@ -2556,6 +2548,14 @@ Convert datetime values between different formats
         {
           "$ref": "#/definitions/DateTimeOutputFormat"
         }
+      ]
+    },
+    "outputAttribute": {
+      "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
+      "default": null,
+      "type": [
+        "string",
+        "null"
       ]
     }
   },
@@ -2751,16 +2751,6 @@ Dissolve Features by Grouping Attributes
   "description": "Configure how to dissolve features by grouping them based on shared attributes",
   "type": "object",
   "properties": {
-    "attributeAccumulation": {
-      "title": "Attribute Accumulation",
-      "description": "Strategy for handling attributes when dissolving features",
-      "default": "useOneFeature",
-      "allOf": [
-        {
-          "$ref": "#/definitions/AttributeAccumulationStrategy"
-        }
-      ]
-    },
     "groupBy": {
       "title": "Group By Attributes",
       "description": "List of attribute names to group features by before dissolving. Features with the same values for these attributes will be dissolved together",
@@ -2780,6 +2770,16 @@ Dissolve Features by Grouping Attributes
         "null"
       ],
       "format": "double"
+    },
+    "attributeAccumulation": {
+      "title": "Attribute Accumulation",
+      "description": "Strategy for handling attributes when dissolving features",
+      "default": "useOneFeature",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AttributeAccumulationStrategy"
+        }
+      ]
     }
   },
   "definitions": {
@@ -3009,15 +3009,6 @@ Reads CityGML 2.0 files: resolves gml:id references and xlink:href links across 
     "dataset"
   ],
   "properties": {
-    "cityGmlAttributesKey": {
-      "title": "City GML Attributes Key",
-      "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
-      "default": null,
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "dataset": {
       "title": "Dataset",
       "description": "Path expression resolving to the CityGML 2.0 file to read.",
@@ -3049,10 +3040,10 @@ Reads CityGML 2.0 files: resolves gml:id references and xlink:href links across 
         "type": "string"
       }
     },
-    "flattenMeasureTypes": {
-      "title": "Flatten Measure Types",
-      "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
-      "default": false,
+    "keepAttributes": {
+      "title": "Keep Attributes",
+      "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
+      "default": true,
       "type": "boolean"
     },
     "flattenSingleChildObjects": {
@@ -3061,11 +3052,20 @@ Reads CityGML 2.0 files: resolves gml:id references and xlink:href links across 
       "default": false,
       "type": "boolean"
     },
-    "keepAttributes": {
-      "title": "Keep Attributes",
-      "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
-      "default": true,
+    "flattenMeasureTypes": {
+      "title": "Flatten Measure Types",
+      "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
+      "default": false,
       "type": "boolean"
+    },
+    "cityGmlAttributesKey": {
+      "title": "City GML Attributes Key",
+      "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
     }
   }
 }
@@ -3092,15 +3092,6 @@ Reads CityGML 3.0 files: resolves gml:id references and xlink:href links across 
     "dataset"
   ],
   "properties": {
-    "cityGmlAttributesKey": {
-      "title": "City GML Attributes Key",
-      "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
-      "default": null,
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "dataset": {
       "title": "Dataset",
       "description": "Path expression resolving to the CityGML 3.0 file to read.",
@@ -3132,10 +3123,10 @@ Reads CityGML 3.0 files: resolves gml:id references and xlink:href links across 
         "type": "string"
       }
     },
-    "flattenMeasureTypes": {
-      "title": "Flatten Measure Types",
-      "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
-      "default": false,
+    "keepAttributes": {
+      "title": "Keep Attributes",
+      "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
+      "default": true,
       "type": "boolean"
     },
     "flattenSingleChildObjects": {
@@ -3144,11 +3135,20 @@ Reads CityGML 3.0 files: resolves gml:id references and xlink:href links across 
       "default": false,
       "type": "boolean"
     },
-    "keepAttributes": {
-      "title": "Keep Attributes",
-      "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
-      "default": true,
+    "flattenMeasureTypes": {
+      "title": "Flatten Measure Types",
+      "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
+      "default": false,
       "type": "boolean"
+    },
+    "cityGmlAttributesKey": {
+      "title": "City GML Attributes Key",
+      "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
     }
   }
 }
@@ -3176,31 +3176,6 @@ Reads and processes features from CityGML files with optional flattening
     "dataset"
   ],
   "properties": {
-    "codelistsPath": {
-      "title": "Codelists Path",
-      "description": "Optional path to the codelists directory for resolving codelist values",
-      "type": [
-        "object",
-        "null"
-      ],
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr",
-            "string"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
     "dataset": {
       "title": "Dataset",
       "description": "Path or expression to the CityGML dataset file to be read",
@@ -3230,6 +3205,31 @@ Reads and processes features from CityGML files with optional flattening
         "boolean",
         "null"
       ]
+    },
+    "codelistsPath": {
+      "title": "Codelists Path",
+      "description": "Optional path to the codelists directory for resolving codelist values",
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
     }
   }
 }
@@ -3373,19 +3373,6 @@ Extract File Paths from Dataset to Features
     "sourceDataset"
   ],
   "properties": {
-    "destPrefix": {
-      "title": "Destination Prefix",
-      "description": "Optional prefix to add to extracted file paths",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "extractArchive": {
-      "title": "Extract Archive",
-      "description": "Whether to extract archive files found in the dataset",
-      "type": "boolean"
-    },
     "sourceDataset": {
       "title": "Source Dataset",
       "description": "Expression to get the source dataset path or URL",
@@ -3407,6 +3394,19 @@ Extract File Paths from Dataset to Features
           "type": "string"
         }
       }
+    },
+    "extractArchive": {
+      "title": "Extract Archive",
+      "description": "Whether to extract archive files found in the dataset",
+      "type": "boolean"
+    },
+    "destPrefix": {
+      "title": "Destination Prefix",
+      "description": "Optional prefix to add to extracted file paths",
+      "type": [
+        "string",
+        "null"
+      ]
     }
   }
 }
@@ -3511,17 +3511,6 @@ Joins requestor and supplier features based on matching attribute values with co
     "joinType"
   ],
   "properties": {
-    "conflictResolution": {
-      "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ConflictResolution"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "joinType": {
       "description": "Join type: inner, left, or full",
       "allOf": [
@@ -3532,6 +3521,16 @@ Joins requestor and supplier features based on matching attribute values with co
     },
     "requestorAttribute": {
       "description": "Attributes from requestor features to use for matching (alternative to requestorAttributeValue)",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Attribute"
+      }
+    },
+    "supplierAttribute": {
+      "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
       "type": [
         "array",
         "null"
@@ -3563,16 +3562,6 @@ Joins requestor and supplier features based on matching attribute values with co
         }
       }
     },
-    "supplierAttribute": {
-      "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/Attribute"
-      }
-    },
     "supplierAttributeValue": {
       "description": "Expression to evaluate for supplier feature matching values (alternative to supplierAttribute)",
       "type": [
@@ -3595,30 +3584,20 @@ Joins requestor and supplier features based on matching attribute values with co
           "type": "string"
         }
       }
+    },
+    "conflictResolution": {
+      "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ConflictResolution"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {
-    "Attribute": {
-      "type": "string"
-    },
-    "ConflictResolution": {
-      "oneOf": [
-        {
-          "description": "Requestor attributes win on conflict",
-          "type": "string",
-          "enum": [
-            "requestorWins"
-          ]
-        },
-        {
-          "description": "Supplier attributes win on conflict (default)",
-          "type": "string",
-          "enum": [
-            "supplierWins"
-          ]
-        }
-      ]
-    },
     "JoinType": {
       "oneOf": [
         {
@@ -3640,6 +3619,27 @@ Joins requestor and supplier features based on matching attribute values with co
           "type": "string",
           "enum": [
             "full"
+          ]
+        }
+      ]
+    },
+    "Attribute": {
+      "type": "string"
+    },
+    "ConflictResolution": {
+      "oneOf": [
+        {
+          "description": "Requestor attributes win on conflict",
+          "type": "string",
+          "enum": [
+            "requestorWins"
+          ]
+        },
+        {
+          "description": "Supplier attributes win on conflict (default)",
+          "type": "string",
+          "enum": [
+            "supplierWins"
           ]
         }
       ]
@@ -3714,15 +3714,18 @@ Merges requestor and supplier features based on matching attribute values
   "description": "Configuration for merging requestor and supplier features based on matching attributes or expressions.",
   "type": "object",
   "properties": {
-    "completeGrouped": {
-      "description": "Whether to complete grouped features before processing the next group",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
     "requestorAttribute": {
       "description": "Attributes from requestor features to use for matching (alternative to requestor_attribute_value)",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Attribute"
+      }
+    },
+    "supplierAttribute": {
+      "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
       "type": [
         "array",
         "null"
@@ -3754,16 +3757,6 @@ Merges requestor and supplier features based on matching attribute values
         }
       }
     },
-    "supplierAttribute": {
-      "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/Attribute"
-      }
-    },
     "supplierAttributeValue": {
       "description": "Expression to evaluate for supplier feature matching values (alternative to supplier_attribute)",
       "type": [
@@ -3786,6 +3779,13 @@ Merges requestor and supplier features based on matching attribute values
           "type": "string"
         }
       }
+    },
+    "completeGrouped": {
+      "description": "Whether to complete grouped features before processing the next group",
+      "type": [
+        "boolean",
+        "null"
+      ]
     }
   },
   "definitions": {
@@ -3824,27 +3824,11 @@ Reads features from various file formats (CSV, TSV, JSON) with configurable pars
         "format"
       ],
       "properties": {
-        "dataset": {
-          "title": "Dataset",
-          "description": "Path or expression to the dataset file to be read",
-          "type": "object",
-          "format": "code",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "flowExpr",
-                "string"
-              ]
-            },
-            "value": {
-              "type": "string"
-            }
-          }
+        "format": {
+          "type": "string",
+          "enum": [
+            "csv"
+          ]
         },
         "encoding": {
           "title": "Character Encoding",
@@ -3854,42 +3838,6 @@ Reads features from various file formats (CSV, TSV, JSON) with configurable pars
             "null"
           ]
         },
-        "format": {
-          "type": "string",
-          "enum": [
-            "csv"
-          ]
-        },
-        "headerRows": {
-          "title": "Header Row Count",
-          "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0.0
-        },
-        "offset": {
-          "description": "The offset of the first row to read",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0.0
-        }
-      }
-    },
-    {
-      "title": "Common Reader Parameters",
-      "description": "Shared configuration for all feature reader formats.",
-      "type": "object",
-      "required": [
-        "dataset",
-        "format"
-      ],
-      "properties": {
         "dataset": {
           "title": "Dataset",
           "description": "Path or expression to the dataset file to be read",
@@ -3911,6 +3859,42 @@ Reads features from various file formats (CSV, TSV, JSON) with configurable pars
               "type": "string"
             }
           }
+        },
+        "offset": {
+          "description": "The offset of the first row to read",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "headerRows": {
+          "title": "Header Row Count",
+          "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    {
+      "title": "Common Reader Parameters",
+      "description": "Shared configuration for all feature reader formats.",
+      "type": "object",
+      "required": [
+        "dataset",
+        "format"
+      ],
+      "properties": {
+        "format": {
+          "type": "string",
+          "enum": [
+            "tsv"
+          ]
         },
         "encoding": {
           "title": "Character Encoding",
@@ -3920,42 +3904,6 @@ Reads features from various file formats (CSV, TSV, JSON) with configurable pars
             "null"
           ]
         },
-        "format": {
-          "type": "string",
-          "enum": [
-            "tsv"
-          ]
-        },
-        "headerRows": {
-          "title": "Header Row Count",
-          "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0.0
-        },
-        "offset": {
-          "description": "The offset of the first row to read",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0.0
-        }
-      }
-    },
-    {
-      "title": "Common Reader Parameters",
-      "description": "Shared configuration for all feature reader formats.",
-      "type": "object",
-      "required": [
-        "dataset",
-        "format"
-      ],
-      "properties": {
         "dataset": {
           "title": "Dataset",
           "description": "Path or expression to the dataset file to be read",
@@ -3978,11 +3926,63 @@ Reads features from various file formats (CSV, TSV, JSON) with configurable pars
             }
           }
         },
+        "offset": {
+          "description": "The offset of the first row to read",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "headerRows": {
+          "title": "Header Row Count",
+          "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        }
+      }
+    },
+    {
+      "title": "Common Reader Parameters",
+      "description": "Shared configuration for all feature reader formats.",
+      "type": "object",
+      "required": [
+        "dataset",
+        "format"
+      ],
+      "properties": {
         "format": {
           "type": "string",
           "enum": [
             "json"
           ]
+        },
+        "dataset": {
+          "title": "Dataset",
+          "description": "Path or expression to the dataset file to be read",
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
         }
       }
     }
@@ -4240,28 +4240,6 @@ Writes features from various formats
         "output"
       ],
       "properties": {
-        "converter": {
-          "type": [
-            "object",
-            "null"
-          ],
-          "format": "code",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "flowExpr"
-              ]
-            },
-            "value": {
-              "type": "string"
-            }
-          }
-        },
         "format": {
           "type": "string",
           "enum": [
@@ -4288,6 +4266,28 @@ Writes features from various formats
               "type": "string"
             }
           }
+        },
+        "converter": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -4300,34 +4300,11 @@ Writes features from various formats
         "output"
       ],
       "properties": {
-        "epsgCode": {
-          "description": "EPSG code for coordinate reference system",
-          "default": null,
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint32",
-          "minimum": 0.0
-        },
         "format": {
           "type": "string",
           "enum": [
             "citygml"
           ]
-        },
-        "lodFilter": {
-          "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-          "default": null,
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          }
         },
         "output": {
           "title": "Output path",
@@ -4349,6 +4326,29 @@ Writes features from various formats
               "type": "string"
             }
           }
+        },
+        "lodFilter": {
+          "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+          "default": null,
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          }
+        },
+        "epsgCode": {
+          "description": "EPSG code for coordinate reference system",
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
         },
         "prettyPrint": {
           "description": "Whether to format output with indentation (default: true)",
@@ -4387,11 +4387,6 @@ Extracts file paths from directories or archives, creating features for each dis
     "sourceDataset"
   ],
   "properties": {
-    "extractArchive": {
-      "title": "Extract Archive",
-      "description": "Whether to extract files from archives (zip files, etc.) or just list them",
-      "type": "boolean"
-    },
     "sourceDataset": {
       "title": "Source Dataset",
       "description": "Path or expression pointing to the source directory or archive file",
@@ -4413,6 +4408,11 @@ Extracts file paths from directories or archives, creating features for each dis
           "type": "string"
         }
       }
+    },
+    "extractArchive": {
+      "title": "Extract Archive",
+      "description": "Whether to extract files from archives (zip files, etc.) or just list them",
+      "type": "boolean"
     }
   }
 }
@@ -4557,16 +4557,6 @@ Writes geographic features to GeoJSON files with optional grouping
     "output"
   ],
   "properties": {
-    "groupBy": {
-      "description": "Optional attributes to group features by, creating separate files for each group",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/Attribute"
-      }
-    },
     "output": {
       "description": "Output path or expression for the GeoJSON file to create",
       "type": "object",
@@ -4586,6 +4576,16 @@ Writes geographic features to GeoJSON files with optional grouping
         "value": {
           "type": "string"
         }
+      }
+    },
+    "groupBy": {
+      "description": "Optional attributes to group features by, creating separate files for each group",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Attribute"
       }
     }
   },
@@ -4614,6 +4614,32 @@ Reads geographic features from GeoPackage (.gpkg) files with support for vector 
   "title": "GeoPackageReaderParam",
   "type": "object",
   "properties": {
+    "readMode": {
+      "default": "features",
+      "allOf": [
+        {
+          "$ref": "#/definitions/GeoPackageReadMode"
+        }
+      ]
+    },
+    "layerName": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "includeMetadata": {
+      "default": false,
+      "type": "boolean"
+    },
+    "tileFormat": {
+      "default": "png",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TileFormat"
+        }
+      ]
+    },
     "attributeFilter": {
       "default": null,
       "type": [
@@ -4629,6 +4655,17 @@ Reads geographic features from GeoPackage (.gpkg) files with support for vector 
       ],
       "format": "uint",
       "minimum": 0.0
+    },
+    "force2D": {
+      "default": false,
+      "type": "boolean"
+    },
+    "spatialFilter": {
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "dataset": {
       "title": "File Path",
@@ -4655,14 +4692,6 @@ Reads geographic features from GeoPackage (.gpkg) files with support for vector 
         }
       }
     },
-    "force2D": {
-      "default": false,
-      "type": "boolean"
-    },
-    "includeMetadata": {
-      "default": false,
-      "type": "boolean"
-    },
     "inline": {
       "title": "Inline Content",
       "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -4687,35 +4716,6 @@ Reads geographic features from GeoPackage (.gpkg) files with support for vector 
           "type": "string"
         }
       }
-    },
-    "layerName": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "readMode": {
-      "default": "features",
-      "allOf": [
-        {
-          "$ref": "#/definitions/GeoPackageReadMode"
-        }
-      ]
-    },
-    "spatialFilter": {
-      "default": null,
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "tileFormat": {
-      "default": "png",
-      "allOf": [
-        {
-          "$ref": "#/definitions/TileFormat"
-        }
-      ]
     }
   },
   "definitions": {
@@ -4761,21 +4761,6 @@ Writes geographic features to GeoPackage (.gpkg) files with proper SQLite struct
     "output"
   ],
   "properties": {
-    "createSpatialIndex": {
-      "description": "Create RTree spatial index (default: true)",
-      "default": true,
-      "type": "boolean"
-    },
-    "geometryColumn": {
-      "description": "Geometry column name (default: \"geom\")",
-      "default": "geom",
-      "type": "string"
-    },
-    "geometryType": {
-      "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
-      "default": "GEOMETRY",
-      "type": "string"
-    },
     "output": {
       "description": "Output path for the GeoPackage file to create",
       "type": "object",
@@ -4797,10 +4782,15 @@ Writes geographic features to GeoPackage (.gpkg) files with proper SQLite struct
         }
       }
     },
-    "overwrite": {
-      "description": "Overwrite existing file (default: false)",
-      "default": false,
-      "type": "boolean"
+    "tableName": {
+      "description": "Table name to create (default: \"features\")",
+      "default": "features",
+      "type": "string"
+    },
+    "geometryColumn": {
+      "description": "Geometry column name (default: \"geom\")",
+      "default": "geom",
+      "type": "string"
     },
     "srsId": {
       "description": "Spatial Reference System ID (default: 4326 for WGS84)",
@@ -4808,10 +4798,20 @@ Writes geographic features to GeoPackage (.gpkg) files with proper SQLite struct
       "type": "integer",
       "format": "int32"
     },
-    "tableName": {
-      "description": "Table name to create (default: \"features\")",
-      "default": "features",
+    "geometryType": {
+      "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
+      "default": "GEOMETRY",
       "type": "string"
+    },
+    "createSpatialIndex": {
+      "description": "Create RTree spatial index (default: true)",
+      "default": true,
+      "type": "boolean"
+    },
+    "overwrite": {
+      "description": "Overwrite existing file (default: false)",
+      "default": false,
+      "type": "boolean"
     }
   }
 }
@@ -5261,6 +5261,24 @@ Reads 3D models from glTF 2.0 files, supporting meshes, nodes, scenes, and geome
   "title": "GltfReaderParam",
   "type": "object",
   "properties": {
+    "triangulate": {
+      "title": "Triangulate",
+      "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
+      "default": true,
+      "type": "boolean"
+    },
+    "mergeMeshes": {
+      "title": "Merge Meshes",
+      "description": "If true, combines all meshes from the glTF file into a single output feature",
+      "default": false,
+      "type": "boolean"
+    },
+    "includeNodes": {
+      "title": "Include Nodes",
+      "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
+      "default": true,
+      "type": "boolean"
+    },
     "dataset": {
       "title": "File Path",
       "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -5286,12 +5304,6 @@ Reads 3D models from glTF 2.0 files, supporting meshes, nodes, scenes, and geome
         }
       }
     },
-    "includeNodes": {
-      "title": "Include Nodes",
-      "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
-      "default": true,
-      "type": "boolean"
-    },
     "inline": {
       "title": "Inline Content",
       "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -5316,18 +5328,6 @@ Reads 3D models from glTF 2.0 files, supporting meshes, nodes, scenes, and geome
           "type": "string"
         }
       }
-    },
-    "mergeMeshes": {
-      "title": "Merge Meshes",
-      "description": "If true, combines all meshes from the glTF file into a single output feature",
-      "default": false,
-      "type": "boolean"
-    },
-    "triangulate": {
-      "title": "Triangulate",
-      "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
-      "default": true,
-      "type": "boolean"
     }
   }
 }
@@ -5355,20 +5355,6 @@ Writes 3D features to GLTF format with optional texture attachment
     "output"
   ],
   "properties": {
-    "attachTexture": {
-      "description": "Whether to attach texture information to the GLTF model",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "dracoCompression": {
-      "description": "Apply Draco compression to the geometry",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
     "output": {
       "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
       "type": "object",
@@ -5389,6 +5375,20 @@ Writes 3D features to GLTF format with optional texture attachment
           "type": "string"
         }
       }
+    },
+    "attachTexture": {
+      "description": "Whether to attach texture information to the GLTF model",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "dracoCompression": {
+      "description": "Apply Draco compression to the geometry",
+      "type": [
+        "boolean",
+        "null"
+      ]
     },
     "schemaKey": {
       "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
@@ -5421,6 +5421,20 @@ Divide Polygons into Regular Grid Cells
     "unitSquareSize"
   ],
   "properties": {
+    "unitSquareSize": {
+      "title": "Unit Square Size",
+      "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
+      "type": "number",
+      "format": "double"
+    },
+    "keepSquareOnly": {
+      "title": "Keep Square Only",
+      "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "groupBy": {
       "title": "Group By Attributes",
       "description": "Attributes used to group features - each group gets its own grid origin",
@@ -5431,20 +5445,6 @@ Divide Polygons into Regular Grid Cells
       "items": {
         "$ref": "#/definitions/Attribute"
       }
-    },
-    "keepSquareOnly": {
-      "title": "Keep Square Only",
-      "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
-    "unitSquareSize": {
-      "title": "Unit Square Size",
-      "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
-      "type": "number",
-      "format": "double"
     }
   },
   "definitions": {
@@ -5478,12 +5478,78 @@ Make HTTP/HTTPS requests and enrich features with response data
     "url"
   ],
   "properties": {
+    "url": {
+      "title": "URL",
+      "description": "The target URL for the HTTP request (supports expressions)",
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "method": {
+      "title": "HTTP Method",
+      "description": "The HTTP method to use for the request",
+      "default": "GET",
+      "allOf": [
+        {
+          "$ref": "#/definitions/HttpMethod"
+        }
+      ]
+    },
     "authentication": {
       "title": "Authentication",
       "description": "Authentication method and credentials for the request",
       "anyOf": [
         {
           "$ref": "#/definitions/Authentication"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "customHeaders": {
+      "title": "Custom Headers",
+      "description": "Additional HTTP headers to include in the request",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/HeaderParam"
+      }
+    },
+    "queryParameters": {
+      "title": "Query Parameters",
+      "description": "URL query parameters to append to the request",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/QueryParam"
+      }
+    },
+    "requestBody": {
+      "title": "Request Body",
+      "description": "The body content to send with the request",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/RequestBody"
         },
         {
           "type": "null"
@@ -5498,16 +5564,17 @@ Make HTTP/HTTPS requests and enrich features with response data
         "null"
       ]
     },
-    "customHeaders": {
-      "title": "Custom Headers",
-      "description": "Additional HTTP headers to include in the request",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/HeaderParam"
-      }
+    "timeouts": {
+      "title": "Timeouts",
+      "description": "Connection and transfer timeout settings",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TimeoutConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "httpOptions": {
       "title": "HTTP Options",
@@ -5515,63 +5582,6 @@ Make HTTP/HTTPS requests and enrich features with response data
       "anyOf": [
         {
           "$ref": "#/definitions/HttpOptions"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "method": {
-      "title": "HTTP Method",
-      "description": "The HTTP method to use for the request",
-      "default": "GET",
-      "allOf": [
-        {
-          "$ref": "#/definitions/HttpMethod"
-        }
-      ]
-    },
-    "observability": {
-      "title": "Observability",
-      "description": "Track additional metrics and diagnostics",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ObservabilityConfig"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "queryParameters": {
-      "title": "Query Parameters",
-      "description": "URL query parameters to append to the request",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/QueryParam"
-      }
-    },
-    "rateLimit": {
-      "title": "Rate Limiting",
-      "description": "Rate limiting configuration to control request frequency",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/RateLimitConfig"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "requestBody": {
-      "title": "Request Body",
-      "description": "The body content to send with the request",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/RequestBody"
         },
         {
           "type": "null"
@@ -5602,386 +5612,32 @@ Make HTTP/HTTPS requests and enrich features with response data
         }
       ]
     },
-    "timeouts": {
-      "title": "Timeouts",
-      "description": "Connection and transfer timeout settings",
+    "rateLimit": {
+      "title": "Rate Limiting",
+      "description": "Rate limiting configuration to control request frequency",
       "anyOf": [
         {
-          "$ref": "#/definitions/TimeoutConfig"
+          "$ref": "#/definitions/RateLimitConfig"
         },
         {
           "type": "null"
         }
       ]
     },
-    "url": {
-      "title": "URL",
-      "description": "The target URL for the HTTP request (supports expressions)",
-      "type": "object",
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr",
-            "string"
-          ]
+    "observability": {
+      "title": "Observability",
+      "description": "Track additional metrics and diagnostics",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ObservabilityConfig"
         },
-        "value": {
-          "type": "string"
+        {
+          "type": "null"
         }
-      }
+      ]
     }
   },
   "definitions": {
-    "ApiKeyLocation": {
-      "title": "API Key Location",
-      "description": "Where to include the API key in the request",
-      "oneOf": [
-        {
-          "title": "Header",
-          "description": "Include API key in HTTP header",
-          "type": "string",
-          "enum": [
-            "header"
-          ]
-        },
-        {
-          "title": "Query Parameter",
-          "description": "Include API key in URL query string",
-          "type": "string",
-          "enum": [
-            "query"
-          ]
-        }
-      ]
-    },
-    "Authentication": {
-      "title": "Authentication",
-      "description": "Authentication method and credentials for HTTP requests",
-      "oneOf": [
-        {
-          "title": "Basic Authentication",
-          "description": "HTTP Basic authentication with username and password",
-          "type": "object",
-          "required": [
-            "password",
-            "type",
-            "username"
-          ],
-          "properties": {
-            "password": {
-              "title": "Password",
-              "description": "The password for basic authentication",
-              "type": "object",
-              "format": "code",
-              "required": [
-                "type",
-                "value"
-              ],
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "flowExpr",
-                    "string"
-                  ]
-                },
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "basic"
-              ]
-            },
-            "username": {
-              "title": "Username",
-              "description": "The username for basic authentication",
-              "type": "object",
-              "format": "code",
-              "required": [
-                "type",
-                "value"
-              ],
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "flowExpr",
-                    "string"
-                  ]
-                },
-                "value": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Bearer Token",
-          "description": "Bearer token authentication (OAuth 2.0)",
-          "type": "object",
-          "required": [
-            "token",
-            "type"
-          ],
-          "properties": {
-            "token": {
-              "title": "Token",
-              "description": "The bearer token value",
-              "type": "object",
-              "format": "code",
-              "required": [
-                "type",
-                "value"
-              ],
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "flowExpr",
-                    "string"
-                  ]
-                },
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "bearer"
-              ]
-            }
-          }
-        },
-        {
-          "title": "API Key",
-          "description": "API key authentication in header or query parameter",
-          "type": "object",
-          "required": [
-            "keyName",
-            "keyValue",
-            "type"
-          ],
-          "properties": {
-            "keyName": {
-              "title": "Key Name",
-              "description": "The name of the API key parameter",
-              "type": "string"
-            },
-            "keyValue": {
-              "title": "Key Value",
-              "description": "The API key value",
-              "type": "object",
-              "format": "code",
-              "required": [
-                "type",
-                "value"
-              ],
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "flowExpr",
-                    "string"
-                  ]
-                },
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "location": {
-              "title": "Location",
-              "description": "Where to include the API key (header or query parameter)",
-              "default": "header",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/ApiKeyLocation"
-                }
-              ]
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "apiKey"
-              ]
-            }
-          }
-        }
-      ]
-    },
-    "BinarySource": {
-      "title": "Binary Source",
-      "description": "Source of binary data for request body",
-      "oneOf": [
-        {
-          "title": "Base64 Encoded",
-          "description": "Binary data encoded as base64 string",
-          "type": "object",
-          "required": [
-            "data",
-            "type"
-          ],
-          "properties": {
-            "data": {
-              "title": "Data",
-              "description": "Base64-encoded binary data (supports expressions)",
-              "type": "object",
-              "format": "code",
-              "required": [
-                "type",
-                "value"
-              ],
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "flowExpr",
-                    "string"
-                  ]
-                },
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "base64"
-              ]
-            }
-          }
-        },
-        {
-          "title": "From File",
-          "description": "Read binary data from a file",
-          "type": "object",
-          "required": [
-            "path",
-            "type"
-          ],
-          "properties": {
-            "path": {
-              "title": "File Path",
-              "description": "Path to the file to read (supports expressions)",
-              "type": "object",
-              "format": "code",
-              "required": [
-                "type",
-                "value"
-              ],
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "flowExpr",
-                    "string"
-                  ]
-                },
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            }
-          }
-        }
-      ]
-    },
-    "FormField": {
-      "title": "Form Field",
-      "description": "A name-value pair for URL-encoded form data",
-      "type": "object",
-      "required": [
-        "name",
-        "value"
-      ],
-      "properties": {
-        "name": {
-          "title": "Field Name",
-          "description": "The name of the form field",
-          "type": "string"
-        },
-        "value": {
-          "title": "Field Value",
-          "description": "The value of the form field (supports expressions)",
-          "type": "object",
-          "format": "code",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "flowExpr",
-                "string"
-              ]
-            },
-            "value": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
-    "HeaderParam": {
-      "title": "HTTP Header",
-      "description": "A custom HTTP header to include in the request",
-      "type": "object",
-      "required": [
-        "name",
-        "value"
-      ],
-      "properties": {
-        "name": {
-          "title": "Header Name",
-          "description": "The name of the HTTP header",
-          "type": "string"
-        },
-        "value": {
-          "title": "Header Value",
-          "description": "The value of the header (supports expressions)",
-          "type": "object",
-          "format": "code",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "flowExpr",
-                "string"
-              ]
-            },
-            "value": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
     "HttpMethod": {
       "title": "HTTP Method",
       "description": "The HTTP request method to use",
@@ -6100,75 +5756,51 @@ Make HTTP/HTTPS requests and enrich features with response data
         }
       ]
     },
-    "HttpOptions": {
-      "title": "HTTP Options",
-      "description": "Configure HTTP client behavior",
-      "type": "object",
-      "properties": {
-        "followRedirects": {
-          "title": "Follow Redirects",
-          "description": "Whether to automatically follow HTTP redirects (default: true)",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "maxRedirects": {
-          "title": "Max Redirects",
-          "description": "Maximum number of redirects to follow (default: 10)",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint8",
-          "minimum": 0.0
-        },
-        "userAgent": {
-          "title": "User Agent",
-          "description": "Custom User-Agent header value",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "verifySsl": {
-          "title": "Verify SSL",
-          "description": "Whether to verify SSL/TLS certificates (default: true)",
-          "type": [
-            "boolean",
-            "null"
-          ]
-        }
-      }
-    },
-    "MultipartPart": {
-      "title": "Multipart Part",
-      "description": "A part in a multipart/form-data request",
+    "Authentication": {
+      "title": "Authentication",
+      "description": "Authentication method and credentials for HTTP requests",
       "oneOf": [
         {
-          "title": "Text Field",
-          "description": "A text field in the multipart form",
+          "title": "Basic Authentication",
+          "description": "HTTP Basic authentication with username and password",
           "type": "object",
           "required": [
-            "name",
+            "password",
             "type",
-            "value"
+            "username"
           ],
           "properties": {
-            "name": {
-              "title": "Field Name",
-              "description": "The name of the form field",
-              "type": "string"
-            },
             "type": {
               "type": "string",
               "enum": [
-                "text"
+                "basic"
               ]
             },
-            "value": {
-              "title": "Field Value",
-              "description": "The value of the form field (supports expressions)",
+            "username": {
+              "title": "Username",
+              "description": "The username for basic authentication",
+              "type": "object",
+              "format": "code",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "flowExpr",
+                    "string"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "password": {
+              "title": "Password",
+              "description": "The password for basic authentication",
               "type": "object",
               "format": "code",
               "required": [
@@ -6191,115 +5823,158 @@ Make HTTP/HTTPS requests and enrich features with response data
           }
         },
         {
-          "title": "File Upload",
-          "description": "A file upload in the multipart form",
+          "title": "Bearer Token",
+          "description": "Bearer token authentication (OAuth 2.0)",
           "type": "object",
           "required": [
-            "name",
-            "source",
+            "token",
             "type"
           ],
           "properties": {
-            "contentType": {
-              "title": "Content Type",
-              "description": "MIME type of the file",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "filename": {
-              "title": "Filename",
-              "description": "The filename to send in the Content-Disposition header",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "name": {
-              "title": "Field Name",
-              "description": "The name of the file upload field",
-              "type": "string"
-            },
-            "source": {
-              "title": "File Source",
-              "description": "Source of the file data (base64 or file path)",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/BinarySource"
-                }
-              ]
-            },
             "type": {
               "type": "string",
               "enum": [
-                "file"
+                "bearer"
+              ]
+            },
+            "token": {
+              "title": "Token",
+              "description": "The bearer token value",
+              "type": "object",
+              "format": "code",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "flowExpr",
+                    "string"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "API Key",
+          "description": "API key authentication in header or query parameter",
+          "type": "object",
+          "required": [
+            "keyName",
+            "keyValue",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "apiKey"
+              ]
+            },
+            "keyName": {
+              "title": "Key Name",
+              "description": "The name of the API key parameter",
+              "type": "string"
+            },
+            "keyValue": {
+              "title": "Key Value",
+              "description": "The API key value",
+              "type": "object",
+              "format": "code",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "flowExpr",
+                    "string"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "location": {
+              "title": "Location",
+              "description": "Where to include the API key (header or query parameter)",
+              "default": "header",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ApiKeyLocation"
+                }
               ]
             }
           }
         }
       ]
     },
-    "ObservabilityConfig": {
-      "title": "Observability Configuration",
-      "description": "Track additional metrics and diagnostics about HTTP requests",
+    "ApiKeyLocation": {
+      "title": "API Key Location",
+      "description": "Where to include the API key in the request",
+      "oneOf": [
+        {
+          "title": "Header",
+          "description": "Include API key in HTTP header",
+          "type": "string",
+          "enum": [
+            "header"
+          ]
+        },
+        {
+          "title": "Query Parameter",
+          "description": "Include API key in URL query string",
+          "type": "string",
+          "enum": [
+            "query"
+          ]
+        }
+      ]
+    },
+    "HeaderParam": {
+      "title": "HTTP Header",
+      "description": "A custom HTTP header to include in the request",
       "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
       "properties": {
-        "bytesAttribute": {
-          "title": "Bytes Attribute",
-          "description": "Feature attribute name to store the response body size",
-          "type": [
-            "string",
-            "null"
-          ]
+        "name": {
+          "title": "Header Name",
+          "description": "The name of the HTTP header",
+          "type": "string"
         },
-        "durationAttribute": {
-          "title": "Duration Attribute",
-          "description": "Feature attribute name to store request duration in milliseconds",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "finalUrlAttribute": {
-          "title": "Final URL Attribute",
-          "description": "Feature attribute name to store the final URL after redirects",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "retryCountAttribute": {
-          "title": "Retry Count Attribute",
-          "description": "Feature attribute name to store the number of retry attempts",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "trackBytes": {
-          "title": "Track Bytes",
-          "description": "Whether to track the response body size in bytes (default: false)",
-          "default": false,
-          "type": "boolean"
-        },
-        "trackDuration": {
-          "title": "Track Duration",
-          "description": "Whether to track the total request duration (default: true)",
-          "default": true,
-          "type": "boolean"
-        },
-        "trackFinalUrl": {
-          "title": "Track Final URL",
-          "description": "Whether to track the final URL after redirects (default: false)",
-          "default": false,
-          "type": "boolean"
-        },
-        "trackRetryCount": {
-          "title": "Track Retry Count",
-          "description": "Whether to track the number of retry attempts (default: true)",
-          "default": true,
-          "type": "boolean"
+        "value": {
+          "title": "Header Value",
+          "description": "The value of the header (supports expressions)",
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -6341,41 +6016,6 @@ Make HTTP/HTTPS requests and enrich features with response data
         }
       }
     },
-    "RateLimitConfig": {
-      "title": "Rate Limit Configuration",
-      "description": "Control the rate of HTTP requests to avoid overwhelming the server",
-      "type": "object",
-      "required": [
-        "requests"
-      ],
-      "properties": {
-        "intervalMs": {
-          "title": "Interval",
-          "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
-          "default": 1000,
-          "type": "integer",
-          "format": "uint64",
-          "minimum": 0.0
-        },
-        "requests": {
-          "title": "Requests",
-          "description": "Maximum number of requests allowed within the interval",
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
-        },
-        "timing": {
-          "title": "Timing Strategy",
-          "description": "How to distribute requests within the interval (default: Burst)",
-          "default": "burst",
-          "allOf": [
-            {
-              "$ref": "#/definitions/TimingStrategy"
-            }
-          ]
-        }
-      }
-    },
     "RequestBody": {
       "title": "Request Body",
       "description": "The body content to send with the HTTP request",
@@ -6389,6 +6029,12 @@ Make HTTP/HTTPS requests and enrich features with response data
             "type"
           ],
           "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "text"
+              ]
+            },
             "content": {
               "title": "Content",
               "description": "The text content to send (supports expressions)",
@@ -6418,12 +6064,6 @@ Make HTTP/HTTPS requests and enrich features with response data
                 "string",
                 "null"
               ]
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "text"
-              ]
             }
           }
         },
@@ -6436,12 +6076,10 @@ Make HTTP/HTTPS requests and enrich features with response data
             "type"
           ],
           "properties": {
-            "contentType": {
-              "title": "Content Type",
-              "description": "Content-Type header (e.g., application/octet-stream, image/png)",
-              "type": [
-                "string",
-                "null"
+            "type": {
+              "type": "string",
+              "enum": [
+                "binary"
               ]
             },
             "source": {
@@ -6453,10 +6091,12 @@ Make HTTP/HTTPS requests and enrich features with response data
                 }
               ]
             },
-            "type": {
-              "type": "string",
-              "enum": [
-                "binary"
+            "contentType": {
+              "title": "Content Type",
+              "description": "Content-Type header (e.g., application/octet-stream, image/png)",
+              "type": [
+                "string",
+                "null"
               ]
             }
           }
@@ -6470,6 +6110,12 @@ Make HTTP/HTTPS requests and enrich features with response data
             "type"
           ],
           "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "formUrlEncoded"
+              ]
+            },
             "fields": {
               "title": "Form Fields",
               "description": "List of form field name-value pairs",
@@ -6477,12 +6123,6 @@ Make HTTP/HTTPS requests and enrich features with response data
               "items": {
                 "$ref": "#/definitions/FormField"
               }
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "formUrlEncoded"
-              ]
             }
           }
         },
@@ -6495,6 +6135,12 @@ Make HTTP/HTTPS requests and enrich features with response data
             "type"
           ],
           "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "multipart"
+              ]
+            },
             "parts": {
               "title": "Parts",
               "description": "List of multipart form parts (text fields or file uploads)",
@@ -6502,34 +6148,315 @@ Make HTTP/HTTPS requests and enrich features with response data
               "items": {
                 "$ref": "#/definitions/MultipartPart"
               }
-            },
+            }
+          }
+        }
+      ]
+    },
+    "BinarySource": {
+      "title": "Binary Source",
+      "description": "Source of binary data for request body",
+      "oneOf": [
+        {
+          "title": "Base64 Encoded",
+          "description": "Binary data encoded as base64 string",
+          "type": "object",
+          "required": [
+            "data",
+            "type"
+          ],
+          "properties": {
             "type": {
               "type": "string",
               "enum": [
-                "multipart"
+                "base64"
+              ]
+            },
+            "data": {
+              "title": "Data",
+              "description": "Base64-encoded binary data (supports expressions)",
+              "type": "object",
+              "format": "code",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "flowExpr",
+                    "string"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "From File",
+          "description": "Read binary data from a file",
+          "type": "object",
+          "required": [
+            "path",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "path": {
+              "title": "File Path",
+              "description": "Path to the file to read (supports expressions)",
+              "type": "object",
+              "format": "code",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "flowExpr",
+                    "string"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "FormField": {
+      "title": "Form Field",
+      "description": "A name-value pair for URL-encoded form data",
+      "type": "object",
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "title": "Field Name",
+          "description": "The name of the form field",
+          "type": "string"
+        },
+        "value": {
+          "title": "Field Value",
+          "description": "The value of the form field (supports expressions)",
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "MultipartPart": {
+      "title": "Multipart Part",
+      "description": "A part in a multipart/form-data request",
+      "oneOf": [
+        {
+          "title": "Text Field",
+          "description": "A text field in the multipart form",
+          "type": "object",
+          "required": [
+            "name",
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "text"
+              ]
+            },
+            "name": {
+              "title": "Field Name",
+              "description": "The name of the form field",
+              "type": "string"
+            },
+            "value": {
+              "title": "Field Value",
+              "description": "The value of the form field (supports expressions)",
+              "type": "object",
+              "format": "code",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "flowExpr",
+                    "string"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "title": "File Upload",
+          "description": "A file upload in the multipart form",
+          "type": "object",
+          "required": [
+            "name",
+            "source",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "name": {
+              "title": "Field Name",
+              "description": "The name of the file upload field",
+              "type": "string"
+            },
+            "source": {
+              "title": "File Source",
+              "description": "Source of the file data (base64 or file path)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/BinarySource"
+                }
+              ]
+            },
+            "filename": {
+              "title": "Filename",
+              "description": "The filename to send in the Content-Disposition header",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "contentType": {
+              "title": "Content Type",
+              "description": "MIME type of the file",
+              "type": [
+                "string",
+                "null"
               ]
             }
           }
         }
       ]
     },
-    "ResponseConfig": {
-      "title": "Response Configuration",
-      "description": "Configure how HTTP response data is stored and processed",
+    "TimeoutConfig": {
+      "title": "Timeout Configuration",
+      "description": "Configure connection and transfer timeouts for HTTP requests",
       "type": "object",
       "properties": {
-        "autoDetectEncoding": {
-          "title": "Auto Detect Encoding",
-          "description": "Automatically detect character encoding from response headers",
+        "connectionTimeout": {
+          "title": "Connection Timeout",
+          "description": "Maximum time in seconds to establish a connection (default: 60)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "transferTimeout": {
+          "title": "Transfer Timeout",
+          "description": "Maximum time in seconds to complete the entire request (default: 90)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "HttpOptions": {
+      "title": "HTTP Options",
+      "description": "Configure HTTP client behavior",
+      "type": "object",
+      "properties": {
+        "userAgent": {
+          "title": "User Agent",
+          "description": "Custom User-Agent header value",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "verifySsl": {
+          "title": "Verify SSL",
+          "description": "Whether to verify SSL/TLS certificates (default: true)",
           "type": [
             "boolean",
             "null"
           ]
         },
-        "errorAttribute": {
-          "title": "Error Attribute",
-          "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
-          "default": "_http_error",
+        "followRedirects": {
+          "title": "Follow Redirects",
+          "description": "Whether to automatically follow HTTP redirects (default: true)",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "maxRedirects": {
+          "title": "Max Redirects",
+          "description": "Maximum number of redirects to follow (default: 10)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint8",
+          "minimum": 0.0
+        }
+      }
+    },
+    "ResponseConfig": {
+      "title": "Response Configuration",
+      "description": "Configure how HTTP response data is stored and processed",
+      "type": "object",
+      "properties": {
+        "responseBodyAttribute": {
+          "title": "Response Body Attribute",
+          "description": "Feature attribute name to store the response body (default: \"_response_body\")",
+          "default": "_response_body",
+          "type": "string"
+        },
+        "statusCodeAttribute": {
+          "title": "Status Code Attribute",
+          "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
+          "default": "_http_status_code",
           "type": "string"
         },
         "headersAttribute": {
@@ -6538,33 +6465,11 @@ Make HTTP/HTTPS requests and enrich features with response data
           "default": "_headers",
           "type": "string"
         },
-        "maxResponseSize": {
-          "title": "Max Response Size",
-          "description": "Maximum response body size in bytes (unlimited if not set)",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
-        },
-        "responseBodyAttribute": {
-          "title": "Response Body Attribute",
-          "description": "Feature attribute name to store the response body (default: \"_response_body\")",
-          "default": "_response_body",
+        "errorAttribute": {
+          "title": "Error Attribute",
+          "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
+          "default": "_http_error",
           "type": "string"
-        },
-        "responseEncoding": {
-          "title": "Response Encoding",
-          "description": "How to encode the response body (text, base64, or binary)",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ResponseEncoding"
-            },
-            {
-              "type": "null"
-            }
-          ]
         },
         "responseHandling": {
           "title": "Response Handling",
@@ -6578,13 +6483,114 @@ Make HTTP/HTTPS requests and enrich features with response data
             }
           ]
         },
-        "statusCodeAttribute": {
-          "title": "Status Code Attribute",
-          "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
-          "default": "_http_status_code",
-          "type": "string"
+        "maxResponseSize": {
+          "title": "Max Response Size",
+          "description": "Maximum response body size in bytes (unlimited if not set)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "responseEncoding": {
+          "title": "Response Encoding",
+          "description": "How to encode the response body (text, base64, or binary)",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ResponseEncoding"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "autoDetectEncoding": {
+          "title": "Auto Detect Encoding",
+          "description": "Automatically detect character encoding from response headers",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
+    },
+    "ResponseHandling": {
+      "title": "Response Handling",
+      "description": "How to handle the HTTP response data",
+      "oneOf": [
+        {
+          "title": "Store in Attribute",
+          "description": "Store response body in a feature attribute",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "attribute"
+              ]
+            }
+          }
+        },
+        {
+          "title": "Save to File",
+          "description": "Save response body to a file",
+          "type": "object",
+          "required": [
+            "path",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "file"
+              ]
+            },
+            "path": {
+              "title": "File Path",
+              "description": "Path where the response should be saved",
+              "type": "object",
+              "format": "code",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "flowExpr",
+                    "string"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
+            },
+            "storePathInAttribute": {
+              "title": "Store Path in Attribute",
+              "description": "Whether to store the file path in a feature attribute",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            "pathAttribute": {
+              "title": "Path Attribute Name",
+              "description": "Attribute name for storing the file path",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      ]
     },
     "ResponseEncoding": {
       "title": "Response Encoding",
@@ -6616,100 +6622,18 @@ Make HTTP/HTTPS requests and enrich features with response data
         }
       ]
     },
-    "ResponseHandling": {
-      "title": "Response Handling",
-      "description": "How to handle the HTTP response data",
-      "oneOf": [
-        {
-          "title": "Store in Attribute",
-          "description": "Store response body in a feature attribute",
-          "type": "object",
-          "required": [
-            "type"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "attribute"
-              ]
-            }
-          }
-        },
-        {
-          "title": "Save to File",
-          "description": "Save response body to a file",
-          "type": "object",
-          "required": [
-            "path",
-            "type"
-          ],
-          "properties": {
-            "path": {
-              "title": "File Path",
-              "description": "Path where the response should be saved",
-              "type": "object",
-              "format": "code",
-              "required": [
-                "type",
-                "value"
-              ],
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "flowExpr",
-                    "string"
-                  ]
-                },
-                "value": {
-                  "type": "string"
-                }
-              }
-            },
-            "pathAttribute": {
-              "title": "Path Attribute Name",
-              "description": "Attribute name for storing the file path",
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "storePathInAttribute": {
-              "title": "Store Path in Attribute",
-              "description": "Whether to store the file path in a feature attribute",
-              "type": [
-                "boolean",
-                "null"
-              ]
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "file"
-              ]
-            }
-          }
-        }
-      ]
-    },
     "RetryConfig": {
       "title": "Retry Configuration",
       "description": "Configure automatic retry behavior for failed requests",
       "type": "object",
       "properties": {
-        "backoffMultiplier": {
-          "title": "Backoff Multiplier",
-          "description": "Multiplier for exponential backoff between retries (default: 2.0)",
-          "default": 2.0,
-          "type": "number",
-          "format": "double"
-        },
-        "honorRetryAfter": {
-          "title": "Honor Retry-After Header",
-          "description": "Whether to respect the Retry-After header from server responses (default: true)",
-          "default": true,
-          "type": "boolean"
+        "maxAttempts": {
+          "title": "Max Attempts",
+          "description": "Maximum number of retry attempts (default: 3)",
+          "default": 3,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
         },
         "initialDelayMs": {
           "title": "Initial Delay",
@@ -6719,13 +6643,12 @@ Make HTTP/HTTPS requests and enrich features with response data
           "format": "uint64",
           "minimum": 0.0
         },
-        "maxAttempts": {
-          "title": "Max Attempts",
-          "description": "Maximum number of retry attempts (default: 3)",
-          "default": 3,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0
+        "backoffMultiplier": {
+          "title": "Backoff Multiplier",
+          "description": "Multiplier for exponential backoff between retries (default: 2.0)",
+          "default": 2.0,
+          "type": "number",
+          "format": "double"
         },
         "maxDelayMs": {
           "title": "Max Delay",
@@ -6747,33 +6670,47 @@ Make HTTP/HTTPS requests and enrich features with response data
             "format": "uint16",
             "minimum": 0.0
           }
+        },
+        "honorRetryAfter": {
+          "title": "Honor Retry-After Header",
+          "description": "Whether to respect the Retry-After header from server responses (default: true)",
+          "default": true,
+          "type": "boolean"
         }
       }
     },
-    "TimeoutConfig": {
-      "title": "Timeout Configuration",
-      "description": "Configure connection and transfer timeouts for HTTP requests",
+    "RateLimitConfig": {
+      "title": "Rate Limit Configuration",
+      "description": "Control the rate of HTTP requests to avoid overwhelming the server",
       "type": "object",
+      "required": [
+        "requests"
+      ],
       "properties": {
-        "connectionTimeout": {
-          "title": "Connection Timeout",
-          "description": "Maximum time in seconds to establish a connection (default: 60)",
-          "type": [
-            "integer",
-            "null"
-          ],
+        "requests": {
+          "title": "Requests",
+          "description": "Maximum number of requests allowed within the interval",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "intervalMs": {
+          "title": "Interval",
+          "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
+          "default": 1000,
+          "type": "integer",
           "format": "uint64",
           "minimum": 0.0
         },
-        "transferTimeout": {
-          "title": "Transfer Timeout",
-          "description": "Maximum time in seconds to complete the entire request (default: 90)",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint64",
-          "minimum": 0.0
+        "timing": {
+          "title": "Timing Strategy",
+          "description": "How to distribute requests within the interval (default: Burst)",
+          "default": "burst",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TimingStrategy"
+            }
+          ]
         }
       }
     },
@@ -6798,6 +6735,69 @@ Make HTTP/HTTPS requests and enrich features with response data
           ]
         }
       ]
+    },
+    "ObservabilityConfig": {
+      "title": "Observability Configuration",
+      "description": "Track additional metrics and diagnostics about HTTP requests",
+      "type": "object",
+      "properties": {
+        "trackDuration": {
+          "title": "Track Duration",
+          "description": "Whether to track the total request duration (default: true)",
+          "default": true,
+          "type": "boolean"
+        },
+        "durationAttribute": {
+          "title": "Duration Attribute",
+          "description": "Feature attribute name to store request duration in milliseconds",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trackFinalUrl": {
+          "title": "Track Final URL",
+          "description": "Whether to track the final URL after redirects (default: false)",
+          "default": false,
+          "type": "boolean"
+        },
+        "finalUrlAttribute": {
+          "title": "Final URL Attribute",
+          "description": "Feature attribute name to store the final URL after redirects",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trackRetryCount": {
+          "title": "Track Retry Count",
+          "description": "Whether to track the number of retry attempts (default: true)",
+          "default": true,
+          "type": "boolean"
+        },
+        "retryCountAttribute": {
+          "title": "Retry Count Attribute",
+          "description": "Feature attribute name to store the number of retry attempts",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trackBytes": {
+          "title": "Track Bytes",
+          "description": "Whether to track the response body size in bytes (default: false)",
+          "default": false,
+          "type": "boolean"
+        },
+        "bytesAttribute": {
+          "title": "Bytes Attribute",
+          "description": "Feature attribute name to store the response body size",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
     }
   }
 }
@@ -6958,19 +6958,6 @@ Convert vector geometries to raster image format
       "format": "uint32",
       "minimum": 0.0
     },
-    "onOverlap": {
-      "title": "On Overlap",
-      "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
-      "default": null,
-      "anyOf": [
-        {
-          "$ref": "#/definitions/OnOverlap"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "saveTo": {
       "title": "Save To",
       "description": "Optional path expression to save the generated image. If not provided, uses default cache directory.",
@@ -6996,6 +6983,19 @@ Convert vector geometries to raster image format
           "type": "string"
         }
       }
+    },
+    "onOverlap": {
+      "title": "On Overlap",
+      "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
+      "default": null,
+      "anyOf": [
+        {
+          "$ref": "#/definitions/OnOverlap"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "definitions": {
@@ -7150,19 +7150,6 @@ Fragments JSON documents into individual features based on a JSONPath query
         "jsonQuery"
       ],
       "properties": {
-        "attributePrefix": {
-          "description": "Optional prefix for flattened attribute names",
-          "default": null,
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "flattenQueryResult": {
-          "description": "If true, flatten JSON object keys into feature attributes",
-          "default": false,
-          "type": "boolean"
-        },
         "inputSource": {
           "type": "string",
           "enum": [
@@ -7181,10 +7168,23 @@ Fragments JSON documents into individual features based on a JSONPath query
           "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
           "type": "string"
         },
+        "flattenQueryResult": {
+          "description": "If true, flatten JSON object keys into feature attributes",
+          "default": false,
+          "type": "boolean"
+        },
         "recursivelyFlatten": {
           "description": "If true, recursively flatten nested objects using dot-separated keys",
           "default": false,
           "type": "boolean"
+        },
+        "attributePrefix": {
+          "description": "Optional prefix for flattened attribute names",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "rejectNoFragments": {
           "description": "If true, reject features that produce no fragments",
@@ -7202,28 +7202,11 @@ Fragments JSON documents into individual features based on a JSONPath query
         "path"
       ],
       "properties": {
-        "attributePrefix": {
-          "description": "Optional prefix for flattened attribute names",
-          "default": null,
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "flattenQueryResult": {
-          "description": "If true, flatten JSON object keys into feature attributes",
-          "default": false,
-          "type": "boolean"
-        },
         "inputSource": {
           "type": "string",
           "enum": [
             "fileUrl"
           ]
-        },
-        "jsonQuery": {
-          "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
-          "type": "string"
         },
         "path": {
           "description": "Expression evaluating to the file path or URL containing JSON",
@@ -7246,10 +7229,27 @@ Fragments JSON documents into individual features based on a JSONPath query
             }
           }
         },
+        "jsonQuery": {
+          "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
+          "type": "string"
+        },
+        "flattenQueryResult": {
+          "description": "If true, flatten JSON object keys into feature attributes",
+          "default": false,
+          "type": "boolean"
+        },
         "recursivelyFlatten": {
           "description": "If true, recursively flatten nested objects using dot-separated keys",
           "default": false,
           "type": "boolean"
+        },
+        "attributePrefix": {
+          "description": "Optional prefix for flattened attribute names",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "rejectNoFragments": {
           "description": "If true, reject features that produce no fragments",
@@ -7362,6 +7362,27 @@ Writes features to JSON files.
     "output"
   ],
   "properties": {
+    "output": {
+      "description": "Output path or expression for the JSON file to create",
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
     "converter": {
       "description": "Optional converter expression to transform features before writing",
       "type": [
@@ -7378,27 +7399,6 @@ Writes features to JSON files.
           "type": "string",
           "enum": [
             "flowExpr"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "output": {
-      "description": "Output path or expression for the JSON file to create",
-      "type": "object",
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr",
-            "string"
           ]
         },
         "value": {
@@ -7440,16 +7440,16 @@ Intersection points are turned into point features that can contain the merged l
         "$ref": "#/definitions/Attribute"
       }
     },
+    "tolerance": {
+      "type": "number",
+      "format": "double"
+    },
     "overlaidListsAttrName": {
       "description": "Name of the attribute to store the overlaid lists. Defaults to \"overlaidLists\".",
       "type": [
         "string",
         "null"
       ]
-    },
-    "tolerance": {
-      "type": "number",
-      "format": "double"
     }
   },
   "definitions": {
@@ -7487,14 +7487,6 @@ Extracts a specific attribute from each element in a list and concatenates them 
     "separateCharacter"
   ],
   "properties": {
-    "attribute": {
-      "description": "Attribute name to extract from each list element",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        }
-      ]
-    },
     "list": {
       "description": "List attribute to read from",
       "allOf": [
@@ -7503,8 +7495,8 @@ Extracts a specific attribute from each element in a list and concatenates them 
         }
       ]
     },
-    "outputAttributeName": {
-      "description": "Name of the attribute to store the concatenated result",
+    "attribute": {
+      "description": "Attribute name to extract from each list element",
       "allOf": [
         {
           "$ref": "#/definitions/Attribute"
@@ -7514,6 +7506,14 @@ Extracts a specific attribute from each element in a list and concatenates them 
     "separateCharacter": {
       "description": "Character(s) to use as separator between concatenated values",
       "type": "string"
+    },
+    "outputAttributeName": {
+      "description": "Name of the attribute to store the concatenated result",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        }
+      ]
     }
   },
   "definitions": {
@@ -7586,6 +7586,20 @@ Copies attributes from a specific list element to become the main attributes of 
     "listIndexToCopy"
   ],
   "properties": {
+    "listAttribute": {
+      "description": "List attribute to read from",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        }
+      ]
+    },
+    "listIndexToCopy": {
+      "description": "Index of the list element to copy (0-based)",
+      "type": "integer",
+      "format": "uint",
+      "minimum": 0.0
+    },
     "copiedAttributePrefix": {
       "description": "Optional prefix to add to copied attribute names",
       "default": null,
@@ -7601,20 +7615,6 @@ Copies attributes from a specific list element to become the main attributes of 
         "string",
         "null"
       ]
-    },
-    "listAttribute": {
-      "description": "List attribute to read from",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        }
-      ]
-    },
-    "listIndexToCopy": {
-      "description": "Index of the list element to copy (0-based)",
-      "type": "integer",
-      "format": "uint",
-      "minimum": 0.0
     }
   },
   "definitions": {
@@ -7650,13 +7650,63 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
     "output"
   ],
   "properties": {
-    "colonToUnderscore": {
-      "title": "Colon to Underscore",
-      "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
-      "type": [
-        "boolean",
-        "null"
-      ]
+    "output": {
+      "title": "Output",
+      "description": "Output directory path or expression for the generated MVT tiles",
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "layerName": {
+      "title": "Layer Name",
+      "description": "Name of the layer within the MVT tiles",
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "minZoom": {
+      "title": "Minimum Zoom",
+      "description": "Minimum zoom level to generate tiles for",
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "maxZoom": {
+      "title": "Maximum Zoom",
+      "description": "Maximum zoom level to generate tiles for",
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
     },
     "compressOutput": {
       "title": "Compress Output",
@@ -7683,6 +7733,22 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
         }
       }
     },
+    "skipUnexposedAttributes": {
+      "title": "Skip Unexposed Attributes",
+      "description": "Skip attributes with double underscore prefix",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "colonToUnderscore": {
+      "title": "Colon to Underscore",
+      "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "extent": {
       "title": "Extent",
       "description": "MVT tile resolution. Default is 4096.",
@@ -7693,77 +7759,11 @@ Writes vector features to Mapbox Vector Tiles (MVT) format with TileJSON 3.0.0 m
       "format": "uint32",
       "minimum": 0.0
     },
-    "layerName": {
-      "title": "Layer Name",
-      "description": "Name of the layer within the MVT tiles",
-      "type": "object",
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr",
-            "string"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "maxZoom": {
-      "title": "Maximum Zoom",
-      "description": "Maximum zoom level to generate tiles for",
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "minZoom": {
-      "title": "Minimum Zoom",
-      "description": "Minimum zoom level to generate tiles for",
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "output": {
-      "title": "Output",
-      "description": "Output directory path or expression for the generated MVT tiles",
-      "type": "object",
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr",
-            "string"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
     "schemaKey": {
       "title": "Schema Key",
       "description": "Attribute key to match data and schema features for attribute filtering and casting. This attribute is excluded from output.",
       "type": [
         "string",
-        "null"
-      ]
-    },
-    "skipUnexposedAttributes": {
-      "title": "Skip Unexposed Attributes",
-      "description": "Skip attributes with double underscore prefix",
-      "type": [
-        "boolean",
         "null"
       ]
     }
@@ -7790,6 +7790,39 @@ Finds the closest candidate features for each base feature based on spatial prox
   "description": "Configuration for finding spatial neighbors between base and candidate features.",
   "type": "object",
   "properties": {
+    "numClosest": {
+      "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
+      "default": 1,
+      "type": "integer",
+      "format": "uint",
+      "minimum": 1.0
+    },
+    "maxDistance": {
+      "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
+    },
+    "distanceAttribute": {
+      "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
+      "default": "_neighbor_distance",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        }
+      ]
+    },
+    "neighborIndexAttribute": {
+      "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
+      "default": "_neighbor_index",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        }
+      ]
+    },
     "attributePrefix": {
       "description": "Prefix applied to transferred candidate attributes to avoid collisions.",
       "default": "_neighbor_",
@@ -7803,12 +7836,12 @@ Finds the closest candidate features for each base feature based on spatial prox
         "$ref": "#/definitions/Attribute"
       }
     },
-    "distanceAttribute": {
-      "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
-      "default": "_neighbor_distance",
+    "mergeStrategy": {
+      "description": "Controls how multiple neighbors are represented on the output.",
+      "default": "closest",
       "allOf": [
         {
-          "$ref": "#/definitions/Attribute"
+          "$ref": "#/definitions/MergeStrategy"
         }
       ]
     },
@@ -7820,70 +7853,11 @@ Finds the closest candidate features for each base feature based on spatial prox
           "$ref": "#/definitions/DistanceMetric"
         }
       ]
-    },
-    "maxDistance": {
-      "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
-      "type": [
-        "number",
-        "null"
-      ],
-      "format": "double"
-    },
-    "mergeStrategy": {
-      "description": "Controls how multiple neighbors are represented on the output.",
-      "default": "closest",
-      "allOf": [
-        {
-          "$ref": "#/definitions/MergeStrategy"
-        }
-      ]
-    },
-    "neighborIndexAttribute": {
-      "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
-      "default": "_neighbor_index",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        }
-      ]
-    },
-    "numClosest": {
-      "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
-      "default": 1,
-      "type": "integer",
-      "format": "uint",
-      "minimum": 1.0
     }
   },
   "definitions": {
     "Attribute": {
       "type": "string"
-    },
-    "DistanceMetric": {
-      "description": "Distance metric for computing spatial proximity.",
-      "oneOf": [
-        {
-          "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
-          "type": "string",
-          "enum": [
-            "euclidean2d"
-          ]
-        },
-        {
-          "description": "3D Euclidean distance using X, Y, and Z coordinates.",
-          "type": "string",
-          "enum": [
-            "euclidean3d"
-          ]
-        },
-        {
-          "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
-          "type": "string",
-          "enum": [
-            "haversine"
-          ]
-        }
-      ]
     },
     "MergeStrategy": {
       "description": "Merge strategy for handling multiple neighbors.",
@@ -7907,6 +7881,32 @@ Finds the closest candidate features for each base feature based on spatial prox
           "type": "string",
           "enum": [
             "arrayAttributes"
+          ]
+        }
+      ]
+    },
+    "DistanceMetric": {
+      "description": "Distance metric for computing spatial proximity.",
+      "oneOf": [
+        {
+          "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
+          "type": "string",
+          "enum": [
+            "euclidean2d"
+          ]
+        },
+        {
+          "description": "3D Euclidean distance using X, Y, and Z coordinates.",
+          "type": "string",
+          "enum": [
+            "euclidean3d"
+          ]
+        },
+        {
+          "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
+          "type": "string",
+          "enum": [
+            "haversine"
           ]
         }
       ]
@@ -7964,10 +7964,6 @@ Replace null-like attribute values with configured defaults
   "description": "NullAttributeMapper parameters",
   "type": "object",
   "properties": {
-    "defaultReplacement": {
-      "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
-      "default": null
-    },
     "mappings": {
       "description": "Per-attribute replacement rules",
       "default": [],
@@ -7975,6 +7971,10 @@ Replace null-like attribute values with configured defaults
       "items": {
         "$ref": "#/definitions/AttributeMapping"
       }
+    },
+    "defaultReplacement": {
+      "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
+      "default": null
     },
     "nullDefinition": {
       "description": "Which states count as \"null\"",
@@ -8014,6 +8014,9 @@ Replace null-like attribute values with configured defaults
           "description": "Name of the attribute to inspect",
           "type": "string"
         },
+        "replacement": {
+          "description": "Value to write when attribute is null-like null means remove the attribute"
+        },
         "onMissing": {
           "description": "What to do when attribute is missing but not in nullDefinition",
           "default": "skip",
@@ -8022,11 +8025,27 @@ Replace null-like attribute values with configured defaults
               "$ref": "#/definitions/OnMissing"
             }
           ]
-        },
-        "replacement": {
-          "description": "Value to write when attribute is null-like null means remove the attribute"
         }
       }
+    },
+    "OnMissing": {
+      "description": "What to do when attribute is missing but not in nullDefinition",
+      "oneOf": [
+        {
+          "description": "Leave unchanged",
+          "type": "string",
+          "enum": [
+            "skip"
+          ]
+        },
+        {
+          "description": "Write replacement value, creating the attribute",
+          "type": "string",
+          "enum": [
+            "create"
+          ]
+        }
+      ]
     },
     "NullKind": {
       "description": "Defines what states count as \"null\"",
@@ -8050,25 +8069,6 @@ Replace null-like attribute values with configured defaults
           "type": "string",
           "enum": [
             "emptyString"
-          ]
-        }
-      ]
-    },
-    "OnMissing": {
-      "description": "What to do when attribute is missing but not in nullDefinition",
-      "oneOf": [
-        {
-          "description": "Leave unchanged",
-          "type": "string",
-          "enum": [
-            "skip"
-          ]
-        },
-        {
-          "description": "Write replacement value, creating the attribute",
-          "type": "string",
-          "enum": [
-            "create"
           ]
         }
       ]
@@ -8117,67 +8117,11 @@ Reads 3D models from Wavefront OBJ files, supporting vertices, faces, normals, t
   "description": "Configuration for reading Wavefront OBJ 3D model files with support for vertices, faces, normals, texture coordinates, and material definitions.",
   "type": "object",
   "properties": {
-    "dataset": {
-      "title": "File Path",
-      "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-      "type": [
-        "object",
-        "null"
-      ],
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr",
-            "string"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "includeNormals": {
-      "title": "Include Normals",
-      "description": "Include vertex normal data in the output geometry",
+    "parseMaterials": {
+      "title": "Parse Materials",
+      "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
       "default": true,
       "type": "boolean"
-    },
-    "includeTexcoords": {
-      "title": "Include Texture Coordinates",
-      "description": "Include texture coordinate (UV) data in the output geometry",
-      "default": true,
-      "type": "boolean"
-    },
-    "inline": {
-      "title": "Inline Content",
-      "description": "Expression that returns the file content as text instead of reading from a file path",
-      "type": [
-        "object",
-        "null"
-      ],
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr",
-            "string"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
     },
     "materialFile": {
       "title": "Material File",
@@ -8205,23 +8149,79 @@ Reads 3D models from Wavefront OBJ files, supporting vertices, faces, normals, t
         }
       }
     },
+    "triangulate": {
+      "title": "Triangulate",
+      "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
+      "default": false,
+      "type": "boolean"
+    },
     "mergeGroups": {
       "title": "Merge Groups",
       "description": "Merge all groups and objects into a single feature instead of creating separate features per group/object",
       "default": false,
       "type": "boolean"
     },
-    "parseMaterials": {
-      "title": "Parse Materials",
-      "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
+    "includeNormals": {
+      "title": "Include Normals",
+      "description": "Include vertex normal data in the output geometry",
       "default": true,
       "type": "boolean"
     },
-    "triangulate": {
-      "title": "Triangulate",
-      "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
-      "default": false,
+    "includeTexcoords": {
+      "title": "Include Texture Coordinates",
+      "description": "Include texture coordinate (UV) data in the output geometry",
+      "default": true,
       "type": "boolean"
+    },
+    "dataset": {
+      "title": "File Path",
+      "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "inline": {
+      "title": "Inline Content",
+      "description": "Expression that returns the file content as text instead of reading from a file path",
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
     }
   }
 }
@@ -8584,15 +8584,24 @@ Extracts attributes from XML fragments based on a schema definition
   "title": "XmlAttributeExtractorParam",
   "type": "object",
   "properties": {
-    "addNsprefixToFeatureTypes": {
-      "type": [
-        "boolean",
-        "null"
-      ]
-    },
     "cityCode": {
       "type": [
         "string",
+        "null"
+      ]
+    },
+    "targetPackages": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "addNsprefixToFeatureTypes": {
+      "type": [
+        "boolean",
         "null"
       ]
     },
@@ -8616,15 +8625,6 @@ Extracts attributes from XML fragments based on a schema definition
         "string",
         "null"
       ]
-    },
-    "targetPackages": {
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": "string"
-      }
     }
   }
 }
@@ -8703,10 +8703,10 @@ Check connectivity between BuildingParts within the same Building using 3D bound
         }
       ]
     },
-    "fileIndexAttribute": {
-      "title": "File Index Attribute",
-      "description": "Attribute containing the file index (default: \"fileIndex\")",
-      "default": "fileIndex",
+    "partIdAttribute": {
+      "title": "Part ID Attribute",
+      "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+      "default": "featureId",
       "allOf": [
         {
           "$ref": "#/definitions/Attribute"
@@ -8723,10 +8723,10 @@ Check connectivity between BuildingParts within the same Building using 3D bound
         }
       ]
     },
-    "partIdAttribute": {
-      "title": "Part ID Attribute",
-      "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-      "default": "featureId",
+    "fileIndexAttribute": {
+      "title": "File Index Attribute",
+      "description": "Attribute containing the file index (default: \"fileIndex\")",
+      "default": "fileIndex",
       "allOf": [
         {
           "$ref": "#/definitions/Attribute"
@@ -8861,6 +8861,16 @@ Validates CityGML mesh triangles by parsing raw XML: (1) each triangle has exact
     "epsgCode"
   ],
   "properties": {
+    "errorAttribute": {
+      "title": "Error Attribute Name",
+      "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
+      "default": "_validation_error",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        }
+      ]
+    },
     "epsgCode": {
       "title": "Target EPSG Code",
       "description": "EPSG code for coordinate transformation from source EPSG 6697. Accepts integer or string expression.",
@@ -8881,16 +8891,6 @@ Validates CityGML mesh triangles by parsing raw XML: (1) each triangle has exact
           "type": "string"
         }
       }
-    },
-    "errorAttribute": {
-      "title": "Error Attribute Name",
-      "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
-      "default": "_validation_error",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        }
-      ]
     }
   },
   "definitions": {
@@ -8943,6 +8943,20 @@ Extract Japanese standard regional mesh code for PLATEAU destination files and a
   "description": "Configure mesh code extraction for Japanese standard regional mesh",
   "type": "object",
   "properties": {
+    "meshType": {
+      "title": "Mesh Type",
+      "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+      "default": 3,
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "meshcodeAttr": {
+      "title": "Mesh Code Attribute Name",
+      "description": "Output attribute name for the mesh code",
+      "default": "_meshcode",
+      "type": "string"
+    },
     "epsgCode": {
       "title": "EPSG Code",
       "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -8967,20 +8981,6 @@ Extract Japanese standard regional mesh code for PLATEAU destination files and a
           "type": "string"
         }
       }
-    },
-    "meshType": {
-      "title": "Mesh Type",
-      "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-      "default": 3,
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "meshcodeAttr": {
-      "title": "Mesh Code Attribute Name",
-      "description": "Output attribute name for the mesh code",
-      "default": "_meshcode",
-      "type": "string"
     }
   }
 }
@@ -9095,17 +9095,6 @@ Generates TIN-based surfaces from flood area polygons for efficient 3D tile gene
   "description": "Configuration for generating TIN surfaces from flood area polygons. This processor converts polygons to triangulated surfaces by: 1. Optionally grouping features by an attribute (e.g., udxDirs) 2. Combining all polygons in each group 3. Sampling points along polygon boundaries at regular intervals 4. Optionally adding interior grid points within polygons 5. Performing Delaunay triangulation to create a TIN surface 6. Filtering triangles to keep only those inside the original polygons",
   "type": "object",
   "properties": {
-    "groupBy": {
-      "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
     "pointSpacing": {
       "description": "Spacing between sampled points in meters (default: 50.0). Points are sampled along polygon boundaries and optionally on an interior grid at this spacing interval.",
       "type": [
@@ -9120,6 +9109,17 @@ Generates TIN-based surfaces from flood area polygons for efficient 3D tile gene
       "type": [
         "boolean",
         "null"
+      ]
+    },
+    "groupBy": {
+      "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        },
+        {
+          "type": "null"
+        }
       ]
     }
   },
@@ -9313,21 +9313,6 @@ Inserts solar radiation measurement attributes into original CityGML files
     "outputDir"
   ],
   "properties": {
-    "gmlIdAttribute": {
-      "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
-      "default": null,
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "measurements": {
-      "description": "Measurement definitions to insert as gen:measureAttribute elements",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/MeasurementDef"
-      }
-    },
     "outputDir": {
       "description": "Output directory expression for modified CityGML files",
       "type": "object",
@@ -9349,6 +9334,14 @@ Inserts solar radiation measurement attributes into original CityGML files
         }
       }
     },
+    "gmlIdAttribute": {
+      "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
+      "default": null,
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "pathAttribute": {
       "description": "Attribute name on path features holding the file path (default: \"path\")",
       "default": null,
@@ -9357,28 +9350,11 @@ Inserts solar radiation measurement attributes into original CityGML files
         "null"
       ]
     },
-    "sourceEpsg": {
-      "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
-      "default": null,
-      "type": [
-        "object",
-        "null"
-      ],
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
+    "measurements": {
+      "description": "Measurement definitions to insert as gen:measureAttribute elements",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/MeasurementDef"
       }
     },
     "textureImagePath": {
@@ -9405,6 +9381,30 @@ Inserts solar radiation measurement attributes into original CityGML files
           "type": "string"
         }
       }
+    },
+    "sourceEpsg": {
+      "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
+      "default": null,
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
     }
   },
   "definitions": {
@@ -9417,12 +9417,12 @@ Inserts solar radiation measurement attributes into original CityGML files
         "uom"
       ],
       "properties": {
-        "attribute": {
-          "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
-          "type": "string"
-        },
         "name": {
           "description": "XML name attribute value (e.g. \"年間予測日射量\")",
+          "type": "string"
+        },
+        "attribute": {
+          "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
           "type": "string"
         },
         "uom": {
@@ -9462,63 +9462,11 @@ Calculates solar position (altitude and azimuth) for geographic features using S
         "type"
       ],
       "properties": {
-        "outputBelowHorizon": {
-          "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-          "default": false,
-          "type": "boolean"
-        },
-        "outputType": {
-          "description": "Output type: unit normal vector or altitude/azimuth angles",
-          "default": "unitNormalVector",
-          "allOf": [
-            {
-              "$ref": "#/definitions/OutputType"
-            }
+        "type": {
+          "type": "string",
+          "enum": [
+            "time"
           ]
-        },
-        "sourceEpsg": {
-          "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
-          "type": "object",
-          "format": "code",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "flowExpr"
-              ]
-            },
-            "value": {
-              "type": "string"
-            }
-          }
-        },
-        "standardMeridian": {
-          "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
-          "default": null,
-          "type": [
-            "object",
-            "null"
-          ],
-          "format": "code",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "flowExpr"
-              ]
-            },
-            "value": {
-              "type": "string"
-            }
-          }
         },
         "time": {
           "description": "Time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
@@ -9541,60 +9489,6 @@ Calculates solar position (altitude and azimuth) for geographic features using S
             }
           }
         },
-        "type": {
-          "type": "string",
-          "enum": [
-            "time"
-          ]
-        }
-      }
-    },
-    {
-      "type": "object",
-      "required": [
-        "end",
-        "sourceEpsg",
-        "start",
-        "step",
-        "stepUnit",
-        "type"
-      ],
-      "properties": {
-        "end": {
-          "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
-          "type": "object",
-          "format": "code",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "flowExpr",
-                "string"
-              ]
-            },
-            "value": {
-              "type": "string"
-            }
-          }
-        },
-        "outputBelowHorizon": {
-          "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-          "default": false,
-          "type": "boolean"
-        },
-        "outputType": {
-          "description": "Output type: unit normal vector or altitude/azimuth angles",
-          "default": "unitNormalVector",
-          "allOf": [
-            {
-              "$ref": "#/definitions/OutputType"
-            }
-          ]
-        },
         "sourceEpsg": {
           "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
           "type": "object",
@@ -9639,8 +9533,62 @@ Calculates solar position (altitude and azimuth) for geographic features using S
             }
           }
         },
+        "outputType": {
+          "description": "Output type: unit normal vector or altitude/azimuth angles",
+          "default": "unitNormalVector",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OutputType"
+            }
+          ]
+        },
+        "outputBelowHorizon": {
+          "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "required": [
+        "end",
+        "sourceEpsg",
+        "start",
+        "step",
+        "stepUnit",
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "duration"
+          ]
+        },
         "start": {
           "description": "Start time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr",
+                "string"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        "end": {
+          "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
           "type": "object",
           "format": "code",
           "required": [
@@ -9688,11 +9636,63 @@ Calculates solar position (altitude and azimuth) for geographic features using S
             }
           ]
         },
-        "type": {
-          "type": "string",
-          "enum": [
-            "duration"
+        "sourceEpsg": {
+          "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        "standardMeridian": {
+          "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
+          "default": null,
+          "type": [
+            "object",
+            "null"
+          ],
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        "outputType": {
+          "description": "Output type: unit normal vector or altitude/azimuth angles",
+          "default": "unitNormalVector",
+          "allOf": [
+            {
+              "$ref": "#/definitions/OutputType"
+            }
           ]
+        },
+        "outputBelowHorizon": {
+          "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+          "default": false,
+          "type": "boolean"
         }
       }
     }
@@ -9756,9 +9756,9 @@ Creates pairs of features from AreaOnAreaOverlayer output for solid intersection
   "title": "SolidIntersectionTestPairCreatorParam",
   "type": "object",
   "properties": {
-    "gmlIdAttribute": {
-      "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-      "default": "gmlId",
+    "pairIdAttribute": {
+      "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+      "default": "pair_id",
       "type": "string"
     },
     "listAttribute": {
@@ -9766,9 +9766,9 @@ Creates pairs of features from AreaOnAreaOverlayer output for solid intersection
       "default": "list",
       "type": "string"
     },
-    "pairIdAttribute": {
-      "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-      "default": "pair_id",
+    "gmlIdAttribute": {
+      "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+      "default": "gmlId",
       "type": "string"
     }
   }
@@ -9929,6 +9929,12 @@ Detect unshared edges in triangular meshes - edges that appear only once. REQUIR
   "description": "Configure unshared edge detection behavior",
   "type": "object",
   "properties": {
+    "tolerance": {
+      "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
+      "default": 0.1,
+      "type": "number",
+      "format": "double"
+    },
     "groupBy": {
       "description": "Group By Attributes. When specified, edge detection is performed independently within each group. Features with the same values for these attributes are grouped together.",
       "default": null,
@@ -9939,12 +9945,6 @@ Detect unshared edges in triangular meshes - edges that appear only once. REQUIR
       "items": {
         "$ref": "#/definitions/Attribute"
       }
-    },
-    "tolerance": {
-      "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
-      "default": 0.1,
-      "type": "number",
-      "format": "double"
     }
   },
   "definitions": {
@@ -9984,10 +9984,10 @@ Check connectivity between BuildingParts within the same Building using 3D bound
         }
       ]
     },
-    "fileIndexAttribute": {
-      "title": "File Index Attribute",
-      "description": "Attribute containing the file index (default: \"fileIndex\")",
-      "default": "fileIndex",
+    "partIdAttribute": {
+      "title": "Part ID Attribute",
+      "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+      "default": "featureId",
       "allOf": [
         {
           "$ref": "#/definitions/Attribute"
@@ -10004,10 +10004,10 @@ Check connectivity between BuildingParts within the same Building using 3D bound
         }
       ]
     },
-    "partIdAttribute": {
-      "title": "Part ID Attribute",
-      "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-      "default": "featureId",
+    "fileIndexAttribute": {
+      "title": "File Index Attribute",
+      "description": "Attribute containing the file index (default: \"fileIndex\")",
+      "default": "fileIndex",
       "allOf": [
         {
           "$ref": "#/definitions/Attribute"
@@ -10091,6 +10091,20 @@ Extract Japanese standard regional mesh code for PLATEAU destination files and a
   "description": "Configure mesh code extraction for Japanese standard regional mesh",
   "type": "object",
   "properties": {
+    "meshType": {
+      "title": "Mesh Type",
+      "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+      "default": 3,
+      "type": "integer",
+      "format": "uint8",
+      "minimum": 0.0
+    },
+    "meshcodeAttr": {
+      "title": "Mesh Code Attribute Name",
+      "description": "Output attribute name for the mesh code",
+      "default": "_meshcode",
+      "type": "string"
+    },
     "epsgCode": {
       "title": "EPSG Code",
       "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -10115,20 +10129,6 @@ Extract Japanese standard regional mesh code for PLATEAU destination files and a
           "type": "string"
         }
       }
-    },
-    "meshType": {
-      "title": "Mesh Type",
-      "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-      "default": 3,
-      "type": "integer",
-      "format": "uint8",
-      "minimum": 0.0
-    },
-    "meshcodeAttr": {
-      "title": "Mesh Code Attribute Name",
-      "description": "Output attribute name for the mesh code",
-      "default": "_meshcode",
-      "type": "string"
     }
   }
 }
@@ -10274,9 +10274,9 @@ Creates pairs of features from AreaOnAreaOverlayer output for solid intersection
   "title": "SolidIntersectionTestPairCreatorParam",
   "type": "object",
   "properties": {
-    "gmlIdAttribute": {
-      "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-      "default": "gmlId",
+    "pairIdAttribute": {
+      "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+      "default": "pair_id",
       "type": "string"
     },
     "listAttribute": {
@@ -10284,9 +10284,9 @@ Creates pairs of features from AreaOnAreaOverlayer output for solid intersection
       "default": "list",
       "type": "string"
     },
-    "pairIdAttribute": {
-      "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-      "default": "pair_id",
+    "gmlIdAttribute": {
+      "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+      "default": "gmlId",
       "type": "string"
     }
   }
@@ -10493,6 +10493,31 @@ Execute Python Scripts with Geospatial Data Processing
   "title": "PythonScriptProcessorParam",
   "type": "object",
   "properties": {
+    "script": {
+      "title": "Inline Script",
+      "description": "Python script code to execute inline",
+      "type": [
+        "object",
+        "null"
+      ],
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr",
+            "string"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
     "pythonFile": {
       "title": "Python File",
       "description": "Path to a Python script file (supports file://, http://, https://, gs://, etc.)",
@@ -10525,31 +10550,6 @@ Execute Python Scripts with Geospatial Data Processing
         "string",
         "null"
       ]
-    },
-    "script": {
-      "title": "Inline Script",
-      "description": "Python script code to execute inline",
-      "type": [
-        "object",
-        "null"
-      ],
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr",
-            "string"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
     },
     "timeoutSeconds": {
       "title": "Timeout Seconds",
@@ -10589,6 +10589,34 @@ Computes intersection points between rays and geometries
     "ray"
   ],
   "properties": {
+    "ray": {
+      "description": "Defines how to extract ray data from feature attributes",
+      "allOf": [
+        {
+          "$ref": "#/definitions/RayDefinition"
+        }
+      ]
+    },
+    "pairId": {
+      "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
     "closestIntersectionOnly": {
       "description": "When true (default), return only the closest intersection point per ray-geometry pair. When false, return all intersection points.",
       "default": null,
@@ -10613,8 +10641,8 @@ Computes intersection points between rays and geometries
         }
       }
     },
-    "geomId": {
-      "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
+    "tolerance": {
+      "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
       "default": null,
       "type": [
         "object",
@@ -10670,36 +10698,8 @@ Computes intersection points between rays and geometries
         }
       ]
     },
-    "pairId": {
-      "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
-      "type": "object",
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "ray": {
-      "description": "Defines how to extract ray data from feature attributes",
-      "allOf": [
-        {
-          "$ref": "#/definitions/RayDefinition"
-        }
-      ]
-    },
-    "tolerance": {
-      "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
+    "geomId": {
+      "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
       "default": null,
       "type": [
         "object",
@@ -10724,28 +10724,6 @@ Computes intersection points between rays and geometries
     }
   },
   "definitions": {
-    "Attribute": {
-      "type": "string"
-    },
-    "OutputGeometryType": {
-      "description": "Output geometry type for ray intersection results",
-      "oneOf": [
-        {
-          "description": "Output a point at the intersection location (default behavior)",
-          "type": "string",
-          "enum": [
-            "pointOfIntersection"
-          ]
-        },
-        {
-          "description": "Output a line segment from ray origin to intersection point",
-          "type": "string",
-          "enum": [
-            "lineSegmentToIntersection"
-          ]
-        }
-      ]
-    },
     "RayDefinition": {
       "description": "Defines how ray data is extracted from feature attributes.",
       "type": "object",
@@ -10758,30 +10736,6 @@ Computes intersection points between rays and geometries
         "posZ"
       ],
       "properties": {
-        "dirX": {
-          "description": "Attribute containing ray direction X component",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Attribute"
-            }
-          ]
-        },
-        "dirY": {
-          "description": "Attribute containing ray direction Y component",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Attribute"
-            }
-          ]
-        },
-        "dirZ": {
-          "description": "Attribute containing ray direction Z component",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Attribute"
-            }
-          ]
-        },
         "posX": {
           "description": "Attribute containing ray origin X coordinate",
           "allOf": [
@@ -10805,8 +10759,54 @@ Computes intersection points between rays and geometries
               "$ref": "#/definitions/Attribute"
             }
           ]
+        },
+        "dirX": {
+          "description": "Attribute containing ray direction X component",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Attribute"
+            }
+          ]
+        },
+        "dirY": {
+          "description": "Attribute containing ray direction Y component",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Attribute"
+            }
+          ]
+        },
+        "dirZ": {
+          "description": "Attribute containing ray direction Z component",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Attribute"
+            }
+          ]
         }
       }
+    },
+    "Attribute": {
+      "type": "string"
+    },
+    "OutputGeometryType": {
+      "description": "Output geometry type for ray intersection results",
+      "oneOf": [
+        {
+          "description": "Output a point at the intersection location (default behavior)",
+          "type": "string",
+          "enum": [
+            "pointOfIntersection"
+          ]
+        },
+        {
+          "description": "Output a line segment from ray origin to intersection point",
+          "type": "string",
+          "enum": [
+            "lineSegmentToIntersection"
+          ]
+        }
+      ]
     }
   }
 }
@@ -10879,6 +10879,12 @@ Rotate a 3D polygon using from/to vectors or axis-angle specification
             "type"
           ],
           "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "fromToVectors"
+              ]
+            },
             "fromX": {
               "description": "X component of the source direction vector",
               "type": "object",
@@ -10998,12 +11004,6 @@ Rotate a 3D polygon using from/to vectors or axis-angle specification
                   "type": "string"
                 }
               }
-            },
-            "type": {
-              "type": "string",
-              "enum": [
-                "fromToVectors"
-              ]
             }
           }
         },
@@ -11018,25 +11018,11 @@ Rotate a 3D polygon using from/to vectors or axis-angle specification
             "type"
           ],
           "properties": {
-            "angle": {
-              "description": "Rotation angle in degrees",
-              "type": "object",
-              "format": "code",
-              "required": [
-                "type",
-                "value"
-              ],
-              "properties": {
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "flowExpr"
-                  ]
-                },
-                "value": {
-                  "type": "string"
-                }
-              }
+            "type": {
+              "type": "string",
+              "enum": [
+                "axisAngle"
+              ]
             },
             "axisX": {
               "description": "X component of the rotation axis",
@@ -11098,11 +11084,25 @@ Rotate a 3D polygon using from/to vectors or axis-angle specification
                 }
               }
             },
-            "type": {
-              "type": "string",
-              "enum": [
-                "axisAngle"
-              ]
+            "angle": {
+              "description": "Rotation angle in degrees",
+              "type": "object",
+              "format": "code",
+              "required": [
+                "type",
+                "value"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "flowExpr"
+                  ]
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
             }
           }
         }
@@ -11132,6 +11132,20 @@ Reads geographic features from Shapefile archives (.zip containing .shp, .dbf, .
   "description": "Configuration for reading Shapefile archives as geographic features. Expects a ZIP archive containing the required Shapefile components (.shp, .dbf, .shx).",
   "type": "object",
   "properties": {
+    "encoding": {
+      "title": "Character Encoding",
+      "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "force2d": {
+      "title": "Force 2D",
+      "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+      "default": false,
+      "type": "boolean"
+    },
     "allowEmptyPath": {
       "title": "Allow Null Path",
       "description": "If true, a dataset expression that evaluates to null produces zero features instead of an error. This is useful for optional shapefile inputs where the path may not be configured.",
@@ -11162,20 +11176,6 @@ Reads geographic features from Shapefile archives (.zip containing .shp, .dbf, .
           "type": "string"
         }
       }
-    },
-    "encoding": {
-      "title": "Character Encoding",
-      "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
-      "type": [
-        "string",
-        "null"
-      ]
-    },
-    "force2d": {
-      "title": "Force 2D",
-      "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-      "default": false,
-      "type": "boolean"
     },
     "inline": {
       "title": "Inline Content",
@@ -11227,16 +11227,6 @@ Writes geographic features to ESRI Shapefile format with optional grouping
     "output"
   ],
   "properties": {
-    "groupBy": {
-      "description": "Optional attributes to group features by, creating separate files for each group",
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "$ref": "#/definitions/Attribute"
-      }
-    },
     "output": {
       "description": "Output path or expression for the Shapefile to create",
       "type": "object",
@@ -11256,6 +11246,16 @@ Writes geographic features to ESRI Shapefile format with optional grouping
         "value": {
           "type": "string"
         }
+      }
+    },
+    "groupBy": {
+      "description": "Optional attributes to group features by, creating separate files for each group",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/Attribute"
       }
     }
   },
@@ -11334,20 +11334,21 @@ Filter Features by Spatial Relationship
   "description": "Configure spatial relationship testing between filter and candidate geometries",
   "type": "object",
   "properties": {
-    "mergeFilterAttributes": {
-      "title": "Merge Filter Attributes",
-      "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
-      "default": false,
-      "type": "boolean"
-    },
-    "mergedAttributesPrefix": {
-      "title": "Merged Attributes Prefix",
-      "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
-      "default": null,
-      "type": [
-        "string",
-        "null"
+    "predicate": {
+      "title": "Spatial Predicate",
+      "description": "The spatial relationship to test between filter and candidate geometries",
+      "default": "intersects",
+      "allOf": [
+        {
+          "$ref": "#/definitions/SpatialPredicate"
+        }
       ]
+    },
+    "passOnMultipleMatches": {
+      "title": "Pass on Multiple Matches",
+      "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
+      "default": true,
+      "type": "boolean"
     },
     "outputMatchCountAttribute": {
       "title": "Output Match Count Attribute",
@@ -11362,27 +11363,23 @@ Filter Features by Spatial Relationship
         }
       ]
     },
-    "passOnMultipleMatches": {
-      "title": "Pass on Multiple Matches",
-      "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
-      "default": true,
+    "mergeFilterAttributes": {
+      "title": "Merge Filter Attributes",
+      "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
+      "default": false,
       "type": "boolean"
     },
-    "predicate": {
-      "title": "Spatial Predicate",
-      "description": "The spatial relationship to test between filter and candidate geometries",
-      "default": "intersects",
-      "allOf": [
-        {
-          "$ref": "#/definitions/SpatialPredicate"
-        }
+    "mergedAttributesPrefix": {
+      "title": "Merged Attributes Prefix",
+      "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
+      "default": null,
+      "type": [
+        "string",
+        "null"
       ]
     }
   },
   "definitions": {
-    "Attribute": {
-      "type": "string"
-    },
     "SpatialPredicate": {
       "oneOf": [
         {
@@ -11449,6 +11446,9 @@ Filter Features by Spatial Relationship
           ]
         }
       ]
+    },
+    "Attribute": {
+      "type": "string"
     }
   }
 }
@@ -11480,9 +11480,9 @@ Read Features from SQL Database
     "sql"
   ],
   "properties": {
-    "databaseUrl": {
-      "title": "Database URL",
-      "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
+    "sql": {
+      "title": "SQL Query",
+      "description": "SQL query expression to execute for retrieving data",
       "type": "object",
       "format": "code",
       "required": [
@@ -11502,9 +11502,9 @@ Read Features from SQL Database
         }
       }
     },
-    "sql": {
-      "title": "SQL Query",
-      "description": "SQL query expression to execute for retrieving data",
+    "databaseUrl": {
+      "title": "Database URL",
+      "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
       "type": "object",
       "format": "code",
       "required": [
@@ -11549,13 +11549,17 @@ Calculates statistical aggregations on feature attributes with customizable expr
     "calculations"
   ],
   "properties": {
-    "calculations": {
-      "title": "Calculations",
-      "description": "List of statistical calculations to perform on grouped features",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Calculation"
-      }
+    "groupId": {
+      "title": "Group id",
+      "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "groupBy": {
       "title": "Group by",
@@ -11568,17 +11572,13 @@ Calculates statistical aggregations on feature attributes with customizable expr
         "$ref": "#/definitions/Attribute"
       }
     },
-    "groupId": {
-      "title": "Group id",
-      "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        },
-        {
-          "type": "null"
-        }
-      ]
+    "calculations": {
+      "title": "Calculations",
+      "description": "List of statistical calculations to perform on grouped features",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Calculation"
+      }
     }
   },
   "definitions": {
@@ -11592,6 +11592,14 @@ Calculates statistical aggregations on feature attributes with customizable expr
         "newAttribute"
       ],
       "properties": {
+        "newAttribute": {
+          "title": "New attribute name",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Attribute"
+            }
+          ]
+        },
         "expr": {
           "title": "Calculation to perform",
           "type": "object",
@@ -11611,14 +11619,6 @@ Calculates statistical aggregations on feature attributes with customizable expr
               "type": "string"
             }
           }
-        },
-        "newAttribute": {
-          "title": "New attribute name",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Attribute"
-            }
-          ]
         }
       }
     }
@@ -11654,33 +11654,6 @@ Replace Geometry with 3D Box from Attributes
     "minZ"
   ],
   "properties": {
-    "maxX": {
-      "title": "Maximum X Attribute",
-      "description": "Name of attribute containing the maximum X coordinate",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        }
-      ]
-    },
-    "maxY": {
-      "title": "Maximum Y Attribute",
-      "description": "Name of attribute containing the maximum Y coordinate",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        }
-      ]
-    },
-    "maxZ": {
-      "title": "Maximum Z Attribute",
-      "description": "Name of attribute containing the maximum Z coordinate",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Attribute"
-        }
-      ]
-    },
     "minX": {
       "title": "Minimum X Attribute",
       "description": "Name of attribute containing the minimum X coordinate",
@@ -11702,6 +11675,33 @@ Replace Geometry with 3D Box from Attributes
     "minZ": {
       "title": "Minimum Z Attribute",
       "description": "Name of attribute containing the minimum Z coordinate",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        }
+      ]
+    },
+    "maxX": {
+      "title": "Maximum X Attribute",
+      "description": "Name of attribute containing the maximum X coordinate",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        }
+      ]
+    },
+    "maxY": {
+      "title": "Maximum Y Attribute",
+      "description": "Name of attribute containing the maximum Y coordinate",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Attribute"
+        }
+      ]
+    },
+    "maxZ": {
+      "title": "Maximum Z Attribute",
+      "description": "Name of attribute containing the maximum Z coordinate",
       "allOf": [
         {
           "$ref": "#/definitions/Attribute"
@@ -11834,69 +11834,6 @@ Rotate 3D Geometry Around Arbitrary Axis
         }
       }
     },
-    "directionX": {
-      "title": "Direction X",
-      "description": "X component of the rotation axis direction vector",
-      "type": "object",
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "directionY": {
-      "title": "Direction Y",
-      "description": "Y component of the rotation axis direction vector",
-      "type": "object",
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
-    "directionZ": {
-      "title": "Direction Z",
-      "description": "Z component of the rotation axis direction vector",
-      "type": "object",
-      "format": "code",
-      "required": [
-        "type",
-        "value"
-      ],
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "flowExpr"
-          ]
-        },
-        "value": {
-          "type": "string"
-        }
-      }
-    },
     "originX": {
       "title": "Origin X",
       "description": "X coordinate of the rotation origin point",
@@ -11942,6 +11879,69 @@ Rotate 3D Geometry Around Arbitrary Axis
     "originZ": {
       "title": "Origin Z",
       "description": "Z coordinate of the rotation origin point",
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "directionX": {
+      "title": "Direction X",
+      "description": "X component of the rotation axis direction vector",
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "directionY": {
+      "title": "Direction Y",
+      "description": "Y component of the rotation axis direction vector",
+      "type": "object",
+      "format": "code",
+      "required": [
+        "type",
+        "value"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "flowExpr"
+          ]
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "directionZ": {
+      "title": "Direction Z",
+      "description": "Z component of the rotation axis direction vector",
       "type": "object",
       "format": "code",
       "required": [
@@ -12104,27 +12104,11 @@ Fragments large XML documents into smaller pieces based on specified element pat
         "source"
       ],
       "properties": {
-        "attribute": {
-          "$ref": "#/definitions/Attribute"
-        },
-        "elementsToExclude": {
-          "type": "object",
-          "format": "code",
-          "required": [
-            "type",
-            "value"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "flowExpr"
-              ]
-            },
-            "value": {
-              "type": "string"
-            }
-          }
+        "source": {
+          "type": "string",
+          "enum": [
+            "url"
+          ]
         },
         "elementsToMatch": {
           "type": "object",
@@ -12145,11 +12129,27 @@ Fragments large XML documents into smaller pieces based on specified element pat
             }
           }
         },
-        "source": {
-          "type": "string",
-          "enum": [
-            "url"
-          ]
+        "elementsToExclude": {
+          "type": "object",
+          "format": "code",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "flowExpr"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        "attribute": {
+          "$ref": "#/definitions/Attribute"
         }
       }
     }
@@ -12199,19 +12199,19 @@ Validates XML documents against XSD schemas with success/failure routing
     "Attribute": {
       "type": "string"
     },
+    "XmlInputType": {
+      "type": "string",
+      "enum": [
+        "file",
+        "text"
+      ]
+    },
     "ValidationType": {
       "type": "string",
       "enum": [
         "syntax",
         "syntaxAndNamespace",
         "syntaxAndSchema"
-      ]
-    },
-    "XmlInputType": {
-      "type": "string",
-      "enum": [
-        "file",
-        "text"
       ]
     }
   }

--- a/engine/schema/actions.json
+++ b/engine/schema/actions.json
@@ -39,12 +39,6 @@
               }
             ]
           },
-          "multiplier": {
-            "description": "Multiplier to scale the area values (default: 1.0)",
-            "default": 1.0,
-            "type": "number",
-            "format": "double"
-          },
           "outputAttribute": {
             "description": "Name of the attribute to store the calculated area (default: \"area\")",
             "default": "area",
@@ -53,6 +47,12 @@
                 "$ref": "#/definitions/Attribute"
               }
             ]
+          },
+          "multiplier": {
+            "description": "Multiplier to scale the area values (default: 1.0)",
+            "default": 1.0,
+            "type": "number",
+            "format": "double"
           }
         },
         "definitions": {
@@ -93,6 +93,17 @@
         "description": "Configure how area overlay analysis is performed",
         "type": "object",
         "properties": {
+          "groupBy": {
+            "title": "Group By Attributes",
+            "description": "Optional attributes to group features by during overlay analysis",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "accumulationMode": {
             "title": "Accumulation Mode",
             "description": "Controls how attributes from input features are handled in output features",
@@ -110,17 +121,6 @@
               "string",
               "null"
             ]
-          },
-          "groupBy": {
-            "title": "Group By Attributes",
-            "description": "Optional attributes to group features by during overlay analysis",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
           },
           "outputAttribute": {
             "title": "Output Attribute",
@@ -141,15 +141,15 @@
           }
         },
         "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
           "AccumulationMode": {
             "type": "string",
             "enum": [
               "useAttributesFromOneFeature",
               "dropIncomingAttributes"
             ]
-          },
-          "Attribute": {
-            "type": "string"
           }
         }
       },
@@ -212,14 +212,6 @@
               }
             }
           },
-          "calculationAttribute": {
-            "title": "Attribute to store calculation result",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "calculationValue": {
             "title": "Value to use for calculation",
             "type": [
@@ -227,6 +219,14 @@
               "null"
             ],
             "format": "int64"
+          },
+          "calculationAttribute": {
+            "title": "Attribute to store calculation result",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           },
           "method": {
             "title": "Method to use for aggregation",
@@ -244,6 +244,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "New attribute to create",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "attribute": {
                 "title": "Existing attribute to use",
                 "anyOf": [
@@ -277,14 +285,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "New attribute to create",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           },
@@ -388,6 +388,14 @@
           "rules"
         ],
         "properties": {
+          "rules": {
+            "title": "Conversion Rules",
+            "description": "List of rules defining how to map attributes using the conversion table",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AttributeConversionTableRule"
+            }
+          },
           "dataset": {
             "title": "Dataset URI",
             "description": "Path or URI to external conversion table file",
@@ -413,15 +421,6 @@
               }
             }
           },
-          "format": {
-            "title": "Table Format",
-            "description": "Format of the conversion table (CSV, TSV, or JSON)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/ConversionTableFormat"
-              }
-            ]
-          },
           "inline": {
             "title": "Inline Table Data",
             "description": "Conversion table data provided directly as string content",
@@ -430,19 +429,17 @@
               "null"
             ]
           },
-          "rules": {
-            "title": "Conversion Rules",
-            "description": "List of rules defining how to map attributes using the conversion table",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/AttributeConversionTableRule"
-            }
+          "format": {
+            "title": "Table Format",
+            "description": "Format of the conversion table (CSV, TSV, or JSON)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/ConversionTableFormat"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "AttributeConversionTableRule": {
             "type": "object",
             "required": [
@@ -452,17 +449,6 @@
               "featureTo"
             ],
             "properties": {
-              "conversionTableKeys": {
-                "title": "Keys to match in conversion table",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "conversionTableTo": {
-                "title": "Attribute to convert to",
-                "type": "string"
-              },
               "featureFroms": {
                 "title": "Attributes to convert from",
                 "type": "array",
@@ -477,8 +463,22 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "conversionTableKeys": {
+                "title": "Keys to match in conversion table",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "conversionTableTo": {
+                "title": "Attribute to convert to",
+                "type": "string"
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
           },
           "ConversionTableFormat": {
             "type": "string",
@@ -647,15 +647,6 @@
           }
         },
         "definitions": {
-          "Method": {
-            "type": "string",
-            "enum": [
-              "convert",
-              "create",
-              "rename",
-              "remove"
-            ]
-          },
           "Operation": {
             "type": "object",
             "required": [
@@ -701,6 +692,15 @@
                 }
               }
             }
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "convert",
+              "create",
+              "rename",
+              "remove"
+            ]
           }
         }
       },
@@ -748,13 +748,6 @@
                   "null"
                 ]
               },
-              "childAttribute": {
-                "title": "Child attribute name",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
               "expr": {
                 "title": "Expression to evaluate",
                 "type": [
@@ -779,6 +772,27 @@
                   }
                 }
               },
+              "valueAttribute": {
+                "title": "Attribute name to get value from",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
+                "title": "Parent attribute name",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "childAttribute": {
+                "title": "Child attribute name",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "multipleExpr": {
                 "title": "Expression to evaluate multiple attributes",
                 "type": [
@@ -801,20 +815,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "parentAttribute": {
-                "title": "Parent attribute name",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "title": "Attribute name to get value from",
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
           }
@@ -848,10 +848,6 @@
           "rangeTable"
         ],
         "properties": {
-          "defaultValue": {
-            "title": "Default Value",
-            "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
-          },
           "inputAttribute": {
             "title": "Input Attribute",
             "description": "The attribute to evaluate for range mapping",
@@ -869,6 +865,10 @@
             "items": {
               "$ref": "#/definitions/RangeEntry"
             }
+          },
+          "defaultValue": {
+            "title": "Default Value",
+            "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
           }
         },
         "definitions": {
@@ -887,15 +887,15 @@
                 "type": "number",
                 "format": "double"
               },
-              "outputValue": {
-                "title": "Output Value",
-                "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
-              },
               "to": {
                 "title": "To (Maximum)",
                 "description": "The maximum value of the range (exclusive)",
                 "type": "number",
                 "format": "double"
+              },
+              "outputValue": {
+                "title": "Output Value",
+                "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
               }
             }
           }
@@ -923,13 +923,13 @@
         "description": "Configuration for extracting boundaries from geometries.",
         "type": "object",
         "properties": {
-          "exteriorOnly": {
-            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
+          "keepEmptyBoundaries": {
+            "description": "Whether to keep features with empty boundaries (default: false)",
             "default": false,
             "type": "boolean"
           },
-          "keepEmptyBoundaries": {
-            "description": "Whether to keep features with empty boundaries (default: false)",
+          "exteriorOnly": {
+            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
             "default": false,
             "type": "boolean"
           }
@@ -956,18 +956,6 @@
         "title": "BoundsExtractor Parameters",
         "type": "object",
         "properties": {
-          "xmax": {
-            "title": "Maximum X Attribute",
-            "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "xmin": {
             "title": "Minimum X Attribute",
             "description": "Attribute name for storing the minimum X coordinate (defaults to \"xmin\")",
@@ -980,9 +968,9 @@
               }
             ]
           },
-          "ymax": {
-            "title": "Maximum Y Attribute",
-            "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
+          "xmax": {
+            "title": "Maximum X Attribute",
+            "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1004,9 +992,9 @@
               }
             ]
           },
-          "zmax": {
-            "title": "Maximum Z Attribute",
-            "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
+          "ymax": {
+            "title": "Maximum Y Attribute",
+            "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1019,6 +1007,18 @@
           "zmin": {
             "title": "Minimum Z Attribute",
             "description": "Attribute name for storing the minimum Z coordinate (defaults to \"zmin\")",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "zmax": {
+            "title": "Maximum Z Attribute",
+            "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1130,6 +1130,15 @@
           "renameValue"
         ],
         "properties": {
+          "renameType": {
+            "title": "Which Attributes to Rename",
+            "description": "Choose whether to rename all attributes or only selected ones",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RenameType"
+              }
+            ]
+          },
           "renameAction": {
             "title": "Rename Operation",
             "description": "The type of renaming operation to perform on the attribute names",
@@ -1139,13 +1148,12 @@
               }
             ]
           },
-          "renameType": {
-            "title": "Which Attributes to Rename",
-            "description": "Choose whether to rename all attributes or only selected ones",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RenameType"
-              }
+          "textToFind": {
+            "title": "Text Pattern to Find",
+            "description": "Regular expression pattern to match when using \"Replace Text\" operation",
+            "type": [
+              "string",
+              "null"
             ]
           },
           "renameValue": {
@@ -1163,17 +1171,29 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "title": "Text Pattern to Find",
-            "description": "Regular expression pattern to match when using \"Replace Text\" operation",
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
         "definitions": {
+          "RenameType": {
+            "oneOf": [
+              {
+                "title": "All Attributes",
+                "description": "Rename all attributes in the feature",
+                "type": "string",
+                "enum": [
+                  "All"
+                ]
+              },
+              {
+                "title": "Selected Attributes",
+                "description": "Rename only specific attributes listed below",
+                "type": "string",
+                "enum": [
+                  "Selected"
+                ]
+              }
+            ]
+          },
           "RenameAction": {
             "oneOf": [
               {
@@ -1217,26 +1237,6 @@
                 ]
               }
             ]
-          },
-          "RenameType": {
-            "oneOf": [
-              {
-                "title": "All Attributes",
-                "description": "Rename all attributes in the feature",
-                "type": "string",
-                "enum": [
-                  "All"
-                ]
-              },
-              {
-                "title": "Selected Attributes",
-                "description": "Rename only specific attributes listed below",
-                "type": "string",
-                "enum": [
-                  "Selected"
-                ]
-              }
-            ]
           }
         }
       },
@@ -1262,22 +1262,6 @@
         "description": "Configure how the CSG builder pairs features from left and right ports",
         "type": "object",
         "properties": {
-          "createList": {
-            "title": "Create List",
-            "description": "When enabled, creates a list of attribute values from both children (left and right)",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "listAttributeName": {
-            "title": "List Attribute Name",
-            "description": "Name of the attribute to create the list from (required when create_list is true)",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "pairIdAttribute": {
             "title": "Pair ID Attribute",
             "description": "Expression to evaluate the pair ID used to match features from left and right ports",
@@ -1301,6 +1285,22 @@
                 "type": "string"
               }
             }
+          },
+          "createList": {
+            "title": "Create List",
+            "description": "When enabled, creates a list of attribute values from both children (left and right)",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "listAttributeName": {
+            "title": "List Attribute Name",
+            "description": "Name of the attribute to create the list from (required when create_list is true)",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -1445,6 +1445,42 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "title": "Output Path",
+            "description": "Directory path where the 3D tiles will be written",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "Minimum Zoom Level",
+            "description": "Minimum zoom level for tile generation (0-24)",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "Maximum Zoom Level",
+            "description": "Maximum zoom level for tile generation (0-24)",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
           "attachTexture": {
             "title": "Attach Textures",
             "description": "Whether to include texture information in the generated tiles",
@@ -1486,55 +1522,19 @@
               "null"
             ]
           },
-          "maxZoom": {
-            "title": "Maximum Zoom Level",
-            "description": "Maximum zoom level for tile generation (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "Minimum Zoom Level",
-            "description": "Minimum zoom level for tile generation (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "Output Path",
-            "description": "Directory path where the 3D tiles will be written",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
+          "skipUnexposedAttributes": {
+            "title": "Skip unexposed Attributes",
+            "description": "Skip attributes with double underscore prefix",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "title": "Schema Key",
             "description": "Attribute key whose value identifies the schema type and determines the output filename: all features sharing the same value are written to the same file. This attribute is excluded from output.",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "Skip unexposed Attributes",
-            "description": "Skip attributes with double underscore prefix",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -1589,12 +1589,6 @@
               }
             }
           },
-          "flatten": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -1619,6 +1613,12 @@
                 "type": "string"
               }
             }
+          },
+          "flatten": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         }
       },
@@ -1647,29 +1647,6 @@
           "output"
         ],
         "properties": {
-          "epsgCode": {
-            "description": "EPSG code for coordinate reference system",
-            "default": null,
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "lodFilter": {
-            "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-            "default": null,
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          },
           "output": {
             "description": "Output file path expression",
             "type": "object",
@@ -1690,6 +1667,29 @@
                 "type": "string"
               }
             }
+          },
+          "lodFilter": {
+            "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+            "default": null,
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "epsgCode": {
+            "description": "EPSG code for coordinate reference system",
+            "default": null,
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
           },
           "prettyPrint": {
             "description": "Whether to format output with indentation (default: true)",
@@ -1807,15 +1807,6 @@
           "mode"
         ],
         "properties": {
-          "defaultZValue": {
-            "title": "Default Z Value",
-            "description": "Z value to use for 2D geometries that have no Z coordinate.",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
           "mode": {
             "title": "Extraction Mode",
             "description": "How to extract coordinates from geometry vertices.",
@@ -1824,12 +1815,18 @@
                 "$ref": "#/definitions/CoordinateExtractionMode"
               }
             ]
+          },
+          "defaultZValue": {
+            "title": "Default Z Value",
+            "description": "Z value to use for 2D geometries that have no Z coordinate.",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "CoordinateExtractionMode": {
             "description": "Extraction mode: determines how coordinates are output.",
             "oneOf": [
@@ -1840,6 +1837,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "allCoordinates"
+                    ]
+                  },
                   "coordinatesListName": {
                     "title": "Coordinates List Name",
                     "description": "Name of the list attribute that will store coordinate objects (default: \"_indices\")",
@@ -1848,12 +1851,6 @@
                       {
                         "$ref": "#/definitions/Attribute"
                       }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "allCoordinates"
                     ]
                   }
                 }
@@ -1866,17 +1863,17 @@
                   "type"
                 ],
                 "properties": {
-                  "coordinateIndex": {
-                    "title": "Coordinate Index",
-                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
-                    "type": "integer",
-                    "format": "int64"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
                       "specifyCoordinate"
                     ]
+                  },
+                  "coordinateIndex": {
+                    "title": "Coordinate Index",
+                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "xAttribute": {
                     "title": "X Attribute Name",
@@ -1911,6 +1908,9 @@
                 }
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -1940,6 +1940,23 @@
           "format"
         ],
         "properties": {
+          "format": {
+            "title": "File Format",
+            "description": "Choose the delimiter format for the input file",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "encoding": {
+            "title": "Character Encoding",
+            "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -1964,45 +1981,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "Character Encoding",
-            "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "format": {
-            "title": "File Format",
-            "description": "Choose the delimiter format for the input file",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "Geometry Configuration",
-            "description": "Optional configuration for parsing geometry from CSV columns",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "headerRows": {
-            "title": "Header Row Count",
-            "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint",
-            "minimum": 0.0
           },
           "inline": {
             "title": "Inline Content",
@@ -2038,6 +2016,28 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "headerRows": {
+            "title": "Header Row Count",
+            "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint",
+            "minimum": 0.0
+          },
+          "geometry": {
+            "title": "Geometry Configuration",
+            "description": "Optional configuration for parsing geometry from CSV columns",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2152,26 +2152,6 @@
           "output"
         ],
         "properties": {
-          "format": {
-            "description": "File format: csv (comma) or tsv (tab)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "Geometry Configuration",
-            "description": "Optional configuration for exporting geometry to CSV columns",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryExportConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "output": {
             "description": "Output path or expression for the CSV/TSV file to create",
             "type": "object",
@@ -2192,6 +2172,26 @@
                 "type": "string"
               }
             }
+          },
+          "format": {
+            "description": "File format: csv (comma) or tsv (tab)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "geometry": {
+            "title": "Geometry Configuration",
+            "description": "Optional configuration for exporting geometry to CSV columns",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryExportConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2290,6 +2290,28 @@
         "description": "Configuration for reading CZML files as geographic features.",
         "type": "object",
         "properties": {
+          "force2d": {
+            "title": "Force 2D",
+            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+            "default": false,
+            "type": "boolean"
+          },
+          "skipDocumentPacket": {
+            "title": "Skip Document Packet",
+            "description": "If true, skips the document packet (first packet with version/clock info)",
+            "default": true,
+            "type": "boolean"
+          },
+          "timeSampling": {
+            "title": "Time Sampling Strategy",
+            "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
+            "default": "preserveRaw",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TimeSamplingStrategy"
+              }
+            ]
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -2315,12 +2337,6 @@
               }
             }
           },
-          "force2d": {
-            "title": "Force 2D",
-            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -2345,22 +2361,6 @@
                 "type": "string"
               }
             }
-          },
-          "skipDocumentPacket": {
-            "title": "Skip Document Packet",
-            "description": "If true, skips the document packet (first packet with version/clock info)",
-            "default": true,
-            "type": "boolean"
-          },
-          "timeSampling": {
-            "title": "Time Sampling Strategy",
-            "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
-            "default": "preserveRaw",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TimeSamplingStrategy"
-              }
-            ]
           }
         },
         "definitions": {
@@ -2415,87 +2415,6 @@
           "output"
         ],
         "properties": {
-          "colorAttribute": {
-            "title": "Color Attribute",
-            "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "epoch": {
-            "title": "Epoch",
-            "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "groupBy": {
-            "title": "Group By Attributes",
-            "description": "Attributes used to group features into separate CZML files",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
-          "groupTimeseriesBy": {
-            "title": "Group Timeseries By",
-            "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "heightAttribute": {
-            "title": "Height Attribute",
-            "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "interpolationAlgorithm": {
-            "title": "Interpolation Algorithm",
-            "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
-            "default": "LINEAR",
-            "allOf": [
-              {
-                "$ref": "#/definitions/InterpolationAlgorithm"
-              }
-            ]
-          },
-          "interpolationDegree": {
-            "title": "Interpolation Degree",
-            "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
-            "default": 1,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "opacity": {
-            "title": "Opacity",
-            "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
-            "default": 180,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
           "output": {
             "title": "Output File Path",
             "description": "Path where the CZML file will be written",
@@ -2518,9 +2437,90 @@
               }
             }
           },
+          "groupBy": {
+            "title": "Group By Attributes",
+            "description": "Attributes used to group features into separate CZML files",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "timeField": {
             "title": "Time Field",
             "description": "Attribute containing the timestamp for each feature. Supports two formats: - **ISO 8601 strings**: e.g., \"2024-01-01T00:00:00Z\", \"2024-01-01T12:30:45+09:00\" - **Numeric values**: Seconds as offset from epoch (e.g., \"0\", \"60\", \"120.5\")\n\nWhen set together with `groupTimeseriesBy`, features sharing the same group key are combined into a single CZML entity with time-tagged position samples for animation in Cesium.\n\n**Example workflow configuration:** ```yaml - action: CzmlWriter with: output: \"output.czml\" timeField: \"timestamp\" groupTimeseriesBy: \"vehicleId\" epoch: \"2024-01-01T00:00:00Z\"  # Optional for numeric times (auto-defaults to Unix epoch) ```",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "epoch": {
+            "title": "Epoch",
+            "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "interpolationAlgorithm": {
+            "title": "Interpolation Algorithm",
+            "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
+            "default": "LINEAR",
+            "allOf": [
+              {
+                "$ref": "#/definitions/InterpolationAlgorithm"
+              }
+            ]
+          },
+          "interpolationDegree": {
+            "title": "Interpolation Degree",
+            "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
+            "default": 1,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "groupTimeseriesBy": {
+            "title": "Group Timeseries By",
+            "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "colorAttribute": {
+            "title": "Color Attribute",
+            "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "opacity": {
+            "title": "Opacity",
+            "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
+            "default": 180,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "heightAttribute": {
+            "title": "Height Attribute",
+            "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -2598,14 +2598,6 @@
               }
             ]
           },
-          "outputAttribute": {
-            "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "outputFormat": {
             "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode).",
             "default": "auto",
@@ -2613,6 +2605,14 @@
               {
                 "$ref": "#/definitions/DateTimeOutputFormat"
               }
+            ]
+          },
+          "outputAttribute": {
+            "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
@@ -2819,16 +2819,6 @@
         "description": "Configure how to dissolve features by grouping them based on shared attributes",
         "type": "object",
         "properties": {
-          "attributeAccumulation": {
-            "title": "Attribute Accumulation",
-            "description": "Strategy for handling attributes when dissolving features",
-            "default": "useOneFeature",
-            "allOf": [
-              {
-                "$ref": "#/definitions/AttributeAccumulationStrategy"
-              }
-            ]
-          },
           "groupBy": {
             "title": "Group By Attributes",
             "description": "List of attribute names to group features by before dissolving. Features with the same values for these attributes will be dissolved together",
@@ -2848,6 +2838,16 @@
               "null"
             ],
             "format": "double"
+          },
+          "attributeAccumulation": {
+            "title": "Attribute Accumulation",
+            "description": "Strategy for handling attributes when dissolving features",
+            "default": "useOneFeature",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AttributeAccumulationStrategy"
+              }
+            ]
           }
         },
         "definitions": {
@@ -3089,15 +3089,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "City GML Attributes Key",
-            "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Path expression resolving to the CityGML 2.0 file to read.",
@@ -3129,10 +3120,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "Flatten Measure Types",
-            "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
-            "default": false,
+          "keepAttributes": {
+            "title": "Keep Attributes",
+            "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3141,11 +3132,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "Keep Attributes",
-            "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "Flatten Measure Types",
+            "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "City GML Attributes Key",
+            "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3173,15 +3173,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "City GML Attributes Key",
-            "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Path expression resolving to the CityGML 3.0 file to read.",
@@ -3213,10 +3204,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "Flatten Measure Types",
-            "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
-            "default": false,
+          "keepAttributes": {
+            "title": "Keep Attributes",
+            "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3225,11 +3216,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "Keep Attributes",
-            "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "Flatten Measure Types",
+            "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "City GML Attributes Key",
+            "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3258,31 +3258,6 @@
           "dataset"
         ],
         "properties": {
-          "codelistsPath": {
-            "title": "Codelists Path",
-            "description": "Optional path to the codelists directory for resolving codelist values",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Path or expression to the CityGML dataset file to be read",
@@ -3312,6 +3287,31 @@
               "boolean",
               "null"
             ]
+          },
+          "codelistsPath": {
+            "title": "Codelists Path",
+            "description": "Optional path to the codelists directory for resolving codelist values",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -3463,19 +3463,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "destPrefix": {
-            "title": "Destination Prefix",
-            "description": "Optional prefix to add to extracted file paths",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "extractArchive": {
-            "title": "Extract Archive",
-            "description": "Whether to extract archive files found in the dataset",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Expression to get the source dataset path or URL",
@@ -3497,6 +3484,19 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "Extract Archive",
+            "description": "Whether to extract archive files found in the dataset",
+            "type": "boolean"
+          },
+          "destPrefix": {
+            "title": "Destination Prefix",
+            "description": "Optional prefix to add to extracted file paths",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3606,17 +3606,6 @@
           "joinType"
         ],
         "properties": {
-          "conflictResolution": {
-            "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ConflictResolution"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "joinType": {
             "description": "Join type: inner, left, or full",
             "allOf": [
@@ -3627,6 +3616,16 @@
           },
           "requestorAttribute": {
             "description": "Attributes from requestor features to use for matching (alternative to requestorAttributeValue)",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
             "type": [
               "array",
               "null"
@@ -3658,16 +3657,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "Expression to evaluate for supplier feature matching values (alternative to supplierAttribute)",
             "type": [
@@ -3690,30 +3679,20 @@
                 "type": "string"
               }
             }
+          },
+          "conflictResolution": {
+            "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ConflictResolution"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "ConflictResolution": {
-            "oneOf": [
-              {
-                "description": "Requestor attributes win on conflict",
-                "type": "string",
-                "enum": [
-                  "requestorWins"
-                ]
-              },
-              {
-                "description": "Supplier attributes win on conflict (default)",
-                "type": "string",
-                "enum": [
-                  "supplierWins"
-                ]
-              }
-            ]
-          },
           "JoinType": {
             "oneOf": [
               {
@@ -3735,6 +3714,27 @@
                 "type": "string",
                 "enum": [
                   "full"
+                ]
+              }
+            ]
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "ConflictResolution": {
+            "oneOf": [
+              {
+                "description": "Requestor attributes win on conflict",
+                "type": "string",
+                "enum": [
+                  "requestorWins"
+                ]
+              },
+              {
+                "description": "Supplier attributes win on conflict (default)",
+                "type": "string",
+                "enum": [
+                  "supplierWins"
                 ]
               }
             ]
@@ -3816,15 +3816,18 @@
         "description": "Configuration for merging requestor and supplier features based on matching attributes or expressions.",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "description": "Whether to complete grouped features before processing the next group",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "description": "Attributes from requestor features to use for matching (alternative to requestor_attribute_value)",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
             "type": [
               "array",
               "null"
@@ -3856,16 +3859,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "Expression to evaluate for supplier feature matching values (alternative to supplier_attribute)",
             "type": [
@@ -3888,6 +3881,13 @@
                 "type": "string"
               }
             }
+          },
+          "completeGrouped": {
+            "description": "Whether to complete grouped features before processing the next group",
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
         "definitions": {
@@ -3927,27 +3927,11 @@
               "format"
             ],
             "properties": {
-              "dataset": {
-                "title": "Dataset",
-                "description": "Path or expression to the dataset file to be read",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3957,42 +3941,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "csv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4014,6 +3962,42 @@
                     "type": "string"
                   }
                 }
+              },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -4023,42 +4007,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "tsv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4081,11 +4029,63 @@
                   }
                 }
               },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
               "format": {
                 "type": "string",
                 "enum": [
                   "json"
                 ]
+              },
+              "dataset": {
+                "title": "Dataset",
+                "description": "Path or expression to the dataset file to be read",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -4349,28 +4349,6 @@
               "output"
             ],
             "properties": {
-              "converter": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
               "format": {
                 "type": "string",
                 "enum": [
@@ -4397,6 +4375,28 @@
                     "type": "string"
                   }
                 }
+              },
+              "converter": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -4409,34 +4409,11 @@
               "output"
             ],
             "properties": {
-              "epsgCode": {
-                "description": "EPSG code for coordinate reference system",
-                "default": null,
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint32",
-                "minimum": 0.0
-              },
               "format": {
                 "type": "string",
                 "enum": [
                   "citygml"
                 ]
-              },
-              "lodFilter": {
-                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-                "default": null,
-                "type": [
-                  "array",
-                  "null"
-                ],
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0.0
-                }
               },
               "output": {
                 "title": "Output path",
@@ -4458,6 +4435,29 @@
                     "type": "string"
                   }
                 }
+              },
+              "lodFilter": {
+                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+                "default": null,
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              },
+              "epsgCode": {
+                "description": "EPSG code for coordinate reference system",
+                "default": null,
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4497,11 +4497,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "extractArchive": {
-            "title": "Extract Archive",
-            "description": "Whether to extract files from archives (zip files, etc.) or just list them",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Path or expression pointing to the source directory or archive file",
@@ -4523,6 +4518,11 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "Extract Archive",
+            "description": "Whether to extract files from archives (zip files, etc.) or just list them",
+            "type": "boolean"
           }
         }
       },
@@ -4680,16 +4680,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "Optional attributes to group features by, creating separate files for each group",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "Output path or expression for the GeoJSON file to create",
             "type": "object",
@@ -4709,6 +4699,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "Optional attributes to group features by, creating separate files for each group",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -4739,6 +4739,32 @@
         "title": "GeoPackageReaderParam",
         "type": "object",
         "properties": {
+          "readMode": {
+            "default": "features",
+            "allOf": [
+              {
+                "$ref": "#/definitions/GeoPackageReadMode"
+              }
+            ]
+          },
+          "layerName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "includeMetadata": {
+            "default": false,
+            "type": "boolean"
+          },
+          "tileFormat": {
+            "default": "png",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TileFormat"
+              }
+            ]
+          },
           "attributeFilter": {
             "default": null,
             "type": [
@@ -4754,6 +4780,17 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "force2D": {
+            "default": false,
+            "type": "boolean"
+          },
+          "spatialFilter": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "dataset": {
             "title": "File Path",
@@ -4780,14 +4817,6 @@
               }
             }
           },
-          "force2D": {
-            "default": false,
-            "type": "boolean"
-          },
-          "includeMetadata": {
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -4812,35 +4841,6 @@
                 "type": "string"
               }
             }
-          },
-          "layerName": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "readMode": {
-            "default": "features",
-            "allOf": [
-              {
-                "$ref": "#/definitions/GeoPackageReadMode"
-              }
-            ]
-          },
-          "spatialFilter": {
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tileFormat": {
-            "default": "png",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TileFormat"
-              }
-            ]
           }
         },
         "definitions": {
@@ -4888,21 +4888,6 @@
           "output"
         ],
         "properties": {
-          "createSpatialIndex": {
-            "description": "Create RTree spatial index (default: true)",
-            "default": true,
-            "type": "boolean"
-          },
-          "geometryColumn": {
-            "description": "Geometry column name (default: \"geom\")",
-            "default": "geom",
-            "type": "string"
-          },
-          "geometryType": {
-            "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
-            "default": "GEOMETRY",
-            "type": "string"
-          },
           "output": {
             "description": "Output path for the GeoPackage file to create",
             "type": "object",
@@ -4924,10 +4909,15 @@
               }
             }
           },
-          "overwrite": {
-            "description": "Overwrite existing file (default: false)",
-            "default": false,
-            "type": "boolean"
+          "tableName": {
+            "description": "Table name to create (default: \"features\")",
+            "default": "features",
+            "type": "string"
+          },
+          "geometryColumn": {
+            "description": "Geometry column name (default: \"geom\")",
+            "default": "geom",
+            "type": "string"
           },
           "srsId": {
             "description": "Spatial Reference System ID (default: 4326 for WGS84)",
@@ -4935,10 +4925,20 @@
             "type": "integer",
             "format": "int32"
           },
-          "tableName": {
-            "description": "Table name to create (default: \"features\")",
-            "default": "features",
+          "geometryType": {
+            "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
+            "default": "GEOMETRY",
             "type": "string"
+          },
+          "createSpatialIndex": {
+            "description": "Create RTree spatial index (default: true)",
+            "default": true,
+            "type": "boolean"
+          },
+          "overwrite": {
+            "description": "Overwrite existing file (default: false)",
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -5411,6 +5411,24 @@
         "title": "GltfReaderParam",
         "type": "object",
         "properties": {
+          "triangulate": {
+            "title": "Triangulate",
+            "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
+            "default": true,
+            "type": "boolean"
+          },
+          "mergeMeshes": {
+            "title": "Merge Meshes",
+            "description": "If true, combines all meshes from the glTF file into a single output feature",
+            "default": false,
+            "type": "boolean"
+          },
+          "includeNodes": {
+            "title": "Include Nodes",
+            "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
+            "default": true,
+            "type": "boolean"
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -5436,12 +5454,6 @@
               }
             }
           },
-          "includeNodes": {
-            "title": "Include Nodes",
-            "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
-            "default": true,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -5466,18 +5478,6 @@
                 "type": "string"
               }
             }
-          },
-          "mergeMeshes": {
-            "title": "Merge Meshes",
-            "description": "If true, combines all meshes from the glTF file into a single output feature",
-            "default": false,
-            "type": "boolean"
-          },
-          "triangulate": {
-            "title": "Triangulate",
-            "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
-            "default": true,
-            "type": "boolean"
           }
         }
       },
@@ -5505,20 +5505,6 @@
           "output"
         ],
         "properties": {
-          "attachTexture": {
-            "description": "Whether to attach texture information to the GLTF model",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "dracoCompression": {
-            "description": "Apply Draco compression to the geometry",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "output": {
             "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
             "type": "object",
@@ -5539,6 +5525,20 @@
                 "type": "string"
               }
             }
+          },
+          "attachTexture": {
+            "description": "Whether to attach texture information to the GLTF model",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "dracoCompression": {
+            "description": "Apply Draco compression to the geometry",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
@@ -5571,6 +5571,20 @@
           "unitSquareSize"
         ],
         "properties": {
+          "unitSquareSize": {
+            "title": "Unit Square Size",
+            "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
+            "type": "number",
+            "format": "double"
+          },
+          "keepSquareOnly": {
+            "title": "Keep Square Only",
+            "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "title": "Group By Attributes",
             "description": "Attributes used to group features - each group gets its own grid origin",
@@ -5581,20 +5595,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "keepSquareOnly": {
-            "title": "Keep Square Only",
-            "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "unitSquareSize": {
-            "title": "Unit Square Size",
-            "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -5631,12 +5631,78 @@
           "url"
         ],
         "properties": {
+          "url": {
+            "title": "URL",
+            "description": "The target URL for the HTTP request (supports expressions)",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "method": {
+            "title": "HTTP Method",
+            "description": "The HTTP method to use for the request",
+            "default": "GET",
+            "allOf": [
+              {
+                "$ref": "#/definitions/HttpMethod"
+              }
+            ]
+          },
           "authentication": {
             "title": "Authentication",
             "description": "Authentication method and credentials for the request",
             "anyOf": [
               {
                 "$ref": "#/definitions/Authentication"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "customHeaders": {
+            "title": "Custom Headers",
+            "description": "Additional HTTP headers to include in the request",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/HeaderParam"
+            }
+          },
+          "queryParameters": {
+            "title": "Query Parameters",
+            "description": "URL query parameters to append to the request",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/QueryParam"
+            }
+          },
+          "requestBody": {
+            "title": "Request Body",
+            "description": "The body content to send with the request",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5651,16 +5717,17 @@
               "null"
             ]
           },
-          "customHeaders": {
-            "title": "Custom Headers",
-            "description": "Additional HTTP headers to include in the request",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/HeaderParam"
-            }
+          "timeouts": {
+            "title": "Timeouts",
+            "description": "Connection and transfer timeout settings",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TimeoutConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "httpOptions": {
             "title": "HTTP Options",
@@ -5668,63 +5735,6 @@
             "anyOf": [
               {
                 "$ref": "#/definitions/HttpOptions"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "method": {
-            "title": "HTTP Method",
-            "description": "The HTTP method to use for the request",
-            "default": "GET",
-            "allOf": [
-              {
-                "$ref": "#/definitions/HttpMethod"
-              }
-            ]
-          },
-          "observability": {
-            "title": "Observability",
-            "description": "Track additional metrics and diagnostics",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ObservabilityConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "queryParameters": {
-            "title": "Query Parameters",
-            "description": "URL query parameters to append to the request",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/QueryParam"
-            }
-          },
-          "rateLimit": {
-            "title": "Rate Limiting",
-            "description": "Rate limiting configuration to control request frequency",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RateLimitConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "requestBody": {
-            "title": "Request Body",
-            "description": "The body content to send with the request",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5755,386 +5765,32 @@
               }
             ]
           },
-          "timeouts": {
-            "title": "Timeouts",
-            "description": "Connection and transfer timeout settings",
+          "rateLimit": {
+            "title": "Rate Limiting",
+            "description": "Rate limiting configuration to control request frequency",
             "anyOf": [
               {
-                "$ref": "#/definitions/TimeoutConfig"
+                "$ref": "#/definitions/RateLimitConfig"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "url": {
-            "title": "URL",
-            "description": "The target URL for the HTTP request (supports expressions)",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
+          "observability": {
+            "title": "Observability",
+            "description": "Track additional metrics and diagnostics",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ObservabilityConfig"
               },
-              "value": {
-                "type": "string"
+              {
+                "type": "null"
               }
-            }
+            ]
           }
         },
         "definitions": {
-          "ApiKeyLocation": {
-            "title": "API Key Location",
-            "description": "Where to include the API key in the request",
-            "oneOf": [
-              {
-                "title": "Header",
-                "description": "Include API key in HTTP header",
-                "type": "string",
-                "enum": [
-                  "header"
-                ]
-              },
-              {
-                "title": "Query Parameter",
-                "description": "Include API key in URL query string",
-                "type": "string",
-                "enum": [
-                  "query"
-                ]
-              }
-            ]
-          },
-          "Authentication": {
-            "title": "Authentication",
-            "description": "Authentication method and credentials for HTTP requests",
-            "oneOf": [
-              {
-                "title": "Basic Authentication",
-                "description": "HTTP Basic authentication with username and password",
-                "type": "object",
-                "required": [
-                  "password",
-                  "type",
-                  "username"
-                ],
-                "properties": {
-                  "password": {
-                    "title": "Password",
-                    "description": "The password for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "basic"
-                    ]
-                  },
-                  "username": {
-                    "title": "Username",
-                    "description": "The username for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "title": "Bearer Token",
-                "description": "Bearer token authentication (OAuth 2.0)",
-                "type": "object",
-                "required": [
-                  "token",
-                  "type"
-                ],
-                "properties": {
-                  "token": {
-                    "title": "Token",
-                    "description": "The bearer token value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "bearer"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "API Key",
-                "description": "API key authentication in header or query parameter",
-                "type": "object",
-                "required": [
-                  "keyName",
-                  "keyValue",
-                  "type"
-                ],
-                "properties": {
-                  "keyName": {
-                    "title": "Key Name",
-                    "description": "The name of the API key parameter",
-                    "type": "string"
-                  },
-                  "keyValue": {
-                    "title": "Key Value",
-                    "description": "The API key value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "location": {
-                    "title": "Location",
-                    "description": "Where to include the API key (header or query parameter)",
-                    "default": "header",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/ApiKeyLocation"
-                      }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "apiKey"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "BinarySource": {
-            "title": "Binary Source",
-            "description": "Source of binary data for request body",
-            "oneOf": [
-              {
-                "title": "Base64 Encoded",
-                "description": "Binary data encoded as base64 string",
-                "type": "object",
-                "required": [
-                  "data",
-                  "type"
-                ],
-                "properties": {
-                  "data": {
-                    "title": "Data",
-                    "description": "Base64-encoded binary data (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "base64"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "From File",
-                "description": "Read binary data from a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path to the file to read (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "FormField": {
-            "title": "Form Field",
-            "description": "A name-value pair for URL-encoded form data",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "Field Name",
-                "description": "The name of the form field",
-                "type": "string"
-              },
-              "value": {
-                "title": "Field Value",
-                "description": "The value of the form field (supports expressions)",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "HeaderParam": {
-            "title": "HTTP Header",
-            "description": "A custom HTTP header to include in the request",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "Header Name",
-                "description": "The name of the HTTP header",
-                "type": "string"
-              },
-              "value": {
-                "title": "Header Value",
-                "description": "The value of the header (supports expressions)",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
           "HttpMethod": {
             "title": "HTTP Method",
             "description": "The HTTP request method to use",
@@ -6253,75 +5909,51 @@
               }
             ]
           },
-          "HttpOptions": {
-            "title": "HTTP Options",
-            "description": "Configure HTTP client behavior",
-            "type": "object",
-            "properties": {
-              "followRedirects": {
-                "title": "Follow Redirects",
-                "description": "Whether to automatically follow HTTP redirects (default: true)",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "maxRedirects": {
-                "title": "Max Redirects",
-                "description": "Maximum number of redirects to follow (default: 10)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "userAgent": {
-                "title": "User Agent",
-                "description": "Custom User-Agent header value",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "verifySsl": {
-                "title": "Verify SSL",
-                "description": "Whether to verify SSL/TLS certificates (default: true)",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            }
-          },
-          "MultipartPart": {
-            "title": "Multipart Part",
-            "description": "A part in a multipart/form-data request",
+          "Authentication": {
+            "title": "Authentication",
+            "description": "Authentication method and credentials for HTTP requests",
             "oneOf": [
               {
-                "title": "Text Field",
-                "description": "A text field in the multipart form",
+                "title": "Basic Authentication",
+                "description": "HTTP Basic authentication with username and password",
                 "type": "object",
                 "required": [
-                  "name",
+                  "password",
                   "type",
-                  "value"
+                  "username"
                 ],
                 "properties": {
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the form field",
-                    "type": "string"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "text"
+                      "basic"
                     ]
                   },
-                  "value": {
-                    "title": "Field Value",
-                    "description": "The value of the form field (supports expressions)",
+                  "username": {
+                    "title": "Username",
+                    "description": "The username for basic authentication",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "The password for basic authentication",
                     "type": "object",
                     "format": "code",
                     "required": [
@@ -6344,115 +5976,158 @@
                 }
               },
               {
-                "title": "File Upload",
-                "description": "A file upload in the multipart form",
+                "title": "Bearer Token",
+                "description": "Bearer token authentication (OAuth 2.0)",
                 "type": "object",
                 "required": [
-                  "name",
-                  "source",
+                  "token",
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "MIME type of the file",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "description": "The filename to send in the Content-Disposition header",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the file upload field",
-                    "type": "string"
-                  },
-                  "source": {
-                    "title": "File Source",
-                    "description": "Source of the file data (base64 or file path)",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/BinarySource"
-                      }
-                    ]
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "file"
+                      "bearer"
+                    ]
+                  },
+                  "token": {
+                    "title": "Token",
+                    "description": "The bearer token value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "API Key",
+                "description": "API key authentication in header or query parameter",
+                "type": "object",
+                "required": [
+                  "keyName",
+                  "keyValue",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "apiKey"
+                    ]
+                  },
+                  "keyName": {
+                    "title": "Key Name",
+                    "description": "The name of the API key parameter",
+                    "type": "string"
+                  },
+                  "keyValue": {
+                    "title": "Key Value",
+                    "description": "The API key value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "location": {
+                    "title": "Location",
+                    "description": "Where to include the API key (header or query parameter)",
+                    "default": "header",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/ApiKeyLocation"
+                      }
                     ]
                   }
                 }
               }
             ]
           },
-          "ObservabilityConfig": {
-            "title": "Observability Configuration",
-            "description": "Track additional metrics and diagnostics about HTTP requests",
+          "ApiKeyLocation": {
+            "title": "API Key Location",
+            "description": "Where to include the API key in the request",
+            "oneOf": [
+              {
+                "title": "Header",
+                "description": "Include API key in HTTP header",
+                "type": "string",
+                "enum": [
+                  "header"
+                ]
+              },
+              {
+                "title": "Query Parameter",
+                "description": "Include API key in URL query string",
+                "type": "string",
+                "enum": [
+                  "query"
+                ]
+              }
+            ]
+          },
+          "HeaderParam": {
+            "title": "HTTP Header",
+            "description": "A custom HTTP header to include in the request",
             "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
             "properties": {
-              "bytesAttribute": {
-                "title": "Bytes Attribute",
-                "description": "Feature attribute name to store the response body size",
-                "type": [
-                  "string",
-                  "null"
-                ]
+              "name": {
+                "title": "Header Name",
+                "description": "The name of the HTTP header",
+                "type": "string"
               },
-              "durationAttribute": {
-                "title": "Duration Attribute",
-                "description": "Feature attribute name to store request duration in milliseconds",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "finalUrlAttribute": {
-                "title": "Final URL Attribute",
-                "description": "Feature attribute name to store the final URL after redirects",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "retryCountAttribute": {
-                "title": "Retry Count Attribute",
-                "description": "Feature attribute name to store the number of retry attempts",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "trackBytes": {
-                "title": "Track Bytes",
-                "description": "Whether to track the response body size in bytes (default: false)",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackDuration": {
-                "title": "Track Duration",
-                "description": "Whether to track the total request duration (default: true)",
-                "default": true,
-                "type": "boolean"
-              },
-              "trackFinalUrl": {
-                "title": "Track Final URL",
-                "description": "Whether to track the final URL after redirects (default: false)",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackRetryCount": {
-                "title": "Track Retry Count",
-                "description": "Whether to track the number of retry attempts (default: true)",
-                "default": true,
-                "type": "boolean"
+              "value": {
+                "title": "Header Value",
+                "description": "The value of the header (supports expressions)",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -6494,41 +6169,6 @@
               }
             }
           },
-          "RateLimitConfig": {
-            "title": "Rate Limit Configuration",
-            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
-            "type": "object",
-            "required": [
-              "requests"
-            ],
-            "properties": {
-              "intervalMs": {
-                "title": "Interval",
-                "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
-                "default": 1000,
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "requests": {
-                "title": "Requests",
-                "description": "Maximum number of requests allowed within the interval",
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
-              },
-              "timing": {
-                "title": "Timing Strategy",
-                "description": "How to distribute requests within the interval (default: Burst)",
-                "default": "burst",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/TimingStrategy"
-                  }
-                ]
-              }
-            }
-          },
           "RequestBody": {
             "title": "Request Body",
             "description": "The body content to send with the HTTP request",
@@ -6542,6 +6182,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
                   "content": {
                     "title": "Content",
                     "description": "The text content to send (supports expressions)",
@@ -6571,12 +6217,6 @@
                       "string",
                       "null"
                     ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "text"
-                    ]
                   }
                 }
               },
@@ -6589,12 +6229,10 @@
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
-                    "type": [
-                      "string",
-                      "null"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "binary"
                     ]
                   },
                   "source": {
@@ -6606,10 +6244,12 @@
                       }
                     ]
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "binary"
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
@@ -6623,6 +6263,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "formUrlEncoded"
+                    ]
+                  },
                   "fields": {
                     "title": "Form Fields",
                     "description": "List of form field name-value pairs",
@@ -6630,12 +6276,6 @@
                     "items": {
                       "$ref": "#/definitions/FormField"
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "formUrlEncoded"
-                    ]
                   }
                 }
               },
@@ -6648,6 +6288,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "multipart"
+                    ]
+                  },
                   "parts": {
                     "title": "Parts",
                     "description": "List of multipart form parts (text fields or file uploads)",
@@ -6655,34 +6301,315 @@
                     "items": {
                       "$ref": "#/definitions/MultipartPart"
                     }
-                  },
+                  }
+                }
+              }
+            ]
+          },
+          "BinarySource": {
+            "title": "Binary Source",
+            "description": "Source of binary data for request body",
+            "oneOf": [
+              {
+                "title": "Base64 Encoded",
+                "description": "Binary data encoded as base64 string",
+                "type": "object",
+                "required": [
+                  "data",
+                  "type"
+                ],
+                "properties": {
                   "type": {
                     "type": "string",
                     "enum": [
-                      "multipart"
+                      "base64"
+                    ]
+                  },
+                  "data": {
+                    "title": "Data",
+                    "description": "Base64-encoded binary data (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "From File",
+                "description": "Read binary data from a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path to the file to read (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "FormField": {
+            "title": "Form Field",
+            "description": "A name-value pair for URL-encoded form data",
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "title": "Field Name",
+                "description": "The name of the form field",
+                "type": "string"
+              },
+              "value": {
+                "title": "Field Value",
+                "description": "The value of the form field (supports expressions)",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "MultipartPart": {
+            "title": "Multipart Part",
+            "description": "A part in a multipart/form-data request",
+            "oneOf": [
+              {
+                "title": "Text Field",
+                "description": "A text field in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the form field",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Field Value",
+                    "description": "The value of the form field (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "File Upload",
+                "description": "A file upload in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "source",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the file upload field",
+                    "type": "string"
+                  },
+                  "source": {
+                    "title": "File Source",
+                    "description": "Source of the file data (base64 or file path)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/BinarySource"
+                      }
+                    ]
+                  },
+                  "filename": {
+                    "title": "Filename",
+                    "description": "The filename to send in the Content-Disposition header",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "MIME type of the file",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
               }
             ]
           },
-          "ResponseConfig": {
-            "title": "Response Configuration",
-            "description": "Configure how HTTP response data is stored and processed",
+          "TimeoutConfig": {
+            "title": "Timeout Configuration",
+            "description": "Configure connection and transfer timeouts for HTTP requests",
             "type": "object",
             "properties": {
-              "autoDetectEncoding": {
-                "title": "Auto Detect Encoding",
-                "description": "Automatically detect character encoding from response headers",
+              "connectionTimeout": {
+                "title": "Connection Timeout",
+                "description": "Maximum time in seconds to establish a connection (default: 60)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "transferTimeout": {
+                "title": "Transfer Timeout",
+                "description": "Maximum time in seconds to complete the entire request (default: 90)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          },
+          "HttpOptions": {
+            "title": "HTTP Options",
+            "description": "Configure HTTP client behavior",
+            "type": "object",
+            "properties": {
+              "userAgent": {
+                "title": "User Agent",
+                "description": "Custom User-Agent header value",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifySsl": {
+                "title": "Verify SSL",
+                "description": "Whether to verify SSL/TLS certificates (default: true)",
                 "type": [
                   "boolean",
                   "null"
                 ]
               },
-              "errorAttribute": {
-                "title": "Error Attribute",
-                "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
-                "default": "_http_error",
+              "followRedirects": {
+                "title": "Follow Redirects",
+                "description": "Whether to automatically follow HTTP redirects (default: true)",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "maxRedirects": {
+                "title": "Max Redirects",
+                "description": "Maximum number of redirects to follow (default: 10)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint8",
+                "minimum": 0.0
+              }
+            }
+          },
+          "ResponseConfig": {
+            "title": "Response Configuration",
+            "description": "Configure how HTTP response data is stored and processed",
+            "type": "object",
+            "properties": {
+              "responseBodyAttribute": {
+                "title": "Response Body Attribute",
+                "description": "Feature attribute name to store the response body (default: \"_response_body\")",
+                "default": "_response_body",
+                "type": "string"
+              },
+              "statusCodeAttribute": {
+                "title": "Status Code Attribute",
+                "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
+                "default": "_http_status_code",
                 "type": "string"
               },
               "headersAttribute": {
@@ -6691,33 +6618,11 @@
                 "default": "_headers",
                 "type": "string"
               },
-              "maxResponseSize": {
-                "title": "Max Response Size",
-                "description": "Maximum response body size in bytes (unlimited if not set)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "responseBodyAttribute": {
-                "title": "Response Body Attribute",
-                "description": "Feature attribute name to store the response body (default: \"_response_body\")",
-                "default": "_response_body",
+              "errorAttribute": {
+                "title": "Error Attribute",
+                "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
+                "default": "_http_error",
                 "type": "string"
-              },
-              "responseEncoding": {
-                "title": "Response Encoding",
-                "description": "How to encode the response body (text, base64, or binary)",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/ResponseEncoding"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
               },
               "responseHandling": {
                 "title": "Response Handling",
@@ -6731,13 +6636,114 @@
                   }
                 ]
               },
-              "statusCodeAttribute": {
-                "title": "Status Code Attribute",
-                "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
-                "default": "_http_status_code",
-                "type": "string"
+              "maxResponseSize": {
+                "title": "Max Response Size",
+                "description": "Maximum response body size in bytes (unlimited if not set)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "responseEncoding": {
+                "title": "Response Encoding",
+                "description": "How to encode the response body (text, base64, or binary)",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/ResponseEncoding"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "autoDetectEncoding": {
+                "title": "Auto Detect Encoding",
+                "description": "Automatically detect character encoding from response headers",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             }
+          },
+          "ResponseHandling": {
+            "title": "Response Handling",
+            "description": "How to handle the HTTP response data",
+            "oneOf": [
+              {
+                "title": "Store in Attribute",
+                "description": "Store response body in a feature attribute",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "attribute"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "Save to File",
+                "description": "Save response body to a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path where the response should be saved",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "storePathInAttribute": {
+                    "title": "Store Path in Attribute",
+                    "description": "Whether to store the file path in a feature attribute",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "pathAttribute": {
+                    "title": "Path Attribute Name",
+                    "description": "Attribute name for storing the file path",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           "ResponseEncoding": {
             "title": "Response Encoding",
@@ -6769,100 +6775,18 @@
               }
             ]
           },
-          "ResponseHandling": {
-            "title": "Response Handling",
-            "description": "How to handle the HTTP response data",
-            "oneOf": [
-              {
-                "title": "Store in Attribute",
-                "description": "Store response body in a feature attribute",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "attribute"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "Save to File",
-                "description": "Save response body to a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path where the response should be saved",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "pathAttribute": {
-                    "title": "Path Attribute Name",
-                    "description": "Attribute name for storing the file path",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "storePathInAttribute": {
-                    "title": "Store Path in Attribute",
-                    "description": "Whether to store the file path in a feature attribute",
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
           "RetryConfig": {
             "title": "Retry Configuration",
             "description": "Configure automatic retry behavior for failed requests",
             "type": "object",
             "properties": {
-              "backoffMultiplier": {
-                "title": "Backoff Multiplier",
-                "description": "Multiplier for exponential backoff between retries (default: 2.0)",
-                "default": 2.0,
-                "type": "number",
-                "format": "double"
-              },
-              "honorRetryAfter": {
-                "title": "Honor Retry-After Header",
-                "description": "Whether to respect the Retry-After header from server responses (default: true)",
-                "default": true,
-                "type": "boolean"
+              "maxAttempts": {
+                "title": "Max Attempts",
+                "description": "Maximum number of retry attempts (default: 3)",
+                "default": 3,
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
               },
               "initialDelayMs": {
                 "title": "Initial Delay",
@@ -6872,13 +6796,12 @@
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "maxAttempts": {
-                "title": "Max Attempts",
-                "description": "Maximum number of retry attempts (default: 3)",
-                "default": 3,
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
+              "backoffMultiplier": {
+                "title": "Backoff Multiplier",
+                "description": "Multiplier for exponential backoff between retries (default: 2.0)",
+                "default": 2.0,
+                "type": "number",
+                "format": "double"
               },
               "maxDelayMs": {
                 "title": "Max Delay",
@@ -6900,33 +6823,47 @@
                   "format": "uint16",
                   "minimum": 0.0
                 }
+              },
+              "honorRetryAfter": {
+                "title": "Honor Retry-After Header",
+                "description": "Whether to respect the Retry-After header from server responses (default: true)",
+                "default": true,
+                "type": "boolean"
               }
             }
           },
-          "TimeoutConfig": {
-            "title": "Timeout Configuration",
-            "description": "Configure connection and transfer timeouts for HTTP requests",
+          "RateLimitConfig": {
+            "title": "Rate Limit Configuration",
+            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
             "type": "object",
+            "required": [
+              "requests"
+            ],
             "properties": {
-              "connectionTimeout": {
-                "title": "Connection Timeout",
-                "description": "Maximum time in seconds to establish a connection (default: 60)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+              "requests": {
+                "title": "Requests",
+                "description": "Maximum number of requests allowed within the interval",
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "intervalMs": {
+                "title": "Interval",
+                "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
+                "default": 1000,
+                "type": "integer",
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "transferTimeout": {
-                "title": "Transfer Timeout",
-                "description": "Maximum time in seconds to complete the entire request (default: 90)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
+              "timing": {
+                "title": "Timing Strategy",
+                "description": "How to distribute requests within the interval (default: Burst)",
+                "default": "burst",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/TimingStrategy"
+                  }
+                ]
               }
             }
           },
@@ -6951,6 +6888,69 @@
                 ]
               }
             ]
+          },
+          "ObservabilityConfig": {
+            "title": "Observability Configuration",
+            "description": "Track additional metrics and diagnostics about HTTP requests",
+            "type": "object",
+            "properties": {
+              "trackDuration": {
+                "title": "Track Duration",
+                "description": "Whether to track the total request duration (default: true)",
+                "default": true,
+                "type": "boolean"
+              },
+              "durationAttribute": {
+                "title": "Duration Attribute",
+                "description": "Feature attribute name to store request duration in milliseconds",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackFinalUrl": {
+                "title": "Track Final URL",
+                "description": "Whether to track the final URL after redirects (default: false)",
+                "default": false,
+                "type": "boolean"
+              },
+              "finalUrlAttribute": {
+                "title": "Final URL Attribute",
+                "description": "Feature attribute name to store the final URL after redirects",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackRetryCount": {
+                "title": "Track Retry Count",
+                "description": "Whether to track the number of retry attempts (default: true)",
+                "default": true,
+                "type": "boolean"
+              },
+              "retryCountAttribute": {
+                "title": "Retry Count Attribute",
+                "description": "Feature attribute name to store the number of retry attempts",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackBytes": {
+                "title": "Track Bytes",
+                "description": "Whether to track the response body size in bytes (default: false)",
+                "default": false,
+                "type": "boolean"
+              },
+              "bytesAttribute": {
+                "title": "Bytes Attribute",
+                "description": "Feature attribute name to store the response body size",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
           }
         }
       },
@@ -7120,19 +7120,6 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "onOverlap": {
-            "title": "On Overlap",
-            "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/OnOverlap"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "saveTo": {
             "title": "Save To",
             "description": "Optional path expression to save the generated image. If not provided, uses default cache directory.",
@@ -7158,6 +7145,19 @@
                 "type": "string"
               }
             }
+          },
+          "onOverlap": {
+            "title": "On Overlap",
+            "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/definitions/OnOverlap"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7322,19 +7322,6 @@
               "jsonQuery"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
@@ -7353,10 +7340,23 @@
                 "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
                 "type": "string"
               },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7374,28 +7374,11 @@
               "path"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
                   "fileUrl"
                 ]
-              },
-              "jsonQuery": {
-                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
-                "type": "string"
               },
               "path": {
                 "description": "Expression evaluating to the file path or URL containing JSON",
@@ -7418,10 +7401,27 @@
                   }
                 }
               },
+              "jsonQuery": {
+                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
+                "type": "string"
+              },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7537,6 +7537,27 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "description": "Output path or expression for the JSON file to create",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "converter": {
             "description": "Optional converter expression to transform features before writing",
             "type": [
@@ -7553,27 +7574,6 @@
                 "type": "string",
                 "enum": [
                   "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "output": {
-            "description": "Output path or expression for the JSON file to create",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
                 ]
               },
               "value": {
@@ -7617,16 +7617,16 @@
               "$ref": "#/definitions/Attribute"
             }
           },
+          "tolerance": {
+            "type": "number",
+            "format": "double"
+          },
           "overlaidListsAttrName": {
             "description": "Name of the attribute to store the overlaid lists. Defaults to \"overlaidLists\".",
             "type": [
               "string",
               "null"
             ]
-          },
-          "tolerance": {
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -7665,14 +7665,6 @@
           "separateCharacter"
         ],
         "properties": {
-          "attribute": {
-            "description": "Attribute name to extract from each list element",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "list": {
             "description": "List attribute to read from",
             "allOf": [
@@ -7681,8 +7673,8 @@
               }
             ]
           },
-          "outputAttributeName": {
-            "description": "Name of the attribute to store the concatenated result",
+          "attribute": {
+            "description": "Attribute name to extract from each list element",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -7692,6 +7684,14 @@
           "separateCharacter": {
             "description": "Character(s) to use as separator between concatenated values",
             "type": "string"
+          },
+          "outputAttributeName": {
+            "description": "Name of the attribute to store the concatenated result",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7768,6 +7768,20 @@
           "listIndexToCopy"
         ],
         "properties": {
+          "listAttribute": {
+            "description": "List attribute to read from",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "listIndexToCopy": {
+            "description": "Index of the list element to copy (0-based)",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          },
           "copiedAttributePrefix": {
             "description": "Optional prefix to add to copied attribute names",
             "default": null,
@@ -7783,20 +7797,6 @@
               "string",
               "null"
             ]
-          },
-          "listAttribute": {
-            "description": "List attribute to read from",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "listIndexToCopy": {
-            "description": "Index of the list element to copy (0-based)",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0.0
           }
         },
         "definitions": {
@@ -7833,13 +7833,63 @@
           "output"
         ],
         "properties": {
-          "colonToUnderscore": {
-            "title": "Colon to Underscore",
-            "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
-            "type": [
-              "boolean",
-              "null"
-            ]
+          "output": {
+            "title": "Output",
+            "description": "Output directory path or expression for the generated MVT tiles",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "layerName": {
+            "title": "Layer Name",
+            "description": "Name of the layer within the MVT tiles",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "Minimum Zoom",
+            "description": "Minimum zoom level to generate tiles for",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "Maximum Zoom",
+            "description": "Maximum zoom level to generate tiles for",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
           },
           "compressOutput": {
             "title": "Compress Output",
@@ -7866,6 +7916,22 @@
               }
             }
           },
+          "skipUnexposedAttributes": {
+            "title": "Skip Unexposed Attributes",
+            "description": "Skip attributes with double underscore prefix",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "colonToUnderscore": {
+            "title": "Colon to Underscore",
+            "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "extent": {
             "title": "Extent",
             "description": "MVT tile resolution. Default is 4096.",
@@ -7876,77 +7942,11 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "layerName": {
-            "title": "Layer Name",
-            "description": "Name of the layer within the MVT tiles",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "maxZoom": {
-            "title": "Maximum Zoom",
-            "description": "Maximum zoom level to generate tiles for",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "Minimum Zoom",
-            "description": "Minimum zoom level to generate tiles for",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "Output",
-            "description": "Output directory path or expression for the generated MVT tiles",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "schemaKey": {
             "title": "Schema Key",
             "description": "Attribute key to match data and schema features for attribute filtering and casting. This attribute is excluded from output.",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "Skip Unexposed Attributes",
-            "description": "Skip attributes with double underscore prefix",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -7975,6 +7975,39 @@
         "description": "Configuration for finding spatial neighbors between base and candidate features.",
         "type": "object",
         "properties": {
+          "numClosest": {
+            "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
+            "default": 1,
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1.0
+          },
+          "maxDistance": {
+            "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "distanceAttribute": {
+            "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
+            "default": "_neighbor_distance",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "neighborIndexAttribute": {
+            "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
+            "default": "_neighbor_index",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "attributePrefix": {
             "description": "Prefix applied to transferred candidate attributes to avoid collisions.",
             "default": "_neighbor_",
@@ -7988,12 +8021,12 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "distanceAttribute": {
-            "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
-            "default": "_neighbor_distance",
+          "mergeStrategy": {
+            "description": "Controls how multiple neighbors are represented on the output.",
+            "default": "closest",
             "allOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/definitions/MergeStrategy"
               }
             ]
           },
@@ -8005,70 +8038,11 @@
                 "$ref": "#/definitions/DistanceMetric"
               }
             ]
-          },
-          "maxDistance": {
-            "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
-          "mergeStrategy": {
-            "description": "Controls how multiple neighbors are represented on the output.",
-            "default": "closest",
-            "allOf": [
-              {
-                "$ref": "#/definitions/MergeStrategy"
-              }
-            ]
-          },
-          "neighborIndexAttribute": {
-            "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
-            "default": "_neighbor_index",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "numClosest": {
-            "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
-            "default": 1,
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1.0
           }
         },
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "DistanceMetric": {
-            "description": "Distance metric for computing spatial proximity.",
-            "oneOf": [
-              {
-                "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
-                "type": "string",
-                "enum": [
-                  "euclidean2d"
-                ]
-              },
-              {
-                "description": "3D Euclidean distance using X, Y, and Z coordinates.",
-                "type": "string",
-                "enum": [
-                  "euclidean3d"
-                ]
-              },
-              {
-                "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
-                "type": "string",
-                "enum": [
-                  "haversine"
-                ]
-              }
-            ]
           },
           "MergeStrategy": {
             "description": "Merge strategy for handling multiple neighbors.",
@@ -8092,6 +8066,32 @@
                 "type": "string",
                 "enum": [
                   "arrayAttributes"
+                ]
+              }
+            ]
+          },
+          "DistanceMetric": {
+            "description": "Distance metric for computing spatial proximity.",
+            "oneOf": [
+              {
+                "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
+                "type": "string",
+                "enum": [
+                  "euclidean2d"
+                ]
+              },
+              {
+                "description": "3D Euclidean distance using X, Y, and Z coordinates.",
+                "type": "string",
+                "enum": [
+                  "euclidean3d"
+                ]
+              },
+              {
+                "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
+                "type": "string",
+                "enum": [
+                  "haversine"
                 ]
               }
             ]
@@ -8155,10 +8155,6 @@
         "description": "NullAttributeMapper parameters",
         "type": "object",
         "properties": {
-          "defaultReplacement": {
-            "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
-            "default": null
-          },
           "mappings": {
             "description": "Per-attribute replacement rules",
             "default": [],
@@ -8166,6 +8162,10 @@
             "items": {
               "$ref": "#/definitions/AttributeMapping"
             }
+          },
+          "defaultReplacement": {
+            "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
+            "default": null
           },
           "nullDefinition": {
             "description": "Which states count as \"null\"",
@@ -8205,6 +8205,9 @@
                 "description": "Name of the attribute to inspect",
                 "type": "string"
               },
+              "replacement": {
+                "description": "Value to write when attribute is null-like null means remove the attribute"
+              },
               "onMissing": {
                 "description": "What to do when attribute is missing but not in nullDefinition",
                 "default": "skip",
@@ -8213,11 +8216,27 @@
                     "$ref": "#/definitions/OnMissing"
                   }
                 ]
-              },
-              "replacement": {
-                "description": "Value to write when attribute is null-like null means remove the attribute"
               }
             }
+          },
+          "OnMissing": {
+            "description": "What to do when attribute is missing but not in nullDefinition",
+            "oneOf": [
+              {
+                "description": "Leave unchanged",
+                "type": "string",
+                "enum": [
+                  "skip"
+                ]
+              },
+              {
+                "description": "Write replacement value, creating the attribute",
+                "type": "string",
+                "enum": [
+                  "create"
+                ]
+              }
+            ]
           },
           "NullKind": {
             "description": "Defines what states count as \"null\"",
@@ -8241,25 +8260,6 @@
                 "type": "string",
                 "enum": [
                   "emptyString"
-                ]
-              }
-            ]
-          },
-          "OnMissing": {
-            "description": "What to do when attribute is missing but not in nullDefinition",
-            "oneOf": [
-              {
-                "description": "Leave unchanged",
-                "type": "string",
-                "enum": [
-                  "skip"
-                ]
-              },
-              {
-                "description": "Write replacement value, creating the attribute",
-                "type": "string",
-                "enum": [
-                  "create"
                 ]
               }
             ]
@@ -8311,67 +8311,11 @@
         "description": "Configuration for reading Wavefront OBJ 3D model files with support for vertices, faces, normals, texture coordinates, and material definitions.",
         "type": "object",
         "properties": {
-          "dataset": {
-            "title": "File Path",
-            "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "includeNormals": {
-            "title": "Include Normals",
-            "description": "Include vertex normal data in the output geometry",
+          "parseMaterials": {
+            "title": "Parse Materials",
+            "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
             "default": true,
             "type": "boolean"
-          },
-          "includeTexcoords": {
-            "title": "Include Texture Coordinates",
-            "description": "Include texture coordinate (UV) data in the output geometry",
-            "default": true,
-            "type": "boolean"
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "materialFile": {
             "title": "Material File",
@@ -8399,23 +8343,79 @@
               }
             }
           },
+          "triangulate": {
+            "title": "Triangulate",
+            "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
+            "default": false,
+            "type": "boolean"
+          },
           "mergeGroups": {
             "title": "Merge Groups",
             "description": "Merge all groups and objects into a single feature instead of creating separate features per group/object",
             "default": false,
             "type": "boolean"
           },
-          "parseMaterials": {
-            "title": "Parse Materials",
-            "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
+          "includeNormals": {
+            "title": "Include Normals",
+            "description": "Include vertex normal data in the output geometry",
             "default": true,
             "type": "boolean"
           },
-          "triangulate": {
-            "title": "Triangulate",
-            "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
-            "default": false,
+          "includeTexcoords": {
+            "title": "Include Texture Coordinates",
+            "description": "Include texture coordinate (UV) data in the output geometry",
+            "default": true,
             "type": "boolean"
+          },
+          "dataset": {
+            "title": "File Path",
+            "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -8807,15 +8807,24 @@
         "title": "XmlAttributeExtractorParam",
         "type": "object",
         "properties": {
-          "addNsprefixToFeatureTypes": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "cityCode": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "targetPackages": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "addNsprefixToFeatureTypes": {
+            "type": [
+              "boolean",
               "null"
             ]
           },
@@ -8839,15 +8848,6 @@
               "string",
               "null"
             ]
-          },
-          "targetPackages": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
           }
         }
       },
@@ -8931,10 +8931,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "File Index Attribute",
-            "description": "Attribute containing the file index (default: \"fileIndex\")",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "Part ID Attribute",
+            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -8951,10 +8951,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "Part ID Attribute",
-            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "File Index Attribute",
+            "description": "Attribute containing the file index (default: \"fileIndex\")",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -9092,6 +9092,16 @@
           "epsgCode"
         ],
         "properties": {
+          "errorAttribute": {
+            "title": "Error Attribute Name",
+            "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
+            "default": "_validation_error",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "epsgCode": {
             "title": "Target EPSG Code",
             "description": "EPSG code for coordinate transformation from source EPSG 6697. Accepts integer or string expression.",
@@ -9112,16 +9122,6 @@
                 "type": "string"
               }
             }
-          },
-          "errorAttribute": {
-            "title": "Error Attribute Name",
-            "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
-            "default": "_validation_error",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
           }
         },
         "definitions": {
@@ -9178,6 +9178,20 @@
         "description": "Configure mesh code extraction for Japanese standard regional mesh",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "Mesh Type",
+            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "Mesh Code Attribute Name",
+            "description": "Output attribute name for the mesh code",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG Code",
             "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -9202,20 +9216,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "Mesh Type",
-            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "Mesh Code Attribute Name",
-            "description": "Output attribute name for the mesh code",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -9333,17 +9333,6 @@
         "description": "Configuration for generating TIN surfaces from flood area polygons. This processor converts polygons to triangulated surfaces by: 1. Optionally grouping features by an attribute (e.g., udxDirs) 2. Combining all polygons in each group 3. Sampling points along polygon boundaries at regular intervals 4. Optionally adding interior grid points within polygons 5. Performing Delaunay triangulation to create a TIN surface 6. Filtering triangles to keep only those inside the original polygons",
         "type": "object",
         "properties": {
-          "groupBy": {
-            "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "pointSpacing": {
             "description": "Spacing between sampled points in meters (default: 50.0). Points are sampled along polygon boundaries and optionally on an interior grid at this spacing interval.",
             "type": [
@@ -9358,6 +9347,17 @@
             "type": [
               "boolean",
               "null"
+            ]
+          },
+          "groupBy": {
+            "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -9556,21 +9556,6 @@
           "outputDir"
         ],
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "measurements": {
-            "description": "Measurement definitions to insert as gen:measureAttribute elements",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/MeasurementDef"
-            }
-          },
           "outputDir": {
             "description": "Output directory expression for modified CityGML files",
             "type": "object",
@@ -9592,6 +9577,14 @@
               }
             }
           },
+          "gmlIdAttribute": {
+            "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "pathAttribute": {
             "description": "Attribute name on path features holding the file path (default: \"path\")",
             "default": null,
@@ -9600,28 +9593,11 @@
               "null"
             ]
           },
-          "sourceEpsg": {
-            "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
-            "default": null,
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
+          "measurements": {
+            "description": "Measurement definitions to insert as gen:measureAttribute elements",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MeasurementDef"
             }
           },
           "textureImagePath": {
@@ -9648,6 +9624,30 @@
                 "type": "string"
               }
             }
+          },
+          "sourceEpsg": {
+            "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
+            "default": null,
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         },
         "definitions": {
@@ -9660,12 +9660,12 @@
               "uom"
             ],
             "properties": {
-              "attribute": {
-                "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
-                "type": "string"
-              },
               "name": {
                 "description": "XML name attribute value (e.g. \"年間予測日射量\")",
+                "type": "string"
+              },
+              "attribute": {
+                "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
                 "type": "string"
               },
               "uom": {
@@ -9706,63 +9706,11 @@
               "type"
             ],
             "properties": {
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
+              "type": {
+                "type": "string",
+                "enum": [
+                  "time"
                 ]
-              },
-              "sourceEpsg": {
-                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "standardMeridian": {
-                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
-                "default": null,
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
               },
               "time": {
                 "description": "Time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
@@ -9785,60 +9733,6 @@
                   }
                 }
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "time"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "end",
-              "sourceEpsg",
-              "start",
-              "step",
-              "stepUnit",
-              "type"
-            ],
-            "properties": {
-              "end": {
-                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
-                ]
-              },
               "sourceEpsg": {
                 "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
                 "type": "object",
@@ -9883,8 +9777,62 @@
                   }
                 }
               },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
+                ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "end",
+              "sourceEpsg",
+              "start",
+              "step",
+              "stepUnit",
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "duration"
+                ]
+              },
               "start": {
                 "description": "Start time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "end": {
+                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
                 "type": "object",
                 "format": "code",
                 "required": [
@@ -9932,11 +9880,63 @@
                   }
                 ]
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "duration"
+              "sourceEpsg": {
+                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "standardMeridian": {
+                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
+                "default": null,
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
                 ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
               }
             }
           }
@@ -10001,9 +10001,9 @@
         "title": "SolidIntersectionTestPairCreatorParam",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10011,9 +10011,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10180,6 +10180,12 @@
         "description": "Configure unshared edge detection behavior",
         "type": "object",
         "properties": {
+          "tolerance": {
+            "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          },
           "groupBy": {
             "description": "Group By Attributes. When specified, edge detection is performed independently within each group. Features with the same values for these attributes are grouped together.",
             "default": null,
@@ -10190,12 +10196,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "tolerance": {
-            "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
-            "default": 0.1,
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -10236,10 +10236,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "File Index Attribute",
-            "description": "Attribute containing the file index (default: \"fileIndex\")",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "Part ID Attribute",
+            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10256,10 +10256,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "Part ID Attribute",
-            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "File Index Attribute",
+            "description": "Attribute containing the file index (default: \"fileIndex\")",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10345,6 +10345,20 @@
         "description": "Configure mesh code extraction for Japanese standard regional mesh",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "Mesh Type",
+            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "Mesh Code Attribute Name",
+            "description": "Output attribute name for the mesh code",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG Code",
             "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -10369,20 +10383,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "Mesh Type",
-            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "Mesh Code Attribute Name",
-            "description": "Output attribute name for the mesh code",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -10532,9 +10532,9 @@
         "title": "SolidIntersectionTestPairCreatorParam",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10542,9 +10542,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10763,6 +10763,31 @@
         "title": "PythonScriptProcessorParam",
         "type": "object",
         "properties": {
+          "script": {
+            "title": "Inline Script",
+            "description": "Python script code to execute inline",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "pythonFile": {
             "title": "Python File",
             "description": "Path to a Python script file (supports file://, http://, https://, gs://, etc.)",
@@ -10795,31 +10820,6 @@
               "string",
               "null"
             ]
-          },
-          "script": {
-            "title": "Inline Script",
-            "description": "Python script code to execute inline",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "timeoutSeconds": {
             "title": "Timeout Seconds",
@@ -10860,6 +10860,34 @@
           "ray"
         ],
         "properties": {
+          "ray": {
+            "description": "Defines how to extract ray data from feature attributes",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RayDefinition"
+              }
+            ]
+          },
+          "pairId": {
+            "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "closestIntersectionOnly": {
             "description": "When true (default), return only the closest intersection point per ray-geometry pair. When false, return all intersection points.",
             "default": null,
@@ -10884,8 +10912,8 @@
               }
             }
           },
-          "geomId": {
-            "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
+          "tolerance": {
+            "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
             "default": null,
             "type": [
               "object",
@@ -10941,36 +10969,8 @@
               }
             ]
           },
-          "pairId": {
-            "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "ray": {
-            "description": "Defines how to extract ray data from feature attributes",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RayDefinition"
-              }
-            ]
-          },
-          "tolerance": {
-            "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
+          "geomId": {
+            "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
             "default": null,
             "type": [
               "object",
@@ -10995,28 +10995,6 @@
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "OutputGeometryType": {
-            "description": "Output geometry type for ray intersection results",
-            "oneOf": [
-              {
-                "description": "Output a point at the intersection location (default behavior)",
-                "type": "string",
-                "enum": [
-                  "pointOfIntersection"
-                ]
-              },
-              {
-                "description": "Output a line segment from ray origin to intersection point",
-                "type": "string",
-                "enum": [
-                  "lineSegmentToIntersection"
-                ]
-              }
-            ]
-          },
           "RayDefinition": {
             "description": "Defines how ray data is extracted from feature attributes.",
             "type": "object",
@@ -11029,30 +11007,6 @@
               "posZ"
             ],
             "properties": {
-              "dirX": {
-                "description": "Attribute containing ray direction X component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirY": {
-                "description": "Attribute containing ray direction Y component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirZ": {
-                "description": "Attribute containing ray direction Z component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
               "posX": {
                 "description": "Attribute containing ray origin X coordinate",
                 "allOf": [
@@ -11076,8 +11030,54 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "dirX": {
+                "description": "Attribute containing ray direction X component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirY": {
+                "description": "Attribute containing ray direction Y component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirZ": {
+                "description": "Attribute containing ray direction Z component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "OutputGeometryType": {
+            "description": "Output geometry type for ray intersection results",
+            "oneOf": [
+              {
+                "description": "Output a point at the intersection location (default behavior)",
+                "type": "string",
+                "enum": [
+                  "pointOfIntersection"
+                ]
+              },
+              {
+                "description": "Output a line segment from ray origin to intersection point",
+                "type": "string",
+                "enum": [
+                  "lineSegmentToIntersection"
+                ]
+              }
+            ]
           }
         }
       },
@@ -11160,6 +11160,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fromToVectors"
+                    ]
+                  },
                   "fromX": {
                     "description": "X component of the source direction vector",
                     "type": "object",
@@ -11279,12 +11285,6 @@
                         "type": "string"
                       }
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "fromToVectors"
-                    ]
                   }
                 }
               },
@@ -11299,25 +11299,11 @@
                   "type"
                 ],
                 "properties": {
-                  "angle": {
-                    "description": "Rotation angle in degrees",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "axisAngle"
+                    ]
                   },
                   "axisX": {
                     "description": "X component of the rotation axis",
@@ -11379,11 +11365,25 @@
                       }
                     }
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "axisAngle"
-                    ]
+                  "angle": {
+                    "description": "Rotation angle in degrees",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -11414,6 +11414,20 @@
         "description": "Configuration for reading Shapefile archives as geographic features. Expects a ZIP archive containing the required Shapefile components (.shp, .dbf, .shx).",
         "type": "object",
         "properties": {
+          "encoding": {
+            "title": "Character Encoding",
+            "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "force2d": {
+            "title": "Force 2D",
+            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+            "default": false,
+            "type": "boolean"
+          },
           "allowEmptyPath": {
             "title": "Allow Null Path",
             "description": "If true, a dataset expression that evaluates to null produces zero features instead of an error. This is useful for optional shapefile inputs where the path may not be configured.",
@@ -11444,20 +11458,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "Character Encoding",
-            "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "force2d": {
-            "title": "Force 2D",
-            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-            "default": false,
-            "type": "boolean"
           },
           "inline": {
             "title": "Inline Content",
@@ -11511,16 +11511,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "Optional attributes to group features by, creating separate files for each group",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "Output path or expression for the Shapefile to create",
             "type": "object",
@@ -11540,6 +11530,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "Optional attributes to group features by, creating separate files for each group",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -11621,20 +11621,21 @@
         "description": "Configure spatial relationship testing between filter and candidate geometries",
         "type": "object",
         "properties": {
-          "mergeFilterAttributes": {
-            "title": "Merge Filter Attributes",
-            "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
-            "default": false,
-            "type": "boolean"
-          },
-          "mergedAttributesPrefix": {
-            "title": "Merged Attributes Prefix",
-            "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
-            "default": null,
-            "type": [
-              "string",
-              "null"
+          "predicate": {
+            "title": "Spatial Predicate",
+            "description": "The spatial relationship to test between filter and candidate geometries",
+            "default": "intersects",
+            "allOf": [
+              {
+                "$ref": "#/definitions/SpatialPredicate"
+              }
             ]
+          },
+          "passOnMultipleMatches": {
+            "title": "Pass on Multiple Matches",
+            "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
+            "default": true,
+            "type": "boolean"
           },
           "outputMatchCountAttribute": {
             "title": "Output Match Count Attribute",
@@ -11649,27 +11650,23 @@
               }
             ]
           },
-          "passOnMultipleMatches": {
-            "title": "Pass on Multiple Matches",
-            "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
-            "default": true,
+          "mergeFilterAttributes": {
+            "title": "Merge Filter Attributes",
+            "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
+            "default": false,
             "type": "boolean"
           },
-          "predicate": {
-            "title": "Spatial Predicate",
-            "description": "The spatial relationship to test between filter and candidate geometries",
-            "default": "intersects",
-            "allOf": [
-              {
-                "$ref": "#/definitions/SpatialPredicate"
-              }
+          "mergedAttributesPrefix": {
+            "title": "Merged Attributes Prefix",
+            "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "SpatialPredicate": {
             "oneOf": [
               {
@@ -11736,6 +11733,9 @@
                 ]
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -11768,9 +11768,9 @@
           "sql"
         ],
         "properties": {
-          "databaseUrl": {
-            "title": "Database URL",
-            "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
+          "sql": {
+            "title": "SQL Query",
+            "description": "SQL query expression to execute for retrieving data",
             "type": "object",
             "format": "code",
             "required": [
@@ -11790,9 +11790,9 @@
               }
             }
           },
-          "sql": {
-            "title": "SQL Query",
-            "description": "SQL query expression to execute for retrieving data",
+          "databaseUrl": {
+            "title": "Database URL",
+            "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
             "type": "object",
             "format": "code",
             "required": [
@@ -11839,13 +11839,17 @@
           "calculations"
         ],
         "properties": {
-          "calculations": {
-            "title": "Calculations",
-            "description": "List of statistical calculations to perform on grouped features",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/Calculation"
-            }
+          "groupId": {
+            "title": "Group id",
+            "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "groupBy": {
             "title": "Group by",
@@ -11858,17 +11862,13 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "groupId": {
-            "title": "Group id",
-            "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
+          "calculations": {
+            "title": "Calculations",
+            "description": "List of statistical calculations to perform on grouped features",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Calculation"
+            }
           }
         },
         "definitions": {
@@ -11882,6 +11882,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "New attribute name",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "expr": {
                 "title": "Calculation to perform",
                 "type": "object",
@@ -11901,14 +11909,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "New attribute name",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           }
@@ -11948,33 +11948,6 @@
           "minZ"
         ],
         "properties": {
-          "maxX": {
-            "title": "Maximum X Attribute",
-            "description": "Name of attribute containing the maximum X coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxY": {
-            "title": "Maximum Y Attribute",
-            "description": "Name of attribute containing the maximum Y coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxZ": {
-            "title": "Maximum Z Attribute",
-            "description": "Name of attribute containing the maximum Z coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "minX": {
             "title": "Minimum X Attribute",
             "description": "Name of attribute containing the minimum X coordinate",
@@ -11996,6 +11969,33 @@
           "minZ": {
             "title": "Minimum Z Attribute",
             "description": "Name of attribute containing the minimum Z coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxX": {
+            "title": "Maximum X Attribute",
+            "description": "Name of attribute containing the maximum X coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxY": {
+            "title": "Maximum Y Attribute",
+            "description": "Name of attribute containing the maximum Y coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxZ": {
+            "title": "Maximum Z Attribute",
+            "description": "Name of attribute containing the maximum Z coordinate",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -12135,69 +12135,6 @@
               }
             }
           },
-          "directionX": {
-            "title": "Direction X",
-            "description": "X component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionY": {
-            "title": "Direction Y",
-            "description": "Y component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionZ": {
-            "title": "Direction Z",
-            "description": "Z component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "originX": {
             "title": "Origin X",
             "description": "X coordinate of the rotation origin point",
@@ -12243,6 +12180,69 @@
           "originZ": {
             "title": "Origin Z",
             "description": "Z coordinate of the rotation origin point",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionX": {
+            "title": "Direction X",
+            "description": "X component of the rotation axis direction vector",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionY": {
+            "title": "Direction Y",
+            "description": "Y component of the rotation axis direction vector",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionZ": {
+            "title": "Direction Z",
+            "description": "Z component of the rotation axis direction vector",
             "type": "object",
             "format": "code",
             "required": [
@@ -12419,27 +12419,11 @@
               "source"
             ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
-              },
-              "elementsToExclude": {
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "source": {
+                "type": "string",
+                "enum": [
+                  "url"
+                ]
               },
               "elementsToMatch": {
                 "type": "object",
@@ -12460,11 +12444,27 @@
                   }
                 }
               },
-              "source": {
-                "type": "string",
-                "enum": [
-                  "url"
-                ]
+              "elementsToExclude": {
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               }
             }
           }
@@ -12517,19 +12517,19 @@
           "Attribute": {
             "type": "string"
           },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          },
           "ValidationType": {
             "type": "string",
             "enum": [
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }

--- a/engine/schema/actions_en.json
+++ b/engine/schema/actions_en.json
@@ -39,12 +39,6 @@
               }
             ]
           },
-          "multiplier": {
-            "description": "Multiplier to scale the area values (default: 1.0)",
-            "default": 1.0,
-            "type": "number",
-            "format": "double"
-          },
           "outputAttribute": {
             "description": "Name of the attribute to store the calculated area (default: \"area\")",
             "default": "area",
@@ -53,6 +47,12 @@
                 "$ref": "#/definitions/Attribute"
               }
             ]
+          },
+          "multiplier": {
+            "description": "Multiplier to scale the area values (default: 1.0)",
+            "default": 1.0,
+            "type": "number",
+            "format": "double"
           }
         },
         "definitions": {
@@ -93,6 +93,17 @@
         "description": "Configure how area overlay analysis is performed",
         "type": "object",
         "properties": {
+          "groupBy": {
+            "title": "Group By Attributes",
+            "description": "Optional attributes to group features by during overlay analysis",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "accumulationMode": {
             "title": "Accumulation Mode",
             "description": "Controls how attributes from input features are handled in output features",
@@ -110,17 +121,6 @@
               "string",
               "null"
             ]
-          },
-          "groupBy": {
-            "title": "Group By Attributes",
-            "description": "Optional attributes to group features by during overlay analysis",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
           },
           "outputAttribute": {
             "title": "Output Attribute",
@@ -141,15 +141,15 @@
           }
         },
         "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
           "AccumulationMode": {
             "type": "string",
             "enum": [
               "useAttributesFromOneFeature",
               "dropIncomingAttributes"
             ]
-          },
-          "Attribute": {
-            "type": "string"
           }
         }
       },
@@ -212,14 +212,6 @@
               }
             }
           },
-          "calculationAttribute": {
-            "title": "Attribute to store calculation result",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "calculationValue": {
             "title": "Value to use for calculation",
             "type": [
@@ -227,6 +219,14 @@
               "null"
             ],
             "format": "int64"
+          },
+          "calculationAttribute": {
+            "title": "Attribute to store calculation result",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           },
           "method": {
             "title": "Method to use for aggregation",
@@ -244,6 +244,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "New attribute to create",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "attribute": {
                 "title": "Existing attribute to use",
                 "anyOf": [
@@ -277,14 +285,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "New attribute to create",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           },
@@ -388,6 +388,14 @@
           "rules"
         ],
         "properties": {
+          "rules": {
+            "title": "Conversion Rules",
+            "description": "List of rules defining how to map attributes using the conversion table",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AttributeConversionTableRule"
+            }
+          },
           "dataset": {
             "title": "Dataset URI",
             "description": "Path or URI to external conversion table file",
@@ -413,15 +421,6 @@
               }
             }
           },
-          "format": {
-            "title": "Table Format",
-            "description": "Format of the conversion table (CSV, TSV, or JSON)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/ConversionTableFormat"
-              }
-            ]
-          },
           "inline": {
             "title": "Inline Table Data",
             "description": "Conversion table data provided directly as string content",
@@ -430,19 +429,17 @@
               "null"
             ]
           },
-          "rules": {
-            "title": "Conversion Rules",
-            "description": "List of rules defining how to map attributes using the conversion table",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/AttributeConversionTableRule"
-            }
+          "format": {
+            "title": "Table Format",
+            "description": "Format of the conversion table (CSV, TSV, or JSON)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/ConversionTableFormat"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "AttributeConversionTableRule": {
             "type": "object",
             "required": [
@@ -452,17 +449,6 @@
               "featureTo"
             ],
             "properties": {
-              "conversionTableKeys": {
-                "title": "Keys to match in conversion table",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "conversionTableTo": {
-                "title": "Attribute to convert to",
-                "type": "string"
-              },
               "featureFroms": {
                 "title": "Attributes to convert from",
                 "type": "array",
@@ -477,8 +463,22 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "conversionTableKeys": {
+                "title": "Keys to match in conversion table",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "conversionTableTo": {
+                "title": "Attribute to convert to",
+                "type": "string"
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
           },
           "ConversionTableFormat": {
             "type": "string",
@@ -647,15 +647,6 @@
           }
         },
         "definitions": {
-          "Method": {
-            "type": "string",
-            "enum": [
-              "convert",
-              "create",
-              "rename",
-              "remove"
-            ]
-          },
           "Operation": {
             "type": "object",
             "required": [
@@ -701,6 +692,15 @@
                 }
               }
             }
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "convert",
+              "create",
+              "rename",
+              "remove"
+            ]
           }
         }
       },
@@ -748,13 +748,6 @@
                   "null"
                 ]
               },
-              "childAttribute": {
-                "title": "Child attribute name",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
               "expr": {
                 "title": "Expression to evaluate",
                 "type": [
@@ -779,6 +772,27 @@
                   }
                 }
               },
+              "valueAttribute": {
+                "title": "Attribute name to get value from",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
+                "title": "Parent attribute name",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "childAttribute": {
+                "title": "Child attribute name",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "multipleExpr": {
                 "title": "Expression to evaluate multiple attributes",
                 "type": [
@@ -801,20 +815,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "parentAttribute": {
-                "title": "Parent attribute name",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "title": "Attribute name to get value from",
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
           }
@@ -848,10 +848,6 @@
           "rangeTable"
         ],
         "properties": {
-          "defaultValue": {
-            "title": "Default Value",
-            "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
-          },
           "inputAttribute": {
             "title": "Input Attribute",
             "description": "The attribute to evaluate for range mapping",
@@ -869,6 +865,10 @@
             "items": {
               "$ref": "#/definitions/RangeEntry"
             }
+          },
+          "defaultValue": {
+            "title": "Default Value",
+            "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
           }
         },
         "definitions": {
@@ -887,15 +887,15 @@
                 "type": "number",
                 "format": "double"
               },
-              "outputValue": {
-                "title": "Output Value",
-                "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
-              },
               "to": {
                 "title": "To (Maximum)",
                 "description": "The maximum value of the range (exclusive)",
                 "type": "number",
                 "format": "double"
+              },
+              "outputValue": {
+                "title": "Output Value",
+                "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
               }
             }
           }
@@ -923,13 +923,13 @@
         "description": "Configuration for extracting boundaries from geometries.",
         "type": "object",
         "properties": {
-          "exteriorOnly": {
-            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
+          "keepEmptyBoundaries": {
+            "description": "Whether to keep features with empty boundaries (default: false)",
             "default": false,
             "type": "boolean"
           },
-          "keepEmptyBoundaries": {
-            "description": "Whether to keep features with empty boundaries (default: false)",
+          "exteriorOnly": {
+            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
             "default": false,
             "type": "boolean"
           }
@@ -956,18 +956,6 @@
         "title": "BoundsExtractor Parameters",
         "type": "object",
         "properties": {
-          "xmax": {
-            "title": "Maximum X Attribute",
-            "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "xmin": {
             "title": "Minimum X Attribute",
             "description": "Attribute name for storing the minimum X coordinate (defaults to \"xmin\")",
@@ -980,9 +968,9 @@
               }
             ]
           },
-          "ymax": {
-            "title": "Maximum Y Attribute",
-            "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
+          "xmax": {
+            "title": "Maximum X Attribute",
+            "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1004,9 +992,9 @@
               }
             ]
           },
-          "zmax": {
-            "title": "Maximum Z Attribute",
-            "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
+          "ymax": {
+            "title": "Maximum Y Attribute",
+            "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1019,6 +1007,18 @@
           "zmin": {
             "title": "Minimum Z Attribute",
             "description": "Attribute name for storing the minimum Z coordinate (defaults to \"zmin\")",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "zmax": {
+            "title": "Maximum Z Attribute",
+            "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1130,6 +1130,15 @@
           "renameValue"
         ],
         "properties": {
+          "renameType": {
+            "title": "Which Attributes to Rename",
+            "description": "Choose whether to rename all attributes or only selected ones",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RenameType"
+              }
+            ]
+          },
           "renameAction": {
             "title": "Rename Operation",
             "description": "The type of renaming operation to perform on the attribute names",
@@ -1139,13 +1148,12 @@
               }
             ]
           },
-          "renameType": {
-            "title": "Which Attributes to Rename",
-            "description": "Choose whether to rename all attributes or only selected ones",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RenameType"
-              }
+          "textToFind": {
+            "title": "Text Pattern to Find",
+            "description": "Regular expression pattern to match when using \"Replace Text\" operation",
+            "type": [
+              "string",
+              "null"
             ]
           },
           "renameValue": {
@@ -1163,17 +1171,29 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "title": "Text Pattern to Find",
-            "description": "Regular expression pattern to match when using \"Replace Text\" operation",
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
         "definitions": {
+          "RenameType": {
+            "oneOf": [
+              {
+                "title": "All Attributes",
+                "description": "Rename all attributes in the feature",
+                "type": "string",
+                "enum": [
+                  "All"
+                ]
+              },
+              {
+                "title": "Selected Attributes",
+                "description": "Rename only specific attributes listed below",
+                "type": "string",
+                "enum": [
+                  "Selected"
+                ]
+              }
+            ]
+          },
           "RenameAction": {
             "oneOf": [
               {
@@ -1217,26 +1237,6 @@
                 ]
               }
             ]
-          },
-          "RenameType": {
-            "oneOf": [
-              {
-                "title": "All Attributes",
-                "description": "Rename all attributes in the feature",
-                "type": "string",
-                "enum": [
-                  "All"
-                ]
-              },
-              {
-                "title": "Selected Attributes",
-                "description": "Rename only specific attributes listed below",
-                "type": "string",
-                "enum": [
-                  "Selected"
-                ]
-              }
-            ]
           }
         }
       },
@@ -1262,22 +1262,6 @@
         "description": "Configure how the CSG builder pairs features from left and right ports",
         "type": "object",
         "properties": {
-          "createList": {
-            "title": "Create List",
-            "description": "When enabled, creates a list of attribute values from both children (left and right)",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "listAttributeName": {
-            "title": "List Attribute Name",
-            "description": "Name of the attribute to create the list from (required when create_list is true)",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "pairIdAttribute": {
             "title": "Pair ID Attribute",
             "description": "Expression to evaluate the pair ID used to match features from left and right ports",
@@ -1301,6 +1285,22 @@
                 "type": "string"
               }
             }
+          },
+          "createList": {
+            "title": "Create List",
+            "description": "When enabled, creates a list of attribute values from both children (left and right)",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "listAttributeName": {
+            "title": "List Attribute Name",
+            "description": "Name of the attribute to create the list from (required when create_list is true)",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -1445,6 +1445,42 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "title": "Output Path",
+            "description": "Directory path where the 3D tiles will be written",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "Minimum Zoom Level",
+            "description": "Minimum zoom level for tile generation (0-24)",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "Maximum Zoom Level",
+            "description": "Maximum zoom level for tile generation (0-24)",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
           "attachTexture": {
             "title": "Attach Textures",
             "description": "Whether to include texture information in the generated tiles",
@@ -1486,55 +1522,19 @@
               "null"
             ]
           },
-          "maxZoom": {
-            "title": "Maximum Zoom Level",
-            "description": "Maximum zoom level for tile generation (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "Minimum Zoom Level",
-            "description": "Minimum zoom level for tile generation (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "Output Path",
-            "description": "Directory path where the 3D tiles will be written",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
+          "skipUnexposedAttributes": {
+            "title": "Skip unexposed Attributes",
+            "description": "Skip attributes with double underscore prefix",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "title": "Schema Key",
             "description": "Attribute key whose value identifies the schema type and determines the output filename: all features sharing the same value are written to the same file. This attribute is excluded from output.",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "Skip unexposed Attributes",
-            "description": "Skip attributes with double underscore prefix",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -1589,12 +1589,6 @@
               }
             }
           },
-          "flatten": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -1619,6 +1613,12 @@
                 "type": "string"
               }
             }
+          },
+          "flatten": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         }
       },
@@ -1647,29 +1647,6 @@
           "output"
         ],
         "properties": {
-          "epsgCode": {
-            "description": "EPSG code for coordinate reference system",
-            "default": null,
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "lodFilter": {
-            "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-            "default": null,
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          },
           "output": {
             "description": "Output file path expression",
             "type": "object",
@@ -1690,6 +1667,29 @@
                 "type": "string"
               }
             }
+          },
+          "lodFilter": {
+            "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+            "default": null,
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "epsgCode": {
+            "description": "EPSG code for coordinate reference system",
+            "default": null,
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
           },
           "prettyPrint": {
             "description": "Whether to format output with indentation (default: true)",
@@ -1807,15 +1807,6 @@
           "mode"
         ],
         "properties": {
-          "defaultZValue": {
-            "title": "Default Z Value",
-            "description": "Z value to use for 2D geometries that have no Z coordinate.",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
           "mode": {
             "title": "Extraction Mode",
             "description": "How to extract coordinates from geometry vertices.",
@@ -1824,12 +1815,18 @@
                 "$ref": "#/definitions/CoordinateExtractionMode"
               }
             ]
+          },
+          "defaultZValue": {
+            "title": "Default Z Value",
+            "description": "Z value to use for 2D geometries that have no Z coordinate.",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "CoordinateExtractionMode": {
             "description": "Extraction mode: determines how coordinates are output.",
             "oneOf": [
@@ -1840,6 +1837,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "allCoordinates"
+                    ]
+                  },
                   "coordinatesListName": {
                     "title": "Coordinates List Name",
                     "description": "Name of the list attribute that will store coordinate objects (default: \"_indices\")",
@@ -1848,12 +1851,6 @@
                       {
                         "$ref": "#/definitions/Attribute"
                       }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "allCoordinates"
                     ]
                   }
                 }
@@ -1866,17 +1863,17 @@
                   "type"
                 ],
                 "properties": {
-                  "coordinateIndex": {
-                    "title": "Coordinate Index",
-                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
-                    "type": "integer",
-                    "format": "int64"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
                       "specifyCoordinate"
                     ]
+                  },
+                  "coordinateIndex": {
+                    "title": "Coordinate Index",
+                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "xAttribute": {
                     "title": "X Attribute Name",
@@ -1911,6 +1908,9 @@
                 }
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -1940,6 +1940,23 @@
           "format"
         ],
         "properties": {
+          "format": {
+            "title": "File Format",
+            "description": "Choose the delimiter format for the input file",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "encoding": {
+            "title": "Character Encoding",
+            "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -1964,45 +1981,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "Character Encoding",
-            "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "format": {
-            "title": "File Format",
-            "description": "Choose the delimiter format for the input file",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "Geometry Configuration",
-            "description": "Optional configuration for parsing geometry from CSV columns",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "headerRows": {
-            "title": "Header Row Count",
-            "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint",
-            "minimum": 0.0
           },
           "inline": {
             "title": "Inline Content",
@@ -2038,6 +2016,28 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "headerRows": {
+            "title": "Header Row Count",
+            "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint",
+            "minimum": 0.0
+          },
+          "geometry": {
+            "title": "Geometry Configuration",
+            "description": "Optional configuration for parsing geometry from CSV columns",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2152,26 +2152,6 @@
           "output"
         ],
         "properties": {
-          "format": {
-            "description": "File format: csv (comma) or tsv (tab)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "Geometry Configuration",
-            "description": "Optional configuration for exporting geometry to CSV columns",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryExportConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "output": {
             "description": "Output path or expression for the CSV/TSV file to create",
             "type": "object",
@@ -2192,6 +2172,26 @@
                 "type": "string"
               }
             }
+          },
+          "format": {
+            "description": "File format: csv (comma) or tsv (tab)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "geometry": {
+            "title": "Geometry Configuration",
+            "description": "Optional configuration for exporting geometry to CSV columns",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryExportConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2290,6 +2290,28 @@
         "description": "Configuration for reading CZML files as geographic features.",
         "type": "object",
         "properties": {
+          "force2d": {
+            "title": "Force 2D",
+            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+            "default": false,
+            "type": "boolean"
+          },
+          "skipDocumentPacket": {
+            "title": "Skip Document Packet",
+            "description": "If true, skips the document packet (first packet with version/clock info)",
+            "default": true,
+            "type": "boolean"
+          },
+          "timeSampling": {
+            "title": "Time Sampling Strategy",
+            "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
+            "default": "preserveRaw",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TimeSamplingStrategy"
+              }
+            ]
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -2315,12 +2337,6 @@
               }
             }
           },
-          "force2d": {
-            "title": "Force 2D",
-            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -2345,22 +2361,6 @@
                 "type": "string"
               }
             }
-          },
-          "skipDocumentPacket": {
-            "title": "Skip Document Packet",
-            "description": "If true, skips the document packet (first packet with version/clock info)",
-            "default": true,
-            "type": "boolean"
-          },
-          "timeSampling": {
-            "title": "Time Sampling Strategy",
-            "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
-            "default": "preserveRaw",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TimeSamplingStrategy"
-              }
-            ]
           }
         },
         "definitions": {
@@ -2415,87 +2415,6 @@
           "output"
         ],
         "properties": {
-          "colorAttribute": {
-            "title": "Color Attribute",
-            "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "epoch": {
-            "title": "Epoch",
-            "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "groupBy": {
-            "title": "Group By Attributes",
-            "description": "Attributes used to group features into separate CZML files",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
-          "groupTimeseriesBy": {
-            "title": "Group Timeseries By",
-            "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "heightAttribute": {
-            "title": "Height Attribute",
-            "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "interpolationAlgorithm": {
-            "title": "Interpolation Algorithm",
-            "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
-            "default": "LINEAR",
-            "allOf": [
-              {
-                "$ref": "#/definitions/InterpolationAlgorithm"
-              }
-            ]
-          },
-          "interpolationDegree": {
-            "title": "Interpolation Degree",
-            "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
-            "default": 1,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "opacity": {
-            "title": "Opacity",
-            "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
-            "default": 180,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
           "output": {
             "title": "Output File Path",
             "description": "Path where the CZML file will be written",
@@ -2518,9 +2437,90 @@
               }
             }
           },
+          "groupBy": {
+            "title": "Group By Attributes",
+            "description": "Attributes used to group features into separate CZML files",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "timeField": {
             "title": "Time Field",
             "description": "Attribute containing the timestamp for each feature. Supports two formats: - **ISO 8601 strings**: e.g., \"2024-01-01T00:00:00Z\", \"2024-01-01T12:30:45+09:00\" - **Numeric values**: Seconds as offset from epoch (e.g., \"0\", \"60\", \"120.5\")\n\nWhen set together with `groupTimeseriesBy`, features sharing the same group key are combined into a single CZML entity with time-tagged position samples for animation in Cesium.\n\n**Example workflow configuration:** ```yaml - action: CzmlWriter with: output: \"output.czml\" timeField: \"timestamp\" groupTimeseriesBy: \"vehicleId\" epoch: \"2024-01-01T00:00:00Z\"  # Optional for numeric times (auto-defaults to Unix epoch) ```",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "epoch": {
+            "title": "Epoch",
+            "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "interpolationAlgorithm": {
+            "title": "Interpolation Algorithm",
+            "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
+            "default": "LINEAR",
+            "allOf": [
+              {
+                "$ref": "#/definitions/InterpolationAlgorithm"
+              }
+            ]
+          },
+          "interpolationDegree": {
+            "title": "Interpolation Degree",
+            "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
+            "default": 1,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "groupTimeseriesBy": {
+            "title": "Group Timeseries By",
+            "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "colorAttribute": {
+            "title": "Color Attribute",
+            "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "opacity": {
+            "title": "Opacity",
+            "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
+            "default": 180,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "heightAttribute": {
+            "title": "Height Attribute",
+            "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -2598,14 +2598,6 @@
               }
             ]
           },
-          "outputAttribute": {
-            "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "outputFormat": {
             "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode).",
             "default": "auto",
@@ -2613,6 +2605,14 @@
               {
                 "$ref": "#/definitions/DateTimeOutputFormat"
               }
+            ]
+          },
+          "outputAttribute": {
+            "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
@@ -2819,16 +2819,6 @@
         "description": "Configure how to dissolve features by grouping them based on shared attributes",
         "type": "object",
         "properties": {
-          "attributeAccumulation": {
-            "title": "Attribute Accumulation",
-            "description": "Strategy for handling attributes when dissolving features",
-            "default": "useOneFeature",
-            "allOf": [
-              {
-                "$ref": "#/definitions/AttributeAccumulationStrategy"
-              }
-            ]
-          },
           "groupBy": {
             "title": "Group By Attributes",
             "description": "List of attribute names to group features by before dissolving. Features with the same values for these attributes will be dissolved together",
@@ -2848,6 +2838,16 @@
               "null"
             ],
             "format": "double"
+          },
+          "attributeAccumulation": {
+            "title": "Attribute Accumulation",
+            "description": "Strategy for handling attributes when dissolving features",
+            "default": "useOneFeature",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AttributeAccumulationStrategy"
+              }
+            ]
           }
         },
         "definitions": {
@@ -3089,15 +3089,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "City GML Attributes Key",
-            "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Path expression resolving to the CityGML 2.0 file to read.",
@@ -3129,10 +3120,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "Flatten Measure Types",
-            "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
-            "default": false,
+          "keepAttributes": {
+            "title": "Keep Attributes",
+            "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3141,11 +3132,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "Keep Attributes",
-            "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "Flatten Measure Types",
+            "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "City GML Attributes Key",
+            "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3173,15 +3173,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "City GML Attributes Key",
-            "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Path expression resolving to the CityGML 3.0 file to read.",
@@ -3213,10 +3204,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "Flatten Measure Types",
-            "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
-            "default": false,
+          "keepAttributes": {
+            "title": "Keep Attributes",
+            "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3225,11 +3216,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "Keep Attributes",
-            "description": "When false, XML attributes (`@`-prefixed entries such as `@gml:id`, `@codeSpace`) are dropped from parsed features. Defaults to true.",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "Flatten Measure Types",
+            "description": "When true, elements with a single `uom` attribute and numeric text content are converted to a number value, with the unit stored as a sibling `{name}_uom` key. Defaults to false.",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "City GML Attributes Key",
+            "description": "When set, parsed CityGML attributes are nested under this key in the output feature. When null, attributes are emitted at the top level. Defaults to null.",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3258,31 +3258,6 @@
           "dataset"
         ],
         "properties": {
-          "codelistsPath": {
-            "title": "Codelists Path",
-            "description": "Optional path to the codelists directory for resolving codelist values",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Path or expression to the CityGML dataset file to be read",
@@ -3312,6 +3287,31 @@
               "boolean",
               "null"
             ]
+          },
+          "codelistsPath": {
+            "title": "Codelists Path",
+            "description": "Optional path to the codelists directory for resolving codelist values",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -3463,19 +3463,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "destPrefix": {
-            "title": "Destination Prefix",
-            "description": "Optional prefix to add to extracted file paths",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "extractArchive": {
-            "title": "Extract Archive",
-            "description": "Whether to extract archive files found in the dataset",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Expression to get the source dataset path or URL",
@@ -3497,6 +3484,19 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "Extract Archive",
+            "description": "Whether to extract archive files found in the dataset",
+            "type": "boolean"
+          },
+          "destPrefix": {
+            "title": "Destination Prefix",
+            "description": "Optional prefix to add to extracted file paths",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3606,17 +3606,6 @@
           "joinType"
         ],
         "properties": {
-          "conflictResolution": {
-            "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ConflictResolution"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "joinType": {
             "description": "Join type: inner, left, or full",
             "allOf": [
@@ -3627,6 +3616,16 @@
           },
           "requestorAttribute": {
             "description": "Attributes from requestor features to use for matching (alternative to requestorAttributeValue)",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
             "type": [
               "array",
               "null"
@@ -3658,16 +3657,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "Expression to evaluate for supplier feature matching values (alternative to supplierAttribute)",
             "type": [
@@ -3690,30 +3679,20 @@
                 "type": "string"
               }
             }
+          },
+          "conflictResolution": {
+            "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ConflictResolution"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "ConflictResolution": {
-            "oneOf": [
-              {
-                "description": "Requestor attributes win on conflict",
-                "type": "string",
-                "enum": [
-                  "requestorWins"
-                ]
-              },
-              {
-                "description": "Supplier attributes win on conflict (default)",
-                "type": "string",
-                "enum": [
-                  "supplierWins"
-                ]
-              }
-            ]
-          },
           "JoinType": {
             "oneOf": [
               {
@@ -3735,6 +3714,27 @@
                 "type": "string",
                 "enum": [
                   "full"
+                ]
+              }
+            ]
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "ConflictResolution": {
+            "oneOf": [
+              {
+                "description": "Requestor attributes win on conflict",
+                "type": "string",
+                "enum": [
+                  "requestorWins"
+                ]
+              },
+              {
+                "description": "Supplier attributes win on conflict (default)",
+                "type": "string",
+                "enum": [
+                  "supplierWins"
                 ]
               }
             ]
@@ -3816,15 +3816,18 @@
         "description": "Configuration for merging requestor and supplier features based on matching attributes or expressions.",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "description": "Whether to complete grouped features before processing the next group",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "description": "Attributes from requestor features to use for matching (alternative to requestor_attribute_value)",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
             "type": [
               "array",
               "null"
@@ -3856,16 +3859,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "Expression to evaluate for supplier feature matching values (alternative to supplier_attribute)",
             "type": [
@@ -3888,6 +3881,13 @@
                 "type": "string"
               }
             }
+          },
+          "completeGrouped": {
+            "description": "Whether to complete grouped features before processing the next group",
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
         "definitions": {
@@ -3927,27 +3927,11 @@
               "format"
             ],
             "properties": {
-              "dataset": {
-                "title": "Dataset",
-                "description": "Path or expression to the dataset file to be read",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3957,42 +3941,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "csv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4014,6 +3962,42 @@
                     "type": "string"
                   }
                 }
+              },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -4023,42 +4007,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "tsv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4081,11 +4029,63 @@
                   }
                 }
               },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
               "format": {
                 "type": "string",
                 "enum": [
                   "json"
                 ]
+              },
+              "dataset": {
+                "title": "Dataset",
+                "description": "Path or expression to the dataset file to be read",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -4349,28 +4349,6 @@
               "output"
             ],
             "properties": {
-              "converter": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
               "format": {
                 "type": "string",
                 "enum": [
@@ -4397,6 +4375,28 @@
                     "type": "string"
                   }
                 }
+              },
+              "converter": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -4409,34 +4409,11 @@
               "output"
             ],
             "properties": {
-              "epsgCode": {
-                "description": "EPSG code for coordinate reference system",
-                "default": null,
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint32",
-                "minimum": 0.0
-              },
               "format": {
                 "type": "string",
                 "enum": [
                   "citygml"
                 ]
-              },
-              "lodFilter": {
-                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-                "default": null,
-                "type": [
-                  "array",
-                  "null"
-                ],
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0.0
-                }
               },
               "output": {
                 "title": "Output path",
@@ -4458,6 +4435,29 @@
                     "type": "string"
                   }
                 }
+              },
+              "lodFilter": {
+                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+                "default": null,
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              },
+              "epsgCode": {
+                "description": "EPSG code for coordinate reference system",
+                "default": null,
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4497,11 +4497,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "extractArchive": {
-            "title": "Extract Archive",
-            "description": "Whether to extract files from archives (zip files, etc.) or just list them",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Path or expression pointing to the source directory or archive file",
@@ -4523,6 +4518,11 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "Extract Archive",
+            "description": "Whether to extract files from archives (zip files, etc.) or just list them",
+            "type": "boolean"
           }
         }
       },
@@ -4680,16 +4680,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "Optional attributes to group features by, creating separate files for each group",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "Output path or expression for the GeoJSON file to create",
             "type": "object",
@@ -4709,6 +4699,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "Optional attributes to group features by, creating separate files for each group",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -4739,6 +4739,32 @@
         "title": "GeoPackageReaderParam",
         "type": "object",
         "properties": {
+          "readMode": {
+            "default": "features",
+            "allOf": [
+              {
+                "$ref": "#/definitions/GeoPackageReadMode"
+              }
+            ]
+          },
+          "layerName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "includeMetadata": {
+            "default": false,
+            "type": "boolean"
+          },
+          "tileFormat": {
+            "default": "png",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TileFormat"
+              }
+            ]
+          },
           "attributeFilter": {
             "default": null,
             "type": [
@@ -4754,6 +4780,17 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "force2D": {
+            "default": false,
+            "type": "boolean"
+          },
+          "spatialFilter": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "dataset": {
             "title": "File Path",
@@ -4780,14 +4817,6 @@
               }
             }
           },
-          "force2D": {
-            "default": false,
-            "type": "boolean"
-          },
-          "includeMetadata": {
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -4812,35 +4841,6 @@
                 "type": "string"
               }
             }
-          },
-          "layerName": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "readMode": {
-            "default": "features",
-            "allOf": [
-              {
-                "$ref": "#/definitions/GeoPackageReadMode"
-              }
-            ]
-          },
-          "spatialFilter": {
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tileFormat": {
-            "default": "png",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TileFormat"
-              }
-            ]
           }
         },
         "definitions": {
@@ -4888,21 +4888,6 @@
           "output"
         ],
         "properties": {
-          "createSpatialIndex": {
-            "description": "Create RTree spatial index (default: true)",
-            "default": true,
-            "type": "boolean"
-          },
-          "geometryColumn": {
-            "description": "Geometry column name (default: \"geom\")",
-            "default": "geom",
-            "type": "string"
-          },
-          "geometryType": {
-            "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
-            "default": "GEOMETRY",
-            "type": "string"
-          },
           "output": {
             "description": "Output path for the GeoPackage file to create",
             "type": "object",
@@ -4924,10 +4909,15 @@
               }
             }
           },
-          "overwrite": {
-            "description": "Overwrite existing file (default: false)",
-            "default": false,
-            "type": "boolean"
+          "tableName": {
+            "description": "Table name to create (default: \"features\")",
+            "default": "features",
+            "type": "string"
+          },
+          "geometryColumn": {
+            "description": "Geometry column name (default: \"geom\")",
+            "default": "geom",
+            "type": "string"
           },
           "srsId": {
             "description": "Spatial Reference System ID (default: 4326 for WGS84)",
@@ -4935,10 +4925,20 @@
             "type": "integer",
             "format": "int32"
           },
-          "tableName": {
-            "description": "Table name to create (default: \"features\")",
-            "default": "features",
+          "geometryType": {
+            "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
+            "default": "GEOMETRY",
             "type": "string"
+          },
+          "createSpatialIndex": {
+            "description": "Create RTree spatial index (default: true)",
+            "default": true,
+            "type": "boolean"
+          },
+          "overwrite": {
+            "description": "Overwrite existing file (default: false)",
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -5411,6 +5411,24 @@
         "title": "GltfReaderParam",
         "type": "object",
         "properties": {
+          "triangulate": {
+            "title": "Triangulate",
+            "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
+            "default": true,
+            "type": "boolean"
+          },
+          "mergeMeshes": {
+            "title": "Merge Meshes",
+            "description": "If true, combines all meshes from the glTF file into a single output feature",
+            "default": false,
+            "type": "boolean"
+          },
+          "includeNodes": {
+            "title": "Include Nodes",
+            "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
+            "default": true,
+            "type": "boolean"
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -5436,12 +5454,6 @@
               }
             }
           },
-          "includeNodes": {
-            "title": "Include Nodes",
-            "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
-            "default": true,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -5466,18 +5478,6 @@
                 "type": "string"
               }
             }
-          },
-          "mergeMeshes": {
-            "title": "Merge Meshes",
-            "description": "If true, combines all meshes from the glTF file into a single output feature",
-            "default": false,
-            "type": "boolean"
-          },
-          "triangulate": {
-            "title": "Triangulate",
-            "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
-            "default": true,
-            "type": "boolean"
           }
         }
       },
@@ -5505,20 +5505,6 @@
           "output"
         ],
         "properties": {
-          "attachTexture": {
-            "description": "Whether to attach texture information to the GLTF model",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "dracoCompression": {
-            "description": "Apply Draco compression to the geometry",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "output": {
             "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
             "type": "object",
@@ -5539,6 +5525,20 @@
                 "type": "string"
               }
             }
+          },
+          "attachTexture": {
+            "description": "Whether to attach texture information to the GLTF model",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "dracoCompression": {
+            "description": "Apply Draco compression to the geometry",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
@@ -5571,6 +5571,20 @@
           "unitSquareSize"
         ],
         "properties": {
+          "unitSquareSize": {
+            "title": "Unit Square Size",
+            "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
+            "type": "number",
+            "format": "double"
+          },
+          "keepSquareOnly": {
+            "title": "Keep Square Only",
+            "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "title": "Group By Attributes",
             "description": "Attributes used to group features - each group gets its own grid origin",
@@ -5581,20 +5595,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "keepSquareOnly": {
-            "title": "Keep Square Only",
-            "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "unitSquareSize": {
-            "title": "Unit Square Size",
-            "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -5631,12 +5631,78 @@
           "url"
         ],
         "properties": {
+          "url": {
+            "title": "URL",
+            "description": "The target URL for the HTTP request (supports expressions)",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "method": {
+            "title": "HTTP Method",
+            "description": "The HTTP method to use for the request",
+            "default": "GET",
+            "allOf": [
+              {
+                "$ref": "#/definitions/HttpMethod"
+              }
+            ]
+          },
           "authentication": {
             "title": "Authentication",
             "description": "Authentication method and credentials for the request",
             "anyOf": [
               {
                 "$ref": "#/definitions/Authentication"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "customHeaders": {
+            "title": "Custom Headers",
+            "description": "Additional HTTP headers to include in the request",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/HeaderParam"
+            }
+          },
+          "queryParameters": {
+            "title": "Query Parameters",
+            "description": "URL query parameters to append to the request",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/QueryParam"
+            }
+          },
+          "requestBody": {
+            "title": "Request Body",
+            "description": "The body content to send with the request",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5651,16 +5717,17 @@
               "null"
             ]
           },
-          "customHeaders": {
-            "title": "Custom Headers",
-            "description": "Additional HTTP headers to include in the request",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/HeaderParam"
-            }
+          "timeouts": {
+            "title": "Timeouts",
+            "description": "Connection and transfer timeout settings",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TimeoutConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "httpOptions": {
             "title": "HTTP Options",
@@ -5668,63 +5735,6 @@
             "anyOf": [
               {
                 "$ref": "#/definitions/HttpOptions"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "method": {
-            "title": "HTTP Method",
-            "description": "The HTTP method to use for the request",
-            "default": "GET",
-            "allOf": [
-              {
-                "$ref": "#/definitions/HttpMethod"
-              }
-            ]
-          },
-          "observability": {
-            "title": "Observability",
-            "description": "Track additional metrics and diagnostics",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ObservabilityConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "queryParameters": {
-            "title": "Query Parameters",
-            "description": "URL query parameters to append to the request",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/QueryParam"
-            }
-          },
-          "rateLimit": {
-            "title": "Rate Limiting",
-            "description": "Rate limiting configuration to control request frequency",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RateLimitConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "requestBody": {
-            "title": "Request Body",
-            "description": "The body content to send with the request",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5755,386 +5765,32 @@
               }
             ]
           },
-          "timeouts": {
-            "title": "Timeouts",
-            "description": "Connection and transfer timeout settings",
+          "rateLimit": {
+            "title": "Rate Limiting",
+            "description": "Rate limiting configuration to control request frequency",
             "anyOf": [
               {
-                "$ref": "#/definitions/TimeoutConfig"
+                "$ref": "#/definitions/RateLimitConfig"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "url": {
-            "title": "URL",
-            "description": "The target URL for the HTTP request (supports expressions)",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
+          "observability": {
+            "title": "Observability",
+            "description": "Track additional metrics and diagnostics",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ObservabilityConfig"
               },
-              "value": {
-                "type": "string"
+              {
+                "type": "null"
               }
-            }
+            ]
           }
         },
         "definitions": {
-          "ApiKeyLocation": {
-            "title": "API Key Location",
-            "description": "Where to include the API key in the request",
-            "oneOf": [
-              {
-                "title": "Header",
-                "description": "Include API key in HTTP header",
-                "type": "string",
-                "enum": [
-                  "header"
-                ]
-              },
-              {
-                "title": "Query Parameter",
-                "description": "Include API key in URL query string",
-                "type": "string",
-                "enum": [
-                  "query"
-                ]
-              }
-            ]
-          },
-          "Authentication": {
-            "title": "Authentication",
-            "description": "Authentication method and credentials for HTTP requests",
-            "oneOf": [
-              {
-                "title": "Basic Authentication",
-                "description": "HTTP Basic authentication with username and password",
-                "type": "object",
-                "required": [
-                  "password",
-                  "type",
-                  "username"
-                ],
-                "properties": {
-                  "password": {
-                    "title": "Password",
-                    "description": "The password for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "basic"
-                    ]
-                  },
-                  "username": {
-                    "title": "Username",
-                    "description": "The username for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "title": "Bearer Token",
-                "description": "Bearer token authentication (OAuth 2.0)",
-                "type": "object",
-                "required": [
-                  "token",
-                  "type"
-                ],
-                "properties": {
-                  "token": {
-                    "title": "Token",
-                    "description": "The bearer token value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "bearer"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "API Key",
-                "description": "API key authentication in header or query parameter",
-                "type": "object",
-                "required": [
-                  "keyName",
-                  "keyValue",
-                  "type"
-                ],
-                "properties": {
-                  "keyName": {
-                    "title": "Key Name",
-                    "description": "The name of the API key parameter",
-                    "type": "string"
-                  },
-                  "keyValue": {
-                    "title": "Key Value",
-                    "description": "The API key value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "location": {
-                    "title": "Location",
-                    "description": "Where to include the API key (header or query parameter)",
-                    "default": "header",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/ApiKeyLocation"
-                      }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "apiKey"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "BinarySource": {
-            "title": "Binary Source",
-            "description": "Source of binary data for request body",
-            "oneOf": [
-              {
-                "title": "Base64 Encoded",
-                "description": "Binary data encoded as base64 string",
-                "type": "object",
-                "required": [
-                  "data",
-                  "type"
-                ],
-                "properties": {
-                  "data": {
-                    "title": "Data",
-                    "description": "Base64-encoded binary data (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "base64"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "From File",
-                "description": "Read binary data from a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path to the file to read (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "FormField": {
-            "title": "Form Field",
-            "description": "A name-value pair for URL-encoded form data",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "Field Name",
-                "description": "The name of the form field",
-                "type": "string"
-              },
-              "value": {
-                "title": "Field Value",
-                "description": "The value of the form field (supports expressions)",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "HeaderParam": {
-            "title": "HTTP Header",
-            "description": "A custom HTTP header to include in the request",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "Header Name",
-                "description": "The name of the HTTP header",
-                "type": "string"
-              },
-              "value": {
-                "title": "Header Value",
-                "description": "The value of the header (supports expressions)",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
           "HttpMethod": {
             "title": "HTTP Method",
             "description": "The HTTP request method to use",
@@ -6253,75 +5909,51 @@
               }
             ]
           },
-          "HttpOptions": {
-            "title": "HTTP Options",
-            "description": "Configure HTTP client behavior",
-            "type": "object",
-            "properties": {
-              "followRedirects": {
-                "title": "Follow Redirects",
-                "description": "Whether to automatically follow HTTP redirects (default: true)",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "maxRedirects": {
-                "title": "Max Redirects",
-                "description": "Maximum number of redirects to follow (default: 10)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "userAgent": {
-                "title": "User Agent",
-                "description": "Custom User-Agent header value",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "verifySsl": {
-                "title": "Verify SSL",
-                "description": "Whether to verify SSL/TLS certificates (default: true)",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            }
-          },
-          "MultipartPart": {
-            "title": "Multipart Part",
-            "description": "A part in a multipart/form-data request",
+          "Authentication": {
+            "title": "Authentication",
+            "description": "Authentication method and credentials for HTTP requests",
             "oneOf": [
               {
-                "title": "Text Field",
-                "description": "A text field in the multipart form",
+                "title": "Basic Authentication",
+                "description": "HTTP Basic authentication with username and password",
                 "type": "object",
                 "required": [
-                  "name",
+                  "password",
                   "type",
-                  "value"
+                  "username"
                 ],
                 "properties": {
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the form field",
-                    "type": "string"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "text"
+                      "basic"
                     ]
                   },
-                  "value": {
-                    "title": "Field Value",
-                    "description": "The value of the form field (supports expressions)",
+                  "username": {
+                    "title": "Username",
+                    "description": "The username for basic authentication",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "The password for basic authentication",
                     "type": "object",
                     "format": "code",
                     "required": [
@@ -6344,115 +5976,158 @@
                 }
               },
               {
-                "title": "File Upload",
-                "description": "A file upload in the multipart form",
+                "title": "Bearer Token",
+                "description": "Bearer token authentication (OAuth 2.0)",
                 "type": "object",
                 "required": [
-                  "name",
-                  "source",
+                  "token",
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "MIME type of the file",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "description": "The filename to send in the Content-Disposition header",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the file upload field",
-                    "type": "string"
-                  },
-                  "source": {
-                    "title": "File Source",
-                    "description": "Source of the file data (base64 or file path)",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/BinarySource"
-                      }
-                    ]
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "file"
+                      "bearer"
+                    ]
+                  },
+                  "token": {
+                    "title": "Token",
+                    "description": "The bearer token value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "API Key",
+                "description": "API key authentication in header or query parameter",
+                "type": "object",
+                "required": [
+                  "keyName",
+                  "keyValue",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "apiKey"
+                    ]
+                  },
+                  "keyName": {
+                    "title": "Key Name",
+                    "description": "The name of the API key parameter",
+                    "type": "string"
+                  },
+                  "keyValue": {
+                    "title": "Key Value",
+                    "description": "The API key value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "location": {
+                    "title": "Location",
+                    "description": "Where to include the API key (header or query parameter)",
+                    "default": "header",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/ApiKeyLocation"
+                      }
                     ]
                   }
                 }
               }
             ]
           },
-          "ObservabilityConfig": {
-            "title": "Observability Configuration",
-            "description": "Track additional metrics and diagnostics about HTTP requests",
+          "ApiKeyLocation": {
+            "title": "API Key Location",
+            "description": "Where to include the API key in the request",
+            "oneOf": [
+              {
+                "title": "Header",
+                "description": "Include API key in HTTP header",
+                "type": "string",
+                "enum": [
+                  "header"
+                ]
+              },
+              {
+                "title": "Query Parameter",
+                "description": "Include API key in URL query string",
+                "type": "string",
+                "enum": [
+                  "query"
+                ]
+              }
+            ]
+          },
+          "HeaderParam": {
+            "title": "HTTP Header",
+            "description": "A custom HTTP header to include in the request",
             "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
             "properties": {
-              "bytesAttribute": {
-                "title": "Bytes Attribute",
-                "description": "Feature attribute name to store the response body size",
-                "type": [
-                  "string",
-                  "null"
-                ]
+              "name": {
+                "title": "Header Name",
+                "description": "The name of the HTTP header",
+                "type": "string"
               },
-              "durationAttribute": {
-                "title": "Duration Attribute",
-                "description": "Feature attribute name to store request duration in milliseconds",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "finalUrlAttribute": {
-                "title": "Final URL Attribute",
-                "description": "Feature attribute name to store the final URL after redirects",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "retryCountAttribute": {
-                "title": "Retry Count Attribute",
-                "description": "Feature attribute name to store the number of retry attempts",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "trackBytes": {
-                "title": "Track Bytes",
-                "description": "Whether to track the response body size in bytes (default: false)",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackDuration": {
-                "title": "Track Duration",
-                "description": "Whether to track the total request duration (default: true)",
-                "default": true,
-                "type": "boolean"
-              },
-              "trackFinalUrl": {
-                "title": "Track Final URL",
-                "description": "Whether to track the final URL after redirects (default: false)",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackRetryCount": {
-                "title": "Track Retry Count",
-                "description": "Whether to track the number of retry attempts (default: true)",
-                "default": true,
-                "type": "boolean"
+              "value": {
+                "title": "Header Value",
+                "description": "The value of the header (supports expressions)",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -6494,41 +6169,6 @@
               }
             }
           },
-          "RateLimitConfig": {
-            "title": "Rate Limit Configuration",
-            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
-            "type": "object",
-            "required": [
-              "requests"
-            ],
-            "properties": {
-              "intervalMs": {
-                "title": "Interval",
-                "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
-                "default": 1000,
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "requests": {
-                "title": "Requests",
-                "description": "Maximum number of requests allowed within the interval",
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
-              },
-              "timing": {
-                "title": "Timing Strategy",
-                "description": "How to distribute requests within the interval (default: Burst)",
-                "default": "burst",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/TimingStrategy"
-                  }
-                ]
-              }
-            }
-          },
           "RequestBody": {
             "title": "Request Body",
             "description": "The body content to send with the HTTP request",
@@ -6542,6 +6182,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
                   "content": {
                     "title": "Content",
                     "description": "The text content to send (supports expressions)",
@@ -6571,12 +6217,6 @@
                       "string",
                       "null"
                     ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "text"
-                    ]
                   }
                 }
               },
@@ -6589,12 +6229,10 @@
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
-                    "type": [
-                      "string",
-                      "null"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "binary"
                     ]
                   },
                   "source": {
@@ -6606,10 +6244,12 @@
                       }
                     ]
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "binary"
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
@@ -6623,6 +6263,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "formUrlEncoded"
+                    ]
+                  },
                   "fields": {
                     "title": "Form Fields",
                     "description": "List of form field name-value pairs",
@@ -6630,12 +6276,6 @@
                     "items": {
                       "$ref": "#/definitions/FormField"
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "formUrlEncoded"
-                    ]
                   }
                 }
               },
@@ -6648,6 +6288,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "multipart"
+                    ]
+                  },
                   "parts": {
                     "title": "Parts",
                     "description": "List of multipart form parts (text fields or file uploads)",
@@ -6655,34 +6301,315 @@
                     "items": {
                       "$ref": "#/definitions/MultipartPart"
                     }
-                  },
+                  }
+                }
+              }
+            ]
+          },
+          "BinarySource": {
+            "title": "Binary Source",
+            "description": "Source of binary data for request body",
+            "oneOf": [
+              {
+                "title": "Base64 Encoded",
+                "description": "Binary data encoded as base64 string",
+                "type": "object",
+                "required": [
+                  "data",
+                  "type"
+                ],
+                "properties": {
                   "type": {
                     "type": "string",
                     "enum": [
-                      "multipart"
+                      "base64"
+                    ]
+                  },
+                  "data": {
+                    "title": "Data",
+                    "description": "Base64-encoded binary data (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "From File",
+                "description": "Read binary data from a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path to the file to read (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "FormField": {
+            "title": "Form Field",
+            "description": "A name-value pair for URL-encoded form data",
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "title": "Field Name",
+                "description": "The name of the form field",
+                "type": "string"
+              },
+              "value": {
+                "title": "Field Value",
+                "description": "The value of the form field (supports expressions)",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "MultipartPart": {
+            "title": "Multipart Part",
+            "description": "A part in a multipart/form-data request",
+            "oneOf": [
+              {
+                "title": "Text Field",
+                "description": "A text field in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the form field",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Field Value",
+                    "description": "The value of the form field (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "File Upload",
+                "description": "A file upload in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "source",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the file upload field",
+                    "type": "string"
+                  },
+                  "source": {
+                    "title": "File Source",
+                    "description": "Source of the file data (base64 or file path)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/BinarySource"
+                      }
+                    ]
+                  },
+                  "filename": {
+                    "title": "Filename",
+                    "description": "The filename to send in the Content-Disposition header",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "MIME type of the file",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
               }
             ]
           },
-          "ResponseConfig": {
-            "title": "Response Configuration",
-            "description": "Configure how HTTP response data is stored and processed",
+          "TimeoutConfig": {
+            "title": "Timeout Configuration",
+            "description": "Configure connection and transfer timeouts for HTTP requests",
             "type": "object",
             "properties": {
-              "autoDetectEncoding": {
-                "title": "Auto Detect Encoding",
-                "description": "Automatically detect character encoding from response headers",
+              "connectionTimeout": {
+                "title": "Connection Timeout",
+                "description": "Maximum time in seconds to establish a connection (default: 60)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "transferTimeout": {
+                "title": "Transfer Timeout",
+                "description": "Maximum time in seconds to complete the entire request (default: 90)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          },
+          "HttpOptions": {
+            "title": "HTTP Options",
+            "description": "Configure HTTP client behavior",
+            "type": "object",
+            "properties": {
+              "userAgent": {
+                "title": "User Agent",
+                "description": "Custom User-Agent header value",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifySsl": {
+                "title": "Verify SSL",
+                "description": "Whether to verify SSL/TLS certificates (default: true)",
                 "type": [
                   "boolean",
                   "null"
                 ]
               },
-              "errorAttribute": {
-                "title": "Error Attribute",
-                "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
-                "default": "_http_error",
+              "followRedirects": {
+                "title": "Follow Redirects",
+                "description": "Whether to automatically follow HTTP redirects (default: true)",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "maxRedirects": {
+                "title": "Max Redirects",
+                "description": "Maximum number of redirects to follow (default: 10)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint8",
+                "minimum": 0.0
+              }
+            }
+          },
+          "ResponseConfig": {
+            "title": "Response Configuration",
+            "description": "Configure how HTTP response data is stored and processed",
+            "type": "object",
+            "properties": {
+              "responseBodyAttribute": {
+                "title": "Response Body Attribute",
+                "description": "Feature attribute name to store the response body (default: \"_response_body\")",
+                "default": "_response_body",
+                "type": "string"
+              },
+              "statusCodeAttribute": {
+                "title": "Status Code Attribute",
+                "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
+                "default": "_http_status_code",
                 "type": "string"
               },
               "headersAttribute": {
@@ -6691,33 +6618,11 @@
                 "default": "_headers",
                 "type": "string"
               },
-              "maxResponseSize": {
-                "title": "Max Response Size",
-                "description": "Maximum response body size in bytes (unlimited if not set)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "responseBodyAttribute": {
-                "title": "Response Body Attribute",
-                "description": "Feature attribute name to store the response body (default: \"_response_body\")",
-                "default": "_response_body",
+              "errorAttribute": {
+                "title": "Error Attribute",
+                "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
+                "default": "_http_error",
                 "type": "string"
-              },
-              "responseEncoding": {
-                "title": "Response Encoding",
-                "description": "How to encode the response body (text, base64, or binary)",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/ResponseEncoding"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
               },
               "responseHandling": {
                 "title": "Response Handling",
@@ -6731,13 +6636,114 @@
                   }
                 ]
               },
-              "statusCodeAttribute": {
-                "title": "Status Code Attribute",
-                "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
-                "default": "_http_status_code",
-                "type": "string"
+              "maxResponseSize": {
+                "title": "Max Response Size",
+                "description": "Maximum response body size in bytes (unlimited if not set)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "responseEncoding": {
+                "title": "Response Encoding",
+                "description": "How to encode the response body (text, base64, or binary)",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/ResponseEncoding"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "autoDetectEncoding": {
+                "title": "Auto Detect Encoding",
+                "description": "Automatically detect character encoding from response headers",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             }
+          },
+          "ResponseHandling": {
+            "title": "Response Handling",
+            "description": "How to handle the HTTP response data",
+            "oneOf": [
+              {
+                "title": "Store in Attribute",
+                "description": "Store response body in a feature attribute",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "attribute"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "Save to File",
+                "description": "Save response body to a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path where the response should be saved",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "storePathInAttribute": {
+                    "title": "Store Path in Attribute",
+                    "description": "Whether to store the file path in a feature attribute",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "pathAttribute": {
+                    "title": "Path Attribute Name",
+                    "description": "Attribute name for storing the file path",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           "ResponseEncoding": {
             "title": "Response Encoding",
@@ -6769,100 +6775,18 @@
               }
             ]
           },
-          "ResponseHandling": {
-            "title": "Response Handling",
-            "description": "How to handle the HTTP response data",
-            "oneOf": [
-              {
-                "title": "Store in Attribute",
-                "description": "Store response body in a feature attribute",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "attribute"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "Save to File",
-                "description": "Save response body to a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path where the response should be saved",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "pathAttribute": {
-                    "title": "Path Attribute Name",
-                    "description": "Attribute name for storing the file path",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "storePathInAttribute": {
-                    "title": "Store Path in Attribute",
-                    "description": "Whether to store the file path in a feature attribute",
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
           "RetryConfig": {
             "title": "Retry Configuration",
             "description": "Configure automatic retry behavior for failed requests",
             "type": "object",
             "properties": {
-              "backoffMultiplier": {
-                "title": "Backoff Multiplier",
-                "description": "Multiplier for exponential backoff between retries (default: 2.0)",
-                "default": 2.0,
-                "type": "number",
-                "format": "double"
-              },
-              "honorRetryAfter": {
-                "title": "Honor Retry-After Header",
-                "description": "Whether to respect the Retry-After header from server responses (default: true)",
-                "default": true,
-                "type": "boolean"
+              "maxAttempts": {
+                "title": "Max Attempts",
+                "description": "Maximum number of retry attempts (default: 3)",
+                "default": 3,
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
               },
               "initialDelayMs": {
                 "title": "Initial Delay",
@@ -6872,13 +6796,12 @@
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "maxAttempts": {
-                "title": "Max Attempts",
-                "description": "Maximum number of retry attempts (default: 3)",
-                "default": 3,
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
+              "backoffMultiplier": {
+                "title": "Backoff Multiplier",
+                "description": "Multiplier for exponential backoff between retries (default: 2.0)",
+                "default": 2.0,
+                "type": "number",
+                "format": "double"
               },
               "maxDelayMs": {
                 "title": "Max Delay",
@@ -6900,33 +6823,47 @@
                   "format": "uint16",
                   "minimum": 0.0
                 }
+              },
+              "honorRetryAfter": {
+                "title": "Honor Retry-After Header",
+                "description": "Whether to respect the Retry-After header from server responses (default: true)",
+                "default": true,
+                "type": "boolean"
               }
             }
           },
-          "TimeoutConfig": {
-            "title": "Timeout Configuration",
-            "description": "Configure connection and transfer timeouts for HTTP requests",
+          "RateLimitConfig": {
+            "title": "Rate Limit Configuration",
+            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
             "type": "object",
+            "required": [
+              "requests"
+            ],
             "properties": {
-              "connectionTimeout": {
-                "title": "Connection Timeout",
-                "description": "Maximum time in seconds to establish a connection (default: 60)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+              "requests": {
+                "title": "Requests",
+                "description": "Maximum number of requests allowed within the interval",
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "intervalMs": {
+                "title": "Interval",
+                "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
+                "default": 1000,
+                "type": "integer",
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "transferTimeout": {
-                "title": "Transfer Timeout",
-                "description": "Maximum time in seconds to complete the entire request (default: 90)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
+              "timing": {
+                "title": "Timing Strategy",
+                "description": "How to distribute requests within the interval (default: Burst)",
+                "default": "burst",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/TimingStrategy"
+                  }
+                ]
               }
             }
           },
@@ -6951,6 +6888,69 @@
                 ]
               }
             ]
+          },
+          "ObservabilityConfig": {
+            "title": "Observability Configuration",
+            "description": "Track additional metrics and diagnostics about HTTP requests",
+            "type": "object",
+            "properties": {
+              "trackDuration": {
+                "title": "Track Duration",
+                "description": "Whether to track the total request duration (default: true)",
+                "default": true,
+                "type": "boolean"
+              },
+              "durationAttribute": {
+                "title": "Duration Attribute",
+                "description": "Feature attribute name to store request duration in milliseconds",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackFinalUrl": {
+                "title": "Track Final URL",
+                "description": "Whether to track the final URL after redirects (default: false)",
+                "default": false,
+                "type": "boolean"
+              },
+              "finalUrlAttribute": {
+                "title": "Final URL Attribute",
+                "description": "Feature attribute name to store the final URL after redirects",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackRetryCount": {
+                "title": "Track Retry Count",
+                "description": "Whether to track the number of retry attempts (default: true)",
+                "default": true,
+                "type": "boolean"
+              },
+              "retryCountAttribute": {
+                "title": "Retry Count Attribute",
+                "description": "Feature attribute name to store the number of retry attempts",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackBytes": {
+                "title": "Track Bytes",
+                "description": "Whether to track the response body size in bytes (default: false)",
+                "default": false,
+                "type": "boolean"
+              },
+              "bytesAttribute": {
+                "title": "Bytes Attribute",
+                "description": "Feature attribute name to store the response body size",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
           }
         }
       },
@@ -7120,19 +7120,6 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "onOverlap": {
-            "title": "On Overlap",
-            "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/OnOverlap"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "saveTo": {
             "title": "Save To",
             "description": "Optional path expression to save the generated image. If not provided, uses default cache directory.",
@@ -7158,6 +7145,19 @@
                 "type": "string"
               }
             }
+          },
+          "onOverlap": {
+            "title": "On Overlap",
+            "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/definitions/OnOverlap"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7322,19 +7322,6 @@
               "jsonQuery"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
@@ -7353,10 +7340,23 @@
                 "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
                 "type": "string"
               },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7374,28 +7374,11 @@
               "path"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
                   "fileUrl"
                 ]
-              },
-              "jsonQuery": {
-                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
-                "type": "string"
               },
               "path": {
                 "description": "Expression evaluating to the file path or URL containing JSON",
@@ -7418,10 +7401,27 @@
                   }
                 }
               },
+              "jsonQuery": {
+                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
+                "type": "string"
+              },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7537,6 +7537,27 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "description": "Output path or expression for the JSON file to create",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "converter": {
             "description": "Optional converter expression to transform features before writing",
             "type": [
@@ -7553,27 +7574,6 @@
                 "type": "string",
                 "enum": [
                   "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "output": {
-            "description": "Output path or expression for the JSON file to create",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
                 ]
               },
               "value": {
@@ -7617,16 +7617,16 @@
               "$ref": "#/definitions/Attribute"
             }
           },
+          "tolerance": {
+            "type": "number",
+            "format": "double"
+          },
           "overlaidListsAttrName": {
             "description": "Name of the attribute to store the overlaid lists. Defaults to \"overlaidLists\".",
             "type": [
               "string",
               "null"
             ]
-          },
-          "tolerance": {
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -7665,14 +7665,6 @@
           "separateCharacter"
         ],
         "properties": {
-          "attribute": {
-            "description": "Attribute name to extract from each list element",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "list": {
             "description": "List attribute to read from",
             "allOf": [
@@ -7681,8 +7673,8 @@
               }
             ]
           },
-          "outputAttributeName": {
-            "description": "Name of the attribute to store the concatenated result",
+          "attribute": {
+            "description": "Attribute name to extract from each list element",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -7692,6 +7684,14 @@
           "separateCharacter": {
             "description": "Character(s) to use as separator between concatenated values",
             "type": "string"
+          },
+          "outputAttributeName": {
+            "description": "Name of the attribute to store the concatenated result",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7768,6 +7768,20 @@
           "listIndexToCopy"
         ],
         "properties": {
+          "listAttribute": {
+            "description": "List attribute to read from",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "listIndexToCopy": {
+            "description": "Index of the list element to copy (0-based)",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          },
           "copiedAttributePrefix": {
             "description": "Optional prefix to add to copied attribute names",
             "default": null,
@@ -7783,20 +7797,6 @@
               "string",
               "null"
             ]
-          },
-          "listAttribute": {
-            "description": "List attribute to read from",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "listIndexToCopy": {
-            "description": "Index of the list element to copy (0-based)",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0.0
           }
         },
         "definitions": {
@@ -7833,13 +7833,63 @@
           "output"
         ],
         "properties": {
-          "colonToUnderscore": {
-            "title": "Colon to Underscore",
-            "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
-            "type": [
-              "boolean",
-              "null"
-            ]
+          "output": {
+            "title": "Output",
+            "description": "Output directory path or expression for the generated MVT tiles",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "layerName": {
+            "title": "Layer Name",
+            "description": "Name of the layer within the MVT tiles",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "Minimum Zoom",
+            "description": "Minimum zoom level to generate tiles for",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "Maximum Zoom",
+            "description": "Maximum zoom level to generate tiles for",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
           },
           "compressOutput": {
             "title": "Compress Output",
@@ -7866,6 +7916,22 @@
               }
             }
           },
+          "skipUnexposedAttributes": {
+            "title": "Skip Unexposed Attributes",
+            "description": "Skip attributes with double underscore prefix",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "colonToUnderscore": {
+            "title": "Colon to Underscore",
+            "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "extent": {
             "title": "Extent",
             "description": "MVT tile resolution. Default is 4096.",
@@ -7876,77 +7942,11 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "layerName": {
-            "title": "Layer Name",
-            "description": "Name of the layer within the MVT tiles",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "maxZoom": {
-            "title": "Maximum Zoom",
-            "description": "Maximum zoom level to generate tiles for",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "Minimum Zoom",
-            "description": "Minimum zoom level to generate tiles for",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "Output",
-            "description": "Output directory path or expression for the generated MVT tiles",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "schemaKey": {
             "title": "Schema Key",
             "description": "Attribute key to match data and schema features for attribute filtering and casting. This attribute is excluded from output.",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "Skip Unexposed Attributes",
-            "description": "Skip attributes with double underscore prefix",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -7975,6 +7975,39 @@
         "description": "Configuration for finding spatial neighbors between base and candidate features.",
         "type": "object",
         "properties": {
+          "numClosest": {
+            "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
+            "default": 1,
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1.0
+          },
+          "maxDistance": {
+            "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "distanceAttribute": {
+            "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
+            "default": "_neighbor_distance",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "neighborIndexAttribute": {
+            "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
+            "default": "_neighbor_index",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "attributePrefix": {
             "description": "Prefix applied to transferred candidate attributes to avoid collisions.",
             "default": "_neighbor_",
@@ -7988,12 +8021,12 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "distanceAttribute": {
-            "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
-            "default": "_neighbor_distance",
+          "mergeStrategy": {
+            "description": "Controls how multiple neighbors are represented on the output.",
+            "default": "closest",
             "allOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/definitions/MergeStrategy"
               }
             ]
           },
@@ -8005,70 +8038,11 @@
                 "$ref": "#/definitions/DistanceMetric"
               }
             ]
-          },
-          "maxDistance": {
-            "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
-          "mergeStrategy": {
-            "description": "Controls how multiple neighbors are represented on the output.",
-            "default": "closest",
-            "allOf": [
-              {
-                "$ref": "#/definitions/MergeStrategy"
-              }
-            ]
-          },
-          "neighborIndexAttribute": {
-            "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
-            "default": "_neighbor_index",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "numClosest": {
-            "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
-            "default": 1,
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1.0
           }
         },
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "DistanceMetric": {
-            "description": "Distance metric for computing spatial proximity.",
-            "oneOf": [
-              {
-                "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
-                "type": "string",
-                "enum": [
-                  "euclidean2d"
-                ]
-              },
-              {
-                "description": "3D Euclidean distance using X, Y, and Z coordinates.",
-                "type": "string",
-                "enum": [
-                  "euclidean3d"
-                ]
-              },
-              {
-                "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
-                "type": "string",
-                "enum": [
-                  "haversine"
-                ]
-              }
-            ]
           },
           "MergeStrategy": {
             "description": "Merge strategy for handling multiple neighbors.",
@@ -8092,6 +8066,32 @@
                 "type": "string",
                 "enum": [
                   "arrayAttributes"
+                ]
+              }
+            ]
+          },
+          "DistanceMetric": {
+            "description": "Distance metric for computing spatial proximity.",
+            "oneOf": [
+              {
+                "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
+                "type": "string",
+                "enum": [
+                  "euclidean2d"
+                ]
+              },
+              {
+                "description": "3D Euclidean distance using X, Y, and Z coordinates.",
+                "type": "string",
+                "enum": [
+                  "euclidean3d"
+                ]
+              },
+              {
+                "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
+                "type": "string",
+                "enum": [
+                  "haversine"
                 ]
               }
             ]
@@ -8155,10 +8155,6 @@
         "description": "NullAttributeMapper parameters",
         "type": "object",
         "properties": {
-          "defaultReplacement": {
-            "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
-            "default": null
-          },
           "mappings": {
             "description": "Per-attribute replacement rules",
             "default": [],
@@ -8166,6 +8162,10 @@
             "items": {
               "$ref": "#/definitions/AttributeMapping"
             }
+          },
+          "defaultReplacement": {
+            "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
+            "default": null
           },
           "nullDefinition": {
             "description": "Which states count as \"null\"",
@@ -8205,6 +8205,9 @@
                 "description": "Name of the attribute to inspect",
                 "type": "string"
               },
+              "replacement": {
+                "description": "Value to write when attribute is null-like null means remove the attribute"
+              },
               "onMissing": {
                 "description": "What to do when attribute is missing but not in nullDefinition",
                 "default": "skip",
@@ -8213,11 +8216,27 @@
                     "$ref": "#/definitions/OnMissing"
                   }
                 ]
-              },
-              "replacement": {
-                "description": "Value to write when attribute is null-like null means remove the attribute"
               }
             }
+          },
+          "OnMissing": {
+            "description": "What to do when attribute is missing but not in nullDefinition",
+            "oneOf": [
+              {
+                "description": "Leave unchanged",
+                "type": "string",
+                "enum": [
+                  "skip"
+                ]
+              },
+              {
+                "description": "Write replacement value, creating the attribute",
+                "type": "string",
+                "enum": [
+                  "create"
+                ]
+              }
+            ]
           },
           "NullKind": {
             "description": "Defines what states count as \"null\"",
@@ -8241,25 +8260,6 @@
                 "type": "string",
                 "enum": [
                   "emptyString"
-                ]
-              }
-            ]
-          },
-          "OnMissing": {
-            "description": "What to do when attribute is missing but not in nullDefinition",
-            "oneOf": [
-              {
-                "description": "Leave unchanged",
-                "type": "string",
-                "enum": [
-                  "skip"
-                ]
-              },
-              {
-                "description": "Write replacement value, creating the attribute",
-                "type": "string",
-                "enum": [
-                  "create"
                 ]
               }
             ]
@@ -8311,67 +8311,11 @@
         "description": "Configuration for reading Wavefront OBJ 3D model files with support for vertices, faces, normals, texture coordinates, and material definitions.",
         "type": "object",
         "properties": {
-          "dataset": {
-            "title": "File Path",
-            "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "includeNormals": {
-            "title": "Include Normals",
-            "description": "Include vertex normal data in the output geometry",
+          "parseMaterials": {
+            "title": "Parse Materials",
+            "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
             "default": true,
             "type": "boolean"
-          },
-          "includeTexcoords": {
-            "title": "Include Texture Coordinates",
-            "description": "Include texture coordinate (UV) data in the output geometry",
-            "default": true,
-            "type": "boolean"
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "materialFile": {
             "title": "Material File",
@@ -8399,23 +8343,79 @@
               }
             }
           },
+          "triangulate": {
+            "title": "Triangulate",
+            "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
+            "default": false,
+            "type": "boolean"
+          },
           "mergeGroups": {
             "title": "Merge Groups",
             "description": "Merge all groups and objects into a single feature instead of creating separate features per group/object",
             "default": false,
             "type": "boolean"
           },
-          "parseMaterials": {
-            "title": "Parse Materials",
-            "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
+          "includeNormals": {
+            "title": "Include Normals",
+            "description": "Include vertex normal data in the output geometry",
             "default": true,
             "type": "boolean"
           },
-          "triangulate": {
-            "title": "Triangulate",
-            "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
-            "default": false,
+          "includeTexcoords": {
+            "title": "Include Texture Coordinates",
+            "description": "Include texture coordinate (UV) data in the output geometry",
+            "default": true,
             "type": "boolean"
+          },
+          "dataset": {
+            "title": "File Path",
+            "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -8807,15 +8807,24 @@
         "title": "XmlAttributeExtractorParam",
         "type": "object",
         "properties": {
-          "addNsprefixToFeatureTypes": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "cityCode": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "targetPackages": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "addNsprefixToFeatureTypes": {
+            "type": [
+              "boolean",
               "null"
             ]
           },
@@ -8839,15 +8848,6 @@
               "string",
               "null"
             ]
-          },
-          "targetPackages": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
           }
         }
       },
@@ -8931,10 +8931,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "File Index Attribute",
-            "description": "Attribute containing the file index (default: \"fileIndex\")",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "Part ID Attribute",
+            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -8951,10 +8951,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "Part ID Attribute",
-            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "File Index Attribute",
+            "description": "Attribute containing the file index (default: \"fileIndex\")",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -9092,6 +9092,16 @@
           "epsgCode"
         ],
         "properties": {
+          "errorAttribute": {
+            "title": "Error Attribute Name",
+            "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
+            "default": "_validation_error",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "epsgCode": {
             "title": "Target EPSG Code",
             "description": "EPSG code for coordinate transformation from source EPSG 6697. Accepts integer or string expression.",
@@ -9112,16 +9122,6 @@
                 "type": "string"
               }
             }
-          },
-          "errorAttribute": {
-            "title": "Error Attribute Name",
-            "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
-            "default": "_validation_error",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
           }
         },
         "definitions": {
@@ -9178,6 +9178,20 @@
         "description": "Configure mesh code extraction for Japanese standard regional mesh",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "Mesh Type",
+            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "Mesh Code Attribute Name",
+            "description": "Output attribute name for the mesh code",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG Code",
             "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -9202,20 +9216,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "Mesh Type",
-            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "Mesh Code Attribute Name",
-            "description": "Output attribute name for the mesh code",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -9333,17 +9333,6 @@
         "description": "Configuration for generating TIN surfaces from flood area polygons. This processor converts polygons to triangulated surfaces by: 1. Optionally grouping features by an attribute (e.g., udxDirs) 2. Combining all polygons in each group 3. Sampling points along polygon boundaries at regular intervals 4. Optionally adding interior grid points within polygons 5. Performing Delaunay triangulation to create a TIN surface 6. Filtering triangles to keep only those inside the original polygons",
         "type": "object",
         "properties": {
-          "groupBy": {
-            "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "pointSpacing": {
             "description": "Spacing between sampled points in meters (default: 50.0). Points are sampled along polygon boundaries and optionally on an interior grid at this spacing interval.",
             "type": [
@@ -9358,6 +9347,17 @@
             "type": [
               "boolean",
               "null"
+            ]
+          },
+          "groupBy": {
+            "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -9556,21 +9556,6 @@
           "outputDir"
         ],
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "measurements": {
-            "description": "Measurement definitions to insert as gen:measureAttribute elements",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/MeasurementDef"
-            }
-          },
           "outputDir": {
             "description": "Output directory expression for modified CityGML files",
             "type": "object",
@@ -9592,6 +9577,14 @@
               }
             }
           },
+          "gmlIdAttribute": {
+            "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "pathAttribute": {
             "description": "Attribute name on path features holding the file path (default: \"path\")",
             "default": null,
@@ -9600,28 +9593,11 @@
               "null"
             ]
           },
-          "sourceEpsg": {
-            "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
-            "default": null,
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
+          "measurements": {
+            "description": "Measurement definitions to insert as gen:measureAttribute elements",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MeasurementDef"
             }
           },
           "textureImagePath": {
@@ -9648,6 +9624,30 @@
                 "type": "string"
               }
             }
+          },
+          "sourceEpsg": {
+            "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
+            "default": null,
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         },
         "definitions": {
@@ -9660,12 +9660,12 @@
               "uom"
             ],
             "properties": {
-              "attribute": {
-                "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
-                "type": "string"
-              },
               "name": {
                 "description": "XML name attribute value (e.g. \"年間予測日射量\")",
+                "type": "string"
+              },
+              "attribute": {
+                "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
                 "type": "string"
               },
               "uom": {
@@ -9706,63 +9706,11 @@
               "type"
             ],
             "properties": {
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
+              "type": {
+                "type": "string",
+                "enum": [
+                  "time"
                 ]
-              },
-              "sourceEpsg": {
-                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "standardMeridian": {
-                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
-                "default": null,
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
               },
               "time": {
                 "description": "Time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
@@ -9785,60 +9733,6 @@
                   }
                 }
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "time"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "end",
-              "sourceEpsg",
-              "start",
-              "step",
-              "stepUnit",
-              "type"
-            ],
-            "properties": {
-              "end": {
-                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
-                ]
-              },
               "sourceEpsg": {
                 "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
                 "type": "object",
@@ -9883,8 +9777,62 @@
                   }
                 }
               },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
+                ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "end",
+              "sourceEpsg",
+              "start",
+              "step",
+              "stepUnit",
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "duration"
+                ]
+              },
               "start": {
                 "description": "Start time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "end": {
+                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
                 "type": "object",
                 "format": "code",
                 "required": [
@@ -9932,11 +9880,63 @@
                   }
                 ]
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "duration"
+              "sourceEpsg": {
+                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "standardMeridian": {
+                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
+                "default": null,
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
                 ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
               }
             }
           }
@@ -10001,9 +10001,9 @@
         "title": "SolidIntersectionTestPairCreatorParam",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10011,9 +10011,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10180,6 +10180,12 @@
         "description": "Configure unshared edge detection behavior",
         "type": "object",
         "properties": {
+          "tolerance": {
+            "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          },
           "groupBy": {
             "description": "Group By Attributes. When specified, edge detection is performed independently within each group. Features with the same values for these attributes are grouped together.",
             "default": null,
@@ -10190,12 +10196,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "tolerance": {
-            "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
-            "default": 0.1,
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -10236,10 +10236,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "File Index Attribute",
-            "description": "Attribute containing the file index (default: \"fileIndex\")",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "Part ID Attribute",
+            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10256,10 +10256,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "Part ID Attribute",
-            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "File Index Attribute",
+            "description": "Attribute containing the file index (default: \"fileIndex\")",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10345,6 +10345,20 @@
         "description": "Configure mesh code extraction for Japanese standard regional mesh",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "Mesh Type",
+            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "Mesh Code Attribute Name",
+            "description": "Output attribute name for the mesh code",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG Code",
             "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -10369,20 +10383,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "Mesh Type",
-            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "Mesh Code Attribute Name",
-            "description": "Output attribute name for the mesh code",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -10532,9 +10532,9 @@
         "title": "SolidIntersectionTestPairCreatorParam",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10542,9 +10542,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10763,6 +10763,31 @@
         "title": "PythonScriptProcessorParam",
         "type": "object",
         "properties": {
+          "script": {
+            "title": "Inline Script",
+            "description": "Python script code to execute inline",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "pythonFile": {
             "title": "Python File",
             "description": "Path to a Python script file (supports file://, http://, https://, gs://, etc.)",
@@ -10795,31 +10820,6 @@
               "string",
               "null"
             ]
-          },
-          "script": {
-            "title": "Inline Script",
-            "description": "Python script code to execute inline",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "timeoutSeconds": {
             "title": "Timeout Seconds",
@@ -10860,6 +10860,34 @@
           "ray"
         ],
         "properties": {
+          "ray": {
+            "description": "Defines how to extract ray data from feature attributes",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RayDefinition"
+              }
+            ]
+          },
+          "pairId": {
+            "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "closestIntersectionOnly": {
             "description": "When true (default), return only the closest intersection point per ray-geometry pair. When false, return all intersection points.",
             "default": null,
@@ -10884,8 +10912,8 @@
               }
             }
           },
-          "geomId": {
-            "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
+          "tolerance": {
+            "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
             "default": null,
             "type": [
               "object",
@@ -10941,36 +10969,8 @@
               }
             ]
           },
-          "pairId": {
-            "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "ray": {
-            "description": "Defines how to extract ray data from feature attributes",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RayDefinition"
-              }
-            ]
-          },
-          "tolerance": {
-            "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
+          "geomId": {
+            "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
             "default": null,
             "type": [
               "object",
@@ -10995,28 +10995,6 @@
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "OutputGeometryType": {
-            "description": "Output geometry type for ray intersection results",
-            "oneOf": [
-              {
-                "description": "Output a point at the intersection location (default behavior)",
-                "type": "string",
-                "enum": [
-                  "pointOfIntersection"
-                ]
-              },
-              {
-                "description": "Output a line segment from ray origin to intersection point",
-                "type": "string",
-                "enum": [
-                  "lineSegmentToIntersection"
-                ]
-              }
-            ]
-          },
           "RayDefinition": {
             "description": "Defines how ray data is extracted from feature attributes.",
             "type": "object",
@@ -11029,30 +11007,6 @@
               "posZ"
             ],
             "properties": {
-              "dirX": {
-                "description": "Attribute containing ray direction X component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirY": {
-                "description": "Attribute containing ray direction Y component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirZ": {
-                "description": "Attribute containing ray direction Z component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
               "posX": {
                 "description": "Attribute containing ray origin X coordinate",
                 "allOf": [
@@ -11076,8 +11030,54 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "dirX": {
+                "description": "Attribute containing ray direction X component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirY": {
+                "description": "Attribute containing ray direction Y component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirZ": {
+                "description": "Attribute containing ray direction Z component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "OutputGeometryType": {
+            "description": "Output geometry type for ray intersection results",
+            "oneOf": [
+              {
+                "description": "Output a point at the intersection location (default behavior)",
+                "type": "string",
+                "enum": [
+                  "pointOfIntersection"
+                ]
+              },
+              {
+                "description": "Output a line segment from ray origin to intersection point",
+                "type": "string",
+                "enum": [
+                  "lineSegmentToIntersection"
+                ]
+              }
+            ]
           }
         }
       },
@@ -11160,6 +11160,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fromToVectors"
+                    ]
+                  },
                   "fromX": {
                     "description": "X component of the source direction vector",
                     "type": "object",
@@ -11279,12 +11285,6 @@
                         "type": "string"
                       }
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "fromToVectors"
-                    ]
                   }
                 }
               },
@@ -11299,25 +11299,11 @@
                   "type"
                 ],
                 "properties": {
-                  "angle": {
-                    "description": "Rotation angle in degrees",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "axisAngle"
+                    ]
                   },
                   "axisX": {
                     "description": "X component of the rotation axis",
@@ -11379,11 +11365,25 @@
                       }
                     }
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "axisAngle"
-                    ]
+                  "angle": {
+                    "description": "Rotation angle in degrees",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -11414,6 +11414,20 @@
         "description": "Configuration for reading Shapefile archives as geographic features. Expects a ZIP archive containing the required Shapefile components (.shp, .dbf, .shx).",
         "type": "object",
         "properties": {
+          "encoding": {
+            "title": "Character Encoding",
+            "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "force2d": {
+            "title": "Force 2D",
+            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+            "default": false,
+            "type": "boolean"
+          },
           "allowEmptyPath": {
             "title": "Allow Null Path",
             "description": "If true, a dataset expression that evaluates to null produces zero features instead of an error. This is useful for optional shapefile inputs where the path may not be configured.",
@@ -11444,20 +11458,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "Character Encoding",
-            "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "force2d": {
-            "title": "Force 2D",
-            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-            "default": false,
-            "type": "boolean"
           },
           "inline": {
             "title": "Inline Content",
@@ -11511,16 +11511,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "Optional attributes to group features by, creating separate files for each group",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "Output path or expression for the Shapefile to create",
             "type": "object",
@@ -11540,6 +11530,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "Optional attributes to group features by, creating separate files for each group",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -11621,20 +11621,21 @@
         "description": "Configure spatial relationship testing between filter and candidate geometries",
         "type": "object",
         "properties": {
-          "mergeFilterAttributes": {
-            "title": "Merge Filter Attributes",
-            "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
-            "default": false,
-            "type": "boolean"
-          },
-          "mergedAttributesPrefix": {
-            "title": "Merged Attributes Prefix",
-            "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
-            "default": null,
-            "type": [
-              "string",
-              "null"
+          "predicate": {
+            "title": "Spatial Predicate",
+            "description": "The spatial relationship to test between filter and candidate geometries",
+            "default": "intersects",
+            "allOf": [
+              {
+                "$ref": "#/definitions/SpatialPredicate"
+              }
             ]
+          },
+          "passOnMultipleMatches": {
+            "title": "Pass on Multiple Matches",
+            "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
+            "default": true,
+            "type": "boolean"
           },
           "outputMatchCountAttribute": {
             "title": "Output Match Count Attribute",
@@ -11649,27 +11650,23 @@
               }
             ]
           },
-          "passOnMultipleMatches": {
-            "title": "Pass on Multiple Matches",
-            "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
-            "default": true,
+          "mergeFilterAttributes": {
+            "title": "Merge Filter Attributes",
+            "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
+            "default": false,
             "type": "boolean"
           },
-          "predicate": {
-            "title": "Spatial Predicate",
-            "description": "The spatial relationship to test between filter and candidate geometries",
-            "default": "intersects",
-            "allOf": [
-              {
-                "$ref": "#/definitions/SpatialPredicate"
-              }
+          "mergedAttributesPrefix": {
+            "title": "Merged Attributes Prefix",
+            "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "SpatialPredicate": {
             "oneOf": [
               {
@@ -11736,6 +11733,9 @@
                 ]
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -11768,9 +11768,9 @@
           "sql"
         ],
         "properties": {
-          "databaseUrl": {
-            "title": "Database URL",
-            "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
+          "sql": {
+            "title": "SQL Query",
+            "description": "SQL query expression to execute for retrieving data",
             "type": "object",
             "format": "code",
             "required": [
@@ -11790,9 +11790,9 @@
               }
             }
           },
-          "sql": {
-            "title": "SQL Query",
-            "description": "SQL query expression to execute for retrieving data",
+          "databaseUrl": {
+            "title": "Database URL",
+            "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
             "type": "object",
             "format": "code",
             "required": [
@@ -11839,13 +11839,17 @@
           "calculations"
         ],
         "properties": {
-          "calculations": {
-            "title": "Calculations",
-            "description": "List of statistical calculations to perform on grouped features",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/Calculation"
-            }
+          "groupId": {
+            "title": "Group id",
+            "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "groupBy": {
             "title": "Group by",
@@ -11858,17 +11862,13 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "groupId": {
-            "title": "Group id",
-            "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
+          "calculations": {
+            "title": "Calculations",
+            "description": "List of statistical calculations to perform on grouped features",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Calculation"
+            }
           }
         },
         "definitions": {
@@ -11882,6 +11882,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "New attribute name",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "expr": {
                 "title": "Calculation to perform",
                 "type": "object",
@@ -11901,14 +11909,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "New attribute name",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           }
@@ -11948,33 +11948,6 @@
           "minZ"
         ],
         "properties": {
-          "maxX": {
-            "title": "Maximum X Attribute",
-            "description": "Name of attribute containing the maximum X coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxY": {
-            "title": "Maximum Y Attribute",
-            "description": "Name of attribute containing the maximum Y coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxZ": {
-            "title": "Maximum Z Attribute",
-            "description": "Name of attribute containing the maximum Z coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "minX": {
             "title": "Minimum X Attribute",
             "description": "Name of attribute containing the minimum X coordinate",
@@ -11996,6 +11969,33 @@
           "minZ": {
             "title": "Minimum Z Attribute",
             "description": "Name of attribute containing the minimum Z coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxX": {
+            "title": "Maximum X Attribute",
+            "description": "Name of attribute containing the maximum X coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxY": {
+            "title": "Maximum Y Attribute",
+            "description": "Name of attribute containing the maximum Y coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxZ": {
+            "title": "Maximum Z Attribute",
+            "description": "Name of attribute containing the maximum Z coordinate",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -12135,69 +12135,6 @@
               }
             }
           },
-          "directionX": {
-            "title": "Direction X",
-            "description": "X component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionY": {
-            "title": "Direction Y",
-            "description": "Y component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionZ": {
-            "title": "Direction Z",
-            "description": "Z component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "originX": {
             "title": "Origin X",
             "description": "X coordinate of the rotation origin point",
@@ -12243,6 +12180,69 @@
           "originZ": {
             "title": "Origin Z",
             "description": "Z coordinate of the rotation origin point",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionX": {
+            "title": "Direction X",
+            "description": "X component of the rotation axis direction vector",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionY": {
+            "title": "Direction Y",
+            "description": "Y component of the rotation axis direction vector",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionZ": {
+            "title": "Direction Z",
+            "description": "Z component of the rotation axis direction vector",
             "type": "object",
             "format": "code",
             "required": [
@@ -12419,27 +12419,11 @@
               "source"
             ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
-              },
-              "elementsToExclude": {
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "source": {
+                "type": "string",
+                "enum": [
+                  "url"
+                ]
               },
               "elementsToMatch": {
                 "type": "object",
@@ -12460,11 +12444,27 @@
                   }
                 }
               },
-              "source": {
-                "type": "string",
-                "enum": [
-                  "url"
-                ]
+              "elementsToExclude": {
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               }
             }
           }
@@ -12517,19 +12517,19 @@
           "Attribute": {
             "type": "string"
           },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          },
           "ValidationType": {
             "type": "string",
             "enum": [
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }

--- a/engine/schema/actions_es.json
+++ b/engine/schema/actions_es.json
@@ -39,12 +39,6 @@
               }
             ]
           },
-          "multiplier": {
-            "description": "Multiplier to scale the area values (default: 1.0)",
-            "default": 1.0,
-            "type": "number",
-            "format": "double"
-          },
           "outputAttribute": {
             "description": "Name of the attribute to store the calculated area (default: \"area\")",
             "default": "area",
@@ -53,6 +47,12 @@
                 "$ref": "#/definitions/Attribute"
               }
             ]
+          },
+          "multiplier": {
+            "description": "Multiplier to scale the area values (default: 1.0)",
+            "default": 1.0,
+            "type": "number",
+            "format": "double"
           }
         },
         "definitions": {
@@ -93,6 +93,17 @@
         "description": "Configure how area overlay analysis is performed",
         "type": "object",
         "properties": {
+          "groupBy": {
+            "title": "Group By Attributes",
+            "description": "Optional attributes to group features by during overlay analysis",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "accumulationMode": {
             "title": "Accumulation Mode",
             "description": "Controls how attributes from input features are handled in output features",
@@ -110,17 +121,6 @@
               "string",
               "null"
             ]
-          },
-          "groupBy": {
-            "title": "Group By Attributes",
-            "description": "Optional attributes to group features by during overlay analysis",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
           },
           "outputAttribute": {
             "title": "Output Attribute",
@@ -141,15 +141,15 @@
           }
         },
         "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
           "AccumulationMode": {
             "type": "string",
             "enum": [
               "useAttributesFromOneFeature",
               "dropIncomingAttributes"
             ]
-          },
-          "Attribute": {
-            "type": "string"
           }
         }
       },
@@ -212,14 +212,6 @@
               }
             }
           },
-          "calculationAttribute": {
-            "title": "Attribute to store calculation result",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "calculationValue": {
             "title": "Value to use for calculation",
             "type": [
@@ -227,6 +219,14 @@
               "null"
             ],
             "format": "int64"
+          },
+          "calculationAttribute": {
+            "title": "Attribute to store calculation result",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           },
           "method": {
             "title": "Method to use for aggregation",
@@ -244,6 +244,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "New attribute to create",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "attribute": {
                 "title": "Existing attribute to use",
                 "anyOf": [
@@ -277,14 +285,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "New attribute to create",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           },
@@ -388,6 +388,14 @@
           "rules"
         ],
         "properties": {
+          "rules": {
+            "title": "Conversion Rules",
+            "description": "List of rules defining how to map attributes using the conversion table",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AttributeConversionTableRule"
+            }
+          },
           "dataset": {
             "title": "Dataset URI",
             "description": "Path or URI to external conversion table file",
@@ -413,15 +421,6 @@
               }
             }
           },
-          "format": {
-            "title": "Table Format",
-            "description": "Format of the conversion table (CSV, TSV, or JSON)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/ConversionTableFormat"
-              }
-            ]
-          },
           "inline": {
             "title": "Inline Table Data",
             "description": "Conversion table data provided directly as string content",
@@ -430,19 +429,17 @@
               "null"
             ]
           },
-          "rules": {
-            "title": "Conversion Rules",
-            "description": "List of rules defining how to map attributes using the conversion table",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/AttributeConversionTableRule"
-            }
+          "format": {
+            "title": "Table Format",
+            "description": "Format of the conversion table (CSV, TSV, or JSON)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/ConversionTableFormat"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "AttributeConversionTableRule": {
             "type": "object",
             "required": [
@@ -452,17 +449,6 @@
               "featureTo"
             ],
             "properties": {
-              "conversionTableKeys": {
-                "title": "Keys to match in conversion table",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "conversionTableTo": {
-                "title": "Attribute to convert to",
-                "type": "string"
-              },
               "featureFroms": {
                 "title": "Attributes to convert from",
                 "type": "array",
@@ -477,8 +463,22 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "conversionTableKeys": {
+                "title": "Keys to match in conversion table",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "conversionTableTo": {
+                "title": "Attribute to convert to",
+                "type": "string"
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
           },
           "ConversionTableFormat": {
             "type": "string",
@@ -647,15 +647,6 @@
           }
         },
         "definitions": {
-          "Method": {
-            "type": "string",
-            "enum": [
-              "convert",
-              "create",
-              "rename",
-              "remove"
-            ]
-          },
           "Operation": {
             "type": "object",
             "required": [
@@ -701,6 +692,15 @@
                 }
               }
             }
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "convert",
+              "create",
+              "rename",
+              "remove"
+            ]
           }
         }
       },
@@ -748,13 +748,6 @@
                   "null"
                 ]
               },
-              "childAttribute": {
-                "title": "Child attribute name",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
               "expr": {
                 "title": "Expression to evaluate",
                 "type": [
@@ -779,6 +772,27 @@
                   }
                 }
               },
+              "valueAttribute": {
+                "title": "Attribute name to get value from",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
+                "title": "Parent attribute name",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "childAttribute": {
+                "title": "Child attribute name",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "multipleExpr": {
                 "title": "Expression to evaluate multiple attributes",
                 "type": [
@@ -801,20 +815,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "parentAttribute": {
-                "title": "Parent attribute name",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "title": "Attribute name to get value from",
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
           }
@@ -848,10 +848,6 @@
           "rangeTable"
         ],
         "properties": {
-          "defaultValue": {
-            "title": "Default Value",
-            "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
-          },
           "inputAttribute": {
             "title": "Input Attribute",
             "description": "The attribute to evaluate for range mapping",
@@ -869,6 +865,10 @@
             "items": {
               "$ref": "#/definitions/RangeEntry"
             }
+          },
+          "defaultValue": {
+            "title": "Default Value",
+            "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
           }
         },
         "definitions": {
@@ -887,15 +887,15 @@
                 "type": "number",
                 "format": "double"
               },
-              "outputValue": {
-                "title": "Output Value",
-                "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
-              },
               "to": {
                 "title": "To (Maximum)",
                 "description": "The maximum value of the range (exclusive)",
                 "type": "number",
                 "format": "double"
+              },
+              "outputValue": {
+                "title": "Output Value",
+                "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
               }
             }
           }
@@ -923,13 +923,13 @@
         "description": "Configuration for extracting boundaries from geometries.",
         "type": "object",
         "properties": {
-          "exteriorOnly": {
-            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
+          "keepEmptyBoundaries": {
+            "description": "Whether to keep features with empty boundaries (default: false)",
             "default": false,
             "type": "boolean"
           },
-          "keepEmptyBoundaries": {
-            "description": "Whether to keep features with empty boundaries (default: false)",
+          "exteriorOnly": {
+            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
             "default": false,
             "type": "boolean"
           }
@@ -956,18 +956,6 @@
         "title": "BoundsExtractor Parameters",
         "type": "object",
         "properties": {
-          "xmax": {
-            "title": "Maximum X Attribute",
-            "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "xmin": {
             "title": "Minimum X Attribute",
             "description": "Attribute name for storing the minimum X coordinate (defaults to \"xmin\")",
@@ -980,9 +968,9 @@
               }
             ]
           },
-          "ymax": {
-            "title": "Maximum Y Attribute",
-            "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
+          "xmax": {
+            "title": "Maximum X Attribute",
+            "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1004,9 +992,9 @@
               }
             ]
           },
-          "zmax": {
-            "title": "Maximum Z Attribute",
-            "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
+          "ymax": {
+            "title": "Maximum Y Attribute",
+            "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1019,6 +1007,18 @@
           "zmin": {
             "title": "Minimum Z Attribute",
             "description": "Attribute name for storing the minimum Z coordinate (defaults to \"zmin\")",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "zmax": {
+            "title": "Maximum Z Attribute",
+            "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1130,6 +1130,15 @@
           "renameValue"
         ],
         "properties": {
+          "renameType": {
+            "title": "Which Attributes to Rename",
+            "description": "Choose whether to rename all attributes or only selected ones",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RenameType"
+              }
+            ]
+          },
           "renameAction": {
             "title": "Rename Operation",
             "description": "The type of renaming operation to perform on the attribute names",
@@ -1139,13 +1148,12 @@
               }
             ]
           },
-          "renameType": {
-            "title": "Which Attributes to Rename",
-            "description": "Choose whether to rename all attributes or only selected ones",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RenameType"
-              }
+          "textToFind": {
+            "title": "Text Pattern to Find",
+            "description": "Regular expression pattern to match when using \"Replace Text\" operation",
+            "type": [
+              "string",
+              "null"
             ]
           },
           "renameValue": {
@@ -1163,17 +1171,29 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "title": "Text Pattern to Find",
-            "description": "Regular expression pattern to match when using \"Replace Text\" operation",
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
         "definitions": {
+          "RenameType": {
+            "oneOf": [
+              {
+                "title": "All Attributes",
+                "description": "Rename all attributes in the feature",
+                "type": "string",
+                "enum": [
+                  "All"
+                ]
+              },
+              {
+                "title": "Selected Attributes",
+                "description": "Rename only specific attributes listed below",
+                "type": "string",
+                "enum": [
+                  "Selected"
+                ]
+              }
+            ]
+          },
           "RenameAction": {
             "oneOf": [
               {
@@ -1217,26 +1237,6 @@
                 ]
               }
             ]
-          },
-          "RenameType": {
-            "oneOf": [
-              {
-                "title": "All Attributes",
-                "description": "Rename all attributes in the feature",
-                "type": "string",
-                "enum": [
-                  "All"
-                ]
-              },
-              {
-                "title": "Selected Attributes",
-                "description": "Rename only specific attributes listed below",
-                "type": "string",
-                "enum": [
-                  "Selected"
-                ]
-              }
-            ]
           }
         }
       },
@@ -1262,22 +1262,6 @@
         "description": "Configure how the CSG builder pairs features from left and right ports",
         "type": "object",
         "properties": {
-          "createList": {
-            "title": "Create List",
-            "description": "When enabled, creates a list of attribute values from both children (left and right)",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "listAttributeName": {
-            "title": "List Attribute Name",
-            "description": "Name of the attribute to create the list from (required when create_list is true)",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "pairIdAttribute": {
             "title": "Pair ID Attribute",
             "description": "Expression to evaluate the pair ID used to match features from left and right ports",
@@ -1301,6 +1285,22 @@
                 "type": "string"
               }
             }
+          },
+          "createList": {
+            "title": "Create List",
+            "description": "When enabled, creates a list of attribute values from both children (left and right)",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "listAttributeName": {
+            "title": "List Attribute Name",
+            "description": "Name of the attribute to create the list from (required when create_list is true)",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -1445,6 +1445,42 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "title": "Output Path",
+            "description": "Directory path where the 3D tiles will be written",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "Minimum Zoom Level",
+            "description": "Minimum zoom level for tile generation (0-24)",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "Maximum Zoom Level",
+            "description": "Maximum zoom level for tile generation (0-24)",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
           "attachTexture": {
             "title": "Attach Textures",
             "description": "Whether to include texture information in the generated tiles",
@@ -1486,55 +1522,19 @@
               "null"
             ]
           },
-          "maxZoom": {
-            "title": "Maximum Zoom Level",
-            "description": "Maximum zoom level for tile generation (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "Minimum Zoom Level",
-            "description": "Minimum zoom level for tile generation (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "Output Path",
-            "description": "Directory path where the 3D tiles will be written",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
+          "skipUnexposedAttributes": {
+            "title": "Skip unexposed Attributes",
+            "description": "Skip attributes with double underscore prefix",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "title": "Schema Key",
             "description": "Attribute key whose value identifies the schema type and determines the output filename: all features sharing the same value are written to the same file. This attribute is excluded from output.",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "Skip unexposed Attributes",
-            "description": "Skip attributes with double underscore prefix",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -1589,12 +1589,6 @@
               }
             }
           },
-          "flatten": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -1619,6 +1613,12 @@
                 "type": "string"
               }
             }
+          },
+          "flatten": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         }
       },
@@ -1647,29 +1647,6 @@
           "output"
         ],
         "properties": {
-          "epsgCode": {
-            "description": "EPSG code for coordinate reference system",
-            "default": null,
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "lodFilter": {
-            "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-            "default": null,
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          },
           "output": {
             "description": "Output file path expression",
             "type": "object",
@@ -1690,6 +1667,29 @@
                 "type": "string"
               }
             }
+          },
+          "lodFilter": {
+            "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+            "default": null,
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "epsgCode": {
+            "description": "EPSG code for coordinate reference system",
+            "default": null,
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
           },
           "prettyPrint": {
             "description": "Whether to format output with indentation (default: true)",
@@ -1807,15 +1807,6 @@
           "mode"
         ],
         "properties": {
-          "defaultZValue": {
-            "title": "Default Z Value",
-            "description": "Z value to use for 2D geometries that have no Z coordinate.",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
           "mode": {
             "title": "Extraction Mode",
             "description": "How to extract coordinates from geometry vertices.",
@@ -1824,12 +1815,18 @@
                 "$ref": "#/definitions/CoordinateExtractionMode"
               }
             ]
+          },
+          "defaultZValue": {
+            "title": "Default Z Value",
+            "description": "Z value to use for 2D geometries that have no Z coordinate.",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "CoordinateExtractionMode": {
             "description": "Extraction mode: determines how coordinates are output.",
             "oneOf": [
@@ -1840,6 +1837,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "allCoordinates"
+                    ]
+                  },
                   "coordinatesListName": {
                     "title": "Coordinates List Name",
                     "description": "Name of the list attribute that will store coordinate objects (default: \"_indices\")",
@@ -1848,12 +1851,6 @@
                       {
                         "$ref": "#/definitions/Attribute"
                       }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "allCoordinates"
                     ]
                   }
                 }
@@ -1866,17 +1863,17 @@
                   "type"
                 ],
                 "properties": {
-                  "coordinateIndex": {
-                    "title": "Coordinate Index",
-                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
-                    "type": "integer",
-                    "format": "int64"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
                       "specifyCoordinate"
                     ]
+                  },
+                  "coordinateIndex": {
+                    "title": "Coordinate Index",
+                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "xAttribute": {
                     "title": "X Attribute Name",
@@ -1911,6 +1908,9 @@
                 }
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -1940,6 +1940,23 @@
           "format"
         ],
         "properties": {
+          "format": {
+            "title": "File Format",
+            "description": "Choose the delimiter format for the input file",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "encoding": {
+            "title": "Character Encoding",
+            "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -1964,45 +1981,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "Character Encoding",
-            "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "format": {
-            "title": "File Format",
-            "description": "Choose the delimiter format for the input file",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "Geometry Configuration",
-            "description": "Optional configuration for parsing geometry from CSV columns",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "headerRows": {
-            "title": "Header Row Count",
-            "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint",
-            "minimum": 0.0
           },
           "inline": {
             "title": "Inline Content",
@@ -2038,6 +2016,28 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "headerRows": {
+            "title": "Header Row Count",
+            "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint",
+            "minimum": 0.0
+          },
+          "geometry": {
+            "title": "Geometry Configuration",
+            "description": "Optional configuration for parsing geometry from CSV columns",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2152,26 +2152,6 @@
           "output"
         ],
         "properties": {
-          "format": {
-            "description": "File format: csv (comma) or tsv (tab)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "Geometry Configuration",
-            "description": "Optional configuration for exporting geometry to CSV columns",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryExportConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "output": {
             "description": "Output path or expression for the CSV/TSV file to create",
             "type": "object",
@@ -2192,6 +2172,26 @@
                 "type": "string"
               }
             }
+          },
+          "format": {
+            "description": "File format: csv (comma) or tsv (tab)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "geometry": {
+            "title": "Geometry Configuration",
+            "description": "Optional configuration for exporting geometry to CSV columns",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryExportConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2290,6 +2290,28 @@
         "description": "Configuration for reading CZML files as geographic features.",
         "type": "object",
         "properties": {
+          "force2d": {
+            "title": "Force 2D",
+            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+            "default": false,
+            "type": "boolean"
+          },
+          "skipDocumentPacket": {
+            "title": "Skip Document Packet",
+            "description": "If true, skips the document packet (first packet with version/clock info)",
+            "default": true,
+            "type": "boolean"
+          },
+          "timeSampling": {
+            "title": "Time Sampling Strategy",
+            "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
+            "default": "preserveRaw",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TimeSamplingStrategy"
+              }
+            ]
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -2315,12 +2337,6 @@
               }
             }
           },
-          "force2d": {
-            "title": "Force 2D",
-            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -2345,22 +2361,6 @@
                 "type": "string"
               }
             }
-          },
-          "skipDocumentPacket": {
-            "title": "Skip Document Packet",
-            "description": "If true, skips the document packet (first packet with version/clock info)",
-            "default": true,
-            "type": "boolean"
-          },
-          "timeSampling": {
-            "title": "Time Sampling Strategy",
-            "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
-            "default": "preserveRaw",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TimeSamplingStrategy"
-              }
-            ]
           }
         },
         "definitions": {
@@ -2415,87 +2415,6 @@
           "output"
         ],
         "properties": {
-          "colorAttribute": {
-            "title": "Color Attribute",
-            "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "epoch": {
-            "title": "Epoch",
-            "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "groupBy": {
-            "title": "Group By Attributes",
-            "description": "Attributes used to group features into separate CZML files",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
-          "groupTimeseriesBy": {
-            "title": "Group Timeseries By",
-            "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "heightAttribute": {
-            "title": "Height Attribute",
-            "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "interpolationAlgorithm": {
-            "title": "Interpolation Algorithm",
-            "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
-            "default": "LINEAR",
-            "allOf": [
-              {
-                "$ref": "#/definitions/InterpolationAlgorithm"
-              }
-            ]
-          },
-          "interpolationDegree": {
-            "title": "Interpolation Degree",
-            "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
-            "default": 1,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "opacity": {
-            "title": "Opacity",
-            "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
-            "default": 180,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
           "output": {
             "title": "Output File Path",
             "description": "Path where the CZML file will be written",
@@ -2518,9 +2437,90 @@
               }
             }
           },
+          "groupBy": {
+            "title": "Group By Attributes",
+            "description": "Attributes used to group features into separate CZML files",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "timeField": {
             "title": "Time Field",
             "description": "Attribute containing the timestamp for each feature. Supports two formats: - **ISO 8601 strings**: e.g., \"2024-01-01T00:00:00Z\", \"2024-01-01T12:30:45+09:00\" - **Numeric values**: Seconds as offset from epoch (e.g., \"0\", \"60\", \"120.5\")\n\nWhen set together with `groupTimeseriesBy`, features sharing the same group key are combined into a single CZML entity with time-tagged position samples for animation in Cesium.\n\n**Example workflow configuration:** ```yaml - action: CzmlWriter with: output: \"output.czml\" timeField: \"timestamp\" groupTimeseriesBy: \"vehicleId\" epoch: \"2024-01-01T00:00:00Z\"  # Optional for numeric times (auto-defaults to Unix epoch) ```",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "epoch": {
+            "title": "Epoch",
+            "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "interpolationAlgorithm": {
+            "title": "Interpolation Algorithm",
+            "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
+            "default": "LINEAR",
+            "allOf": [
+              {
+                "$ref": "#/definitions/InterpolationAlgorithm"
+              }
+            ]
+          },
+          "interpolationDegree": {
+            "title": "Interpolation Degree",
+            "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
+            "default": 1,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "groupTimeseriesBy": {
+            "title": "Group Timeseries By",
+            "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "colorAttribute": {
+            "title": "Color Attribute",
+            "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "opacity": {
+            "title": "Opacity",
+            "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
+            "default": 180,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "heightAttribute": {
+            "title": "Height Attribute",
+            "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -2598,14 +2598,6 @@
               }
             ]
           },
-          "outputAttribute": {
-            "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "outputFormat": {
             "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode).",
             "default": "auto",
@@ -2613,6 +2605,14 @@
               {
                 "$ref": "#/definitions/DateTimeOutputFormat"
               }
+            ]
+          },
+          "outputAttribute": {
+            "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
@@ -2819,16 +2819,6 @@
         "description": "Configure how to dissolve features by grouping them based on shared attributes",
         "type": "object",
         "properties": {
-          "attributeAccumulation": {
-            "title": "Attribute Accumulation",
-            "description": "Strategy for handling attributes when dissolving features",
-            "default": "useOneFeature",
-            "allOf": [
-              {
-                "$ref": "#/definitions/AttributeAccumulationStrategy"
-              }
-            ]
-          },
           "groupBy": {
             "title": "Group By Attributes",
             "description": "List of attribute names to group features by before dissolving. Features with the same values for these attributes will be dissolved together",
@@ -2848,6 +2838,16 @@
               "null"
             ],
             "format": "double"
+          },
+          "attributeAccumulation": {
+            "title": "Attribute Accumulation",
+            "description": "Strategy for handling attributes when dissolving features",
+            "default": "useOneFeature",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AttributeAccumulationStrategy"
+              }
+            ]
           }
         },
         "definitions": {
@@ -3089,15 +3089,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "Clave de Atributos CityGML",
-            "description": "Cuando se establece, los atributos CityGML analizados se anidan bajo esta clave en la entidad de salida. Cuando es nulo, los atributos se emiten al nivel superior. Por defecto es nulo.",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Expresión de ruta que resuelve al archivo CityGML 2.0 a leer.",
@@ -3129,10 +3120,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "Aplanar Tipos de Medida",
-            "description": "Cuando es verdadero, los elementos con un único atributo `uom` y contenido de texto numérico se convierten a un valor numérico, con la unidad almacenada como clave hermana `{name}_uom`. Por defecto es false.",
-            "default": false,
+          "keepAttributes": {
+            "title": "Conservar Atributos",
+            "description": "Cuando es falso, los atributos XML (entradas con prefijo `@` como `@gml:id`, `@codeSpace`) se eliminan de las entidades analizadas. Por defecto es true.",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3141,11 +3132,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "Conservar Atributos",
-            "description": "Cuando es falso, los atributos XML (entradas con prefijo `@` como `@gml:id`, `@codeSpace`) se eliminan de las entidades analizadas. Por defecto es true.",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "Aplanar Tipos de Medida",
+            "description": "Cuando es verdadero, los elementos con un único atributo `uom` y contenido de texto numérico se convierten a un valor numérico, con la unidad almacenada como clave hermana `{name}_uom`. Por defecto es false.",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "Clave de Atributos CityGML",
+            "description": "Cuando se establece, los atributos CityGML analizados se anidan bajo esta clave en la entidad de salida. Cuando es nulo, los atributos se emiten al nivel superior. Por defecto es nulo.",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3173,15 +3173,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "Clave de Atributos CityGML",
-            "description": "Cuando se establece, los atributos CityGML analizados se anidan bajo esta clave en la entidad de salida. Cuando es nulo, los atributos se emiten al nivel superior. Por defecto es nulo.",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Expresión de ruta que resuelve al archivo CityGML 3.0 a leer.",
@@ -3213,10 +3204,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "Aplanar Tipos de Medida",
-            "description": "Cuando es verdadero, los elementos con un único atributo `uom` y contenido de texto numérico se convierten a un valor numérico, con la unidad almacenada como clave hermana `{name}_uom`. Por defecto es false.",
-            "default": false,
+          "keepAttributes": {
+            "title": "Conservar Atributos",
+            "description": "Cuando es falso, los atributos XML (entradas con prefijo `@` como `@gml:id`, `@codeSpace`) se eliminan de las entidades analizadas. Por defecto es true.",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3225,11 +3216,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "Conservar Atributos",
-            "description": "Cuando es falso, los atributos XML (entradas con prefijo `@` como `@gml:id`, `@codeSpace`) se eliminan de las entidades analizadas. Por defecto es true.",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "Aplanar Tipos de Medida",
+            "description": "Cuando es verdadero, los elementos con un único atributo `uom` y contenido de texto numérico se convierten a un valor numérico, con la unidad almacenada como clave hermana `{name}_uom`. Por defecto es false.",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "Clave de Atributos CityGML",
+            "description": "Cuando se establece, los atributos CityGML analizados se anidan bajo esta clave en la entidad de salida. Cuando es nulo, los atributos se emiten al nivel superior. Por defecto es nulo.",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3258,31 +3258,6 @@
           "dataset"
         ],
         "properties": {
-          "codelistsPath": {
-            "title": "Codelists Path",
-            "description": "Optional path to the codelists directory for resolving codelist values",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Path or expression to the CityGML dataset file to be read",
@@ -3312,6 +3287,31 @@
               "boolean",
               "null"
             ]
+          },
+          "codelistsPath": {
+            "title": "Codelists Path",
+            "description": "Optional path to the codelists directory for resolving codelist values",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -3463,19 +3463,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "destPrefix": {
-            "title": "Destination Prefix",
-            "description": "Optional prefix to add to extracted file paths",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "extractArchive": {
-            "title": "Extract Archive",
-            "description": "Whether to extract archive files found in the dataset",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Expression to get the source dataset path or URL",
@@ -3497,6 +3484,19 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "Extract Archive",
+            "description": "Whether to extract archive files found in the dataset",
+            "type": "boolean"
+          },
+          "destPrefix": {
+            "title": "Destination Prefix",
+            "description": "Optional prefix to add to extracted file paths",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3606,17 +3606,6 @@
           "joinType"
         ],
         "properties": {
-          "conflictResolution": {
-            "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ConflictResolution"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "joinType": {
             "description": "Join type: inner, left, or full",
             "allOf": [
@@ -3627,6 +3616,16 @@
           },
           "requestorAttribute": {
             "description": "Attributes from requestor features to use for matching (alternative to requestorAttributeValue)",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
             "type": [
               "array",
               "null"
@@ -3658,16 +3657,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "Expression to evaluate for supplier feature matching values (alternative to supplierAttribute)",
             "type": [
@@ -3690,30 +3679,20 @@
                 "type": "string"
               }
             }
+          },
+          "conflictResolution": {
+            "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ConflictResolution"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "ConflictResolution": {
-            "oneOf": [
-              {
-                "description": "Requestor attributes win on conflict",
-                "type": "string",
-                "enum": [
-                  "requestorWins"
-                ]
-              },
-              {
-                "description": "Supplier attributes win on conflict (default)",
-                "type": "string",
-                "enum": [
-                  "supplierWins"
-                ]
-              }
-            ]
-          },
           "JoinType": {
             "oneOf": [
               {
@@ -3735,6 +3714,27 @@
                 "type": "string",
                 "enum": [
                   "full"
+                ]
+              }
+            ]
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "ConflictResolution": {
+            "oneOf": [
+              {
+                "description": "Requestor attributes win on conflict",
+                "type": "string",
+                "enum": [
+                  "requestorWins"
+                ]
+              },
+              {
+                "description": "Supplier attributes win on conflict (default)",
+                "type": "string",
+                "enum": [
+                  "supplierWins"
                 ]
               }
             ]
@@ -3816,15 +3816,18 @@
         "description": "Configuration for merging requestor and supplier features based on matching attributes or expressions.",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "description": "Whether to complete grouped features before processing the next group",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "description": "Attributes from requestor features to use for matching (alternative to requestor_attribute_value)",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
             "type": [
               "array",
               "null"
@@ -3856,16 +3859,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "Expression to evaluate for supplier feature matching values (alternative to supplier_attribute)",
             "type": [
@@ -3888,6 +3881,13 @@
                 "type": "string"
               }
             }
+          },
+          "completeGrouped": {
+            "description": "Whether to complete grouped features before processing the next group",
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
         "definitions": {
@@ -3927,27 +3927,11 @@
               "format"
             ],
             "properties": {
-              "dataset": {
-                "title": "Dataset",
-                "description": "Path or expression to the dataset file to be read",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3957,42 +3941,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "csv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4014,6 +3962,42 @@
                     "type": "string"
                   }
                 }
+              },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -4023,42 +4007,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "tsv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4081,11 +4029,63 @@
                   }
                 }
               },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
               "format": {
                 "type": "string",
                 "enum": [
                   "json"
                 ]
+              },
+              "dataset": {
+                "title": "Dataset",
+                "description": "Path or expression to the dataset file to be read",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -4349,28 +4349,6 @@
               "output"
             ],
             "properties": {
-              "converter": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
               "format": {
                 "type": "string",
                 "enum": [
@@ -4397,6 +4375,28 @@
                     "type": "string"
                   }
                 }
+              },
+              "converter": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -4409,34 +4409,11 @@
               "output"
             ],
             "properties": {
-              "epsgCode": {
-                "description": "EPSG code for coordinate reference system",
-                "default": null,
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint32",
-                "minimum": 0.0
-              },
               "format": {
                 "type": "string",
                 "enum": [
                   "citygml"
                 ]
-              },
-              "lodFilter": {
-                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-                "default": null,
-                "type": [
-                  "array",
-                  "null"
-                ],
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0.0
-                }
               },
               "output": {
                 "title": "Output path",
@@ -4458,6 +4435,29 @@
                     "type": "string"
                   }
                 }
+              },
+              "lodFilter": {
+                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+                "default": null,
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              },
+              "epsgCode": {
+                "description": "EPSG code for coordinate reference system",
+                "default": null,
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4497,11 +4497,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "extractArchive": {
-            "title": "Extract Archive",
-            "description": "Whether to extract files from archives (zip files, etc.) or just list them",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Path or expression pointing to the source directory or archive file",
@@ -4523,6 +4518,11 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "Extract Archive",
+            "description": "Whether to extract files from archives (zip files, etc.) or just list them",
+            "type": "boolean"
           }
         }
       },
@@ -4680,16 +4680,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "Optional attributes to group features by, creating separate files for each group",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "Output path or expression for the GeoJSON file to create",
             "type": "object",
@@ -4709,6 +4699,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "Optional attributes to group features by, creating separate files for each group",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -4739,6 +4739,32 @@
         "title": "GeoPackageReaderParam",
         "type": "object",
         "properties": {
+          "readMode": {
+            "default": "features",
+            "allOf": [
+              {
+                "$ref": "#/definitions/GeoPackageReadMode"
+              }
+            ]
+          },
+          "layerName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "includeMetadata": {
+            "default": false,
+            "type": "boolean"
+          },
+          "tileFormat": {
+            "default": "png",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TileFormat"
+              }
+            ]
+          },
           "attributeFilter": {
             "default": null,
             "type": [
@@ -4754,6 +4780,17 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "force2D": {
+            "default": false,
+            "type": "boolean"
+          },
+          "spatialFilter": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "dataset": {
             "title": "File Path",
@@ -4780,14 +4817,6 @@
               }
             }
           },
-          "force2D": {
-            "default": false,
-            "type": "boolean"
-          },
-          "includeMetadata": {
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -4812,35 +4841,6 @@
                 "type": "string"
               }
             }
-          },
-          "layerName": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "readMode": {
-            "default": "features",
-            "allOf": [
-              {
-                "$ref": "#/definitions/GeoPackageReadMode"
-              }
-            ]
-          },
-          "spatialFilter": {
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tileFormat": {
-            "default": "png",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TileFormat"
-              }
-            ]
           }
         },
         "definitions": {
@@ -4888,21 +4888,6 @@
           "output"
         ],
         "properties": {
-          "createSpatialIndex": {
-            "description": "Create RTree spatial index (default: true)",
-            "default": true,
-            "type": "boolean"
-          },
-          "geometryColumn": {
-            "description": "Geometry column name (default: \"geom\")",
-            "default": "geom",
-            "type": "string"
-          },
-          "geometryType": {
-            "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
-            "default": "GEOMETRY",
-            "type": "string"
-          },
           "output": {
             "description": "Output path for the GeoPackage file to create",
             "type": "object",
@@ -4924,10 +4909,15 @@
               }
             }
           },
-          "overwrite": {
-            "description": "Overwrite existing file (default: false)",
-            "default": false,
-            "type": "boolean"
+          "tableName": {
+            "description": "Table name to create (default: \"features\")",
+            "default": "features",
+            "type": "string"
+          },
+          "geometryColumn": {
+            "description": "Geometry column name (default: \"geom\")",
+            "default": "geom",
+            "type": "string"
           },
           "srsId": {
             "description": "Spatial Reference System ID (default: 4326 for WGS84)",
@@ -4935,10 +4925,20 @@
             "type": "integer",
             "format": "int32"
           },
-          "tableName": {
-            "description": "Table name to create (default: \"features\")",
-            "default": "features",
+          "geometryType": {
+            "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
+            "default": "GEOMETRY",
             "type": "string"
+          },
+          "createSpatialIndex": {
+            "description": "Create RTree spatial index (default: true)",
+            "default": true,
+            "type": "boolean"
+          },
+          "overwrite": {
+            "description": "Overwrite existing file (default: false)",
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -5411,6 +5411,24 @@
         "title": "GltfReaderParam",
         "type": "object",
         "properties": {
+          "triangulate": {
+            "title": "Triangulate",
+            "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
+            "default": true,
+            "type": "boolean"
+          },
+          "mergeMeshes": {
+            "title": "Merge Meshes",
+            "description": "If true, combines all meshes from the glTF file into a single output feature",
+            "default": false,
+            "type": "boolean"
+          },
+          "includeNodes": {
+            "title": "Include Nodes",
+            "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
+            "default": true,
+            "type": "boolean"
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -5436,12 +5454,6 @@
               }
             }
           },
-          "includeNodes": {
-            "title": "Include Nodes",
-            "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
-            "default": true,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -5466,18 +5478,6 @@
                 "type": "string"
               }
             }
-          },
-          "mergeMeshes": {
-            "title": "Merge Meshes",
-            "description": "If true, combines all meshes from the glTF file into a single output feature",
-            "default": false,
-            "type": "boolean"
-          },
-          "triangulate": {
-            "title": "Triangulate",
-            "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
-            "default": true,
-            "type": "boolean"
           }
         }
       },
@@ -5505,20 +5505,6 @@
           "output"
         ],
         "properties": {
-          "attachTexture": {
-            "description": "Whether to attach texture information to the GLTF model",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "dracoCompression": {
-            "description": "Apply Draco compression to the geometry",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "output": {
             "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
             "type": "object",
@@ -5539,6 +5525,20 @@
                 "type": "string"
               }
             }
+          },
+          "attachTexture": {
+            "description": "Whether to attach texture information to the GLTF model",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "dracoCompression": {
+            "description": "Apply Draco compression to the geometry",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
@@ -5571,6 +5571,20 @@
           "unitSquareSize"
         ],
         "properties": {
+          "unitSquareSize": {
+            "title": "Unit Square Size",
+            "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
+            "type": "number",
+            "format": "double"
+          },
+          "keepSquareOnly": {
+            "title": "Keep Square Only",
+            "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "title": "Group By Attributes",
             "description": "Attributes used to group features - each group gets its own grid origin",
@@ -5581,20 +5595,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "keepSquareOnly": {
-            "title": "Keep Square Only",
-            "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "unitSquareSize": {
-            "title": "Unit Square Size",
-            "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -5631,12 +5631,78 @@
           "url"
         ],
         "properties": {
+          "url": {
+            "title": "URL",
+            "description": "The target URL for the HTTP request (supports expressions)",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "method": {
+            "title": "HTTP Method",
+            "description": "The HTTP method to use for the request",
+            "default": "GET",
+            "allOf": [
+              {
+                "$ref": "#/definitions/HttpMethod"
+              }
+            ]
+          },
           "authentication": {
             "title": "Authentication",
             "description": "Authentication method and credentials for the request",
             "anyOf": [
               {
                 "$ref": "#/definitions/Authentication"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "customHeaders": {
+            "title": "Custom Headers",
+            "description": "Additional HTTP headers to include in the request",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/HeaderParam"
+            }
+          },
+          "queryParameters": {
+            "title": "Query Parameters",
+            "description": "URL query parameters to append to the request",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/QueryParam"
+            }
+          },
+          "requestBody": {
+            "title": "Request Body",
+            "description": "The body content to send with the request",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5651,16 +5717,17 @@
               "null"
             ]
           },
-          "customHeaders": {
-            "title": "Custom Headers",
-            "description": "Additional HTTP headers to include in the request",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/HeaderParam"
-            }
+          "timeouts": {
+            "title": "Timeouts",
+            "description": "Connection and transfer timeout settings",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TimeoutConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "httpOptions": {
             "title": "HTTP Options",
@@ -5668,63 +5735,6 @@
             "anyOf": [
               {
                 "$ref": "#/definitions/HttpOptions"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "method": {
-            "title": "HTTP Method",
-            "description": "The HTTP method to use for the request",
-            "default": "GET",
-            "allOf": [
-              {
-                "$ref": "#/definitions/HttpMethod"
-              }
-            ]
-          },
-          "observability": {
-            "title": "Observability",
-            "description": "Track additional metrics and diagnostics",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ObservabilityConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "queryParameters": {
-            "title": "Query Parameters",
-            "description": "URL query parameters to append to the request",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/QueryParam"
-            }
-          },
-          "rateLimit": {
-            "title": "Rate Limiting",
-            "description": "Rate limiting configuration to control request frequency",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RateLimitConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "requestBody": {
-            "title": "Request Body",
-            "description": "The body content to send with the request",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5755,386 +5765,32 @@
               }
             ]
           },
-          "timeouts": {
-            "title": "Timeouts",
-            "description": "Connection and transfer timeout settings",
+          "rateLimit": {
+            "title": "Rate Limiting",
+            "description": "Rate limiting configuration to control request frequency",
             "anyOf": [
               {
-                "$ref": "#/definitions/TimeoutConfig"
+                "$ref": "#/definitions/RateLimitConfig"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "url": {
-            "title": "URL",
-            "description": "The target URL for the HTTP request (supports expressions)",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
+          "observability": {
+            "title": "Observability",
+            "description": "Track additional metrics and diagnostics",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ObservabilityConfig"
               },
-              "value": {
-                "type": "string"
+              {
+                "type": "null"
               }
-            }
+            ]
           }
         },
         "definitions": {
-          "ApiKeyLocation": {
-            "title": "API Key Location",
-            "description": "Where to include the API key in the request",
-            "oneOf": [
-              {
-                "title": "Header",
-                "description": "Include API key in HTTP header",
-                "type": "string",
-                "enum": [
-                  "header"
-                ]
-              },
-              {
-                "title": "Query Parameter",
-                "description": "Include API key in URL query string",
-                "type": "string",
-                "enum": [
-                  "query"
-                ]
-              }
-            ]
-          },
-          "Authentication": {
-            "title": "Authentication",
-            "description": "Authentication method and credentials for HTTP requests",
-            "oneOf": [
-              {
-                "title": "Basic Authentication",
-                "description": "HTTP Basic authentication with username and password",
-                "type": "object",
-                "required": [
-                  "password",
-                  "type",
-                  "username"
-                ],
-                "properties": {
-                  "password": {
-                    "title": "Password",
-                    "description": "The password for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "basic"
-                    ]
-                  },
-                  "username": {
-                    "title": "Username",
-                    "description": "The username for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "title": "Bearer Token",
-                "description": "Bearer token authentication (OAuth 2.0)",
-                "type": "object",
-                "required": [
-                  "token",
-                  "type"
-                ],
-                "properties": {
-                  "token": {
-                    "title": "Token",
-                    "description": "The bearer token value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "bearer"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "API Key",
-                "description": "API key authentication in header or query parameter",
-                "type": "object",
-                "required": [
-                  "keyName",
-                  "keyValue",
-                  "type"
-                ],
-                "properties": {
-                  "keyName": {
-                    "title": "Key Name",
-                    "description": "The name of the API key parameter",
-                    "type": "string"
-                  },
-                  "keyValue": {
-                    "title": "Key Value",
-                    "description": "The API key value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "location": {
-                    "title": "Location",
-                    "description": "Where to include the API key (header or query parameter)",
-                    "default": "header",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/ApiKeyLocation"
-                      }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "apiKey"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "BinarySource": {
-            "title": "Binary Source",
-            "description": "Source of binary data for request body",
-            "oneOf": [
-              {
-                "title": "Base64 Encoded",
-                "description": "Binary data encoded as base64 string",
-                "type": "object",
-                "required": [
-                  "data",
-                  "type"
-                ],
-                "properties": {
-                  "data": {
-                    "title": "Data",
-                    "description": "Base64-encoded binary data (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "base64"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "From File",
-                "description": "Read binary data from a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path to the file to read (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "FormField": {
-            "title": "Form Field",
-            "description": "A name-value pair for URL-encoded form data",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "Field Name",
-                "description": "The name of the form field",
-                "type": "string"
-              },
-              "value": {
-                "title": "Field Value",
-                "description": "The value of the form field (supports expressions)",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "HeaderParam": {
-            "title": "HTTP Header",
-            "description": "A custom HTTP header to include in the request",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "Header Name",
-                "description": "The name of the HTTP header",
-                "type": "string"
-              },
-              "value": {
-                "title": "Header Value",
-                "description": "The value of the header (supports expressions)",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
           "HttpMethod": {
             "title": "HTTP Method",
             "description": "The HTTP request method to use",
@@ -6253,75 +5909,51 @@
               }
             ]
           },
-          "HttpOptions": {
-            "title": "HTTP Options",
-            "description": "Configure HTTP client behavior",
-            "type": "object",
-            "properties": {
-              "followRedirects": {
-                "title": "Follow Redirects",
-                "description": "Whether to automatically follow HTTP redirects (default: true)",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "maxRedirects": {
-                "title": "Max Redirects",
-                "description": "Maximum number of redirects to follow (default: 10)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "userAgent": {
-                "title": "User Agent",
-                "description": "Custom User-Agent header value",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "verifySsl": {
-                "title": "Verify SSL",
-                "description": "Whether to verify SSL/TLS certificates (default: true)",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            }
-          },
-          "MultipartPart": {
-            "title": "Multipart Part",
-            "description": "A part in a multipart/form-data request",
+          "Authentication": {
+            "title": "Authentication",
+            "description": "Authentication method and credentials for HTTP requests",
             "oneOf": [
               {
-                "title": "Text Field",
-                "description": "A text field in the multipart form",
+                "title": "Basic Authentication",
+                "description": "HTTP Basic authentication with username and password",
                 "type": "object",
                 "required": [
-                  "name",
+                  "password",
                   "type",
-                  "value"
+                  "username"
                 ],
                 "properties": {
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the form field",
-                    "type": "string"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "text"
+                      "basic"
                     ]
                   },
-                  "value": {
-                    "title": "Field Value",
-                    "description": "The value of the form field (supports expressions)",
+                  "username": {
+                    "title": "Username",
+                    "description": "The username for basic authentication",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "The password for basic authentication",
                     "type": "object",
                     "format": "code",
                     "required": [
@@ -6344,115 +5976,158 @@
                 }
               },
               {
-                "title": "File Upload",
-                "description": "A file upload in the multipart form",
+                "title": "Bearer Token",
+                "description": "Bearer token authentication (OAuth 2.0)",
                 "type": "object",
                 "required": [
-                  "name",
-                  "source",
+                  "token",
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "MIME type of the file",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "description": "The filename to send in the Content-Disposition header",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the file upload field",
-                    "type": "string"
-                  },
-                  "source": {
-                    "title": "File Source",
-                    "description": "Source of the file data (base64 or file path)",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/BinarySource"
-                      }
-                    ]
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "file"
+                      "bearer"
+                    ]
+                  },
+                  "token": {
+                    "title": "Token",
+                    "description": "The bearer token value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "API Key",
+                "description": "API key authentication in header or query parameter",
+                "type": "object",
+                "required": [
+                  "keyName",
+                  "keyValue",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "apiKey"
+                    ]
+                  },
+                  "keyName": {
+                    "title": "Key Name",
+                    "description": "The name of the API key parameter",
+                    "type": "string"
+                  },
+                  "keyValue": {
+                    "title": "Key Value",
+                    "description": "The API key value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "location": {
+                    "title": "Location",
+                    "description": "Where to include the API key (header or query parameter)",
+                    "default": "header",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/ApiKeyLocation"
+                      }
                     ]
                   }
                 }
               }
             ]
           },
-          "ObservabilityConfig": {
-            "title": "Observability Configuration",
-            "description": "Track additional metrics and diagnostics about HTTP requests",
+          "ApiKeyLocation": {
+            "title": "API Key Location",
+            "description": "Where to include the API key in the request",
+            "oneOf": [
+              {
+                "title": "Header",
+                "description": "Include API key in HTTP header",
+                "type": "string",
+                "enum": [
+                  "header"
+                ]
+              },
+              {
+                "title": "Query Parameter",
+                "description": "Include API key in URL query string",
+                "type": "string",
+                "enum": [
+                  "query"
+                ]
+              }
+            ]
+          },
+          "HeaderParam": {
+            "title": "HTTP Header",
+            "description": "A custom HTTP header to include in the request",
             "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
             "properties": {
-              "bytesAttribute": {
-                "title": "Bytes Attribute",
-                "description": "Feature attribute name to store the response body size",
-                "type": [
-                  "string",
-                  "null"
-                ]
+              "name": {
+                "title": "Header Name",
+                "description": "The name of the HTTP header",
+                "type": "string"
               },
-              "durationAttribute": {
-                "title": "Duration Attribute",
-                "description": "Feature attribute name to store request duration in milliseconds",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "finalUrlAttribute": {
-                "title": "Final URL Attribute",
-                "description": "Feature attribute name to store the final URL after redirects",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "retryCountAttribute": {
-                "title": "Retry Count Attribute",
-                "description": "Feature attribute name to store the number of retry attempts",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "trackBytes": {
-                "title": "Track Bytes",
-                "description": "Whether to track the response body size in bytes (default: false)",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackDuration": {
-                "title": "Track Duration",
-                "description": "Whether to track the total request duration (default: true)",
-                "default": true,
-                "type": "boolean"
-              },
-              "trackFinalUrl": {
-                "title": "Track Final URL",
-                "description": "Whether to track the final URL after redirects (default: false)",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackRetryCount": {
-                "title": "Track Retry Count",
-                "description": "Whether to track the number of retry attempts (default: true)",
-                "default": true,
-                "type": "boolean"
+              "value": {
+                "title": "Header Value",
+                "description": "The value of the header (supports expressions)",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -6494,41 +6169,6 @@
               }
             }
           },
-          "RateLimitConfig": {
-            "title": "Rate Limit Configuration",
-            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
-            "type": "object",
-            "required": [
-              "requests"
-            ],
-            "properties": {
-              "intervalMs": {
-                "title": "Interval",
-                "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
-                "default": 1000,
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "requests": {
-                "title": "Requests",
-                "description": "Maximum number of requests allowed within the interval",
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
-              },
-              "timing": {
-                "title": "Timing Strategy",
-                "description": "How to distribute requests within the interval (default: Burst)",
-                "default": "burst",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/TimingStrategy"
-                  }
-                ]
-              }
-            }
-          },
           "RequestBody": {
             "title": "Request Body",
             "description": "The body content to send with the HTTP request",
@@ -6542,6 +6182,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
                   "content": {
                     "title": "Content",
                     "description": "The text content to send (supports expressions)",
@@ -6571,12 +6217,6 @@
                       "string",
                       "null"
                     ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "text"
-                    ]
                   }
                 }
               },
@@ -6589,12 +6229,10 @@
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
-                    "type": [
-                      "string",
-                      "null"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "binary"
                     ]
                   },
                   "source": {
@@ -6606,10 +6244,12 @@
                       }
                     ]
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "binary"
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
@@ -6623,6 +6263,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "formUrlEncoded"
+                    ]
+                  },
                   "fields": {
                     "title": "Form Fields",
                     "description": "List of form field name-value pairs",
@@ -6630,12 +6276,6 @@
                     "items": {
                       "$ref": "#/definitions/FormField"
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "formUrlEncoded"
-                    ]
                   }
                 }
               },
@@ -6648,6 +6288,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "multipart"
+                    ]
+                  },
                   "parts": {
                     "title": "Parts",
                     "description": "List of multipart form parts (text fields or file uploads)",
@@ -6655,34 +6301,315 @@
                     "items": {
                       "$ref": "#/definitions/MultipartPart"
                     }
-                  },
+                  }
+                }
+              }
+            ]
+          },
+          "BinarySource": {
+            "title": "Binary Source",
+            "description": "Source of binary data for request body",
+            "oneOf": [
+              {
+                "title": "Base64 Encoded",
+                "description": "Binary data encoded as base64 string",
+                "type": "object",
+                "required": [
+                  "data",
+                  "type"
+                ],
+                "properties": {
                   "type": {
                     "type": "string",
                     "enum": [
-                      "multipart"
+                      "base64"
+                    ]
+                  },
+                  "data": {
+                    "title": "Data",
+                    "description": "Base64-encoded binary data (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "From File",
+                "description": "Read binary data from a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path to the file to read (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "FormField": {
+            "title": "Form Field",
+            "description": "A name-value pair for URL-encoded form data",
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "title": "Field Name",
+                "description": "The name of the form field",
+                "type": "string"
+              },
+              "value": {
+                "title": "Field Value",
+                "description": "The value of the form field (supports expressions)",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "MultipartPart": {
+            "title": "Multipart Part",
+            "description": "A part in a multipart/form-data request",
+            "oneOf": [
+              {
+                "title": "Text Field",
+                "description": "A text field in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the form field",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Field Value",
+                    "description": "The value of the form field (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "File Upload",
+                "description": "A file upload in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "source",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the file upload field",
+                    "type": "string"
+                  },
+                  "source": {
+                    "title": "File Source",
+                    "description": "Source of the file data (base64 or file path)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/BinarySource"
+                      }
+                    ]
+                  },
+                  "filename": {
+                    "title": "Filename",
+                    "description": "The filename to send in the Content-Disposition header",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "MIME type of the file",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
               }
             ]
           },
-          "ResponseConfig": {
-            "title": "Response Configuration",
-            "description": "Configure how HTTP response data is stored and processed",
+          "TimeoutConfig": {
+            "title": "Timeout Configuration",
+            "description": "Configure connection and transfer timeouts for HTTP requests",
             "type": "object",
             "properties": {
-              "autoDetectEncoding": {
-                "title": "Auto Detect Encoding",
-                "description": "Automatically detect character encoding from response headers",
+              "connectionTimeout": {
+                "title": "Connection Timeout",
+                "description": "Maximum time in seconds to establish a connection (default: 60)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "transferTimeout": {
+                "title": "Transfer Timeout",
+                "description": "Maximum time in seconds to complete the entire request (default: 90)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          },
+          "HttpOptions": {
+            "title": "HTTP Options",
+            "description": "Configure HTTP client behavior",
+            "type": "object",
+            "properties": {
+              "userAgent": {
+                "title": "User Agent",
+                "description": "Custom User-Agent header value",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifySsl": {
+                "title": "Verify SSL",
+                "description": "Whether to verify SSL/TLS certificates (default: true)",
                 "type": [
                   "boolean",
                   "null"
                 ]
               },
-              "errorAttribute": {
-                "title": "Error Attribute",
-                "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
-                "default": "_http_error",
+              "followRedirects": {
+                "title": "Follow Redirects",
+                "description": "Whether to automatically follow HTTP redirects (default: true)",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "maxRedirects": {
+                "title": "Max Redirects",
+                "description": "Maximum number of redirects to follow (default: 10)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint8",
+                "minimum": 0.0
+              }
+            }
+          },
+          "ResponseConfig": {
+            "title": "Response Configuration",
+            "description": "Configure how HTTP response data is stored and processed",
+            "type": "object",
+            "properties": {
+              "responseBodyAttribute": {
+                "title": "Response Body Attribute",
+                "description": "Feature attribute name to store the response body (default: \"_response_body\")",
+                "default": "_response_body",
+                "type": "string"
+              },
+              "statusCodeAttribute": {
+                "title": "Status Code Attribute",
+                "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
+                "default": "_http_status_code",
                 "type": "string"
               },
               "headersAttribute": {
@@ -6691,33 +6618,11 @@
                 "default": "_headers",
                 "type": "string"
               },
-              "maxResponseSize": {
-                "title": "Max Response Size",
-                "description": "Maximum response body size in bytes (unlimited if not set)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "responseBodyAttribute": {
-                "title": "Response Body Attribute",
-                "description": "Feature attribute name to store the response body (default: \"_response_body\")",
-                "default": "_response_body",
+              "errorAttribute": {
+                "title": "Error Attribute",
+                "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
+                "default": "_http_error",
                 "type": "string"
-              },
-              "responseEncoding": {
-                "title": "Response Encoding",
-                "description": "How to encode the response body (text, base64, or binary)",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/ResponseEncoding"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
               },
               "responseHandling": {
                 "title": "Response Handling",
@@ -6731,13 +6636,114 @@
                   }
                 ]
               },
-              "statusCodeAttribute": {
-                "title": "Status Code Attribute",
-                "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
-                "default": "_http_status_code",
-                "type": "string"
+              "maxResponseSize": {
+                "title": "Max Response Size",
+                "description": "Maximum response body size in bytes (unlimited if not set)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "responseEncoding": {
+                "title": "Response Encoding",
+                "description": "How to encode the response body (text, base64, or binary)",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/ResponseEncoding"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "autoDetectEncoding": {
+                "title": "Auto Detect Encoding",
+                "description": "Automatically detect character encoding from response headers",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             }
+          },
+          "ResponseHandling": {
+            "title": "Response Handling",
+            "description": "How to handle the HTTP response data",
+            "oneOf": [
+              {
+                "title": "Store in Attribute",
+                "description": "Store response body in a feature attribute",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "attribute"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "Save to File",
+                "description": "Save response body to a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path where the response should be saved",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "storePathInAttribute": {
+                    "title": "Store Path in Attribute",
+                    "description": "Whether to store the file path in a feature attribute",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "pathAttribute": {
+                    "title": "Path Attribute Name",
+                    "description": "Attribute name for storing the file path",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           "ResponseEncoding": {
             "title": "Response Encoding",
@@ -6769,100 +6775,18 @@
               }
             ]
           },
-          "ResponseHandling": {
-            "title": "Response Handling",
-            "description": "How to handle the HTTP response data",
-            "oneOf": [
-              {
-                "title": "Store in Attribute",
-                "description": "Store response body in a feature attribute",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "attribute"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "Save to File",
-                "description": "Save response body to a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path where the response should be saved",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "pathAttribute": {
-                    "title": "Path Attribute Name",
-                    "description": "Attribute name for storing the file path",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "storePathInAttribute": {
-                    "title": "Store Path in Attribute",
-                    "description": "Whether to store the file path in a feature attribute",
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
           "RetryConfig": {
             "title": "Retry Configuration",
             "description": "Configure automatic retry behavior for failed requests",
             "type": "object",
             "properties": {
-              "backoffMultiplier": {
-                "title": "Backoff Multiplier",
-                "description": "Multiplier for exponential backoff between retries (default: 2.0)",
-                "default": 2.0,
-                "type": "number",
-                "format": "double"
-              },
-              "honorRetryAfter": {
-                "title": "Honor Retry-After Header",
-                "description": "Whether to respect the Retry-After header from server responses (default: true)",
-                "default": true,
-                "type": "boolean"
+              "maxAttempts": {
+                "title": "Max Attempts",
+                "description": "Maximum number of retry attempts (default: 3)",
+                "default": 3,
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
               },
               "initialDelayMs": {
                 "title": "Initial Delay",
@@ -6872,13 +6796,12 @@
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "maxAttempts": {
-                "title": "Max Attempts",
-                "description": "Maximum number of retry attempts (default: 3)",
-                "default": 3,
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
+              "backoffMultiplier": {
+                "title": "Backoff Multiplier",
+                "description": "Multiplier for exponential backoff between retries (default: 2.0)",
+                "default": 2.0,
+                "type": "number",
+                "format": "double"
               },
               "maxDelayMs": {
                 "title": "Max Delay",
@@ -6900,33 +6823,47 @@
                   "format": "uint16",
                   "minimum": 0.0
                 }
+              },
+              "honorRetryAfter": {
+                "title": "Honor Retry-After Header",
+                "description": "Whether to respect the Retry-After header from server responses (default: true)",
+                "default": true,
+                "type": "boolean"
               }
             }
           },
-          "TimeoutConfig": {
-            "title": "Timeout Configuration",
-            "description": "Configure connection and transfer timeouts for HTTP requests",
+          "RateLimitConfig": {
+            "title": "Rate Limit Configuration",
+            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
             "type": "object",
+            "required": [
+              "requests"
+            ],
             "properties": {
-              "connectionTimeout": {
-                "title": "Connection Timeout",
-                "description": "Maximum time in seconds to establish a connection (default: 60)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+              "requests": {
+                "title": "Requests",
+                "description": "Maximum number of requests allowed within the interval",
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "intervalMs": {
+                "title": "Interval",
+                "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
+                "default": 1000,
+                "type": "integer",
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "transferTimeout": {
-                "title": "Transfer Timeout",
-                "description": "Maximum time in seconds to complete the entire request (default: 90)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
+              "timing": {
+                "title": "Timing Strategy",
+                "description": "How to distribute requests within the interval (default: Burst)",
+                "default": "burst",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/TimingStrategy"
+                  }
+                ]
               }
             }
           },
@@ -6951,6 +6888,69 @@
                 ]
               }
             ]
+          },
+          "ObservabilityConfig": {
+            "title": "Observability Configuration",
+            "description": "Track additional metrics and diagnostics about HTTP requests",
+            "type": "object",
+            "properties": {
+              "trackDuration": {
+                "title": "Track Duration",
+                "description": "Whether to track the total request duration (default: true)",
+                "default": true,
+                "type": "boolean"
+              },
+              "durationAttribute": {
+                "title": "Duration Attribute",
+                "description": "Feature attribute name to store request duration in milliseconds",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackFinalUrl": {
+                "title": "Track Final URL",
+                "description": "Whether to track the final URL after redirects (default: false)",
+                "default": false,
+                "type": "boolean"
+              },
+              "finalUrlAttribute": {
+                "title": "Final URL Attribute",
+                "description": "Feature attribute name to store the final URL after redirects",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackRetryCount": {
+                "title": "Track Retry Count",
+                "description": "Whether to track the number of retry attempts (default: true)",
+                "default": true,
+                "type": "boolean"
+              },
+              "retryCountAttribute": {
+                "title": "Retry Count Attribute",
+                "description": "Feature attribute name to store the number of retry attempts",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackBytes": {
+                "title": "Track Bytes",
+                "description": "Whether to track the response body size in bytes (default: false)",
+                "default": false,
+                "type": "boolean"
+              },
+              "bytesAttribute": {
+                "title": "Bytes Attribute",
+                "description": "Feature attribute name to store the response body size",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
           }
         }
       },
@@ -7120,19 +7120,6 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "onOverlap": {
-            "title": "On Overlap",
-            "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/OnOverlap"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "saveTo": {
             "title": "Save To",
             "description": "Optional path expression to save the generated image. If not provided, uses default cache directory.",
@@ -7158,6 +7145,19 @@
                 "type": "string"
               }
             }
+          },
+          "onOverlap": {
+            "title": "On Overlap",
+            "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/definitions/OnOverlap"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7322,19 +7322,6 @@
               "jsonQuery"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
@@ -7353,10 +7340,23 @@
                 "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
                 "type": "string"
               },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7374,28 +7374,11 @@
               "path"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
                   "fileUrl"
                 ]
-              },
-              "jsonQuery": {
-                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
-                "type": "string"
               },
               "path": {
                 "description": "Expression evaluating to the file path or URL containing JSON",
@@ -7418,10 +7401,27 @@
                   }
                 }
               },
+              "jsonQuery": {
+                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
+                "type": "string"
+              },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7537,6 +7537,27 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "description": "Output path or expression for the JSON file to create",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "converter": {
             "description": "Optional converter expression to transform features before writing",
             "type": [
@@ -7553,27 +7574,6 @@
                 "type": "string",
                 "enum": [
                   "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "output": {
-            "description": "Output path or expression for the JSON file to create",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
                 ]
               },
               "value": {
@@ -7617,16 +7617,16 @@
               "$ref": "#/definitions/Attribute"
             }
           },
+          "tolerance": {
+            "type": "number",
+            "format": "double"
+          },
           "overlaidListsAttrName": {
             "description": "Name of the attribute to store the overlaid lists. Defaults to \"overlaidLists\".",
             "type": [
               "string",
               "null"
             ]
-          },
-          "tolerance": {
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -7665,14 +7665,6 @@
           "separateCharacter"
         ],
         "properties": {
-          "attribute": {
-            "description": "Attribute name to extract from each list element",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "list": {
             "description": "List attribute to read from",
             "allOf": [
@@ -7681,8 +7673,8 @@
               }
             ]
           },
-          "outputAttributeName": {
-            "description": "Name of the attribute to store the concatenated result",
+          "attribute": {
+            "description": "Attribute name to extract from each list element",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -7692,6 +7684,14 @@
           "separateCharacter": {
             "description": "Character(s) to use as separator between concatenated values",
             "type": "string"
+          },
+          "outputAttributeName": {
+            "description": "Name of the attribute to store the concatenated result",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7768,6 +7768,20 @@
           "listIndexToCopy"
         ],
         "properties": {
+          "listAttribute": {
+            "description": "List attribute to read from",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "listIndexToCopy": {
+            "description": "Index of the list element to copy (0-based)",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          },
           "copiedAttributePrefix": {
             "description": "Optional prefix to add to copied attribute names",
             "default": null,
@@ -7783,20 +7797,6 @@
               "string",
               "null"
             ]
-          },
-          "listAttribute": {
-            "description": "List attribute to read from",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "listIndexToCopy": {
-            "description": "Index of the list element to copy (0-based)",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0.0
           }
         },
         "definitions": {
@@ -7833,13 +7833,63 @@
           "output"
         ],
         "properties": {
-          "colonToUnderscore": {
-            "title": "Colon to Underscore",
-            "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
-            "type": [
-              "boolean",
-              "null"
-            ]
+          "output": {
+            "title": "Output",
+            "description": "Output directory path or expression for the generated MVT tiles",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "layerName": {
+            "title": "Layer Name",
+            "description": "Name of the layer within the MVT tiles",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "Minimum Zoom",
+            "description": "Minimum zoom level to generate tiles for",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "Maximum Zoom",
+            "description": "Maximum zoom level to generate tiles for",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
           },
           "compressOutput": {
             "title": "Compress Output",
@@ -7866,6 +7916,22 @@
               }
             }
           },
+          "skipUnexposedAttributes": {
+            "title": "Skip Unexposed Attributes",
+            "description": "Skip attributes with double underscore prefix",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "colonToUnderscore": {
+            "title": "Colon to Underscore",
+            "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "extent": {
             "title": "Extent",
             "description": "MVT tile resolution. Default is 4096.",
@@ -7876,77 +7942,11 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "layerName": {
-            "title": "Layer Name",
-            "description": "Name of the layer within the MVT tiles",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "maxZoom": {
-            "title": "Maximum Zoom",
-            "description": "Maximum zoom level to generate tiles for",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "Minimum Zoom",
-            "description": "Minimum zoom level to generate tiles for",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "Output",
-            "description": "Output directory path or expression for the generated MVT tiles",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "schemaKey": {
             "title": "Schema Key",
             "description": "Attribute key to match data and schema features for attribute filtering and casting. This attribute is excluded from output.",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "Skip Unexposed Attributes",
-            "description": "Skip attributes with double underscore prefix",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -7975,6 +7975,39 @@
         "description": "Configuration for finding spatial neighbors between base and candidate features.",
         "type": "object",
         "properties": {
+          "numClosest": {
+            "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
+            "default": 1,
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1.0
+          },
+          "maxDistance": {
+            "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "distanceAttribute": {
+            "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
+            "default": "_neighbor_distance",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "neighborIndexAttribute": {
+            "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
+            "default": "_neighbor_index",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "attributePrefix": {
             "description": "Prefix applied to transferred candidate attributes to avoid collisions.",
             "default": "_neighbor_",
@@ -7988,12 +8021,12 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "distanceAttribute": {
-            "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
-            "default": "_neighbor_distance",
+          "mergeStrategy": {
+            "description": "Controls how multiple neighbors are represented on the output.",
+            "default": "closest",
             "allOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/definitions/MergeStrategy"
               }
             ]
           },
@@ -8005,70 +8038,11 @@
                 "$ref": "#/definitions/DistanceMetric"
               }
             ]
-          },
-          "maxDistance": {
-            "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
-          "mergeStrategy": {
-            "description": "Controls how multiple neighbors are represented on the output.",
-            "default": "closest",
-            "allOf": [
-              {
-                "$ref": "#/definitions/MergeStrategy"
-              }
-            ]
-          },
-          "neighborIndexAttribute": {
-            "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
-            "default": "_neighbor_index",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "numClosest": {
-            "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
-            "default": 1,
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1.0
           }
         },
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "DistanceMetric": {
-            "description": "Distance metric for computing spatial proximity.",
-            "oneOf": [
-              {
-                "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
-                "type": "string",
-                "enum": [
-                  "euclidean2d"
-                ]
-              },
-              {
-                "description": "3D Euclidean distance using X, Y, and Z coordinates.",
-                "type": "string",
-                "enum": [
-                  "euclidean3d"
-                ]
-              },
-              {
-                "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
-                "type": "string",
-                "enum": [
-                  "haversine"
-                ]
-              }
-            ]
           },
           "MergeStrategy": {
             "description": "Merge strategy for handling multiple neighbors.",
@@ -8092,6 +8066,32 @@
                 "type": "string",
                 "enum": [
                   "arrayAttributes"
+                ]
+              }
+            ]
+          },
+          "DistanceMetric": {
+            "description": "Distance metric for computing spatial proximity.",
+            "oneOf": [
+              {
+                "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
+                "type": "string",
+                "enum": [
+                  "euclidean2d"
+                ]
+              },
+              {
+                "description": "3D Euclidean distance using X, Y, and Z coordinates.",
+                "type": "string",
+                "enum": [
+                  "euclidean3d"
+                ]
+              },
+              {
+                "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
+                "type": "string",
+                "enum": [
+                  "haversine"
                 ]
               }
             ]
@@ -8155,10 +8155,6 @@
         "description": "NullAttributeMapper parameters",
         "type": "object",
         "properties": {
-          "defaultReplacement": {
-            "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
-            "default": null
-          },
           "mappings": {
             "description": "Per-attribute replacement rules",
             "default": [],
@@ -8166,6 +8162,10 @@
             "items": {
               "$ref": "#/definitions/AttributeMapping"
             }
+          },
+          "defaultReplacement": {
+            "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
+            "default": null
           },
           "nullDefinition": {
             "description": "Which states count as \"null\"",
@@ -8205,6 +8205,9 @@
                 "description": "Name of the attribute to inspect",
                 "type": "string"
               },
+              "replacement": {
+                "description": "Value to write when attribute is null-like null means remove the attribute"
+              },
               "onMissing": {
                 "description": "What to do when attribute is missing but not in nullDefinition",
                 "default": "skip",
@@ -8213,11 +8216,27 @@
                     "$ref": "#/definitions/OnMissing"
                   }
                 ]
-              },
-              "replacement": {
-                "description": "Value to write when attribute is null-like null means remove the attribute"
               }
             }
+          },
+          "OnMissing": {
+            "description": "What to do when attribute is missing but not in nullDefinition",
+            "oneOf": [
+              {
+                "description": "Leave unchanged",
+                "type": "string",
+                "enum": [
+                  "skip"
+                ]
+              },
+              {
+                "description": "Write replacement value, creating the attribute",
+                "type": "string",
+                "enum": [
+                  "create"
+                ]
+              }
+            ]
           },
           "NullKind": {
             "description": "Defines what states count as \"null\"",
@@ -8241,25 +8260,6 @@
                 "type": "string",
                 "enum": [
                   "emptyString"
-                ]
-              }
-            ]
-          },
-          "OnMissing": {
-            "description": "What to do when attribute is missing but not in nullDefinition",
-            "oneOf": [
-              {
-                "description": "Leave unchanged",
-                "type": "string",
-                "enum": [
-                  "skip"
-                ]
-              },
-              {
-                "description": "Write replacement value, creating the attribute",
-                "type": "string",
-                "enum": [
-                  "create"
                 ]
               }
             ]
@@ -8311,67 +8311,11 @@
         "description": "Configuration for reading Wavefront OBJ 3D model files with support for vertices, faces, normals, texture coordinates, and material definitions.",
         "type": "object",
         "properties": {
-          "dataset": {
-            "title": "File Path",
-            "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "includeNormals": {
-            "title": "Include Normals",
-            "description": "Include vertex normal data in the output geometry",
+          "parseMaterials": {
+            "title": "Parse Materials",
+            "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
             "default": true,
             "type": "boolean"
-          },
-          "includeTexcoords": {
-            "title": "Include Texture Coordinates",
-            "description": "Include texture coordinate (UV) data in the output geometry",
-            "default": true,
-            "type": "boolean"
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "materialFile": {
             "title": "Material File",
@@ -8399,23 +8343,79 @@
               }
             }
           },
+          "triangulate": {
+            "title": "Triangulate",
+            "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
+            "default": false,
+            "type": "boolean"
+          },
           "mergeGroups": {
             "title": "Merge Groups",
             "description": "Merge all groups and objects into a single feature instead of creating separate features per group/object",
             "default": false,
             "type": "boolean"
           },
-          "parseMaterials": {
-            "title": "Parse Materials",
-            "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
+          "includeNormals": {
+            "title": "Include Normals",
+            "description": "Include vertex normal data in the output geometry",
             "default": true,
             "type": "boolean"
           },
-          "triangulate": {
-            "title": "Triangulate",
-            "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
-            "default": false,
+          "includeTexcoords": {
+            "title": "Include Texture Coordinates",
+            "description": "Include texture coordinate (UV) data in the output geometry",
+            "default": true,
             "type": "boolean"
+          },
+          "dataset": {
+            "title": "File Path",
+            "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -8807,15 +8807,24 @@
         "title": "XmlAttributeExtractorParam",
         "type": "object",
         "properties": {
-          "addNsprefixToFeatureTypes": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "cityCode": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "targetPackages": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "addNsprefixToFeatureTypes": {
+            "type": [
+              "boolean",
               "null"
             ]
           },
@@ -8839,15 +8848,6 @@
               "string",
               "null"
             ]
-          },
-          "targetPackages": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
           }
         }
       },
@@ -8931,10 +8931,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "File Index Attribute",
-            "description": "Attribute containing the file index (default: \"fileIndex\")",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "Part ID Attribute",
+            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -8951,10 +8951,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "Part ID Attribute",
-            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "File Index Attribute",
+            "description": "Attribute containing the file index (default: \"fileIndex\")",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -9092,6 +9092,16 @@
           "epsgCode"
         ],
         "properties": {
+          "errorAttribute": {
+            "title": "Error Attribute Name",
+            "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
+            "default": "_validation_error",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "epsgCode": {
             "title": "Target EPSG Code",
             "description": "EPSG code for coordinate transformation from source EPSG 6697. Accepts integer or string expression.",
@@ -9112,16 +9122,6 @@
                 "type": "string"
               }
             }
-          },
-          "errorAttribute": {
-            "title": "Error Attribute Name",
-            "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
-            "default": "_validation_error",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
           }
         },
         "definitions": {
@@ -9178,6 +9178,20 @@
         "description": "Configure mesh code extraction for Japanese standard regional mesh",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "Mesh Type",
+            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "Mesh Code Attribute Name",
+            "description": "Output attribute name for the mesh code",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG Code",
             "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -9202,20 +9216,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "Mesh Type",
-            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "Mesh Code Attribute Name",
-            "description": "Output attribute name for the mesh code",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -9333,17 +9333,6 @@
         "description": "Configuration for generating TIN surfaces from flood area polygons. This processor converts polygons to triangulated surfaces by: 1. Optionally grouping features by an attribute (e.g., udxDirs) 2. Combining all polygons in each group 3. Sampling points along polygon boundaries at regular intervals 4. Optionally adding interior grid points within polygons 5. Performing Delaunay triangulation to create a TIN surface 6. Filtering triangles to keep only those inside the original polygons",
         "type": "object",
         "properties": {
-          "groupBy": {
-            "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "pointSpacing": {
             "description": "Spacing between sampled points in meters (default: 50.0). Points are sampled along polygon boundaries and optionally on an interior grid at this spacing interval.",
             "type": [
@@ -9358,6 +9347,17 @@
             "type": [
               "boolean",
               "null"
+            ]
+          },
+          "groupBy": {
+            "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -9556,21 +9556,6 @@
           "outputDir"
         ],
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "measurements": {
-            "description": "Measurement definitions to insert as gen:measureAttribute elements",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/MeasurementDef"
-            }
-          },
           "outputDir": {
             "description": "Output directory expression for modified CityGML files",
             "type": "object",
@@ -9592,6 +9577,14 @@
               }
             }
           },
+          "gmlIdAttribute": {
+            "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "pathAttribute": {
             "description": "Attribute name on path features holding the file path (default: \"path\")",
             "default": null,
@@ -9600,28 +9593,11 @@
               "null"
             ]
           },
-          "sourceEpsg": {
-            "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
-            "default": null,
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
+          "measurements": {
+            "description": "Measurement definitions to insert as gen:measureAttribute elements",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MeasurementDef"
             }
           },
           "textureImagePath": {
@@ -9648,6 +9624,30 @@
                 "type": "string"
               }
             }
+          },
+          "sourceEpsg": {
+            "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
+            "default": null,
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         },
         "definitions": {
@@ -9660,12 +9660,12 @@
               "uom"
             ],
             "properties": {
-              "attribute": {
-                "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
-                "type": "string"
-              },
               "name": {
                 "description": "XML name attribute value (e.g. \"年間予測日射量\")",
+                "type": "string"
+              },
+              "attribute": {
+                "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
                 "type": "string"
               },
               "uom": {
@@ -9706,63 +9706,11 @@
               "type"
             ],
             "properties": {
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
+              "type": {
+                "type": "string",
+                "enum": [
+                  "time"
                 ]
-              },
-              "sourceEpsg": {
-                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "standardMeridian": {
-                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
-                "default": null,
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
               },
               "time": {
                 "description": "Time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
@@ -9785,60 +9733,6 @@
                   }
                 }
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "time"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "end",
-              "sourceEpsg",
-              "start",
-              "step",
-              "stepUnit",
-              "type"
-            ],
-            "properties": {
-              "end": {
-                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
-                ]
-              },
               "sourceEpsg": {
                 "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
                 "type": "object",
@@ -9883,8 +9777,62 @@
                   }
                 }
               },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
+                ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "end",
+              "sourceEpsg",
+              "start",
+              "step",
+              "stepUnit",
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "duration"
+                ]
+              },
               "start": {
                 "description": "Start time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "end": {
+                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
                 "type": "object",
                 "format": "code",
                 "required": [
@@ -9932,11 +9880,63 @@
                   }
                 ]
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "duration"
+              "sourceEpsg": {
+                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "standardMeridian": {
+                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
+                "default": null,
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
                 ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
               }
             }
           }
@@ -10001,9 +10001,9 @@
         "title": "SolidIntersectionTestPairCreatorParam",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10011,9 +10011,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10180,6 +10180,12 @@
         "description": "Configure unshared edge detection behavior",
         "type": "object",
         "properties": {
+          "tolerance": {
+            "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          },
           "groupBy": {
             "description": "Group By Attributes. When specified, edge detection is performed independently within each group. Features with the same values for these attributes are grouped together.",
             "default": null,
@@ -10190,12 +10196,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "tolerance": {
-            "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
-            "default": 0.1,
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -10236,10 +10236,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "File Index Attribute",
-            "description": "Attribute containing the file index (default: \"fileIndex\")",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "Part ID Attribute",
+            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10256,10 +10256,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "Part ID Attribute",
-            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "File Index Attribute",
+            "description": "Attribute containing the file index (default: \"fileIndex\")",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10345,6 +10345,20 @@
         "description": "Configure mesh code extraction for Japanese standard regional mesh",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "Mesh Type",
+            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "Mesh Code Attribute Name",
+            "description": "Output attribute name for the mesh code",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG Code",
             "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -10369,20 +10383,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "Mesh Type",
-            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "Mesh Code Attribute Name",
-            "description": "Output attribute name for the mesh code",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -10532,9 +10532,9 @@
         "title": "SolidIntersectionTestPairCreatorParam",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10542,9 +10542,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10763,6 +10763,31 @@
         "title": "PythonScriptProcessorParam",
         "type": "object",
         "properties": {
+          "script": {
+            "title": "Inline Script",
+            "description": "Python script code to execute inline",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "pythonFile": {
             "title": "Python File",
             "description": "Path to a Python script file (supports file://, http://, https://, gs://, etc.)",
@@ -10795,31 +10820,6 @@
               "string",
               "null"
             ]
-          },
-          "script": {
-            "title": "Inline Script",
-            "description": "Python script code to execute inline",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "timeoutSeconds": {
             "title": "Timeout Seconds",
@@ -10860,6 +10860,34 @@
           "ray"
         ],
         "properties": {
+          "ray": {
+            "description": "Defines how to extract ray data from feature attributes",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RayDefinition"
+              }
+            ]
+          },
+          "pairId": {
+            "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "closestIntersectionOnly": {
             "description": "When true (default), return only the closest intersection point per ray-geometry pair. When false, return all intersection points.",
             "default": null,
@@ -10884,8 +10912,8 @@
               }
             }
           },
-          "geomId": {
-            "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
+          "tolerance": {
+            "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
             "default": null,
             "type": [
               "object",
@@ -10941,36 +10969,8 @@
               }
             ]
           },
-          "pairId": {
-            "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "ray": {
-            "description": "Defines how to extract ray data from feature attributes",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RayDefinition"
-              }
-            ]
-          },
-          "tolerance": {
-            "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
+          "geomId": {
+            "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
             "default": null,
             "type": [
               "object",
@@ -10995,28 +10995,6 @@
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "OutputGeometryType": {
-            "description": "Output geometry type for ray intersection results",
-            "oneOf": [
-              {
-                "description": "Output a point at the intersection location (default behavior)",
-                "type": "string",
-                "enum": [
-                  "pointOfIntersection"
-                ]
-              },
-              {
-                "description": "Output a line segment from ray origin to intersection point",
-                "type": "string",
-                "enum": [
-                  "lineSegmentToIntersection"
-                ]
-              }
-            ]
-          },
           "RayDefinition": {
             "description": "Defines how ray data is extracted from feature attributes.",
             "type": "object",
@@ -11029,30 +11007,6 @@
               "posZ"
             ],
             "properties": {
-              "dirX": {
-                "description": "Attribute containing ray direction X component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirY": {
-                "description": "Attribute containing ray direction Y component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirZ": {
-                "description": "Attribute containing ray direction Z component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
               "posX": {
                 "description": "Attribute containing ray origin X coordinate",
                 "allOf": [
@@ -11076,8 +11030,54 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "dirX": {
+                "description": "Attribute containing ray direction X component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirY": {
+                "description": "Attribute containing ray direction Y component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirZ": {
+                "description": "Attribute containing ray direction Z component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "OutputGeometryType": {
+            "description": "Output geometry type for ray intersection results",
+            "oneOf": [
+              {
+                "description": "Output a point at the intersection location (default behavior)",
+                "type": "string",
+                "enum": [
+                  "pointOfIntersection"
+                ]
+              },
+              {
+                "description": "Output a line segment from ray origin to intersection point",
+                "type": "string",
+                "enum": [
+                  "lineSegmentToIntersection"
+                ]
+              }
+            ]
           }
         }
       },
@@ -11160,6 +11160,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fromToVectors"
+                    ]
+                  },
                   "fromX": {
                     "description": "X component of the source direction vector",
                     "type": "object",
@@ -11279,12 +11285,6 @@
                         "type": "string"
                       }
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "fromToVectors"
-                    ]
                   }
                 }
               },
@@ -11299,25 +11299,11 @@
                   "type"
                 ],
                 "properties": {
-                  "angle": {
-                    "description": "Rotation angle in degrees",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "axisAngle"
+                    ]
                   },
                   "axisX": {
                     "description": "X component of the rotation axis",
@@ -11379,11 +11365,25 @@
                       }
                     }
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "axisAngle"
-                    ]
+                  "angle": {
+                    "description": "Rotation angle in degrees",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -11414,6 +11414,20 @@
         "description": "Configuration for reading Shapefile archives as geographic features. Expects a ZIP archive containing the required Shapefile components (.shp, .dbf, .shx).",
         "type": "object",
         "properties": {
+          "encoding": {
+            "title": "Character Encoding",
+            "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "force2d": {
+            "title": "Force 2D",
+            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+            "default": false,
+            "type": "boolean"
+          },
           "allowEmptyPath": {
             "title": "Allow Null Path",
             "description": "If true, a dataset expression that evaluates to null produces zero features instead of an error. This is useful for optional shapefile inputs where the path may not be configured.",
@@ -11444,20 +11458,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "Character Encoding",
-            "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "force2d": {
-            "title": "Force 2D",
-            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-            "default": false,
-            "type": "boolean"
           },
           "inline": {
             "title": "Inline Content",
@@ -11511,16 +11511,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "Optional attributes to group features by, creating separate files for each group",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "Output path or expression for the Shapefile to create",
             "type": "object",
@@ -11540,6 +11530,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "Optional attributes to group features by, creating separate files for each group",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -11621,20 +11621,21 @@
         "description": "Configure spatial relationship testing between filter and candidate geometries",
         "type": "object",
         "properties": {
-          "mergeFilterAttributes": {
-            "title": "Merge Filter Attributes",
-            "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
-            "default": false,
-            "type": "boolean"
-          },
-          "mergedAttributesPrefix": {
-            "title": "Merged Attributes Prefix",
-            "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
-            "default": null,
-            "type": [
-              "string",
-              "null"
+          "predicate": {
+            "title": "Spatial Predicate",
+            "description": "The spatial relationship to test between filter and candidate geometries",
+            "default": "intersects",
+            "allOf": [
+              {
+                "$ref": "#/definitions/SpatialPredicate"
+              }
             ]
+          },
+          "passOnMultipleMatches": {
+            "title": "Pass on Multiple Matches",
+            "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
+            "default": true,
+            "type": "boolean"
           },
           "outputMatchCountAttribute": {
             "title": "Output Match Count Attribute",
@@ -11649,27 +11650,23 @@
               }
             ]
           },
-          "passOnMultipleMatches": {
-            "title": "Pass on Multiple Matches",
-            "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
-            "default": true,
+          "mergeFilterAttributes": {
+            "title": "Merge Filter Attributes",
+            "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
+            "default": false,
             "type": "boolean"
           },
-          "predicate": {
-            "title": "Spatial Predicate",
-            "description": "The spatial relationship to test between filter and candidate geometries",
-            "default": "intersects",
-            "allOf": [
-              {
-                "$ref": "#/definitions/SpatialPredicate"
-              }
+          "mergedAttributesPrefix": {
+            "title": "Merged Attributes Prefix",
+            "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "SpatialPredicate": {
             "oneOf": [
               {
@@ -11736,6 +11733,9 @@
                 ]
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -11768,9 +11768,9 @@
           "sql"
         ],
         "properties": {
-          "databaseUrl": {
-            "title": "Database URL",
-            "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
+          "sql": {
+            "title": "SQL Query",
+            "description": "SQL query expression to execute for retrieving data",
             "type": "object",
             "format": "code",
             "required": [
@@ -11790,9 +11790,9 @@
               }
             }
           },
-          "sql": {
-            "title": "SQL Query",
-            "description": "SQL query expression to execute for retrieving data",
+          "databaseUrl": {
+            "title": "Database URL",
+            "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
             "type": "object",
             "format": "code",
             "required": [
@@ -11839,13 +11839,17 @@
           "calculations"
         ],
         "properties": {
-          "calculations": {
-            "title": "Calculations",
-            "description": "List of statistical calculations to perform on grouped features",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/Calculation"
-            }
+          "groupId": {
+            "title": "Group id",
+            "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "groupBy": {
             "title": "Group by",
@@ -11858,17 +11862,13 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "groupId": {
-            "title": "Group id",
-            "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
+          "calculations": {
+            "title": "Calculations",
+            "description": "List of statistical calculations to perform on grouped features",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Calculation"
+            }
           }
         },
         "definitions": {
@@ -11882,6 +11882,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "New attribute name",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "expr": {
                 "title": "Calculation to perform",
                 "type": "object",
@@ -11901,14 +11909,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "New attribute name",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           }
@@ -11948,33 +11948,6 @@
           "minZ"
         ],
         "properties": {
-          "maxX": {
-            "title": "Maximum X Attribute",
-            "description": "Name of attribute containing the maximum X coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxY": {
-            "title": "Maximum Y Attribute",
-            "description": "Name of attribute containing the maximum Y coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxZ": {
-            "title": "Maximum Z Attribute",
-            "description": "Name of attribute containing the maximum Z coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "minX": {
             "title": "Minimum X Attribute",
             "description": "Name of attribute containing the minimum X coordinate",
@@ -11996,6 +11969,33 @@
           "minZ": {
             "title": "Minimum Z Attribute",
             "description": "Name of attribute containing the minimum Z coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxX": {
+            "title": "Maximum X Attribute",
+            "description": "Name of attribute containing the maximum X coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxY": {
+            "title": "Maximum Y Attribute",
+            "description": "Name of attribute containing the maximum Y coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxZ": {
+            "title": "Maximum Z Attribute",
+            "description": "Name of attribute containing the maximum Z coordinate",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -12135,69 +12135,6 @@
               }
             }
           },
-          "directionX": {
-            "title": "Direction X",
-            "description": "X component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionY": {
-            "title": "Direction Y",
-            "description": "Y component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionZ": {
-            "title": "Direction Z",
-            "description": "Z component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "originX": {
             "title": "Origin X",
             "description": "X coordinate of the rotation origin point",
@@ -12243,6 +12180,69 @@
           "originZ": {
             "title": "Origin Z",
             "description": "Z coordinate of the rotation origin point",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionX": {
+            "title": "Direction X",
+            "description": "X component of the rotation axis direction vector",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionY": {
+            "title": "Direction Y",
+            "description": "Y component of the rotation axis direction vector",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionZ": {
+            "title": "Direction Z",
+            "description": "Z component of the rotation axis direction vector",
             "type": "object",
             "format": "code",
             "required": [
@@ -12419,27 +12419,11 @@
               "source"
             ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
-              },
-              "elementsToExclude": {
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "source": {
+                "type": "string",
+                "enum": [
+                  "url"
+                ]
               },
               "elementsToMatch": {
                 "type": "object",
@@ -12460,11 +12444,27 @@
                   }
                 }
               },
-              "source": {
-                "type": "string",
-                "enum": [
-                  "url"
-                ]
+              "elementsToExclude": {
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               }
             }
           }
@@ -12517,19 +12517,19 @@
           "Attribute": {
             "type": "string"
           },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          },
           "ValidationType": {
             "type": "string",
             "enum": [
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }

--- a/engine/schema/actions_fr.json
+++ b/engine/schema/actions_fr.json
@@ -39,12 +39,6 @@
               }
             ]
           },
-          "multiplier": {
-            "description": "Multiplier to scale the area values (default: 1.0)",
-            "default": 1.0,
-            "type": "number",
-            "format": "double"
-          },
           "outputAttribute": {
             "description": "Name of the attribute to store the calculated area (default: \"area\")",
             "default": "area",
@@ -53,6 +47,12 @@
                 "$ref": "#/definitions/Attribute"
               }
             ]
+          },
+          "multiplier": {
+            "description": "Multiplier to scale the area values (default: 1.0)",
+            "default": 1.0,
+            "type": "number",
+            "format": "double"
           }
         },
         "definitions": {
@@ -93,6 +93,17 @@
         "description": "Configure how area overlay analysis is performed",
         "type": "object",
         "properties": {
+          "groupBy": {
+            "title": "Group By Attributes",
+            "description": "Optional attributes to group features by during overlay analysis",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "accumulationMode": {
             "title": "Accumulation Mode",
             "description": "Controls how attributes from input features are handled in output features",
@@ -110,17 +121,6 @@
               "string",
               "null"
             ]
-          },
-          "groupBy": {
-            "title": "Group By Attributes",
-            "description": "Optional attributes to group features by during overlay analysis",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
           },
           "outputAttribute": {
             "title": "Output Attribute",
@@ -141,15 +141,15 @@
           }
         },
         "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
           "AccumulationMode": {
             "type": "string",
             "enum": [
               "useAttributesFromOneFeature",
               "dropIncomingAttributes"
             ]
-          },
-          "Attribute": {
-            "type": "string"
           }
         }
       },
@@ -212,14 +212,6 @@
               }
             }
           },
-          "calculationAttribute": {
-            "title": "Attribute to store calculation result",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "calculationValue": {
             "title": "Value to use for calculation",
             "type": [
@@ -227,6 +219,14 @@
               "null"
             ],
             "format": "int64"
+          },
+          "calculationAttribute": {
+            "title": "Attribute to store calculation result",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           },
           "method": {
             "title": "Method to use for aggregation",
@@ -244,6 +244,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "New attribute to create",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "attribute": {
                 "title": "Existing attribute to use",
                 "anyOf": [
@@ -277,14 +285,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "New attribute to create",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           },
@@ -388,6 +388,14 @@
           "rules"
         ],
         "properties": {
+          "rules": {
+            "title": "Conversion Rules",
+            "description": "List of rules defining how to map attributes using the conversion table",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AttributeConversionTableRule"
+            }
+          },
           "dataset": {
             "title": "Dataset URI",
             "description": "Path or URI to external conversion table file",
@@ -413,15 +421,6 @@
               }
             }
           },
-          "format": {
-            "title": "Table Format",
-            "description": "Format of the conversion table (CSV, TSV, or JSON)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/ConversionTableFormat"
-              }
-            ]
-          },
           "inline": {
             "title": "Inline Table Data",
             "description": "Conversion table data provided directly as string content",
@@ -430,19 +429,17 @@
               "null"
             ]
           },
-          "rules": {
-            "title": "Conversion Rules",
-            "description": "List of rules defining how to map attributes using the conversion table",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/AttributeConversionTableRule"
-            }
+          "format": {
+            "title": "Table Format",
+            "description": "Format of the conversion table (CSV, TSV, or JSON)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/ConversionTableFormat"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "AttributeConversionTableRule": {
             "type": "object",
             "required": [
@@ -452,17 +449,6 @@
               "featureTo"
             ],
             "properties": {
-              "conversionTableKeys": {
-                "title": "Keys to match in conversion table",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "conversionTableTo": {
-                "title": "Attribute to convert to",
-                "type": "string"
-              },
               "featureFroms": {
                 "title": "Attributes to convert from",
                 "type": "array",
@@ -477,8 +463,22 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "conversionTableKeys": {
+                "title": "Keys to match in conversion table",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "conversionTableTo": {
+                "title": "Attribute to convert to",
+                "type": "string"
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
           },
           "ConversionTableFormat": {
             "type": "string",
@@ -647,15 +647,6 @@
           }
         },
         "definitions": {
-          "Method": {
-            "type": "string",
-            "enum": [
-              "convert",
-              "create",
-              "rename",
-              "remove"
-            ]
-          },
           "Operation": {
             "type": "object",
             "required": [
@@ -701,6 +692,15 @@
                 }
               }
             }
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "convert",
+              "create",
+              "rename",
+              "remove"
+            ]
           }
         }
       },
@@ -748,13 +748,6 @@
                   "null"
                 ]
               },
-              "childAttribute": {
-                "title": "Child attribute name",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
               "expr": {
                 "title": "Expression to evaluate",
                 "type": [
@@ -779,6 +772,27 @@
                   }
                 }
               },
+              "valueAttribute": {
+                "title": "Attribute name to get value from",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
+                "title": "Parent attribute name",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "childAttribute": {
+                "title": "Child attribute name",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "multipleExpr": {
                 "title": "Expression to evaluate multiple attributes",
                 "type": [
@@ -801,20 +815,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "parentAttribute": {
-                "title": "Parent attribute name",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "title": "Attribute name to get value from",
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
           }
@@ -848,10 +848,6 @@
           "rangeTable"
         ],
         "properties": {
-          "defaultValue": {
-            "title": "Default Value",
-            "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
-          },
           "inputAttribute": {
             "title": "Input Attribute",
             "description": "The attribute to evaluate for range mapping",
@@ -869,6 +865,10 @@
             "items": {
               "$ref": "#/definitions/RangeEntry"
             }
+          },
+          "defaultValue": {
+            "title": "Default Value",
+            "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
           }
         },
         "definitions": {
@@ -887,15 +887,15 @@
                 "type": "number",
                 "format": "double"
               },
-              "outputValue": {
-                "title": "Output Value",
-                "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
-              },
               "to": {
                 "title": "To (Maximum)",
                 "description": "The maximum value of the range (exclusive)",
                 "type": "number",
                 "format": "double"
+              },
+              "outputValue": {
+                "title": "Output Value",
+                "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
               }
             }
           }
@@ -923,13 +923,13 @@
         "description": "Configuration for extracting boundaries from geometries.",
         "type": "object",
         "properties": {
-          "exteriorOnly": {
-            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
+          "keepEmptyBoundaries": {
+            "description": "Whether to keep features with empty boundaries (default: false)",
             "default": false,
             "type": "boolean"
           },
-          "keepEmptyBoundaries": {
-            "description": "Whether to keep features with empty boundaries (default: false)",
+          "exteriorOnly": {
+            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
             "default": false,
             "type": "boolean"
           }
@@ -956,18 +956,6 @@
         "title": "BoundsExtractor Parameters",
         "type": "object",
         "properties": {
-          "xmax": {
-            "title": "Maximum X Attribute",
-            "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "xmin": {
             "title": "Minimum X Attribute",
             "description": "Attribute name for storing the minimum X coordinate (defaults to \"xmin\")",
@@ -980,9 +968,9 @@
               }
             ]
           },
-          "ymax": {
-            "title": "Maximum Y Attribute",
-            "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
+          "xmax": {
+            "title": "Maximum X Attribute",
+            "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1004,9 +992,9 @@
               }
             ]
           },
-          "zmax": {
-            "title": "Maximum Z Attribute",
-            "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
+          "ymax": {
+            "title": "Maximum Y Attribute",
+            "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1019,6 +1007,18 @@
           "zmin": {
             "title": "Minimum Z Attribute",
             "description": "Attribute name for storing the minimum Z coordinate (defaults to \"zmin\")",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "zmax": {
+            "title": "Maximum Z Attribute",
+            "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1130,6 +1130,15 @@
           "renameValue"
         ],
         "properties": {
+          "renameType": {
+            "title": "Which Attributes to Rename",
+            "description": "Choose whether to rename all attributes or only selected ones",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RenameType"
+              }
+            ]
+          },
           "renameAction": {
             "title": "Rename Operation",
             "description": "The type of renaming operation to perform on the attribute names",
@@ -1139,13 +1148,12 @@
               }
             ]
           },
-          "renameType": {
-            "title": "Which Attributes to Rename",
-            "description": "Choose whether to rename all attributes or only selected ones",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RenameType"
-              }
+          "textToFind": {
+            "title": "Text Pattern to Find",
+            "description": "Regular expression pattern to match when using \"Replace Text\" operation",
+            "type": [
+              "string",
+              "null"
             ]
           },
           "renameValue": {
@@ -1163,17 +1171,29 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "title": "Text Pattern to Find",
-            "description": "Regular expression pattern to match when using \"Replace Text\" operation",
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
         "definitions": {
+          "RenameType": {
+            "oneOf": [
+              {
+                "title": "All Attributes",
+                "description": "Rename all attributes in the feature",
+                "type": "string",
+                "enum": [
+                  "All"
+                ]
+              },
+              {
+                "title": "Selected Attributes",
+                "description": "Rename only specific attributes listed below",
+                "type": "string",
+                "enum": [
+                  "Selected"
+                ]
+              }
+            ]
+          },
           "RenameAction": {
             "oneOf": [
               {
@@ -1217,26 +1237,6 @@
                 ]
               }
             ]
-          },
-          "RenameType": {
-            "oneOf": [
-              {
-                "title": "All Attributes",
-                "description": "Rename all attributes in the feature",
-                "type": "string",
-                "enum": [
-                  "All"
-                ]
-              },
-              {
-                "title": "Selected Attributes",
-                "description": "Rename only specific attributes listed below",
-                "type": "string",
-                "enum": [
-                  "Selected"
-                ]
-              }
-            ]
           }
         }
       },
@@ -1262,22 +1262,6 @@
         "description": "Configure how the CSG builder pairs features from left and right ports",
         "type": "object",
         "properties": {
-          "createList": {
-            "title": "Create List",
-            "description": "When enabled, creates a list of attribute values from both children (left and right)",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "listAttributeName": {
-            "title": "List Attribute Name",
-            "description": "Name of the attribute to create the list from (required when create_list is true)",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "pairIdAttribute": {
             "title": "Pair ID Attribute",
             "description": "Expression to evaluate the pair ID used to match features from left and right ports",
@@ -1301,6 +1285,22 @@
                 "type": "string"
               }
             }
+          },
+          "createList": {
+            "title": "Create List",
+            "description": "When enabled, creates a list of attribute values from both children (left and right)",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "listAttributeName": {
+            "title": "List Attribute Name",
+            "description": "Name of the attribute to create the list from (required when create_list is true)",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -1445,6 +1445,42 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "title": "Output Path",
+            "description": "Directory path where the 3D tiles will be written",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "Minimum Zoom Level",
+            "description": "Minimum zoom level for tile generation (0-24)",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "Maximum Zoom Level",
+            "description": "Maximum zoom level for tile generation (0-24)",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
           "attachTexture": {
             "title": "Attach Textures",
             "description": "Whether to include texture information in the generated tiles",
@@ -1486,55 +1522,19 @@
               "null"
             ]
           },
-          "maxZoom": {
-            "title": "Maximum Zoom Level",
-            "description": "Maximum zoom level for tile generation (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "Minimum Zoom Level",
-            "description": "Minimum zoom level for tile generation (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "Output Path",
-            "description": "Directory path where the 3D tiles will be written",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
+          "skipUnexposedAttributes": {
+            "title": "Skip unexposed Attributes",
+            "description": "Skip attributes with double underscore prefix",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "title": "Schema Key",
             "description": "Attribute key whose value identifies the schema type and determines the output filename: all features sharing the same value are written to the same file. This attribute is excluded from output.",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "Skip unexposed Attributes",
-            "description": "Skip attributes with double underscore prefix",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -1589,12 +1589,6 @@
               }
             }
           },
-          "flatten": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -1619,6 +1613,12 @@
                 "type": "string"
               }
             }
+          },
+          "flatten": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         }
       },
@@ -1647,29 +1647,6 @@
           "output"
         ],
         "properties": {
-          "epsgCode": {
-            "description": "EPSG code for coordinate reference system",
-            "default": null,
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "lodFilter": {
-            "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-            "default": null,
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          },
           "output": {
             "description": "Output file path expression",
             "type": "object",
@@ -1690,6 +1667,29 @@
                 "type": "string"
               }
             }
+          },
+          "lodFilter": {
+            "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+            "default": null,
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "epsgCode": {
+            "description": "EPSG code for coordinate reference system",
+            "default": null,
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
           },
           "prettyPrint": {
             "description": "Whether to format output with indentation (default: true)",
@@ -1807,15 +1807,6 @@
           "mode"
         ],
         "properties": {
-          "defaultZValue": {
-            "title": "Default Z Value",
-            "description": "Z value to use for 2D geometries that have no Z coordinate.",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
           "mode": {
             "title": "Extraction Mode",
             "description": "How to extract coordinates from geometry vertices.",
@@ -1824,12 +1815,18 @@
                 "$ref": "#/definitions/CoordinateExtractionMode"
               }
             ]
+          },
+          "defaultZValue": {
+            "title": "Default Z Value",
+            "description": "Z value to use for 2D geometries that have no Z coordinate.",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "CoordinateExtractionMode": {
             "description": "Extraction mode: determines how coordinates are output.",
             "oneOf": [
@@ -1840,6 +1837,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "allCoordinates"
+                    ]
+                  },
                   "coordinatesListName": {
                     "title": "Coordinates List Name",
                     "description": "Name of the list attribute that will store coordinate objects (default: \"_indices\")",
@@ -1848,12 +1851,6 @@
                       {
                         "$ref": "#/definitions/Attribute"
                       }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "allCoordinates"
                     ]
                   }
                 }
@@ -1866,17 +1863,17 @@
                   "type"
                 ],
                 "properties": {
-                  "coordinateIndex": {
-                    "title": "Coordinate Index",
-                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
-                    "type": "integer",
-                    "format": "int64"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
                       "specifyCoordinate"
                     ]
+                  },
+                  "coordinateIndex": {
+                    "title": "Coordinate Index",
+                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "xAttribute": {
                     "title": "X Attribute Name",
@@ -1911,6 +1908,9 @@
                 }
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -1940,6 +1940,23 @@
           "format"
         ],
         "properties": {
+          "format": {
+            "title": "File Format",
+            "description": "Choose the delimiter format for the input file",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "encoding": {
+            "title": "Character Encoding",
+            "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -1964,45 +1981,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "Character Encoding",
-            "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "format": {
-            "title": "File Format",
-            "description": "Choose the delimiter format for the input file",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "Geometry Configuration",
-            "description": "Optional configuration for parsing geometry from CSV columns",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "headerRows": {
-            "title": "Header Row Count",
-            "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint",
-            "minimum": 0.0
           },
           "inline": {
             "title": "Inline Content",
@@ -2038,6 +2016,28 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "headerRows": {
+            "title": "Header Row Count",
+            "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint",
+            "minimum": 0.0
+          },
+          "geometry": {
+            "title": "Geometry Configuration",
+            "description": "Optional configuration for parsing geometry from CSV columns",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2152,26 +2152,6 @@
           "output"
         ],
         "properties": {
-          "format": {
-            "description": "File format: csv (comma) or tsv (tab)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "Geometry Configuration",
-            "description": "Optional configuration for exporting geometry to CSV columns",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryExportConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "output": {
             "description": "Output path or expression for the CSV/TSV file to create",
             "type": "object",
@@ -2192,6 +2172,26 @@
                 "type": "string"
               }
             }
+          },
+          "format": {
+            "description": "File format: csv (comma) or tsv (tab)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "geometry": {
+            "title": "Geometry Configuration",
+            "description": "Optional configuration for exporting geometry to CSV columns",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryExportConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2290,6 +2290,28 @@
         "description": "Configuration for reading CZML files as geographic features.",
         "type": "object",
         "properties": {
+          "force2d": {
+            "title": "Force 2D",
+            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+            "default": false,
+            "type": "boolean"
+          },
+          "skipDocumentPacket": {
+            "title": "Skip Document Packet",
+            "description": "If true, skips the document packet (first packet with version/clock info)",
+            "default": true,
+            "type": "boolean"
+          },
+          "timeSampling": {
+            "title": "Time Sampling Strategy",
+            "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
+            "default": "preserveRaw",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TimeSamplingStrategy"
+              }
+            ]
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -2315,12 +2337,6 @@
               }
             }
           },
-          "force2d": {
-            "title": "Force 2D",
-            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -2345,22 +2361,6 @@
                 "type": "string"
               }
             }
-          },
-          "skipDocumentPacket": {
-            "title": "Skip Document Packet",
-            "description": "If true, skips the document packet (first packet with version/clock info)",
-            "default": true,
-            "type": "boolean"
-          },
-          "timeSampling": {
-            "title": "Time Sampling Strategy",
-            "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
-            "default": "preserveRaw",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TimeSamplingStrategy"
-              }
-            ]
           }
         },
         "definitions": {
@@ -2415,87 +2415,6 @@
           "output"
         ],
         "properties": {
-          "colorAttribute": {
-            "title": "Color Attribute",
-            "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "epoch": {
-            "title": "Epoch",
-            "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "groupBy": {
-            "title": "Group By Attributes",
-            "description": "Attributes used to group features into separate CZML files",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
-          "groupTimeseriesBy": {
-            "title": "Group Timeseries By",
-            "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "heightAttribute": {
-            "title": "Height Attribute",
-            "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "interpolationAlgorithm": {
-            "title": "Interpolation Algorithm",
-            "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
-            "default": "LINEAR",
-            "allOf": [
-              {
-                "$ref": "#/definitions/InterpolationAlgorithm"
-              }
-            ]
-          },
-          "interpolationDegree": {
-            "title": "Interpolation Degree",
-            "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
-            "default": 1,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "opacity": {
-            "title": "Opacity",
-            "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
-            "default": 180,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
           "output": {
             "title": "Output File Path",
             "description": "Path where the CZML file will be written",
@@ -2518,9 +2437,90 @@
               }
             }
           },
+          "groupBy": {
+            "title": "Group By Attributes",
+            "description": "Attributes used to group features into separate CZML files",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "timeField": {
             "title": "Time Field",
             "description": "Attribute containing the timestamp for each feature. Supports two formats: - **ISO 8601 strings**: e.g., \"2024-01-01T00:00:00Z\", \"2024-01-01T12:30:45+09:00\" - **Numeric values**: Seconds as offset from epoch (e.g., \"0\", \"60\", \"120.5\")\n\nWhen set together with `groupTimeseriesBy`, features sharing the same group key are combined into a single CZML entity with time-tagged position samples for animation in Cesium.\n\n**Example workflow configuration:** ```yaml - action: CzmlWriter with: output: \"output.czml\" timeField: \"timestamp\" groupTimeseriesBy: \"vehicleId\" epoch: \"2024-01-01T00:00:00Z\"  # Optional for numeric times (auto-defaults to Unix epoch) ```",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "epoch": {
+            "title": "Epoch",
+            "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "interpolationAlgorithm": {
+            "title": "Interpolation Algorithm",
+            "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
+            "default": "LINEAR",
+            "allOf": [
+              {
+                "$ref": "#/definitions/InterpolationAlgorithm"
+              }
+            ]
+          },
+          "interpolationDegree": {
+            "title": "Interpolation Degree",
+            "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
+            "default": 1,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "groupTimeseriesBy": {
+            "title": "Group Timeseries By",
+            "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "colorAttribute": {
+            "title": "Color Attribute",
+            "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "opacity": {
+            "title": "Opacity",
+            "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
+            "default": 180,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "heightAttribute": {
+            "title": "Height Attribute",
+            "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -2598,14 +2598,6 @@
               }
             ]
           },
-          "outputAttribute": {
-            "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "outputFormat": {
             "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode).",
             "default": "auto",
@@ -2613,6 +2605,14 @@
               {
                 "$ref": "#/definitions/DateTimeOutputFormat"
               }
+            ]
+          },
+          "outputAttribute": {
+            "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
@@ -2819,16 +2819,6 @@
         "description": "Configure how to dissolve features by grouping them based on shared attributes",
         "type": "object",
         "properties": {
-          "attributeAccumulation": {
-            "title": "Attribute Accumulation",
-            "description": "Strategy for handling attributes when dissolving features",
-            "default": "useOneFeature",
-            "allOf": [
-              {
-                "$ref": "#/definitions/AttributeAccumulationStrategy"
-              }
-            ]
-          },
           "groupBy": {
             "title": "Group By Attributes",
             "description": "List of attribute names to group features by before dissolving. Features with the same values for these attributes will be dissolved together",
@@ -2848,6 +2838,16 @@
               "null"
             ],
             "format": "double"
+          },
+          "attributeAccumulation": {
+            "title": "Attribute Accumulation",
+            "description": "Strategy for handling attributes when dissolving features",
+            "default": "useOneFeature",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AttributeAccumulationStrategy"
+              }
+            ]
           }
         },
         "definitions": {
@@ -3089,15 +3089,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "Clé des Attributs CityGML",
-            "description": "Lorsque défini, les attributs CityGML analysés sont imbriqués sous cette clé dans l'entité de sortie. Lorsque nul, les attributs sont émis au niveau supérieur. Par défaut à null.",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Expression de chemin résolvant vers le fichier CityGML 2.0 à lire.",
@@ -3129,10 +3120,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "Aplatir les Types de Mesure",
-            "description": "Lorsque vrai, les éléments avec un seul attribut `uom` et un contenu textuel numérique sont convertis en valeur numérique, l'unité étant stockée comme clé sœur `{name}_uom`. Par défaut à false.",
-            "default": false,
+          "keepAttributes": {
+            "title": "Conserver les Attributs",
+            "description": "Lorsque faux, les attributs XML (entrées préfixées par `@` comme `@gml:id`, `@codeSpace`) sont supprimés des entités analysées. Par défaut à true.",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3141,11 +3132,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "Conserver les Attributs",
-            "description": "Lorsque faux, les attributs XML (entrées préfixées par `@` comme `@gml:id`, `@codeSpace`) sont supprimés des entités analysées. Par défaut à true.",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "Aplatir les Types de Mesure",
+            "description": "Lorsque vrai, les éléments avec un seul attribut `uom` et un contenu textuel numérique sont convertis en valeur numérique, l'unité étant stockée comme clé sœur `{name}_uom`. Par défaut à false.",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "Clé des Attributs CityGML",
+            "description": "Lorsque défini, les attributs CityGML analysés sont imbriqués sous cette clé dans l'entité de sortie. Lorsque nul, les attributs sont émis au niveau supérieur. Par défaut à null.",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3173,15 +3173,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "Clé des Attributs CityGML",
-            "description": "Lorsque défini, les attributs CityGML analysés sont imbriqués sous cette clé dans l'entité de sortie. Lorsque nul, les attributs sont émis au niveau supérieur. Par défaut à null.",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Expression de chemin résolvant vers le fichier CityGML 3.0 à lire.",
@@ -3213,10 +3204,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "Aplatir les Types de Mesure",
-            "description": "Lorsque vrai, les éléments avec un seul attribut `uom` et un contenu textuel numérique sont convertis en valeur numérique, l'unité étant stockée comme clé sœur `{name}_uom`. Par défaut à false.",
-            "default": false,
+          "keepAttributes": {
+            "title": "Conserver les Attributs",
+            "description": "Lorsque faux, les attributs XML (entrées préfixées par `@` comme `@gml:id`, `@codeSpace`) sont supprimés des entités analysées. Par défaut à true.",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3225,11 +3216,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "Conserver les Attributs",
-            "description": "Lorsque faux, les attributs XML (entrées préfixées par `@` comme `@gml:id`, `@codeSpace`) sont supprimés des entités analysées. Par défaut à true.",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "Aplatir les Types de Mesure",
+            "description": "Lorsque vrai, les éléments avec un seul attribut `uom` et un contenu textuel numérique sont convertis en valeur numérique, l'unité étant stockée comme clé sœur `{name}_uom`. Par défaut à false.",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "Clé des Attributs CityGML",
+            "description": "Lorsque défini, les attributs CityGML analysés sont imbriqués sous cette clé dans l'entité de sortie. Lorsque nul, les attributs sont émis au niveau supérieur. Par défaut à null.",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3258,31 +3258,6 @@
           "dataset"
         ],
         "properties": {
-          "codelistsPath": {
-            "title": "Codelists Path",
-            "description": "Optional path to the codelists directory for resolving codelist values",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Path or expression to the CityGML dataset file to be read",
@@ -3312,6 +3287,31 @@
               "boolean",
               "null"
             ]
+          },
+          "codelistsPath": {
+            "title": "Codelists Path",
+            "description": "Optional path to the codelists directory for resolving codelist values",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -3463,19 +3463,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "destPrefix": {
-            "title": "Destination Prefix",
-            "description": "Optional prefix to add to extracted file paths",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "extractArchive": {
-            "title": "Extract Archive",
-            "description": "Whether to extract archive files found in the dataset",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Expression to get the source dataset path or URL",
@@ -3497,6 +3484,19 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "Extract Archive",
+            "description": "Whether to extract archive files found in the dataset",
+            "type": "boolean"
+          },
+          "destPrefix": {
+            "title": "Destination Prefix",
+            "description": "Optional prefix to add to extracted file paths",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3606,17 +3606,6 @@
           "joinType"
         ],
         "properties": {
-          "conflictResolution": {
-            "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ConflictResolution"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "joinType": {
             "description": "Join type: inner, left, or full",
             "allOf": [
@@ -3627,6 +3616,16 @@
           },
           "requestorAttribute": {
             "description": "Attributes from requestor features to use for matching (alternative to requestorAttributeValue)",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
             "type": [
               "array",
               "null"
@@ -3658,16 +3657,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "Expression to evaluate for supplier feature matching values (alternative to supplierAttribute)",
             "type": [
@@ -3690,30 +3679,20 @@
                 "type": "string"
               }
             }
+          },
+          "conflictResolution": {
+            "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ConflictResolution"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "ConflictResolution": {
-            "oneOf": [
-              {
-                "description": "Requestor attributes win on conflict",
-                "type": "string",
-                "enum": [
-                  "requestorWins"
-                ]
-              },
-              {
-                "description": "Supplier attributes win on conflict (default)",
-                "type": "string",
-                "enum": [
-                  "supplierWins"
-                ]
-              }
-            ]
-          },
           "JoinType": {
             "oneOf": [
               {
@@ -3735,6 +3714,27 @@
                 "type": "string",
                 "enum": [
                   "full"
+                ]
+              }
+            ]
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "ConflictResolution": {
+            "oneOf": [
+              {
+                "description": "Requestor attributes win on conflict",
+                "type": "string",
+                "enum": [
+                  "requestorWins"
+                ]
+              },
+              {
+                "description": "Supplier attributes win on conflict (default)",
+                "type": "string",
+                "enum": [
+                  "supplierWins"
                 ]
               }
             ]
@@ -3816,15 +3816,18 @@
         "description": "Configuration for merging requestor and supplier features based on matching attributes or expressions.",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "description": "Whether to complete grouped features before processing the next group",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "description": "Attributes from requestor features to use for matching (alternative to requestor_attribute_value)",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
             "type": [
               "array",
               "null"
@@ -3856,16 +3859,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "Expression to evaluate for supplier feature matching values (alternative to supplier_attribute)",
             "type": [
@@ -3888,6 +3881,13 @@
                 "type": "string"
               }
             }
+          },
+          "completeGrouped": {
+            "description": "Whether to complete grouped features before processing the next group",
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
         "definitions": {
@@ -3927,27 +3927,11 @@
               "format"
             ],
             "properties": {
-              "dataset": {
-                "title": "Dataset",
-                "description": "Path or expression to the dataset file to be read",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3957,42 +3941,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "csv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4014,6 +3962,42 @@
                     "type": "string"
                   }
                 }
+              },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -4023,42 +4007,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "tsv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4081,11 +4029,63 @@
                   }
                 }
               },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
               "format": {
                 "type": "string",
                 "enum": [
                   "json"
                 ]
+              },
+              "dataset": {
+                "title": "Dataset",
+                "description": "Path or expression to the dataset file to be read",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -4349,28 +4349,6 @@
               "output"
             ],
             "properties": {
-              "converter": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
               "format": {
                 "type": "string",
                 "enum": [
@@ -4397,6 +4375,28 @@
                     "type": "string"
                   }
                 }
+              },
+              "converter": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -4409,34 +4409,11 @@
               "output"
             ],
             "properties": {
-              "epsgCode": {
-                "description": "EPSG code for coordinate reference system",
-                "default": null,
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint32",
-                "minimum": 0.0
-              },
               "format": {
                 "type": "string",
                 "enum": [
                   "citygml"
                 ]
-              },
-              "lodFilter": {
-                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-                "default": null,
-                "type": [
-                  "array",
-                  "null"
-                ],
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0.0
-                }
               },
               "output": {
                 "title": "Output path",
@@ -4458,6 +4435,29 @@
                     "type": "string"
                   }
                 }
+              },
+              "lodFilter": {
+                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+                "default": null,
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              },
+              "epsgCode": {
+                "description": "EPSG code for coordinate reference system",
+                "default": null,
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4497,11 +4497,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "extractArchive": {
-            "title": "Extract Archive",
-            "description": "Whether to extract files from archives (zip files, etc.) or just list them",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Path or expression pointing to the source directory or archive file",
@@ -4523,6 +4518,11 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "Extract Archive",
+            "description": "Whether to extract files from archives (zip files, etc.) or just list them",
+            "type": "boolean"
           }
         }
       },
@@ -4680,16 +4680,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "Optional attributes to group features by, creating separate files for each group",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "Output path or expression for the GeoJSON file to create",
             "type": "object",
@@ -4709,6 +4699,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "Optional attributes to group features by, creating separate files for each group",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -4739,6 +4739,32 @@
         "title": "GeoPackageReaderParam",
         "type": "object",
         "properties": {
+          "readMode": {
+            "default": "features",
+            "allOf": [
+              {
+                "$ref": "#/definitions/GeoPackageReadMode"
+              }
+            ]
+          },
+          "layerName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "includeMetadata": {
+            "default": false,
+            "type": "boolean"
+          },
+          "tileFormat": {
+            "default": "png",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TileFormat"
+              }
+            ]
+          },
           "attributeFilter": {
             "default": null,
             "type": [
@@ -4754,6 +4780,17 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "force2D": {
+            "default": false,
+            "type": "boolean"
+          },
+          "spatialFilter": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "dataset": {
             "title": "File Path",
@@ -4780,14 +4817,6 @@
               }
             }
           },
-          "force2D": {
-            "default": false,
-            "type": "boolean"
-          },
-          "includeMetadata": {
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -4812,35 +4841,6 @@
                 "type": "string"
               }
             }
-          },
-          "layerName": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "readMode": {
-            "default": "features",
-            "allOf": [
-              {
-                "$ref": "#/definitions/GeoPackageReadMode"
-              }
-            ]
-          },
-          "spatialFilter": {
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tileFormat": {
-            "default": "png",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TileFormat"
-              }
-            ]
           }
         },
         "definitions": {
@@ -4888,21 +4888,6 @@
           "output"
         ],
         "properties": {
-          "createSpatialIndex": {
-            "description": "Create RTree spatial index (default: true)",
-            "default": true,
-            "type": "boolean"
-          },
-          "geometryColumn": {
-            "description": "Geometry column name (default: \"geom\")",
-            "default": "geom",
-            "type": "string"
-          },
-          "geometryType": {
-            "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
-            "default": "GEOMETRY",
-            "type": "string"
-          },
           "output": {
             "description": "Output path for the GeoPackage file to create",
             "type": "object",
@@ -4924,10 +4909,15 @@
               }
             }
           },
-          "overwrite": {
-            "description": "Overwrite existing file (default: false)",
-            "default": false,
-            "type": "boolean"
+          "tableName": {
+            "description": "Table name to create (default: \"features\")",
+            "default": "features",
+            "type": "string"
+          },
+          "geometryColumn": {
+            "description": "Geometry column name (default: \"geom\")",
+            "default": "geom",
+            "type": "string"
           },
           "srsId": {
             "description": "Spatial Reference System ID (default: 4326 for WGS84)",
@@ -4935,10 +4925,20 @@
             "type": "integer",
             "format": "int32"
           },
-          "tableName": {
-            "description": "Table name to create (default: \"features\")",
-            "default": "features",
+          "geometryType": {
+            "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
+            "default": "GEOMETRY",
             "type": "string"
+          },
+          "createSpatialIndex": {
+            "description": "Create RTree spatial index (default: true)",
+            "default": true,
+            "type": "boolean"
+          },
+          "overwrite": {
+            "description": "Overwrite existing file (default: false)",
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -5411,6 +5411,24 @@
         "title": "GltfReaderParam",
         "type": "object",
         "properties": {
+          "triangulate": {
+            "title": "Triangulate",
+            "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
+            "default": true,
+            "type": "boolean"
+          },
+          "mergeMeshes": {
+            "title": "Merge Meshes",
+            "description": "If true, combines all meshes from the glTF file into a single output feature",
+            "default": false,
+            "type": "boolean"
+          },
+          "includeNodes": {
+            "title": "Include Nodes",
+            "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
+            "default": true,
+            "type": "boolean"
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -5436,12 +5454,6 @@
               }
             }
           },
-          "includeNodes": {
-            "title": "Include Nodes",
-            "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
-            "default": true,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -5466,18 +5478,6 @@
                 "type": "string"
               }
             }
-          },
-          "mergeMeshes": {
-            "title": "Merge Meshes",
-            "description": "If true, combines all meshes from the glTF file into a single output feature",
-            "default": false,
-            "type": "boolean"
-          },
-          "triangulate": {
-            "title": "Triangulate",
-            "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
-            "default": true,
-            "type": "boolean"
           }
         }
       },
@@ -5505,20 +5505,6 @@
           "output"
         ],
         "properties": {
-          "attachTexture": {
-            "description": "Whether to attach texture information to the GLTF model",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "dracoCompression": {
-            "description": "Apply Draco compression to the geometry",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "output": {
             "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
             "type": "object",
@@ -5539,6 +5525,20 @@
                 "type": "string"
               }
             }
+          },
+          "attachTexture": {
+            "description": "Whether to attach texture information to the GLTF model",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "dracoCompression": {
+            "description": "Apply Draco compression to the geometry",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
@@ -5571,6 +5571,20 @@
           "unitSquareSize"
         ],
         "properties": {
+          "unitSquareSize": {
+            "title": "Unit Square Size",
+            "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
+            "type": "number",
+            "format": "double"
+          },
+          "keepSquareOnly": {
+            "title": "Keep Square Only",
+            "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "title": "Group By Attributes",
             "description": "Attributes used to group features - each group gets its own grid origin",
@@ -5581,20 +5595,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "keepSquareOnly": {
-            "title": "Keep Square Only",
-            "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "unitSquareSize": {
-            "title": "Unit Square Size",
-            "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -5631,12 +5631,78 @@
           "url"
         ],
         "properties": {
+          "url": {
+            "title": "URL",
+            "description": "The target URL for the HTTP request (supports expressions)",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "method": {
+            "title": "HTTP Method",
+            "description": "The HTTP method to use for the request",
+            "default": "GET",
+            "allOf": [
+              {
+                "$ref": "#/definitions/HttpMethod"
+              }
+            ]
+          },
           "authentication": {
             "title": "Authentication",
             "description": "Authentication method and credentials for the request",
             "anyOf": [
               {
                 "$ref": "#/definitions/Authentication"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "customHeaders": {
+            "title": "Custom Headers",
+            "description": "Additional HTTP headers to include in the request",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/HeaderParam"
+            }
+          },
+          "queryParameters": {
+            "title": "Query Parameters",
+            "description": "URL query parameters to append to the request",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/QueryParam"
+            }
+          },
+          "requestBody": {
+            "title": "Request Body",
+            "description": "The body content to send with the request",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5651,16 +5717,17 @@
               "null"
             ]
           },
-          "customHeaders": {
-            "title": "Custom Headers",
-            "description": "Additional HTTP headers to include in the request",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/HeaderParam"
-            }
+          "timeouts": {
+            "title": "Timeouts",
+            "description": "Connection and transfer timeout settings",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TimeoutConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "httpOptions": {
             "title": "HTTP Options",
@@ -5668,63 +5735,6 @@
             "anyOf": [
               {
                 "$ref": "#/definitions/HttpOptions"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "method": {
-            "title": "HTTP Method",
-            "description": "The HTTP method to use for the request",
-            "default": "GET",
-            "allOf": [
-              {
-                "$ref": "#/definitions/HttpMethod"
-              }
-            ]
-          },
-          "observability": {
-            "title": "Observability",
-            "description": "Track additional metrics and diagnostics",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ObservabilityConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "queryParameters": {
-            "title": "Query Parameters",
-            "description": "URL query parameters to append to the request",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/QueryParam"
-            }
-          },
-          "rateLimit": {
-            "title": "Rate Limiting",
-            "description": "Rate limiting configuration to control request frequency",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RateLimitConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "requestBody": {
-            "title": "Request Body",
-            "description": "The body content to send with the request",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5755,386 +5765,32 @@
               }
             ]
           },
-          "timeouts": {
-            "title": "Timeouts",
-            "description": "Connection and transfer timeout settings",
+          "rateLimit": {
+            "title": "Rate Limiting",
+            "description": "Rate limiting configuration to control request frequency",
             "anyOf": [
               {
-                "$ref": "#/definitions/TimeoutConfig"
+                "$ref": "#/definitions/RateLimitConfig"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "url": {
-            "title": "URL",
-            "description": "The target URL for the HTTP request (supports expressions)",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
+          "observability": {
+            "title": "Observability",
+            "description": "Track additional metrics and diagnostics",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ObservabilityConfig"
               },
-              "value": {
-                "type": "string"
+              {
+                "type": "null"
               }
-            }
+            ]
           }
         },
         "definitions": {
-          "ApiKeyLocation": {
-            "title": "API Key Location",
-            "description": "Where to include the API key in the request",
-            "oneOf": [
-              {
-                "title": "Header",
-                "description": "Include API key in HTTP header",
-                "type": "string",
-                "enum": [
-                  "header"
-                ]
-              },
-              {
-                "title": "Query Parameter",
-                "description": "Include API key in URL query string",
-                "type": "string",
-                "enum": [
-                  "query"
-                ]
-              }
-            ]
-          },
-          "Authentication": {
-            "title": "Authentication",
-            "description": "Authentication method and credentials for HTTP requests",
-            "oneOf": [
-              {
-                "title": "Basic Authentication",
-                "description": "HTTP Basic authentication with username and password",
-                "type": "object",
-                "required": [
-                  "password",
-                  "type",
-                  "username"
-                ],
-                "properties": {
-                  "password": {
-                    "title": "Password",
-                    "description": "The password for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "basic"
-                    ]
-                  },
-                  "username": {
-                    "title": "Username",
-                    "description": "The username for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "title": "Bearer Token",
-                "description": "Bearer token authentication (OAuth 2.0)",
-                "type": "object",
-                "required": [
-                  "token",
-                  "type"
-                ],
-                "properties": {
-                  "token": {
-                    "title": "Token",
-                    "description": "The bearer token value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "bearer"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "API Key",
-                "description": "API key authentication in header or query parameter",
-                "type": "object",
-                "required": [
-                  "keyName",
-                  "keyValue",
-                  "type"
-                ],
-                "properties": {
-                  "keyName": {
-                    "title": "Key Name",
-                    "description": "The name of the API key parameter",
-                    "type": "string"
-                  },
-                  "keyValue": {
-                    "title": "Key Value",
-                    "description": "The API key value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "location": {
-                    "title": "Location",
-                    "description": "Where to include the API key (header or query parameter)",
-                    "default": "header",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/ApiKeyLocation"
-                      }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "apiKey"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "BinarySource": {
-            "title": "Binary Source",
-            "description": "Source of binary data for request body",
-            "oneOf": [
-              {
-                "title": "Base64 Encoded",
-                "description": "Binary data encoded as base64 string",
-                "type": "object",
-                "required": [
-                  "data",
-                  "type"
-                ],
-                "properties": {
-                  "data": {
-                    "title": "Data",
-                    "description": "Base64-encoded binary data (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "base64"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "From File",
-                "description": "Read binary data from a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path to the file to read (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "FormField": {
-            "title": "Form Field",
-            "description": "A name-value pair for URL-encoded form data",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "Field Name",
-                "description": "The name of the form field",
-                "type": "string"
-              },
-              "value": {
-                "title": "Field Value",
-                "description": "The value of the form field (supports expressions)",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "HeaderParam": {
-            "title": "HTTP Header",
-            "description": "A custom HTTP header to include in the request",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "Header Name",
-                "description": "The name of the HTTP header",
-                "type": "string"
-              },
-              "value": {
-                "title": "Header Value",
-                "description": "The value of the header (supports expressions)",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
           "HttpMethod": {
             "title": "HTTP Method",
             "description": "The HTTP request method to use",
@@ -6253,75 +5909,51 @@
               }
             ]
           },
-          "HttpOptions": {
-            "title": "HTTP Options",
-            "description": "Configure HTTP client behavior",
-            "type": "object",
-            "properties": {
-              "followRedirects": {
-                "title": "Follow Redirects",
-                "description": "Whether to automatically follow HTTP redirects (default: true)",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "maxRedirects": {
-                "title": "Max Redirects",
-                "description": "Maximum number of redirects to follow (default: 10)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "userAgent": {
-                "title": "User Agent",
-                "description": "Custom User-Agent header value",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "verifySsl": {
-                "title": "Verify SSL",
-                "description": "Whether to verify SSL/TLS certificates (default: true)",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            }
-          },
-          "MultipartPart": {
-            "title": "Multipart Part",
-            "description": "A part in a multipart/form-data request",
+          "Authentication": {
+            "title": "Authentication",
+            "description": "Authentication method and credentials for HTTP requests",
             "oneOf": [
               {
-                "title": "Text Field",
-                "description": "A text field in the multipart form",
+                "title": "Basic Authentication",
+                "description": "HTTP Basic authentication with username and password",
                 "type": "object",
                 "required": [
-                  "name",
+                  "password",
                   "type",
-                  "value"
+                  "username"
                 ],
                 "properties": {
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the form field",
-                    "type": "string"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "text"
+                      "basic"
                     ]
                   },
-                  "value": {
-                    "title": "Field Value",
-                    "description": "The value of the form field (supports expressions)",
+                  "username": {
+                    "title": "Username",
+                    "description": "The username for basic authentication",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "The password for basic authentication",
                     "type": "object",
                     "format": "code",
                     "required": [
@@ -6344,115 +5976,158 @@
                 }
               },
               {
-                "title": "File Upload",
-                "description": "A file upload in the multipart form",
+                "title": "Bearer Token",
+                "description": "Bearer token authentication (OAuth 2.0)",
                 "type": "object",
                 "required": [
-                  "name",
-                  "source",
+                  "token",
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "MIME type of the file",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "description": "The filename to send in the Content-Disposition header",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the file upload field",
-                    "type": "string"
-                  },
-                  "source": {
-                    "title": "File Source",
-                    "description": "Source of the file data (base64 or file path)",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/BinarySource"
-                      }
-                    ]
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "file"
+                      "bearer"
+                    ]
+                  },
+                  "token": {
+                    "title": "Token",
+                    "description": "The bearer token value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "API Key",
+                "description": "API key authentication in header or query parameter",
+                "type": "object",
+                "required": [
+                  "keyName",
+                  "keyValue",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "apiKey"
+                    ]
+                  },
+                  "keyName": {
+                    "title": "Key Name",
+                    "description": "The name of the API key parameter",
+                    "type": "string"
+                  },
+                  "keyValue": {
+                    "title": "Key Value",
+                    "description": "The API key value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "location": {
+                    "title": "Location",
+                    "description": "Where to include the API key (header or query parameter)",
+                    "default": "header",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/ApiKeyLocation"
+                      }
                     ]
                   }
                 }
               }
             ]
           },
-          "ObservabilityConfig": {
-            "title": "Observability Configuration",
-            "description": "Track additional metrics and diagnostics about HTTP requests",
+          "ApiKeyLocation": {
+            "title": "API Key Location",
+            "description": "Where to include the API key in the request",
+            "oneOf": [
+              {
+                "title": "Header",
+                "description": "Include API key in HTTP header",
+                "type": "string",
+                "enum": [
+                  "header"
+                ]
+              },
+              {
+                "title": "Query Parameter",
+                "description": "Include API key in URL query string",
+                "type": "string",
+                "enum": [
+                  "query"
+                ]
+              }
+            ]
+          },
+          "HeaderParam": {
+            "title": "HTTP Header",
+            "description": "A custom HTTP header to include in the request",
             "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
             "properties": {
-              "bytesAttribute": {
-                "title": "Bytes Attribute",
-                "description": "Feature attribute name to store the response body size",
-                "type": [
-                  "string",
-                  "null"
-                ]
+              "name": {
+                "title": "Header Name",
+                "description": "The name of the HTTP header",
+                "type": "string"
               },
-              "durationAttribute": {
-                "title": "Duration Attribute",
-                "description": "Feature attribute name to store request duration in milliseconds",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "finalUrlAttribute": {
-                "title": "Final URL Attribute",
-                "description": "Feature attribute name to store the final URL after redirects",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "retryCountAttribute": {
-                "title": "Retry Count Attribute",
-                "description": "Feature attribute name to store the number of retry attempts",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "trackBytes": {
-                "title": "Track Bytes",
-                "description": "Whether to track the response body size in bytes (default: false)",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackDuration": {
-                "title": "Track Duration",
-                "description": "Whether to track the total request duration (default: true)",
-                "default": true,
-                "type": "boolean"
-              },
-              "trackFinalUrl": {
-                "title": "Track Final URL",
-                "description": "Whether to track the final URL after redirects (default: false)",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackRetryCount": {
-                "title": "Track Retry Count",
-                "description": "Whether to track the number of retry attempts (default: true)",
-                "default": true,
-                "type": "boolean"
+              "value": {
+                "title": "Header Value",
+                "description": "The value of the header (supports expressions)",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -6494,41 +6169,6 @@
               }
             }
           },
-          "RateLimitConfig": {
-            "title": "Rate Limit Configuration",
-            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
-            "type": "object",
-            "required": [
-              "requests"
-            ],
-            "properties": {
-              "intervalMs": {
-                "title": "Interval",
-                "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
-                "default": 1000,
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "requests": {
-                "title": "Requests",
-                "description": "Maximum number of requests allowed within the interval",
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
-              },
-              "timing": {
-                "title": "Timing Strategy",
-                "description": "How to distribute requests within the interval (default: Burst)",
-                "default": "burst",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/TimingStrategy"
-                  }
-                ]
-              }
-            }
-          },
           "RequestBody": {
             "title": "Request Body",
             "description": "The body content to send with the HTTP request",
@@ -6542,6 +6182,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
                   "content": {
                     "title": "Content",
                     "description": "The text content to send (supports expressions)",
@@ -6571,12 +6217,6 @@
                       "string",
                       "null"
                     ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "text"
-                    ]
                   }
                 }
               },
@@ -6589,12 +6229,10 @@
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
-                    "type": [
-                      "string",
-                      "null"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "binary"
                     ]
                   },
                   "source": {
@@ -6606,10 +6244,12 @@
                       }
                     ]
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "binary"
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
@@ -6623,6 +6263,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "formUrlEncoded"
+                    ]
+                  },
                   "fields": {
                     "title": "Form Fields",
                     "description": "List of form field name-value pairs",
@@ -6630,12 +6276,6 @@
                     "items": {
                       "$ref": "#/definitions/FormField"
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "formUrlEncoded"
-                    ]
                   }
                 }
               },
@@ -6648,6 +6288,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "multipart"
+                    ]
+                  },
                   "parts": {
                     "title": "Parts",
                     "description": "List of multipart form parts (text fields or file uploads)",
@@ -6655,34 +6301,315 @@
                     "items": {
                       "$ref": "#/definitions/MultipartPart"
                     }
-                  },
+                  }
+                }
+              }
+            ]
+          },
+          "BinarySource": {
+            "title": "Binary Source",
+            "description": "Source of binary data for request body",
+            "oneOf": [
+              {
+                "title": "Base64 Encoded",
+                "description": "Binary data encoded as base64 string",
+                "type": "object",
+                "required": [
+                  "data",
+                  "type"
+                ],
+                "properties": {
                   "type": {
                     "type": "string",
                     "enum": [
-                      "multipart"
+                      "base64"
+                    ]
+                  },
+                  "data": {
+                    "title": "Data",
+                    "description": "Base64-encoded binary data (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "From File",
+                "description": "Read binary data from a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path to the file to read (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "FormField": {
+            "title": "Form Field",
+            "description": "A name-value pair for URL-encoded form data",
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "title": "Field Name",
+                "description": "The name of the form field",
+                "type": "string"
+              },
+              "value": {
+                "title": "Field Value",
+                "description": "The value of the form field (supports expressions)",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "MultipartPart": {
+            "title": "Multipart Part",
+            "description": "A part in a multipart/form-data request",
+            "oneOf": [
+              {
+                "title": "Text Field",
+                "description": "A text field in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the form field",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Field Value",
+                    "description": "The value of the form field (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "File Upload",
+                "description": "A file upload in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "source",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the file upload field",
+                    "type": "string"
+                  },
+                  "source": {
+                    "title": "File Source",
+                    "description": "Source of the file data (base64 or file path)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/BinarySource"
+                      }
+                    ]
+                  },
+                  "filename": {
+                    "title": "Filename",
+                    "description": "The filename to send in the Content-Disposition header",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "MIME type of the file",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
               }
             ]
           },
-          "ResponseConfig": {
-            "title": "Response Configuration",
-            "description": "Configure how HTTP response data is stored and processed",
+          "TimeoutConfig": {
+            "title": "Timeout Configuration",
+            "description": "Configure connection and transfer timeouts for HTTP requests",
             "type": "object",
             "properties": {
-              "autoDetectEncoding": {
-                "title": "Auto Detect Encoding",
-                "description": "Automatically detect character encoding from response headers",
+              "connectionTimeout": {
+                "title": "Connection Timeout",
+                "description": "Maximum time in seconds to establish a connection (default: 60)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "transferTimeout": {
+                "title": "Transfer Timeout",
+                "description": "Maximum time in seconds to complete the entire request (default: 90)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          },
+          "HttpOptions": {
+            "title": "HTTP Options",
+            "description": "Configure HTTP client behavior",
+            "type": "object",
+            "properties": {
+              "userAgent": {
+                "title": "User Agent",
+                "description": "Custom User-Agent header value",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifySsl": {
+                "title": "Verify SSL",
+                "description": "Whether to verify SSL/TLS certificates (default: true)",
                 "type": [
                   "boolean",
                   "null"
                 ]
               },
-              "errorAttribute": {
-                "title": "Error Attribute",
-                "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
-                "default": "_http_error",
+              "followRedirects": {
+                "title": "Follow Redirects",
+                "description": "Whether to automatically follow HTTP redirects (default: true)",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "maxRedirects": {
+                "title": "Max Redirects",
+                "description": "Maximum number of redirects to follow (default: 10)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint8",
+                "minimum": 0.0
+              }
+            }
+          },
+          "ResponseConfig": {
+            "title": "Response Configuration",
+            "description": "Configure how HTTP response data is stored and processed",
+            "type": "object",
+            "properties": {
+              "responseBodyAttribute": {
+                "title": "Response Body Attribute",
+                "description": "Feature attribute name to store the response body (default: \"_response_body\")",
+                "default": "_response_body",
+                "type": "string"
+              },
+              "statusCodeAttribute": {
+                "title": "Status Code Attribute",
+                "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
+                "default": "_http_status_code",
                 "type": "string"
               },
               "headersAttribute": {
@@ -6691,33 +6618,11 @@
                 "default": "_headers",
                 "type": "string"
               },
-              "maxResponseSize": {
-                "title": "Max Response Size",
-                "description": "Maximum response body size in bytes (unlimited if not set)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "responseBodyAttribute": {
-                "title": "Response Body Attribute",
-                "description": "Feature attribute name to store the response body (default: \"_response_body\")",
-                "default": "_response_body",
+              "errorAttribute": {
+                "title": "Error Attribute",
+                "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
+                "default": "_http_error",
                 "type": "string"
-              },
-              "responseEncoding": {
-                "title": "Response Encoding",
-                "description": "How to encode the response body (text, base64, or binary)",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/ResponseEncoding"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
               },
               "responseHandling": {
                 "title": "Response Handling",
@@ -6731,13 +6636,114 @@
                   }
                 ]
               },
-              "statusCodeAttribute": {
-                "title": "Status Code Attribute",
-                "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
-                "default": "_http_status_code",
-                "type": "string"
+              "maxResponseSize": {
+                "title": "Max Response Size",
+                "description": "Maximum response body size in bytes (unlimited if not set)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "responseEncoding": {
+                "title": "Response Encoding",
+                "description": "How to encode the response body (text, base64, or binary)",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/ResponseEncoding"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "autoDetectEncoding": {
+                "title": "Auto Detect Encoding",
+                "description": "Automatically detect character encoding from response headers",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             }
+          },
+          "ResponseHandling": {
+            "title": "Response Handling",
+            "description": "How to handle the HTTP response data",
+            "oneOf": [
+              {
+                "title": "Store in Attribute",
+                "description": "Store response body in a feature attribute",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "attribute"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "Save to File",
+                "description": "Save response body to a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path where the response should be saved",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "storePathInAttribute": {
+                    "title": "Store Path in Attribute",
+                    "description": "Whether to store the file path in a feature attribute",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "pathAttribute": {
+                    "title": "Path Attribute Name",
+                    "description": "Attribute name for storing the file path",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           "ResponseEncoding": {
             "title": "Response Encoding",
@@ -6769,100 +6775,18 @@
               }
             ]
           },
-          "ResponseHandling": {
-            "title": "Response Handling",
-            "description": "How to handle the HTTP response data",
-            "oneOf": [
-              {
-                "title": "Store in Attribute",
-                "description": "Store response body in a feature attribute",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "attribute"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "Save to File",
-                "description": "Save response body to a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path where the response should be saved",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "pathAttribute": {
-                    "title": "Path Attribute Name",
-                    "description": "Attribute name for storing the file path",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "storePathInAttribute": {
-                    "title": "Store Path in Attribute",
-                    "description": "Whether to store the file path in a feature attribute",
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
           "RetryConfig": {
             "title": "Retry Configuration",
             "description": "Configure automatic retry behavior for failed requests",
             "type": "object",
             "properties": {
-              "backoffMultiplier": {
-                "title": "Backoff Multiplier",
-                "description": "Multiplier for exponential backoff between retries (default: 2.0)",
-                "default": 2.0,
-                "type": "number",
-                "format": "double"
-              },
-              "honorRetryAfter": {
-                "title": "Honor Retry-After Header",
-                "description": "Whether to respect the Retry-After header from server responses (default: true)",
-                "default": true,
-                "type": "boolean"
+              "maxAttempts": {
+                "title": "Max Attempts",
+                "description": "Maximum number of retry attempts (default: 3)",
+                "default": 3,
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
               },
               "initialDelayMs": {
                 "title": "Initial Delay",
@@ -6872,13 +6796,12 @@
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "maxAttempts": {
-                "title": "Max Attempts",
-                "description": "Maximum number of retry attempts (default: 3)",
-                "default": 3,
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
+              "backoffMultiplier": {
+                "title": "Backoff Multiplier",
+                "description": "Multiplier for exponential backoff between retries (default: 2.0)",
+                "default": 2.0,
+                "type": "number",
+                "format": "double"
               },
               "maxDelayMs": {
                 "title": "Max Delay",
@@ -6900,33 +6823,47 @@
                   "format": "uint16",
                   "minimum": 0.0
                 }
+              },
+              "honorRetryAfter": {
+                "title": "Honor Retry-After Header",
+                "description": "Whether to respect the Retry-After header from server responses (default: true)",
+                "default": true,
+                "type": "boolean"
               }
             }
           },
-          "TimeoutConfig": {
-            "title": "Timeout Configuration",
-            "description": "Configure connection and transfer timeouts for HTTP requests",
+          "RateLimitConfig": {
+            "title": "Rate Limit Configuration",
+            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
             "type": "object",
+            "required": [
+              "requests"
+            ],
             "properties": {
-              "connectionTimeout": {
-                "title": "Connection Timeout",
-                "description": "Maximum time in seconds to establish a connection (default: 60)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+              "requests": {
+                "title": "Requests",
+                "description": "Maximum number of requests allowed within the interval",
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "intervalMs": {
+                "title": "Interval",
+                "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
+                "default": 1000,
+                "type": "integer",
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "transferTimeout": {
-                "title": "Transfer Timeout",
-                "description": "Maximum time in seconds to complete the entire request (default: 90)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
+              "timing": {
+                "title": "Timing Strategy",
+                "description": "How to distribute requests within the interval (default: Burst)",
+                "default": "burst",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/TimingStrategy"
+                  }
+                ]
               }
             }
           },
@@ -6951,6 +6888,69 @@
                 ]
               }
             ]
+          },
+          "ObservabilityConfig": {
+            "title": "Observability Configuration",
+            "description": "Track additional metrics and diagnostics about HTTP requests",
+            "type": "object",
+            "properties": {
+              "trackDuration": {
+                "title": "Track Duration",
+                "description": "Whether to track the total request duration (default: true)",
+                "default": true,
+                "type": "boolean"
+              },
+              "durationAttribute": {
+                "title": "Duration Attribute",
+                "description": "Feature attribute name to store request duration in milliseconds",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackFinalUrl": {
+                "title": "Track Final URL",
+                "description": "Whether to track the final URL after redirects (default: false)",
+                "default": false,
+                "type": "boolean"
+              },
+              "finalUrlAttribute": {
+                "title": "Final URL Attribute",
+                "description": "Feature attribute name to store the final URL after redirects",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackRetryCount": {
+                "title": "Track Retry Count",
+                "description": "Whether to track the number of retry attempts (default: true)",
+                "default": true,
+                "type": "boolean"
+              },
+              "retryCountAttribute": {
+                "title": "Retry Count Attribute",
+                "description": "Feature attribute name to store the number of retry attempts",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackBytes": {
+                "title": "Track Bytes",
+                "description": "Whether to track the response body size in bytes (default: false)",
+                "default": false,
+                "type": "boolean"
+              },
+              "bytesAttribute": {
+                "title": "Bytes Attribute",
+                "description": "Feature attribute name to store the response body size",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
           }
         }
       },
@@ -7120,19 +7120,6 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "onOverlap": {
-            "title": "On Overlap",
-            "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/OnOverlap"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "saveTo": {
             "title": "Save To",
             "description": "Optional path expression to save the generated image. If not provided, uses default cache directory.",
@@ -7158,6 +7145,19 @@
                 "type": "string"
               }
             }
+          },
+          "onOverlap": {
+            "title": "On Overlap",
+            "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/definitions/OnOverlap"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7322,19 +7322,6 @@
               "jsonQuery"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
@@ -7353,10 +7340,23 @@
                 "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
                 "type": "string"
               },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7374,28 +7374,11 @@
               "path"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
                   "fileUrl"
                 ]
-              },
-              "jsonQuery": {
-                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
-                "type": "string"
               },
               "path": {
                 "description": "Expression evaluating to the file path or URL containing JSON",
@@ -7418,10 +7401,27 @@
                   }
                 }
               },
+              "jsonQuery": {
+                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
+                "type": "string"
+              },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7537,6 +7537,27 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "description": "Output path or expression for the JSON file to create",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "converter": {
             "description": "Optional converter expression to transform features before writing",
             "type": [
@@ -7553,27 +7574,6 @@
                 "type": "string",
                 "enum": [
                   "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "output": {
-            "description": "Output path or expression for the JSON file to create",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
                 ]
               },
               "value": {
@@ -7617,16 +7617,16 @@
               "$ref": "#/definitions/Attribute"
             }
           },
+          "tolerance": {
+            "type": "number",
+            "format": "double"
+          },
           "overlaidListsAttrName": {
             "description": "Name of the attribute to store the overlaid lists. Defaults to \"overlaidLists\".",
             "type": [
               "string",
               "null"
             ]
-          },
-          "tolerance": {
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -7665,14 +7665,6 @@
           "separateCharacter"
         ],
         "properties": {
-          "attribute": {
-            "description": "Attribute name to extract from each list element",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "list": {
             "description": "List attribute to read from",
             "allOf": [
@@ -7681,8 +7673,8 @@
               }
             ]
           },
-          "outputAttributeName": {
-            "description": "Name of the attribute to store the concatenated result",
+          "attribute": {
+            "description": "Attribute name to extract from each list element",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -7692,6 +7684,14 @@
           "separateCharacter": {
             "description": "Character(s) to use as separator between concatenated values",
             "type": "string"
+          },
+          "outputAttributeName": {
+            "description": "Name of the attribute to store the concatenated result",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7768,6 +7768,20 @@
           "listIndexToCopy"
         ],
         "properties": {
+          "listAttribute": {
+            "description": "List attribute to read from",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "listIndexToCopy": {
+            "description": "Index of the list element to copy (0-based)",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          },
           "copiedAttributePrefix": {
             "description": "Optional prefix to add to copied attribute names",
             "default": null,
@@ -7783,20 +7797,6 @@
               "string",
               "null"
             ]
-          },
-          "listAttribute": {
-            "description": "List attribute to read from",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "listIndexToCopy": {
-            "description": "Index of the list element to copy (0-based)",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0.0
           }
         },
         "definitions": {
@@ -7833,13 +7833,63 @@
           "output"
         ],
         "properties": {
-          "colonToUnderscore": {
-            "title": "Colon to Underscore",
-            "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
-            "type": [
-              "boolean",
-              "null"
-            ]
+          "output": {
+            "title": "Output",
+            "description": "Output directory path or expression for the generated MVT tiles",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "layerName": {
+            "title": "Layer Name",
+            "description": "Name of the layer within the MVT tiles",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "Minimum Zoom",
+            "description": "Minimum zoom level to generate tiles for",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "Maximum Zoom",
+            "description": "Maximum zoom level to generate tiles for",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
           },
           "compressOutput": {
             "title": "Compress Output",
@@ -7866,6 +7916,22 @@
               }
             }
           },
+          "skipUnexposedAttributes": {
+            "title": "Skip Unexposed Attributes",
+            "description": "Skip attributes with double underscore prefix",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "colonToUnderscore": {
+            "title": "Colon to Underscore",
+            "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "extent": {
             "title": "Extent",
             "description": "MVT tile resolution. Default is 4096.",
@@ -7876,77 +7942,11 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "layerName": {
-            "title": "Layer Name",
-            "description": "Name of the layer within the MVT tiles",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "maxZoom": {
-            "title": "Maximum Zoom",
-            "description": "Maximum zoom level to generate tiles for",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "Minimum Zoom",
-            "description": "Minimum zoom level to generate tiles for",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "Output",
-            "description": "Output directory path or expression for the generated MVT tiles",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "schemaKey": {
             "title": "Schema Key",
             "description": "Attribute key to match data and schema features for attribute filtering and casting. This attribute is excluded from output.",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "Skip Unexposed Attributes",
-            "description": "Skip attributes with double underscore prefix",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -7975,6 +7975,39 @@
         "description": "Configuration for finding spatial neighbors between base and candidate features.",
         "type": "object",
         "properties": {
+          "numClosest": {
+            "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
+            "default": 1,
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1.0
+          },
+          "maxDistance": {
+            "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "distanceAttribute": {
+            "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
+            "default": "_neighbor_distance",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "neighborIndexAttribute": {
+            "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
+            "default": "_neighbor_index",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "attributePrefix": {
             "description": "Prefix applied to transferred candidate attributes to avoid collisions.",
             "default": "_neighbor_",
@@ -7988,12 +8021,12 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "distanceAttribute": {
-            "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
-            "default": "_neighbor_distance",
+          "mergeStrategy": {
+            "description": "Controls how multiple neighbors are represented on the output.",
+            "default": "closest",
             "allOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/definitions/MergeStrategy"
               }
             ]
           },
@@ -8005,70 +8038,11 @@
                 "$ref": "#/definitions/DistanceMetric"
               }
             ]
-          },
-          "maxDistance": {
-            "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
-          "mergeStrategy": {
-            "description": "Controls how multiple neighbors are represented on the output.",
-            "default": "closest",
-            "allOf": [
-              {
-                "$ref": "#/definitions/MergeStrategy"
-              }
-            ]
-          },
-          "neighborIndexAttribute": {
-            "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
-            "default": "_neighbor_index",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "numClosest": {
-            "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
-            "default": 1,
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1.0
           }
         },
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "DistanceMetric": {
-            "description": "Distance metric for computing spatial proximity.",
-            "oneOf": [
-              {
-                "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
-                "type": "string",
-                "enum": [
-                  "euclidean2d"
-                ]
-              },
-              {
-                "description": "3D Euclidean distance using X, Y, and Z coordinates.",
-                "type": "string",
-                "enum": [
-                  "euclidean3d"
-                ]
-              },
-              {
-                "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
-                "type": "string",
-                "enum": [
-                  "haversine"
-                ]
-              }
-            ]
           },
           "MergeStrategy": {
             "description": "Merge strategy for handling multiple neighbors.",
@@ -8092,6 +8066,32 @@
                 "type": "string",
                 "enum": [
                   "arrayAttributes"
+                ]
+              }
+            ]
+          },
+          "DistanceMetric": {
+            "description": "Distance metric for computing spatial proximity.",
+            "oneOf": [
+              {
+                "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
+                "type": "string",
+                "enum": [
+                  "euclidean2d"
+                ]
+              },
+              {
+                "description": "3D Euclidean distance using X, Y, and Z coordinates.",
+                "type": "string",
+                "enum": [
+                  "euclidean3d"
+                ]
+              },
+              {
+                "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
+                "type": "string",
+                "enum": [
+                  "haversine"
                 ]
               }
             ]
@@ -8155,10 +8155,6 @@
         "description": "NullAttributeMapper parameters",
         "type": "object",
         "properties": {
-          "defaultReplacement": {
-            "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
-            "default": null
-          },
           "mappings": {
             "description": "Per-attribute replacement rules",
             "default": [],
@@ -8166,6 +8162,10 @@
             "items": {
               "$ref": "#/definitions/AttributeMapping"
             }
+          },
+          "defaultReplacement": {
+            "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
+            "default": null
           },
           "nullDefinition": {
             "description": "Which states count as \"null\"",
@@ -8205,6 +8205,9 @@
                 "description": "Name of the attribute to inspect",
                 "type": "string"
               },
+              "replacement": {
+                "description": "Value to write when attribute is null-like null means remove the attribute"
+              },
               "onMissing": {
                 "description": "What to do when attribute is missing but not in nullDefinition",
                 "default": "skip",
@@ -8213,11 +8216,27 @@
                     "$ref": "#/definitions/OnMissing"
                   }
                 ]
-              },
-              "replacement": {
-                "description": "Value to write when attribute is null-like null means remove the attribute"
               }
             }
+          },
+          "OnMissing": {
+            "description": "What to do when attribute is missing but not in nullDefinition",
+            "oneOf": [
+              {
+                "description": "Leave unchanged",
+                "type": "string",
+                "enum": [
+                  "skip"
+                ]
+              },
+              {
+                "description": "Write replacement value, creating the attribute",
+                "type": "string",
+                "enum": [
+                  "create"
+                ]
+              }
+            ]
           },
           "NullKind": {
             "description": "Defines what states count as \"null\"",
@@ -8241,25 +8260,6 @@
                 "type": "string",
                 "enum": [
                   "emptyString"
-                ]
-              }
-            ]
-          },
-          "OnMissing": {
-            "description": "What to do when attribute is missing but not in nullDefinition",
-            "oneOf": [
-              {
-                "description": "Leave unchanged",
-                "type": "string",
-                "enum": [
-                  "skip"
-                ]
-              },
-              {
-                "description": "Write replacement value, creating the attribute",
-                "type": "string",
-                "enum": [
-                  "create"
                 ]
               }
             ]
@@ -8311,67 +8311,11 @@
         "description": "Configuration for reading Wavefront OBJ 3D model files with support for vertices, faces, normals, texture coordinates, and material definitions.",
         "type": "object",
         "properties": {
-          "dataset": {
-            "title": "File Path",
-            "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "includeNormals": {
-            "title": "Include Normals",
-            "description": "Include vertex normal data in the output geometry",
+          "parseMaterials": {
+            "title": "Parse Materials",
+            "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
             "default": true,
             "type": "boolean"
-          },
-          "includeTexcoords": {
-            "title": "Include Texture Coordinates",
-            "description": "Include texture coordinate (UV) data in the output geometry",
-            "default": true,
-            "type": "boolean"
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "materialFile": {
             "title": "Material File",
@@ -8399,23 +8343,79 @@
               }
             }
           },
+          "triangulate": {
+            "title": "Triangulate",
+            "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
+            "default": false,
+            "type": "boolean"
+          },
           "mergeGroups": {
             "title": "Merge Groups",
             "description": "Merge all groups and objects into a single feature instead of creating separate features per group/object",
             "default": false,
             "type": "boolean"
           },
-          "parseMaterials": {
-            "title": "Parse Materials",
-            "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
+          "includeNormals": {
+            "title": "Include Normals",
+            "description": "Include vertex normal data in the output geometry",
             "default": true,
             "type": "boolean"
           },
-          "triangulate": {
-            "title": "Triangulate",
-            "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
-            "default": false,
+          "includeTexcoords": {
+            "title": "Include Texture Coordinates",
+            "description": "Include texture coordinate (UV) data in the output geometry",
+            "default": true,
             "type": "boolean"
+          },
+          "dataset": {
+            "title": "File Path",
+            "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -8807,15 +8807,24 @@
         "title": "XmlAttributeExtractorParam",
         "type": "object",
         "properties": {
-          "addNsprefixToFeatureTypes": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "cityCode": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "targetPackages": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "addNsprefixToFeatureTypes": {
+            "type": [
+              "boolean",
               "null"
             ]
           },
@@ -8839,15 +8848,6 @@
               "string",
               "null"
             ]
-          },
-          "targetPackages": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
           }
         }
       },
@@ -8931,10 +8931,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "File Index Attribute",
-            "description": "Attribute containing the file index (default: \"fileIndex\")",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "Part ID Attribute",
+            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -8951,10 +8951,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "Part ID Attribute",
-            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "File Index Attribute",
+            "description": "Attribute containing the file index (default: \"fileIndex\")",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -9092,6 +9092,16 @@
           "epsgCode"
         ],
         "properties": {
+          "errorAttribute": {
+            "title": "Error Attribute Name",
+            "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
+            "default": "_validation_error",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "epsgCode": {
             "title": "Target EPSG Code",
             "description": "EPSG code for coordinate transformation from source EPSG 6697. Accepts integer or string expression.",
@@ -9112,16 +9122,6 @@
                 "type": "string"
               }
             }
-          },
-          "errorAttribute": {
-            "title": "Error Attribute Name",
-            "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
-            "default": "_validation_error",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
           }
         },
         "definitions": {
@@ -9178,6 +9178,20 @@
         "description": "Configure mesh code extraction for Japanese standard regional mesh",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "Mesh Type",
+            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "Mesh Code Attribute Name",
+            "description": "Output attribute name for the mesh code",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG Code",
             "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -9202,20 +9216,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "Mesh Type",
-            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "Mesh Code Attribute Name",
-            "description": "Output attribute name for the mesh code",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -9333,17 +9333,6 @@
         "description": "Configuration for generating TIN surfaces from flood area polygons. This processor converts polygons to triangulated surfaces by: 1. Optionally grouping features by an attribute (e.g., udxDirs) 2. Combining all polygons in each group 3. Sampling points along polygon boundaries at regular intervals 4. Optionally adding interior grid points within polygons 5. Performing Delaunay triangulation to create a TIN surface 6. Filtering triangles to keep only those inside the original polygons",
         "type": "object",
         "properties": {
-          "groupBy": {
-            "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "pointSpacing": {
             "description": "Spacing between sampled points in meters (default: 50.0). Points are sampled along polygon boundaries and optionally on an interior grid at this spacing interval.",
             "type": [
@@ -9358,6 +9347,17 @@
             "type": [
               "boolean",
               "null"
+            ]
+          },
+          "groupBy": {
+            "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -9556,21 +9556,6 @@
           "outputDir"
         ],
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "measurements": {
-            "description": "Measurement definitions to insert as gen:measureAttribute elements",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/MeasurementDef"
-            }
-          },
           "outputDir": {
             "description": "Output directory expression for modified CityGML files",
             "type": "object",
@@ -9592,6 +9577,14 @@
               }
             }
           },
+          "gmlIdAttribute": {
+            "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "pathAttribute": {
             "description": "Attribute name on path features holding the file path (default: \"path\")",
             "default": null,
@@ -9600,28 +9593,11 @@
               "null"
             ]
           },
-          "sourceEpsg": {
-            "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
-            "default": null,
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
+          "measurements": {
+            "description": "Measurement definitions to insert as gen:measureAttribute elements",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MeasurementDef"
             }
           },
           "textureImagePath": {
@@ -9648,6 +9624,30 @@
                 "type": "string"
               }
             }
+          },
+          "sourceEpsg": {
+            "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
+            "default": null,
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         },
         "definitions": {
@@ -9660,12 +9660,12 @@
               "uom"
             ],
             "properties": {
-              "attribute": {
-                "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
-                "type": "string"
-              },
               "name": {
                 "description": "XML name attribute value (e.g. \"年間予測日射量\")",
+                "type": "string"
+              },
+              "attribute": {
+                "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
                 "type": "string"
               },
               "uom": {
@@ -9706,63 +9706,11 @@
               "type"
             ],
             "properties": {
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
+              "type": {
+                "type": "string",
+                "enum": [
+                  "time"
                 ]
-              },
-              "sourceEpsg": {
-                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "standardMeridian": {
-                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
-                "default": null,
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
               },
               "time": {
                 "description": "Time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
@@ -9785,60 +9733,6 @@
                   }
                 }
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "time"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "end",
-              "sourceEpsg",
-              "start",
-              "step",
-              "stepUnit",
-              "type"
-            ],
-            "properties": {
-              "end": {
-                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
-                ]
-              },
               "sourceEpsg": {
                 "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
                 "type": "object",
@@ -9883,8 +9777,62 @@
                   }
                 }
               },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
+                ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "end",
+              "sourceEpsg",
+              "start",
+              "step",
+              "stepUnit",
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "duration"
+                ]
+              },
               "start": {
                 "description": "Start time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "end": {
+                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
                 "type": "object",
                 "format": "code",
                 "required": [
@@ -9932,11 +9880,63 @@
                   }
                 ]
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "duration"
+              "sourceEpsg": {
+                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "standardMeridian": {
+                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
+                "default": null,
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
                 ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
               }
             }
           }
@@ -10001,9 +10001,9 @@
         "title": "SolidIntersectionTestPairCreatorParam",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10011,9 +10011,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10180,6 +10180,12 @@
         "description": "Configure unshared edge detection behavior",
         "type": "object",
         "properties": {
+          "tolerance": {
+            "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          },
           "groupBy": {
             "description": "Group By Attributes. When specified, edge detection is performed independently within each group. Features with the same values for these attributes are grouped together.",
             "default": null,
@@ -10190,12 +10196,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "tolerance": {
-            "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
-            "default": 0.1,
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -10236,10 +10236,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "File Index Attribute",
-            "description": "Attribute containing the file index (default: \"fileIndex\")",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "Part ID Attribute",
+            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10256,10 +10256,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "Part ID Attribute",
-            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "File Index Attribute",
+            "description": "Attribute containing the file index (default: \"fileIndex\")",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10345,6 +10345,20 @@
         "description": "Configure mesh code extraction for Japanese standard regional mesh",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "Mesh Type",
+            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "Mesh Code Attribute Name",
+            "description": "Output attribute name for the mesh code",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG Code",
             "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -10369,20 +10383,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "Mesh Type",
-            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "Mesh Code Attribute Name",
-            "description": "Output attribute name for the mesh code",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -10532,9 +10532,9 @@
         "title": "SolidIntersectionTestPairCreatorParam",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10542,9 +10542,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10763,6 +10763,31 @@
         "title": "PythonScriptProcessorParam",
         "type": "object",
         "properties": {
+          "script": {
+            "title": "Inline Script",
+            "description": "Python script code to execute inline",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "pythonFile": {
             "title": "Python File",
             "description": "Path to a Python script file (supports file://, http://, https://, gs://, etc.)",
@@ -10795,31 +10820,6 @@
               "string",
               "null"
             ]
-          },
-          "script": {
-            "title": "Inline Script",
-            "description": "Python script code to execute inline",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "timeoutSeconds": {
             "title": "Timeout Seconds",
@@ -10860,6 +10860,34 @@
           "ray"
         ],
         "properties": {
+          "ray": {
+            "description": "Defines how to extract ray data from feature attributes",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RayDefinition"
+              }
+            ]
+          },
+          "pairId": {
+            "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "closestIntersectionOnly": {
             "description": "When true (default), return only the closest intersection point per ray-geometry pair. When false, return all intersection points.",
             "default": null,
@@ -10884,8 +10912,8 @@
               }
             }
           },
-          "geomId": {
-            "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
+          "tolerance": {
+            "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
             "default": null,
             "type": [
               "object",
@@ -10941,36 +10969,8 @@
               }
             ]
           },
-          "pairId": {
-            "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "ray": {
-            "description": "Defines how to extract ray data from feature attributes",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RayDefinition"
-              }
-            ]
-          },
-          "tolerance": {
-            "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
+          "geomId": {
+            "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
             "default": null,
             "type": [
               "object",
@@ -10995,28 +10995,6 @@
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "OutputGeometryType": {
-            "description": "Output geometry type for ray intersection results",
-            "oneOf": [
-              {
-                "description": "Output a point at the intersection location (default behavior)",
-                "type": "string",
-                "enum": [
-                  "pointOfIntersection"
-                ]
-              },
-              {
-                "description": "Output a line segment from ray origin to intersection point",
-                "type": "string",
-                "enum": [
-                  "lineSegmentToIntersection"
-                ]
-              }
-            ]
-          },
           "RayDefinition": {
             "description": "Defines how ray data is extracted from feature attributes.",
             "type": "object",
@@ -11029,30 +11007,6 @@
               "posZ"
             ],
             "properties": {
-              "dirX": {
-                "description": "Attribute containing ray direction X component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirY": {
-                "description": "Attribute containing ray direction Y component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirZ": {
-                "description": "Attribute containing ray direction Z component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
               "posX": {
                 "description": "Attribute containing ray origin X coordinate",
                 "allOf": [
@@ -11076,8 +11030,54 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "dirX": {
+                "description": "Attribute containing ray direction X component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirY": {
+                "description": "Attribute containing ray direction Y component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirZ": {
+                "description": "Attribute containing ray direction Z component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "OutputGeometryType": {
+            "description": "Output geometry type for ray intersection results",
+            "oneOf": [
+              {
+                "description": "Output a point at the intersection location (default behavior)",
+                "type": "string",
+                "enum": [
+                  "pointOfIntersection"
+                ]
+              },
+              {
+                "description": "Output a line segment from ray origin to intersection point",
+                "type": "string",
+                "enum": [
+                  "lineSegmentToIntersection"
+                ]
+              }
+            ]
           }
         }
       },
@@ -11160,6 +11160,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fromToVectors"
+                    ]
+                  },
                   "fromX": {
                     "description": "X component of the source direction vector",
                     "type": "object",
@@ -11279,12 +11285,6 @@
                         "type": "string"
                       }
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "fromToVectors"
-                    ]
                   }
                 }
               },
@@ -11299,25 +11299,11 @@
                   "type"
                 ],
                 "properties": {
-                  "angle": {
-                    "description": "Rotation angle in degrees",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "axisAngle"
+                    ]
                   },
                   "axisX": {
                     "description": "X component of the rotation axis",
@@ -11379,11 +11365,25 @@
                       }
                     }
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "axisAngle"
-                    ]
+                  "angle": {
+                    "description": "Rotation angle in degrees",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -11414,6 +11414,20 @@
         "description": "Configuration for reading Shapefile archives as geographic features. Expects a ZIP archive containing the required Shapefile components (.shp, .dbf, .shx).",
         "type": "object",
         "properties": {
+          "encoding": {
+            "title": "Character Encoding",
+            "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "force2d": {
+            "title": "Force 2D",
+            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+            "default": false,
+            "type": "boolean"
+          },
           "allowEmptyPath": {
             "title": "Allow Null Path",
             "description": "If true, a dataset expression that evaluates to null produces zero features instead of an error. This is useful for optional shapefile inputs where the path may not be configured.",
@@ -11444,20 +11458,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "Character Encoding",
-            "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "force2d": {
-            "title": "Force 2D",
-            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-            "default": false,
-            "type": "boolean"
           },
           "inline": {
             "title": "Inline Content",
@@ -11511,16 +11511,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "Optional attributes to group features by, creating separate files for each group",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "Output path or expression for the Shapefile to create",
             "type": "object",
@@ -11540,6 +11530,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "Optional attributes to group features by, creating separate files for each group",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -11621,20 +11621,21 @@
         "description": "Configure spatial relationship testing between filter and candidate geometries",
         "type": "object",
         "properties": {
-          "mergeFilterAttributes": {
-            "title": "Merge Filter Attributes",
-            "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
-            "default": false,
-            "type": "boolean"
-          },
-          "mergedAttributesPrefix": {
-            "title": "Merged Attributes Prefix",
-            "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
-            "default": null,
-            "type": [
-              "string",
-              "null"
+          "predicate": {
+            "title": "Spatial Predicate",
+            "description": "The spatial relationship to test between filter and candidate geometries",
+            "default": "intersects",
+            "allOf": [
+              {
+                "$ref": "#/definitions/SpatialPredicate"
+              }
             ]
+          },
+          "passOnMultipleMatches": {
+            "title": "Pass on Multiple Matches",
+            "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
+            "default": true,
+            "type": "boolean"
           },
           "outputMatchCountAttribute": {
             "title": "Output Match Count Attribute",
@@ -11649,27 +11650,23 @@
               }
             ]
           },
-          "passOnMultipleMatches": {
-            "title": "Pass on Multiple Matches",
-            "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
-            "default": true,
+          "mergeFilterAttributes": {
+            "title": "Merge Filter Attributes",
+            "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
+            "default": false,
             "type": "boolean"
           },
-          "predicate": {
-            "title": "Spatial Predicate",
-            "description": "The spatial relationship to test between filter and candidate geometries",
-            "default": "intersects",
-            "allOf": [
-              {
-                "$ref": "#/definitions/SpatialPredicate"
-              }
+          "mergedAttributesPrefix": {
+            "title": "Merged Attributes Prefix",
+            "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "SpatialPredicate": {
             "oneOf": [
               {
@@ -11736,6 +11733,9 @@
                 ]
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -11768,9 +11768,9 @@
           "sql"
         ],
         "properties": {
-          "databaseUrl": {
-            "title": "Database URL",
-            "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
+          "sql": {
+            "title": "SQL Query",
+            "description": "SQL query expression to execute for retrieving data",
             "type": "object",
             "format": "code",
             "required": [
@@ -11790,9 +11790,9 @@
               }
             }
           },
-          "sql": {
-            "title": "SQL Query",
-            "description": "SQL query expression to execute for retrieving data",
+          "databaseUrl": {
+            "title": "Database URL",
+            "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
             "type": "object",
             "format": "code",
             "required": [
@@ -11839,13 +11839,17 @@
           "calculations"
         ],
         "properties": {
-          "calculations": {
-            "title": "Calculations",
-            "description": "List of statistical calculations to perform on grouped features",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/Calculation"
-            }
+          "groupId": {
+            "title": "Group id",
+            "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "groupBy": {
             "title": "Group by",
@@ -11858,17 +11862,13 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "groupId": {
-            "title": "Group id",
-            "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
+          "calculations": {
+            "title": "Calculations",
+            "description": "List of statistical calculations to perform on grouped features",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Calculation"
+            }
           }
         },
         "definitions": {
@@ -11882,6 +11882,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "New attribute name",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "expr": {
                 "title": "Calculation to perform",
                 "type": "object",
@@ -11901,14 +11909,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "New attribute name",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           }
@@ -11948,33 +11948,6 @@
           "minZ"
         ],
         "properties": {
-          "maxX": {
-            "title": "Maximum X Attribute",
-            "description": "Name of attribute containing the maximum X coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxY": {
-            "title": "Maximum Y Attribute",
-            "description": "Name of attribute containing the maximum Y coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxZ": {
-            "title": "Maximum Z Attribute",
-            "description": "Name of attribute containing the maximum Z coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "minX": {
             "title": "Minimum X Attribute",
             "description": "Name of attribute containing the minimum X coordinate",
@@ -11996,6 +11969,33 @@
           "minZ": {
             "title": "Minimum Z Attribute",
             "description": "Name of attribute containing the minimum Z coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxX": {
+            "title": "Maximum X Attribute",
+            "description": "Name of attribute containing the maximum X coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxY": {
+            "title": "Maximum Y Attribute",
+            "description": "Name of attribute containing the maximum Y coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxZ": {
+            "title": "Maximum Z Attribute",
+            "description": "Name of attribute containing the maximum Z coordinate",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -12135,69 +12135,6 @@
               }
             }
           },
-          "directionX": {
-            "title": "Direction X",
-            "description": "X component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionY": {
-            "title": "Direction Y",
-            "description": "Y component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionZ": {
-            "title": "Direction Z",
-            "description": "Z component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "originX": {
             "title": "Origin X",
             "description": "X coordinate of the rotation origin point",
@@ -12243,6 +12180,69 @@
           "originZ": {
             "title": "Origin Z",
             "description": "Z coordinate of the rotation origin point",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionX": {
+            "title": "Direction X",
+            "description": "X component of the rotation axis direction vector",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionY": {
+            "title": "Direction Y",
+            "description": "Y component of the rotation axis direction vector",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionZ": {
+            "title": "Direction Z",
+            "description": "Z component of the rotation axis direction vector",
             "type": "object",
             "format": "code",
             "required": [
@@ -12419,27 +12419,11 @@
               "source"
             ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
-              },
-              "elementsToExclude": {
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "source": {
+                "type": "string",
+                "enum": [
+                  "url"
+                ]
               },
               "elementsToMatch": {
                 "type": "object",
@@ -12460,11 +12444,27 @@
                   }
                 }
               },
-              "source": {
-                "type": "string",
-                "enum": [
-                  "url"
-                ]
+              "elementsToExclude": {
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               }
             }
           }
@@ -12517,19 +12517,19 @@
           "Attribute": {
             "type": "string"
           },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          },
           "ValidationType": {
             "type": "string",
             "enum": [
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }

--- a/engine/schema/actions_ja.json
+++ b/engine/schema/actions_ja.json
@@ -40,13 +40,6 @@
             ],
             "title": "面積タイプ"
           },
-          "multiplier": {
-            "description": "面積値をスケールするための乗数",
-            "default": 1.0,
-            "type": "number",
-            "format": "double",
-            "title": "乗数"
-          },
           "outputAttribute": {
             "description": "計算された面積を格納する属性の名前",
             "default": "area",
@@ -56,6 +49,13 @@
               }
             ],
             "title": "出力属性名"
+          },
+          "multiplier": {
+            "description": "面積値をスケールするための乗数",
+            "default": 1.0,
+            "type": "number",
+            "format": "double",
+            "title": "乗数"
           }
         },
         "definitions": {
@@ -96,6 +96,17 @@
         "description": "エリアオーバーレイ解析の実行方法を設定する",
         "type": "object",
         "properties": {
+          "groupBy": {
+            "title": "グループ化属性",
+            "description": "オーバーレイ解析時にフィーチャーをグループ化する属性（任意）",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "accumulationMode": {
             "title": "累積モード",
             "description": "入力フィーチャーの属性を出力フィーチャーに反映する方法を制御する",
@@ -113,17 +124,6 @@
               "string",
               "null"
             ]
-          },
-          "groupBy": {
-            "title": "グループ化属性",
-            "description": "オーバーレイ解析時にフィーチャーをグループ化する属性（任意）",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
           },
           "outputAttribute": {
             "title": "出力属性",
@@ -144,15 +144,15 @@
           }
         },
         "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
           "AccumulationMode": {
             "type": "string",
             "enum": [
               "useAttributesFromOneFeature",
               "dropIncomingAttributes"
             ]
-          },
-          "Attribute": {
-            "type": "string"
           }
         }
       },
@@ -215,14 +215,6 @@
               }
             }
           },
-          "calculationAttribute": {
-            "title": "計算結果を格納する属性",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "calculationValue": {
             "title": "計算に使用する値",
             "type": [
@@ -230,6 +222,14 @@
               "null"
             ],
             "format": "int64"
+          },
+          "calculationAttribute": {
+            "title": "計算結果を格納する属性",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           },
           "method": {
             "title": "集計メソッド",
@@ -247,6 +247,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "作成する新規属性",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "attribute": {
                 "title": "使用する既存属性",
                 "anyOf": [
@@ -280,14 +288,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "作成する新規属性",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           },
@@ -391,6 +391,14 @@
           "rules"
         ],
         "properties": {
+          "rules": {
+            "title": "変換ルール",
+            "description": "変換テーブルを使用して属性をマッピングするルールのリスト",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AttributeConversionTableRule"
+            }
+          },
           "dataset": {
             "title": "データセット URI",
             "description": "外部変換テーブルファイルのパスまたは URI",
@@ -416,15 +424,6 @@
               }
             }
           },
-          "format": {
-            "title": "テーブル形式",
-            "description": "変換テーブルの形式（CSV、TSV、または JSON）",
-            "allOf": [
-              {
-                "$ref": "#/definitions/ConversionTableFormat"
-              }
-            ]
-          },
           "inline": {
             "title": "インラインテーブルデータ",
             "description": "文字列として直接指定する変換テーブルデータ",
@@ -433,19 +432,17 @@
               "null"
             ]
           },
-          "rules": {
-            "title": "変換ルール",
-            "description": "変換テーブルを使用して属性をマッピングするルールのリスト",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/AttributeConversionTableRule"
-            }
+          "format": {
+            "title": "テーブル形式",
+            "description": "変換テーブルの形式（CSV、TSV、または JSON）",
+            "allOf": [
+              {
+                "$ref": "#/definitions/ConversionTableFormat"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "AttributeConversionTableRule": {
             "type": "object",
             "required": [
@@ -455,17 +452,6 @@
               "featureTo"
             ],
             "properties": {
-              "conversionTableKeys": {
-                "title": "変換テーブルで照合するキー",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "conversionTableTo": {
-                "title": "変換先属性",
-                "type": "string"
-              },
               "featureFroms": {
                 "title": "変換元属性",
                 "type": "array",
@@ -480,8 +466,22 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "conversionTableKeys": {
+                "title": "変換テーブルで照合するキー",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "conversionTableTo": {
+                "title": "変換先属性",
+                "type": "string"
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
           },
           "ConversionTableFormat": {
             "type": "string",
@@ -650,15 +650,6 @@
           }
         },
         "definitions": {
-          "Method": {
-            "type": "string",
-            "enum": [
-              "convert",
-              "create",
-              "rename",
-              "remove"
-            ]
-          },
           "Operation": {
             "type": "object",
             "required": [
@@ -704,6 +695,15 @@
                 }
               }
             }
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "convert",
+              "create",
+              "rename",
+              "remove"
+            ]
           }
         }
       },
@@ -751,13 +751,6 @@
                   "null"
                 ]
               },
-              "childAttribute": {
-                "title": "子属性名",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
               "expr": {
                 "title": "評価する式",
                 "type": [
@@ -782,6 +775,27 @@
                   }
                 }
               },
+              "valueAttribute": {
+                "title": "値を取得する属性名",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
+                "title": "親属性名",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "childAttribute": {
+                "title": "子属性名",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "multipleExpr": {
                 "title": "複数属性を評価する式",
                 "type": [
@@ -804,20 +818,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "parentAttribute": {
-                "title": "親属性名",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "title": "値を取得する属性名",
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
           }
@@ -851,10 +851,6 @@
           "rangeTable"
         ],
         "properties": {
-          "defaultValue": {
-            "title": "デフォルト値",
-            "description": "入力がどの範囲にも一致しない場合に使用する値（文字列・数値・真偽値など）"
-          },
           "inputAttribute": {
             "title": "入力属性",
             "description": "範囲マッピングで評価する属性",
@@ -872,6 +868,10 @@
             "items": {
               "$ref": "#/definitions/RangeEntry"
             }
+          },
+          "defaultValue": {
+            "title": "デフォルト値",
+            "description": "入力がどの範囲にも一致しない場合に使用する値（文字列・数値・真偽値など）"
           }
         },
         "definitions": {
@@ -890,15 +890,15 @@
                 "type": "number",
                 "format": "double"
               },
-              "outputValue": {
-                "title": "出力値",
-                "description": "入力がこの範囲に収まる場合に割り当てる値（文字列・数値・真偽値など）"
-              },
               "to": {
                 "title": "終了値（最大値）",
                 "description": "範囲の最大値（未満）",
                 "type": "number",
                 "format": "double"
+              },
+              "outputValue": {
+                "title": "出力値",
+                "description": "入力がこの範囲に収まる場合に割り当てる値（文字列・数値・真偽値など）"
               }
             }
           }
@@ -926,13 +926,13 @@
         "description": "ジオメトリから境界を抽出する設定",
         "type": "object",
         "properties": {
-          "exteriorOnly": {
-            "description": "ポリゴンの外周境界のみ抽出するか（穴を無視）（デフォルト: false）",
+          "keepEmptyBoundaries": {
+            "description": "境界が空のフィーチャーを保持するか（デフォルト: false）",
             "default": false,
             "type": "boolean"
           },
-          "keepEmptyBoundaries": {
-            "description": "境界が空のフィーチャーを保持するか（デフォルト: false）",
+          "exteriorOnly": {
+            "description": "ポリゴンの外周境界のみ抽出するか（穴を無視）（デフォルト: false）",
             "default": false,
             "type": "boolean"
           }
@@ -959,18 +959,6 @@
         "title": "BoundsExtractor パラメータ",
         "type": "object",
         "properties": {
-          "xmax": {
-            "title": "X 最大値属性",
-            "description": "X 座標の最大値を格納する属性名（デフォルト: \"xmax\"）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "xmin": {
             "title": "X 最小値属性",
             "description": "X 座標の最小値を格納する属性名（デフォルト: \"xmin\"）",
@@ -983,9 +971,9 @@
               }
             ]
           },
-          "ymax": {
-            "title": "Y 最大値属性",
-            "description": "Y 座標の最大値を格納する属性名（デフォルト: \"ymax\"）",
+          "xmax": {
+            "title": "X 最大値属性",
+            "description": "X 座標の最大値を格納する属性名（デフォルト: \"xmax\"）",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1007,9 +995,9 @@
               }
             ]
           },
-          "zmax": {
-            "title": "Z 最大値属性",
-            "description": "Z 座標の最大値を格納する属性名（デフォルト: \"zmax\"）",
+          "ymax": {
+            "title": "Y 最大値属性",
+            "description": "Y 座標の最大値を格納する属性名（デフォルト: \"ymax\"）",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1022,6 +1010,18 @@
           "zmin": {
             "title": "Z 最小値属性",
             "description": "Z 座標の最小値を格納する属性名（デフォルト: \"zmin\"）",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "zmax": {
+            "title": "Z 最大値属性",
+            "description": "Z 座標の最大値を格納する属性名（デフォルト: \"zmax\"）",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1133,6 +1133,15 @@
           "renameValue"
         ],
         "properties": {
+          "renameType": {
+            "title": "リネーム対象",
+            "description": "すべての属性をリネームするか、選択した属性のみをリネームするかを選択する",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RenameType"
+              }
+            ]
+          },
           "renameAction": {
             "title": "リネーム操作",
             "description": "属性名に対して実行するリネーム操作の種類",
@@ -1142,13 +1151,12 @@
               }
             ]
           },
-          "renameType": {
-            "title": "リネーム対象",
-            "description": "すべての属性をリネームするか、選択した属性のみをリネームするかを選択する",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RenameType"
-              }
+          "textToFind": {
+            "title": "検索テキストパターン",
+            "description": "「テキストを置換」操作で使用する正規表現パターン",
+            "type": [
+              "string",
+              "null"
             ]
           },
           "renameValue": {
@@ -1166,17 +1174,29 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "title": "検索テキストパターン",
-            "description": "「テキストを置換」操作で使用する正規表現パターン",
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
         "definitions": {
+          "RenameType": {
+            "oneOf": [
+              {
+                "title": "すべての属性",
+                "description": "フィーチャーのすべての属性をリネームする",
+                "type": "string",
+                "enum": [
+                  "All"
+                ]
+              },
+              {
+                "title": "選択した属性",
+                "description": "以下に列挙した特定の属性のみをリネームする",
+                "type": "string",
+                "enum": [
+                  "Selected"
+                ]
+              }
+            ]
+          },
           "RenameAction": {
             "oneOf": [
               {
@@ -1220,26 +1240,6 @@
                 ]
               }
             ]
-          },
-          "RenameType": {
-            "oneOf": [
-              {
-                "title": "すべての属性",
-                "description": "フィーチャーのすべての属性をリネームする",
-                "type": "string",
-                "enum": [
-                  "All"
-                ]
-              },
-              {
-                "title": "選択した属性",
-                "description": "以下に列挙した特定の属性のみをリネームする",
-                "type": "string",
-                "enum": [
-                  "Selected"
-                ]
-              }
-            ]
           }
         }
       },
@@ -1265,22 +1265,6 @@
         "description": "左右のポートからフィーチャーをペアリングする方法を設定する",
         "type": "object",
         "properties": {
-          "createList": {
-            "title": "リストを作成",
-            "description": "有効にすると、左右の子要素から属性値のリストを作成する",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "listAttributeName": {
-            "title": "リスト属性名",
-            "description": "リストを作成する属性名（create_list が true の場合に必須）",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "pairIdAttribute": {
             "title": "ペア ID 属性",
             "description": "左右のポートのフィーチャーを照合するペア ID を評価する式",
@@ -1304,6 +1288,22 @@
                 "type": "string"
               }
             }
+          },
+          "createList": {
+            "title": "リストを作成",
+            "description": "有効にすると、左右の子要素から属性値のリストを作成する",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "listAttributeName": {
+            "title": "リスト属性名",
+            "description": "リストを作成する属性名（create_list が true の場合に必須）",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -1448,6 +1448,42 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "title": "出力パス",
+            "description": "3D タイルを書き出すディレクトリパス",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "最小ズームレベル",
+            "description": "タイル生成の最小ズームレベル（0〜24）",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "最大ズームレベル",
+            "description": "タイル生成の最大ズームレベル（0〜24）",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
           "attachTexture": {
             "title": "テクスチャを添付",
             "description": "生成するタイルにテクスチャ情報を含めるか",
@@ -1489,55 +1525,19 @@
               "null"
             ]
           },
-          "maxZoom": {
-            "title": "最大ズームレベル",
-            "description": "タイル生成の最大ズームレベル（0〜24）",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "最小ズームレベル",
-            "description": "タイル生成の最小ズームレベル（0〜24）",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "出力パス",
-            "description": "3D タイルを書き出すディレクトリパス",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
+          "skipUnexposedAttributes": {
+            "title": "非公開属性をスキップ",
+            "description": "ダブルアンダースコアで始まる属性をスキップする",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "title": "スキーマキー",
             "description": "スキーマタイプを識別し出力ファイル名を決定する属性キー。同じ値を持つすべてのフィーチャーは同一ファイルに書き出される。この属性は出力から除外される。",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "非公開属性をスキップ",
-            "description": "ダブルアンダースコアで始まる属性をスキップする",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -1592,12 +1592,6 @@
               }
             }
           },
-          "flatten": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "inline": {
             "title": "インラインコンテンツ",
             "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
@@ -1622,6 +1616,12 @@
                 "type": "string"
               }
             }
+          },
+          "flatten": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         }
       },
@@ -1650,29 +1650,6 @@
           "output"
         ],
         "properties": {
-          "epsgCode": {
-            "description": "座標参照系の EPSG コード",
-            "default": null,
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "lodFilter": {
-            "description": "含める LOD レベル（例: [0, 1, 2]）。空の場合はすべての LOD を含む。",
-            "default": null,
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          },
           "output": {
             "description": "出力ファイルパスの式",
             "type": "object",
@@ -1693,6 +1670,29 @@
                 "type": "string"
               }
             }
+          },
+          "lodFilter": {
+            "description": "含める LOD レベル（例: [0, 1, 2]）。空の場合はすべての LOD を含む。",
+            "default": null,
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "epsgCode": {
+            "description": "座標参照系の EPSG コード",
+            "default": null,
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
           },
           "prettyPrint": {
             "description": "インデント付きでフォーマット出力するか（デフォルト: true）",
@@ -1810,15 +1810,6 @@
           "mode"
         ],
         "properties": {
-          "defaultZValue": {
-            "title": "デフォルト Z 値",
-            "description": "Z 座標を持たない 2D ジオメトリに使用する Z 値",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
           "mode": {
             "title": "抽出モード",
             "description": "ジオメトリの頂点から座標を抽出する方法",
@@ -1827,12 +1818,18 @@
                 "$ref": "#/definitions/CoordinateExtractionMode"
               }
             ]
+          },
+          "defaultZValue": {
+            "title": "デフォルト Z 値",
+            "description": "Z 座標を持たない 2D ジオメトリに使用する Z 値",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "CoordinateExtractionMode": {
             "description": "Extraction mode: determines how coordinates are output.",
             "oneOf": [
@@ -1843,6 +1840,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "allCoordinates"
+                    ]
+                  },
                   "coordinatesListName": {
                     "title": "Coordinates List Name",
                     "description": "Name of the list attribute that will store coordinate objects (default: \"_indices\")",
@@ -1851,12 +1854,6 @@
                       {
                         "$ref": "#/definitions/Attribute"
                       }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "allCoordinates"
                     ]
                   }
                 }
@@ -1869,17 +1866,17 @@
                   "type"
                 ],
                 "properties": {
-                  "coordinateIndex": {
-                    "title": "Coordinate Index",
-                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
-                    "type": "integer",
-                    "format": "int64"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
                       "specifyCoordinate"
                     ]
+                  },
+                  "coordinateIndex": {
+                    "title": "Coordinate Index",
+                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "xAttribute": {
                     "title": "X Attribute Name",
@@ -1914,6 +1911,9 @@
                 }
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -1943,6 +1943,23 @@
           "format"
         ],
         "properties": {
+          "format": {
+            "title": "ファイル形式",
+            "description": "入力ファイルの区切り形式を選択する",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "encoding": {
+            "title": "文字エンコーディング",
+            "description": "CSV/TSV ファイルの文字エンコーディング。未指定の場合は UTF-8。\n\nサポートされるエンコーディング: - **UTF-8** - Unicode UTF-8（デフォルト）- **Shift-JIS** - 日本語エンコーディング - **EUC-JP** - 日本語エンコーディング - **Windows コードページ** - Windows-1250〜Windows-1258 - **ISO-8859 ファミリー** - ISO-8859-1〜ISO-8859-16\n\nエンコーディングラベルは大文字・小文字を区別しない。",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"data.csv\" や変数参照）",
@@ -1967,45 +1984,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "文字エンコーディング",
-            "description": "CSV/TSV ファイルの文字エンコーディング。未指定の場合は UTF-8。\n\nサポートされるエンコーディング: - **UTF-8** - Unicode UTF-8（デフォルト）- **Shift-JIS** - 日本語エンコーディング - **EUC-JP** - 日本語エンコーディング - **Windows コードページ** - Windows-1250〜Windows-1258 - **ISO-8859 ファミリー** - ISO-8859-1〜ISO-8859-16\n\nエンコーディングラベルは大文字・小文字を区別しない。",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "format": {
-            "title": "ファイル形式",
-            "description": "入力ファイルの区切り形式を選択する",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "ジオメトリ設定",
-            "description": "CSV 列からジオメトリを解析するための設定（任意）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "headerRows": {
-            "title": "ヘッダー行数",
-            "description": "ヘッダーを構成する連続した行数（デフォルト: 1）。0 の場合はヘッダー行を読まず、列名は \"column1\"、\"column2\" などと自動生成される。2 以上の場合、各ヘッダー行の空でない値を \"_\" で結合して列名とする。",
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint",
-            "minimum": 0.0
           },
           "inline": {
             "title": "インラインコンテンツ",
@@ -2041,6 +2019,28 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "headerRows": {
+            "title": "ヘッダー行数",
+            "description": "ヘッダーを構成する連続した行数（デフォルト: 1）。0 の場合はヘッダー行を読まず、列名は \"column1\"、\"column2\" などと自動生成される。2 以上の場合、各ヘッダー行の空でない値を \"_\" で結合して列名とする。",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint",
+            "minimum": 0.0
+          },
+          "geometry": {
+            "title": "ジオメトリ設定",
+            "description": "CSV 列からジオメトリを解析するための設定（任意）",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2155,26 +2155,6 @@
           "output"
         ],
         "properties": {
-          "format": {
-            "description": "ファイル形式: csv（カンマ区切り）または tsv（タブ区切り）",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "ジオメトリ設定",
-            "description": "CSV 列にジオメトリをエクスポートするための設定（任意）",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryExportConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "output": {
             "description": "作成する CSV/TSV ファイルの出力パスまたは式",
             "type": "object",
@@ -2195,6 +2175,26 @@
                 "type": "string"
               }
             }
+          },
+          "format": {
+            "description": "ファイル形式: csv（カンマ区切り）または tsv（タブ区切り）",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "geometry": {
+            "title": "ジオメトリ設定",
+            "description": "CSV 列にジオメトリをエクスポートするための設定（任意）",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryExportConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2293,6 +2293,28 @@
         "description": "CZML ファイルを地理的フィーチャーとして読み込む設定",
         "type": "object",
         "properties": {
+          "force2d": {
+            "title": "2D に強制",
+            "description": "true の場合、すべてのジオメトリを 2D に強制する（Z 値を無視）",
+            "default": false,
+            "type": "boolean"
+          },
+          "skipDocumentPacket": {
+            "title": "ドキュメントパケットをスキップ",
+            "description": "true の場合、ドキュメントパケット（バージョン/クロック情報を含む最初のパケット）をスキップする",
+            "default": true,
+            "type": "boolean"
+          },
+          "timeSampling": {
+            "title": "時系列サンプリング戦略",
+            "description": "CZML パケット内の時間動的プロパティの処理方法。CzmlWriter との無損失ラウンドトリップのためデフォルトは \"preserveRaw\"。",
+            "default": "preserveRaw",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TimeSamplingStrategy"
+              }
+            ]
+          },
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"data.czml\" や変数参照）",
@@ -2318,12 +2340,6 @@
               }
             }
           },
-          "force2d": {
-            "title": "2D に強制",
-            "description": "true の場合、すべてのジオメトリを 2D に強制する（Z 値を無視）",
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "インラインコンテンツ",
             "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
@@ -2348,22 +2364,6 @@
                 "type": "string"
               }
             }
-          },
-          "skipDocumentPacket": {
-            "title": "ドキュメントパケットをスキップ",
-            "description": "true の場合、ドキュメントパケット（バージョン/クロック情報を含む最初のパケット）をスキップする",
-            "default": true,
-            "type": "boolean"
-          },
-          "timeSampling": {
-            "title": "時系列サンプリング戦略",
-            "description": "CZML パケット内の時間動的プロパティの処理方法。CzmlWriter との無損失ラウンドトリップのためデフォルトは \"preserveRaw\"。",
-            "default": "preserveRaw",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TimeSamplingStrategy"
-              }
-            ]
           }
         },
         "definitions": {
@@ -2418,87 +2418,6 @@
           "output"
         ],
         "properties": {
-          "colorAttribute": {
-            "title": "カラー属性",
-            "description": "ポリゴン塗りつぶし色の16進数カラー文字列（例: \"#ffd8c0\"）を含む属性。フィーチャージオメトリからポリゴンジオメトリが自動変換される場合に使用される。",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "epoch": {
-            "title": "エポック",
-            "description": "数値タイムオフセットの基準時刻（ISO 8601 形式）。\n\n**使用するタイミング:** - `timeField` が数値（例: \"0\"、\"60\"、\"3600\"）を含む場合に任意だが推奨 - `timeField` が ISO 8601 日時文字列を含む場合は不要\n\n**形式:** タイムゾーン付き ISO 8601 日時文字列 - 例: \"2024-01-01T00:00:00Z\"、\"2024-06-15T09:00:00+09:00\"\n\n**自動検出:** 省略してすべての時刻値が数値の場合、Unix エポック \"1970-01-01T00:00:00Z\" がデフォルトとなる。カスタム時間範囲の場合は明示的に設定する。",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "groupBy": {
-            "title": "グループ化属性",
-            "description": "フィーチャーを別々の CZML ファイルにグループ化する属性",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
-          "groupTimeseriesBy": {
-            "title": "時系列グループ化属性",
-            "description": "フィーチャーを単一の時間動的 CZML エンティティにグループ化する属性。この属性値が同じフィーチャーは、時刻タグ付き位置を持つ 1 つのパケットに統合される。",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "heightAttribute": {
-            "title": "高さ属性",
-            "description": "ポリゴン押し出し高さの数値を含む属性。設定すると、ポリゴンが地面からこの高さまで押し出される。",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "interpolationAlgorithm": {
-            "title": "補間アルゴリズム",
-            "description": "Cesium が時刻タグ付きサンプル間を補間するアルゴリズム",
-            "default": "LINEAR",
-            "allOf": [
-              {
-                "$ref": "#/definitions/InterpolationAlgorithm"
-              }
-            ]
-          },
-          "interpolationDegree": {
-            "title": "補間次数",
-            "description": "補間の次数（LINEAR は 1、LAGRANGE は通常 5）",
-            "default": 1,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "opacity": {
-            "title": "不透明度",
-            "description": "ポリゴン塗りつぶし色のアルファ値（0〜255）。デフォルト: 180。",
-            "default": 180,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
           "output": {
             "title": "出力ファイルパス",
             "description": "CZML ファイルを書き出すパス",
@@ -2521,9 +2440,90 @@
               }
             }
           },
+          "groupBy": {
+            "title": "グループ化属性",
+            "description": "フィーチャーを別々の CZML ファイルにグループ化する属性",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "timeField": {
             "title": "時刻フィールド",
             "description": "各フィーチャーのタイムスタンプを含む属性。2 種類の形式をサポート: - **ISO 8601 文字列**: 例: \"2024-01-01T00:00:00Z\" - **数値**: エポックからのオフセット秒数（例: \"0\"、\"60\"、\"120.5\"）\n\n`groupTimeseriesBy` と組み合わせると、同じグループキーを持つフィーチャーが Cesium アニメーション用の時刻タグ付き位置サンプルを持つ単一の CZML エンティティに統合される。",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "epoch": {
+            "title": "エポック",
+            "description": "数値タイムオフセットの基準時刻（ISO 8601 形式）。\n\n**使用するタイミング:** - `timeField` が数値（例: \"0\"、\"60\"、\"3600\"）を含む場合に任意だが推奨 - `timeField` が ISO 8601 日時文字列を含む場合は不要\n\n**形式:** タイムゾーン付き ISO 8601 日時文字列 - 例: \"2024-01-01T00:00:00Z\"、\"2024-06-15T09:00:00+09:00\"\n\n**自動検出:** 省略してすべての時刻値が数値の場合、Unix エポック \"1970-01-01T00:00:00Z\" がデフォルトとなる。カスタム時間範囲の場合は明示的に設定する。",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "interpolationAlgorithm": {
+            "title": "補間アルゴリズム",
+            "description": "Cesium が時刻タグ付きサンプル間を補間するアルゴリズム",
+            "default": "LINEAR",
+            "allOf": [
+              {
+                "$ref": "#/definitions/InterpolationAlgorithm"
+              }
+            ]
+          },
+          "interpolationDegree": {
+            "title": "補間次数",
+            "description": "補間の次数（LINEAR は 1、LAGRANGE は通常 5）",
+            "default": 1,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "groupTimeseriesBy": {
+            "title": "時系列グループ化属性",
+            "description": "フィーチャーを単一の時間動的 CZML エンティティにグループ化する属性。この属性値が同じフィーチャーは、時刻タグ付き位置を持つ 1 つのパケットに統合される。",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "colorAttribute": {
+            "title": "カラー属性",
+            "description": "ポリゴン塗りつぶし色の16進数カラー文字列（例: \"#ffd8c0\"）を含む属性。フィーチャージオメトリからポリゴンジオメトリが自動変換される場合に使用される。",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "opacity": {
+            "title": "不透明度",
+            "description": "ポリゴン塗りつぶし色のアルファ値（0〜255）。デフォルト: 180。",
+            "default": 180,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "heightAttribute": {
+            "title": "高さ属性",
+            "description": "ポリゴン押し出し高さの数値を含む属性。設定すると、ポリゴンが地面からこの高さまで押し出される。",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -2601,14 +2601,6 @@
               }
             ]
           },
-          "outputAttribute": {
-            "description": "結果を別の属性に書き込む（入力をそのまま保持）。デフォルトは `attribute` と同じ。",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "outputFormat": {
             "description": "希望する出力形式（デフォルト: auto）。`auto` は型付き DateTime 値として格納（パーサーモード）。その他の形式は文字列/数値として出力（フォーマッターモード）。",
             "default": "auto",
@@ -2616,6 +2608,14 @@
               {
                 "$ref": "#/definitions/DateTimeOutputFormat"
               }
+            ]
+          },
+          "outputAttribute": {
+            "description": "結果を別の属性に書き込む（入力をそのまま保持）。デフォルトは `attribute` と同じ。",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
@@ -2822,16 +2822,6 @@
         "description": "共通属性でフィーチャーをグループ化して融合する方法を設定する",
         "type": "object",
         "properties": {
-          "attributeAccumulation": {
-            "title": "属性の蓄積",
-            "description": "フィーチャー融合時の属性処理戦略",
-            "default": "useOneFeature",
-            "allOf": [
-              {
-                "$ref": "#/definitions/AttributeAccumulationStrategy"
-              }
-            ]
-          },
           "groupBy": {
             "title": "グループ化属性",
             "description": "融合前にフィーチャーをグループ化する属性名のリスト。これらの属性値が同じフィーチャーはまとめて融合される。",
@@ -2851,6 +2841,16 @@
               "null"
             ],
             "format": "double"
+          },
+          "attributeAccumulation": {
+            "title": "属性の蓄積",
+            "description": "フィーチャー融合時の属性処理戦略",
+            "default": "useOneFeature",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AttributeAccumulationStrategy"
+              }
+            ]
           }
         },
         "definitions": {
@@ -3092,15 +3092,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "CityGML属性キー",
-            "description": "設定した場合、解析されたCityGML属性はこのキーの下にネストされてフィーチャーに出力される。nullの場合、属性はトップレベルに出力される。デフォルトはnull。",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "データセット",
             "description": "読み込む CityGML 2.0 ファイルへのパス式",
@@ -3132,10 +3123,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "計測タイプのフラット化",
-            "description": "trueの場合、単一の`uom`属性と数値テキストコンテンツを持つ要素は数値に変換され、単位は兄弟キー`{name}_uom`として格納される。デフォルトはfalse。",
-            "default": false,
+          "keepAttributes": {
+            "title": "属性の保持",
+            "description": "falseの場合、`@gml:id`や`@codeSpace`などの`@`プレフィックス付きXML属性はパースされたフィーチャーから除去される。デフォルトはtrue。",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3144,11 +3135,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "属性の保持",
-            "description": "falseの場合、`@gml:id`や`@codeSpace`などの`@`プレフィックス付きXML属性はパースされたフィーチャーから除去される。デフォルトはtrue。",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "計測タイプのフラット化",
+            "description": "trueの場合、単一の`uom`属性と数値テキストコンテンツを持つ要素は数値に変換され、単位は兄弟キー`{name}_uom`として格納される。デフォルトはfalse。",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "CityGML属性キー",
+            "description": "設定した場合、解析されたCityGML属性はこのキーの下にネストされてフィーチャーに出力される。nullの場合、属性はトップレベルに出力される。デフォルトはnull。",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3176,15 +3176,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "CityGML属性キー",
-            "description": "設定した場合、解析されたCityGML属性はこのキーの下にネストされてフィーチャーに出力される。nullの場合、属性はトップレベルに出力される。デフォルトはnull。",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "データセット",
             "description": "読み込む CityGML 3.0 ファイルへのパス式",
@@ -3216,10 +3207,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "計測タイプのフラット化",
-            "description": "trueの場合、単一の`uom`属性と数値テキストコンテンツを持つ要素は数値に変換され、単位は兄弟キー`{name}_uom`として格納される。デフォルトはfalse。",
-            "default": false,
+          "keepAttributes": {
+            "title": "属性の保持",
+            "description": "falseの場合、`@gml:id`や`@codeSpace`などの`@`プレフィックス付きXML属性はパースされたフィーチャーから除去される。デフォルトはtrue。",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3228,11 +3219,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "属性の保持",
-            "description": "falseの場合、`@gml:id`や`@codeSpace`などの`@`プレフィックス付きXML属性はパースされたフィーチャーから除去される。デフォルトはtrue。",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "計測タイプのフラット化",
+            "description": "trueの場合、単一の`uom`属性と数値テキストコンテンツを持つ要素は数値に変換され、単位は兄弟キー`{name}_uom`として格納される。デフォルトはfalse。",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "CityGML属性キー",
+            "description": "設定した場合、解析されたCityGML属性はこのキーの下にネストされてフィーチャーに出力される。nullの場合、属性はトップレベルに出力される。デフォルトはnull。",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3261,31 +3261,6 @@
           "dataset"
         ],
         "properties": {
-          "codelistsPath": {
-            "title": "コードリストパス",
-            "description": "コードリスト値を解決するためのコードリストディレクトリへのパス（任意）",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "dataset": {
             "title": "データセット",
             "description": "読み込む CityGML データセットファイルへのパスまたは式",
@@ -3315,6 +3290,31 @@
               "boolean",
               "null"
             ]
+          },
+          "codelistsPath": {
+            "title": "コードリストパス",
+            "description": "コードリスト値を解決するためのコードリストディレクトリへのパス（任意）",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -3466,19 +3466,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "destPrefix": {
-            "title": "出力先プレフィックス",
-            "description": "抽出したファイルパスに追加するプレフィックス（任意）",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "extractArchive": {
-            "title": "アーカイブを展開",
-            "description": "データセット内のアーカイブファイルを展開するか",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "ソースデータセット",
             "description": "ソースデータセットのパスまたは URL を取得する式",
@@ -3500,6 +3487,19 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "アーカイブを展開",
+            "description": "データセット内のアーカイブファイルを展開するか",
+            "type": "boolean"
+          },
+          "destPrefix": {
+            "title": "出力先プレフィックス",
+            "description": "抽出したファイルパスに追加するプレフィックス（任意）",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3609,17 +3609,6 @@
           "joinType"
         ],
         "properties": {
-          "conflictResolution": {
-            "description": "リクエスタとサプライヤが同じ属性を持つ場合の競合解決戦略",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ConflictResolution"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "joinType": {
             "description": "結合タイプ: inner（内部結合）、left（左外部結合）、または full（完全外部結合）",
             "allOf": [
@@ -3630,6 +3619,16 @@
           },
           "requestorAttribute": {
             "description": "照合に使用するリクエスタフィーチャーの属性（requestorAttributeValue の代替）",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "照合に使用するサプライヤフィーチャーの属性（supplierAttributeValue の代替）",
             "type": [
               "array",
               "null"
@@ -3661,16 +3660,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "照合に使用するサプライヤフィーチャーの属性（supplierAttributeValue の代替）",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "サプライヤフィーチャーの照合値を評価する式（supplierAttribute の代替）",
             "type": [
@@ -3693,30 +3682,20 @@
                 "type": "string"
               }
             }
+          },
+          "conflictResolution": {
+            "description": "リクエスタとサプライヤが同じ属性を持つ場合の競合解決戦略",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ConflictResolution"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "ConflictResolution": {
-            "oneOf": [
-              {
-                "description": "競合時はリクエスタの属性が優先される",
-                "type": "string",
-                "enum": [
-                  "requestorWins"
-                ]
-              },
-              {
-                "description": "競合時はサプライヤの属性が優先される（デフォルト）",
-                "type": "string",
-                "enum": [
-                  "supplierWins"
-                ]
-              }
-            ]
-          },
           "JoinType": {
             "oneOf": [
               {
@@ -3738,6 +3717,27 @@
                 "type": "string",
                 "enum": [
                   "full"
+                ]
+              }
+            ]
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "ConflictResolution": {
+            "oneOf": [
+              {
+                "description": "競合時はリクエスタの属性が優先される",
+                "type": "string",
+                "enum": [
+                  "requestorWins"
+                ]
+              },
+              {
+                "description": "競合時はサプライヤの属性が優先される（デフォルト）",
+                "type": "string",
+                "enum": [
+                  "supplierWins"
                 ]
               }
             ]
@@ -3819,15 +3819,18 @@
         "description": "属性値または式の一致に基づいてリクエスタとサプライヤのフィーチャーをマージする設定",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "description": "次のグループを処理する前に、グループ化されたフィーチャーを完了するか",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "description": "照合に使用するリクエスタフィーチャーの属性（requestor_attribute_value の代替）",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "照合に使用するサプライヤフィーチャーの属性（supplier_attribute_value の代替）",
             "type": [
               "array",
               "null"
@@ -3859,16 +3862,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "照合に使用するサプライヤフィーチャーの属性（supplier_attribute_value の代替）",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "サプライヤフィーチャーの照合値を評価する式（supplier_attribute の代替）",
             "type": [
@@ -3891,6 +3884,13 @@
                 "type": "string"
               }
             }
+          },
+          "completeGrouped": {
+            "description": "次のグループを処理する前に、グループ化されたフィーチャーを完了するか",
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
         "definitions": {
@@ -3930,27 +3930,11 @@
               "format"
             ],
             "properties": {
-              "dataset": {
-                "title": "Dataset",
-                "description": "Path or expression to the dataset file to be read",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3960,42 +3944,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "csv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4017,6 +3965,42 @@
                     "type": "string"
                   }
                 }
+              },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -4026,42 +4010,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "tsv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4084,11 +4032,63 @@
                   }
                 }
               },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
               "format": {
                 "type": "string",
                 "enum": [
                   "json"
                 ]
+              },
+              "dataset": {
+                "title": "Dataset",
+                "description": "Path or expression to the dataset file to be read",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -4352,28 +4352,6 @@
               "output"
             ],
             "properties": {
-              "converter": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
               "format": {
                 "type": "string",
                 "enum": [
@@ -4400,6 +4378,28 @@
                     "type": "string"
                   }
                 }
+              },
+              "converter": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -4412,34 +4412,11 @@
               "output"
             ],
             "properties": {
-              "epsgCode": {
-                "description": "EPSG code for coordinate reference system",
-                "default": null,
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint32",
-                "minimum": 0.0
-              },
               "format": {
                 "type": "string",
                 "enum": [
                   "citygml"
                 ]
-              },
-              "lodFilter": {
-                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-                "default": null,
-                "type": [
-                  "array",
-                  "null"
-                ],
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0.0
-                }
               },
               "output": {
                 "title": "Output path",
@@ -4461,6 +4438,29 @@
                     "type": "string"
                   }
                 }
+              },
+              "lodFilter": {
+                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+                "default": null,
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              },
+              "epsgCode": {
+                "description": "EPSG code for coordinate reference system",
+                "default": null,
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4500,11 +4500,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "extractArchive": {
-            "title": "アーカイブを展開",
-            "description": "アーカイブ（ZIP ファイルなど）からファイルを展開するか、一覧表示のみするか",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "ソースデータセット",
             "description": "ソースディレクトリまたはアーカイブファイルへのパスまたは式",
@@ -4526,6 +4521,11 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "アーカイブを展開",
+            "description": "アーカイブ（ZIP ファイルなど）からファイルを展開するか、一覧表示のみするか",
+            "type": "boolean"
           }
         }
       },
@@ -4683,16 +4683,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "フィーチャーをグループ化してグループごとに別ファイルを作成する属性（任意）",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "作成する GeoJSON ファイルの出力パスまたは式",
             "type": "object",
@@ -4712,6 +4702,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "フィーチャーをグループ化してグループごとに別ファイルを作成する属性（任意）",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -4742,6 +4742,32 @@
         "title": "GeoPackageReader パラメータ",
         "type": "object",
         "properties": {
+          "readMode": {
+            "default": "features",
+            "allOf": [
+              {
+                "$ref": "#/definitions/GeoPackageReadMode"
+              }
+            ]
+          },
+          "layerName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "includeMetadata": {
+            "default": false,
+            "type": "boolean"
+          },
+          "tileFormat": {
+            "default": "png",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TileFormat"
+              }
+            ]
+          },
           "attributeFilter": {
             "default": null,
             "type": [
@@ -4757,6 +4783,17 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "force2D": {
+            "default": false,
+            "type": "boolean"
+          },
+          "spatialFilter": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "dataset": {
             "title": "ファイルパス",
@@ -4783,14 +4820,6 @@
               }
             }
           },
-          "force2D": {
-            "default": false,
-            "type": "boolean"
-          },
-          "includeMetadata": {
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "インラインコンテンツ",
             "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
@@ -4815,35 +4844,6 @@
                 "type": "string"
               }
             }
-          },
-          "layerName": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "readMode": {
-            "default": "features",
-            "allOf": [
-              {
-                "$ref": "#/definitions/GeoPackageReadMode"
-              }
-            ]
-          },
-          "spatialFilter": {
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tileFormat": {
-            "default": "png",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TileFormat"
-              }
-            ]
           }
         },
         "definitions": {
@@ -4891,21 +4891,6 @@
           "output"
         ],
         "properties": {
-          "createSpatialIndex": {
-            "description": "RTree 空間インデックスを作成する（デフォルト: true）",
-            "default": true,
-            "type": "boolean"
-          },
-          "geometryColumn": {
-            "description": "ジオメトリ列名（デフォルト: \"geom\"）",
-            "default": "geom",
-            "type": "string"
-          },
-          "geometryType": {
-            "description": "テーブルのジオメトリタイプ（Point、LineString、Polygon、MultiPoint、MultiLineString、MultiPolygon、または混在の場合は GEOMETRY）",
-            "default": "GEOMETRY",
-            "type": "string"
-          },
           "output": {
             "description": "作成する GeoPackage ファイルの出力パス",
             "type": "object",
@@ -4927,10 +4912,15 @@
               }
             }
           },
-          "overwrite": {
-            "description": "既存ファイルを上書きする（デフォルト: false）",
-            "default": false,
-            "type": "boolean"
+          "tableName": {
+            "description": "作成するテーブル名（デフォルト: \"features\"）",
+            "default": "features",
+            "type": "string"
+          },
+          "geometryColumn": {
+            "description": "ジオメトリ列名（デフォルト: \"geom\"）",
+            "default": "geom",
+            "type": "string"
           },
           "srsId": {
             "description": "空間参照系 ID（デフォルト: WGS84 の 4326）",
@@ -4938,10 +4928,20 @@
             "type": "integer",
             "format": "int32"
           },
-          "tableName": {
-            "description": "作成するテーブル名（デフォルト: \"features\"）",
-            "default": "features",
+          "geometryType": {
+            "description": "テーブルのジオメトリタイプ（Point、LineString、Polygon、MultiPoint、MultiLineString、MultiPolygon、または混在の場合は GEOMETRY）",
+            "default": "GEOMETRY",
             "type": "string"
+          },
+          "createSpatialIndex": {
+            "description": "RTree 空間インデックスを作成する（デフォルト: true）",
+            "default": true,
+            "type": "boolean"
+          },
+          "overwrite": {
+            "description": "既存ファイルを上書きする（デフォルト: false）",
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -5414,6 +5414,24 @@
         "title": "GltfReader パラメータ",
         "type": "object",
         "properties": {
+          "triangulate": {
+            "title": "三角形分割",
+            "description": "true の場合、すべてのプリミティブを三角形に変換する（将来の使用のために予約済み。現在はすべてのプリミティブが三角形として処理される）",
+            "default": true,
+            "type": "boolean"
+          },
+          "mergeMeshes": {
+            "title": "メッシュをマージ",
+            "description": "true の場合、glTF ファイルのすべてのメッシュを単一の出力フィーチャーに結合する",
+            "default": false,
+            "type": "boolean"
+          },
+          "includeNodes": {
+            "title": "ノードを含める",
+            "description": "true の場合、glTF シーングラフのノード階層情報をフィーチャー属性に含める",
+            "default": true,
+            "type": "boolean"
+          },
           "dataset": {
             "title": "ファイルパス",
             "description": "入力ファイルのパスを返す式（例: \"model.glb\" や変数参照）",
@@ -5439,12 +5457,6 @@
               }
             }
           },
-          "includeNodes": {
-            "title": "ノードを含める",
-            "description": "true の場合、glTF シーングラフのノード階層情報をフィーチャー属性に含める",
-            "default": true,
-            "type": "boolean"
-          },
           "inline": {
             "title": "インラインコンテンツ",
             "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
@@ -5469,18 +5481,6 @@
                 "type": "string"
               }
             }
-          },
-          "mergeMeshes": {
-            "title": "メッシュをマージ",
-            "description": "true の場合、glTF ファイルのすべてのメッシュを単一の出力フィーチャーに結合する",
-            "default": false,
-            "type": "boolean"
-          },
-          "triangulate": {
-            "title": "三角形分割",
-            "description": "true の場合、すべてのプリミティブを三角形に変換する（将来の使用のために予約済み。現在はすべてのプリミティブが三角形として処理される）",
-            "default": true,
-            "type": "boolean"
           }
         }
       },
@@ -5508,20 +5508,6 @@
           "output"
         ],
         "properties": {
-          "attachTexture": {
-            "description": "GLTF モデルにテクスチャ情報を添付するか",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "dracoCompression": {
-            "description": "ジオメトリに Draco 圧縮を適用する",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "output": {
             "description": "出力ファイルパス。`schemaKey` が設定されている場合はディレクトリとして扱われ、各フィーチャータイプは `<output>/<schemaKeyValue>.glb` に書き出される。それ以外は、すべてのフィーチャーがこの単一ファイルに書き出される。",
             "type": "object",
@@ -5542,6 +5528,20 @@
                 "type": "string"
               }
             }
+          },
+          "attachTexture": {
+            "description": "GLTF モデルにテクスチャ情報を添付するか",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "dracoCompression": {
+            "description": "ジオメトリに Draco 圧縮を適用する",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "description": "フィーチャーはこの属性でグループ化され、別々のファイルに書き出される。このキーは出力属性から除外される。",
@@ -5574,6 +5574,20 @@
           "unitSquareSize"
         ],
         "properties": {
+          "unitSquareSize": {
+            "title": "グリッドセルサイズ",
+            "description": "各グリッドセルの辺の長さ（ジオメトリ座標と同じ単位）",
+            "type": "number",
+            "format": "double"
+          },
+          "keepSquareOnly": {
+            "title": "完全なグリッドのみ保持",
+            "description": "true の場合、完全なグリッドセルのみ出力する（端のピースを破棄）。デフォルト: false",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "title": "グループ化属性",
             "description": "フィーチャーをグループ化する属性。各グループは独自のグリッド原点を持つ。",
@@ -5584,20 +5598,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "keepSquareOnly": {
-            "title": "完全なグリッドのみ保持",
-            "description": "true の場合、完全なグリッドセルのみ出力する（端のピースを破棄）。デフォルト: false",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "unitSquareSize": {
-            "title": "グリッドセルサイズ",
-            "description": "各グリッドセルの辺の長さ（ジオメトリ座標と同じ単位）",
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -5634,12 +5634,78 @@
           "url"
         ],
         "properties": {
+          "url": {
+            "title": "URL",
+            "description": "HTTP リクエストの対象 URL（式に対応）",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "method": {
+            "title": "HTTP メソッド",
+            "description": "リクエストで使用する HTTP メソッド",
+            "default": "GET",
+            "allOf": [
+              {
+                "$ref": "#/definitions/HttpMethod"
+              }
+            ]
+          },
           "authentication": {
             "title": "認証",
             "description": "リクエストの認証方法と認証情報",
             "anyOf": [
               {
                 "$ref": "#/definitions/Authentication"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "customHeaders": {
+            "title": "カスタムヘッダー",
+            "description": "リクエストに追加する HTTP ヘッダー",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/HeaderParam"
+            }
+          },
+          "queryParameters": {
+            "title": "クエリパラメータ",
+            "description": "リクエストに追加する URL クエリパラメータ",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/QueryParam"
+            }
+          },
+          "requestBody": {
+            "title": "リクエストボディ",
+            "description": "リクエストとともに送信するボディコンテンツ",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5654,16 +5720,17 @@
               "null"
             ]
           },
-          "customHeaders": {
-            "title": "カスタムヘッダー",
-            "description": "リクエストに追加する HTTP ヘッダー",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/HeaderParam"
-            }
+          "timeouts": {
+            "title": "タイムアウト",
+            "description": "接続・転送タイムアウトの設定",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TimeoutConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "httpOptions": {
             "title": "HTTP オプション",
@@ -5671,63 +5738,6 @@
             "anyOf": [
               {
                 "$ref": "#/definitions/HttpOptions"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "method": {
-            "title": "HTTP メソッド",
-            "description": "リクエストで使用する HTTP メソッド",
-            "default": "GET",
-            "allOf": [
-              {
-                "$ref": "#/definitions/HttpMethod"
-              }
-            ]
-          },
-          "observability": {
-            "title": "オブザーバビリティ",
-            "description": "追加メトリクスと診断情報を記録する",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ObservabilityConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "queryParameters": {
-            "title": "クエリパラメータ",
-            "description": "リクエストに追加する URL クエリパラメータ",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/QueryParam"
-            }
-          },
-          "rateLimit": {
-            "title": "レート制限",
-            "description": "リクエスト頻度を制御するレート制限の設定",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RateLimitConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "requestBody": {
-            "title": "リクエストボディ",
-            "description": "リクエストとともに送信するボディコンテンツ",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5758,386 +5768,32 @@
               }
             ]
           },
-          "timeouts": {
-            "title": "タイムアウト",
-            "description": "接続・転送タイムアウトの設定",
+          "rateLimit": {
+            "title": "レート制限",
+            "description": "リクエスト頻度を制御するレート制限の設定",
             "anyOf": [
               {
-                "$ref": "#/definitions/TimeoutConfig"
+                "$ref": "#/definitions/RateLimitConfig"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "url": {
-            "title": "URL",
-            "description": "HTTP リクエストの対象 URL（式に対応）",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
+          "observability": {
+            "title": "オブザーバビリティ",
+            "description": "追加メトリクスと診断情報を記録する",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ObservabilityConfig"
               },
-              "value": {
-                "type": "string"
+              {
+                "type": "null"
               }
-            }
+            ]
           }
         },
         "definitions": {
-          "ApiKeyLocation": {
-            "title": "API Key Location",
-            "description": "Where to include the API key in the request",
-            "oneOf": [
-              {
-                "title": "ヘッダー",
-                "description": "API キーを HTTP ヘッダーに含める",
-                "type": "string",
-                "enum": [
-                  "header"
-                ]
-              },
-              {
-                "title": "クエリパラメータ",
-                "description": "API キーを URL クエリ文字列に含める",
-                "type": "string",
-                "enum": [
-                  "query"
-                ]
-              }
-            ]
-          },
-          "Authentication": {
-            "title": "Authentication",
-            "description": "Authentication method and credentials for HTTP requests",
-            "oneOf": [
-              {
-                "title": "Basic Authentication",
-                "description": "HTTP Basic authentication with username and password",
-                "type": "object",
-                "required": [
-                  "password",
-                  "type",
-                  "username"
-                ],
-                "properties": {
-                  "password": {
-                    "title": "Password",
-                    "description": "The password for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "basic"
-                    ]
-                  },
-                  "username": {
-                    "title": "Username",
-                    "description": "The username for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "title": "Bearer Token",
-                "description": "Bearer token authentication (OAuth 2.0)",
-                "type": "object",
-                "required": [
-                  "token",
-                  "type"
-                ],
-                "properties": {
-                  "token": {
-                    "title": "Token",
-                    "description": "The bearer token value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "bearer"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "API Key",
-                "description": "API key authentication in header or query parameter",
-                "type": "object",
-                "required": [
-                  "keyName",
-                  "keyValue",
-                  "type"
-                ],
-                "properties": {
-                  "keyName": {
-                    "title": "Key Name",
-                    "description": "The name of the API key parameter",
-                    "type": "string"
-                  },
-                  "keyValue": {
-                    "title": "Key Value",
-                    "description": "The API key value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "location": {
-                    "title": "Location",
-                    "description": "Where to include the API key (header or query parameter)",
-                    "default": "header",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/ApiKeyLocation"
-                      }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "apiKey"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "BinarySource": {
-            "title": "Binary Source",
-            "description": "Source of binary data for request body",
-            "oneOf": [
-              {
-                "title": "Base64 Encoded",
-                "description": "Binary data encoded as base64 string",
-                "type": "object",
-                "required": [
-                  "data",
-                  "type"
-                ],
-                "properties": {
-                  "data": {
-                    "title": "Data",
-                    "description": "Base64-encoded binary data (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "base64"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "From File",
-                "description": "Read binary data from a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path to the file to read (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "FormField": {
-            "title": "Form Field",
-            "description": "A name-value pair for URL-encoded form data",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "フィールド名",
-                "description": "フォームフィールドの名前",
-                "type": "string"
-              },
-              "value": {
-                "title": "フィールド値",
-                "description": "フォームフィールドの値（式に対応）",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "HeaderParam": {
-            "title": "HTTP Header",
-            "description": "A custom HTTP header to include in the request",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "ヘッダー名",
-                "description": "HTTP ヘッダーの名前",
-                "type": "string"
-              },
-              "value": {
-                "title": "ヘッダー値",
-                "description": "ヘッダーの値（式に対応）",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
           "HttpMethod": {
             "title": "HTTP Method",
             "description": "The HTTP request method to use",
@@ -6256,75 +5912,51 @@
               }
             ]
           },
-          "HttpOptions": {
-            "title": "HTTP Options",
-            "description": "Configure HTTP client behavior",
-            "type": "object",
-            "properties": {
-              "followRedirects": {
-                "title": "リダイレクトに従う",
-                "description": "HTTP リダイレクトを自動的に追跡するか（デフォルト: true）",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "maxRedirects": {
-                "title": "最大リダイレクト数",
-                "description": "追跡するリダイレクトの最大数（デフォルト: 10）",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "userAgent": {
-                "title": "ユーザーエージェント",
-                "description": "カスタム User-Agent ヘッダー値",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "verifySsl": {
-                "title": "SSL を検証",
-                "description": "SSL/TLS 証明書を検証するか（デフォルト: true）",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            }
-          },
-          "MultipartPart": {
-            "title": "Multipart Part",
-            "description": "A part in a multipart/form-data request",
+          "Authentication": {
+            "title": "Authentication",
+            "description": "Authentication method and credentials for HTTP requests",
             "oneOf": [
               {
-                "title": "Text Field",
-                "description": "A text field in the multipart form",
+                "title": "Basic Authentication",
+                "description": "HTTP Basic authentication with username and password",
                 "type": "object",
                 "required": [
-                  "name",
+                  "password",
                   "type",
-                  "value"
+                  "username"
                 ],
                 "properties": {
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the form field",
-                    "type": "string"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "text"
+                      "basic"
                     ]
                   },
-                  "value": {
-                    "title": "Field Value",
-                    "description": "The value of the form field (supports expressions)",
+                  "username": {
+                    "title": "Username",
+                    "description": "The username for basic authentication",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "The password for basic authentication",
                     "type": "object",
                     "format": "code",
                     "required": [
@@ -6347,115 +5979,158 @@
                 }
               },
               {
-                "title": "File Upload",
-                "description": "A file upload in the multipart form",
+                "title": "Bearer Token",
+                "description": "Bearer token authentication (OAuth 2.0)",
                 "type": "object",
                 "required": [
-                  "name",
-                  "source",
+                  "token",
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "MIME type of the file",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "description": "The filename to send in the Content-Disposition header",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the file upload field",
-                    "type": "string"
-                  },
-                  "source": {
-                    "title": "File Source",
-                    "description": "Source of the file data (base64 or file path)",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/BinarySource"
-                      }
-                    ]
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "file"
+                      "bearer"
+                    ]
+                  },
+                  "token": {
+                    "title": "Token",
+                    "description": "The bearer token value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "API Key",
+                "description": "API key authentication in header or query parameter",
+                "type": "object",
+                "required": [
+                  "keyName",
+                  "keyValue",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "apiKey"
+                    ]
+                  },
+                  "keyName": {
+                    "title": "Key Name",
+                    "description": "The name of the API key parameter",
+                    "type": "string"
+                  },
+                  "keyValue": {
+                    "title": "Key Value",
+                    "description": "The API key value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "location": {
+                    "title": "Location",
+                    "description": "Where to include the API key (header or query parameter)",
+                    "default": "header",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/ApiKeyLocation"
+                      }
                     ]
                   }
                 }
               }
             ]
           },
-          "ObservabilityConfig": {
-            "title": "Observability Configuration",
-            "description": "Track additional metrics and diagnostics about HTTP requests",
+          "ApiKeyLocation": {
+            "title": "API Key Location",
+            "description": "Where to include the API key in the request",
+            "oneOf": [
+              {
+                "title": "ヘッダー",
+                "description": "API キーを HTTP ヘッダーに含める",
+                "type": "string",
+                "enum": [
+                  "header"
+                ]
+              },
+              {
+                "title": "クエリパラメータ",
+                "description": "API キーを URL クエリ文字列に含める",
+                "type": "string",
+                "enum": [
+                  "query"
+                ]
+              }
+            ]
+          },
+          "HeaderParam": {
+            "title": "HTTP Header",
+            "description": "A custom HTTP header to include in the request",
             "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
             "properties": {
-              "bytesAttribute": {
-                "title": "バイト数属性",
-                "description": "レスポンスボディサイズを格納するフィーチャー属性名",
-                "type": [
-                  "string",
-                  "null"
-                ]
+              "name": {
+                "title": "ヘッダー名",
+                "description": "HTTP ヘッダーの名前",
+                "type": "string"
               },
-              "durationAttribute": {
-                "title": "処理時間属性",
-                "description": "リクエスト処理時間（ミリ秒）を格納するフィーチャー属性名",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "finalUrlAttribute": {
-                "title": "最終 URL 属性",
-                "description": "リダイレクト後の最終 URL を格納するフィーチャー属性名",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "retryCountAttribute": {
-                "title": "リトライ回数属性",
-                "description": "リトライ試行回数を格納するフィーチャー属性名",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "trackBytes": {
-                "title": "バイト数を記録",
-                "description": "レスポンスボディサイズをバイト単位で記録するか（デフォルト: false）",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackDuration": {
-                "title": "処理時間を記録",
-                "description": "リクエストの合計処理時間を記録するか（デフォルト: true）",
-                "default": true,
-                "type": "boolean"
-              },
-              "trackFinalUrl": {
-                "title": "最終 URL を記録",
-                "description": "リダイレクト後の最終 URL を記録するか（デフォルト: false）",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackRetryCount": {
-                "title": "リトライ回数を記録",
-                "description": "リトライ試行回数を記録するか（デフォルト: true）",
-                "default": true,
-                "type": "boolean"
+              "value": {
+                "title": "ヘッダー値",
+                "description": "ヘッダーの値（式に対応）",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -6497,41 +6172,6 @@
               }
             }
           },
-          "RateLimitConfig": {
-            "title": "Rate Limit Configuration",
-            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
-            "type": "object",
-            "required": [
-              "requests"
-            ],
-            "properties": {
-              "intervalMs": {
-                "title": "インターバル",
-                "description": "レート制限の時間間隔（ミリ秒）（デフォルト: 1000ms）",
-                "default": 1000,
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "requests": {
-                "title": "リクエスト数",
-                "description": "インターバル内に許容されるリクエストの最大数",
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
-              },
-              "timing": {
-                "title": "タイミング戦略",
-                "description": "インターバル内でリクエストを分配する方法（デフォルト: Burst）",
-                "default": "burst",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/TimingStrategy"
-                  }
-                ]
-              }
-            }
-          },
           "RequestBody": {
             "title": "Request Body",
             "description": "The body content to send with the HTTP request",
@@ -6545,6 +6185,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
                   "content": {
                     "title": "Content",
                     "description": "The text content to send (supports expressions)",
@@ -6574,12 +6220,6 @@
                       "string",
                       "null"
                     ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "text"
-                    ]
                   }
                 }
               },
@@ -6592,12 +6232,10 @@
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
-                    "type": [
-                      "string",
-                      "null"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "binary"
                     ]
                   },
                   "source": {
@@ -6609,10 +6247,12 @@
                       }
                     ]
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "binary"
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
@@ -6626,6 +6266,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "formUrlEncoded"
+                    ]
+                  },
                   "fields": {
                     "title": "Form Fields",
                     "description": "List of form field name-value pairs",
@@ -6633,12 +6279,6 @@
                     "items": {
                       "$ref": "#/definitions/FormField"
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "formUrlEncoded"
-                    ]
                   }
                 }
               },
@@ -6651,6 +6291,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "multipart"
+                    ]
+                  },
                   "parts": {
                     "title": "Parts",
                     "description": "List of multipart form parts (text fields or file uploads)",
@@ -6658,34 +6304,315 @@
                     "items": {
                       "$ref": "#/definitions/MultipartPart"
                     }
-                  },
+                  }
+                }
+              }
+            ]
+          },
+          "BinarySource": {
+            "title": "Binary Source",
+            "description": "Source of binary data for request body",
+            "oneOf": [
+              {
+                "title": "Base64 Encoded",
+                "description": "Binary data encoded as base64 string",
+                "type": "object",
+                "required": [
+                  "data",
+                  "type"
+                ],
+                "properties": {
                   "type": {
                     "type": "string",
                     "enum": [
-                      "multipart"
+                      "base64"
+                    ]
+                  },
+                  "data": {
+                    "title": "Data",
+                    "description": "Base64-encoded binary data (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "From File",
+                "description": "Read binary data from a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path to the file to read (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "FormField": {
+            "title": "Form Field",
+            "description": "A name-value pair for URL-encoded form data",
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "title": "フィールド名",
+                "description": "フォームフィールドの名前",
+                "type": "string"
+              },
+              "value": {
+                "title": "フィールド値",
+                "description": "フォームフィールドの値（式に対応）",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "MultipartPart": {
+            "title": "Multipart Part",
+            "description": "A part in a multipart/form-data request",
+            "oneOf": [
+              {
+                "title": "Text Field",
+                "description": "A text field in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the form field",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Field Value",
+                    "description": "The value of the form field (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "File Upload",
+                "description": "A file upload in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "source",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the file upload field",
+                    "type": "string"
+                  },
+                  "source": {
+                    "title": "File Source",
+                    "description": "Source of the file data (base64 or file path)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/BinarySource"
+                      }
+                    ]
+                  },
+                  "filename": {
+                    "title": "Filename",
+                    "description": "The filename to send in the Content-Disposition header",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "MIME type of the file",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
               }
             ]
           },
-          "ResponseConfig": {
-            "title": "Response Configuration",
-            "description": "Configure how HTTP response data is stored and processed",
+          "TimeoutConfig": {
+            "title": "Timeout Configuration",
+            "description": "Configure connection and transfer timeouts for HTTP requests",
             "type": "object",
             "properties": {
-              "autoDetectEncoding": {
-                "title": "エンコーディング自動検出",
-                "description": "レスポンスヘッダーから文字エンコーディングを自動検出する",
+              "connectionTimeout": {
+                "title": "接続タイムアウト",
+                "description": "接続確立の最大時間（秒）（デフォルト: 60）",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "transferTimeout": {
+                "title": "転送タイムアウト",
+                "description": "リクエスト全体を完了する最大時間（秒）（デフォルト: 90）",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          },
+          "HttpOptions": {
+            "title": "HTTP Options",
+            "description": "Configure HTTP client behavior",
+            "type": "object",
+            "properties": {
+              "userAgent": {
+                "title": "ユーザーエージェント",
+                "description": "カスタム User-Agent ヘッダー値",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifySsl": {
+                "title": "SSL を検証",
+                "description": "SSL/TLS 証明書を検証するか（デフォルト: true）",
                 "type": [
                   "boolean",
                   "null"
                 ]
               },
-              "errorAttribute": {
-                "title": "エラー属性",
-                "description": "エラーメッセージを格納するフィーチャー属性名（デフォルト: \"_http_error\"）",
-                "default": "_http_error",
+              "followRedirects": {
+                "title": "リダイレクトに従う",
+                "description": "HTTP リダイレクトを自動的に追跡するか（デフォルト: true）",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "maxRedirects": {
+                "title": "最大リダイレクト数",
+                "description": "追跡するリダイレクトの最大数（デフォルト: 10）",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint8",
+                "minimum": 0.0
+              }
+            }
+          },
+          "ResponseConfig": {
+            "title": "Response Configuration",
+            "description": "Configure how HTTP response data is stored and processed",
+            "type": "object",
+            "properties": {
+              "responseBodyAttribute": {
+                "title": "レスポンスボディ属性",
+                "description": "レスポンスボディを格納するフィーチャー属性名（デフォルト: \"_response_body\"）",
+                "default": "_response_body",
+                "type": "string"
+              },
+              "statusCodeAttribute": {
+                "title": "ステータスコード属性",
+                "description": "HTTP ステータスコードを格納するフィーチャー属性名（デフォルト: \"_http_status_code\"）",
+                "default": "_http_status_code",
                 "type": "string"
               },
               "headersAttribute": {
@@ -6694,33 +6621,11 @@
                 "default": "_headers",
                 "type": "string"
               },
-              "maxResponseSize": {
-                "title": "最大レスポンスサイズ",
-                "description": "レスポンスボディの最大サイズ（バイト）（未設定の場合は無制限）",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "responseBodyAttribute": {
-                "title": "レスポンスボディ属性",
-                "description": "レスポンスボディを格納するフィーチャー属性名（デフォルト: \"_response_body\"）",
-                "default": "_response_body",
+              "errorAttribute": {
+                "title": "エラー属性",
+                "description": "エラーメッセージを格納するフィーチャー属性名（デフォルト: \"_http_error\"）",
+                "default": "_http_error",
                 "type": "string"
-              },
-              "responseEncoding": {
-                "title": "レスポンスエンコーディング",
-                "description": "レスポンスボディのエンコード方法（テキスト、base64、またはバイナリ）",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/ResponseEncoding"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
               },
               "responseHandling": {
                 "title": "レスポンス処理",
@@ -6734,13 +6639,114 @@
                   }
                 ]
               },
-              "statusCodeAttribute": {
-                "title": "ステータスコード属性",
-                "description": "HTTP ステータスコードを格納するフィーチャー属性名（デフォルト: \"_http_status_code\"）",
-                "default": "_http_status_code",
-                "type": "string"
+              "maxResponseSize": {
+                "title": "最大レスポンスサイズ",
+                "description": "レスポンスボディの最大サイズ（バイト）（未設定の場合は無制限）",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "responseEncoding": {
+                "title": "レスポンスエンコーディング",
+                "description": "レスポンスボディのエンコード方法（テキスト、base64、またはバイナリ）",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/ResponseEncoding"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "autoDetectEncoding": {
+                "title": "エンコーディング自動検出",
+                "description": "レスポンスヘッダーから文字エンコーディングを自動検出する",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             }
+          },
+          "ResponseHandling": {
+            "title": "Response Handling",
+            "description": "How to handle the HTTP response data",
+            "oneOf": [
+              {
+                "title": "Store in Attribute",
+                "description": "Store response body in a feature attribute",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "attribute"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "Save to File",
+                "description": "Save response body to a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path where the response should be saved",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "storePathInAttribute": {
+                    "title": "Store Path in Attribute",
+                    "description": "Whether to store the file path in a feature attribute",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "pathAttribute": {
+                    "title": "Path Attribute Name",
+                    "description": "Attribute name for storing the file path",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           "ResponseEncoding": {
             "title": "Response Encoding",
@@ -6772,100 +6778,18 @@
               }
             ]
           },
-          "ResponseHandling": {
-            "title": "Response Handling",
-            "description": "How to handle the HTTP response data",
-            "oneOf": [
-              {
-                "title": "Store in Attribute",
-                "description": "Store response body in a feature attribute",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "attribute"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "Save to File",
-                "description": "Save response body to a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path where the response should be saved",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "pathAttribute": {
-                    "title": "Path Attribute Name",
-                    "description": "Attribute name for storing the file path",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "storePathInAttribute": {
-                    "title": "Store Path in Attribute",
-                    "description": "Whether to store the file path in a feature attribute",
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
           "RetryConfig": {
             "title": "Retry Configuration",
             "description": "Configure automatic retry behavior for failed requests",
             "type": "object",
             "properties": {
-              "backoffMultiplier": {
-                "title": "バックオフ乗数",
-                "description": "リトライ間の指数バックオフの乗数（デフォルト: 2.0）",
-                "default": 2.0,
-                "type": "number",
-                "format": "double"
-              },
-              "honorRetryAfter": {
-                "title": "Retry-After ヘッダーを尊重",
-                "description": "サーバーレスポンスの Retry-After ヘッダーを尊重するか（デフォルト: true）",
-                "default": true,
-                "type": "boolean"
+              "maxAttempts": {
+                "title": "最大試行回数",
+                "description": "リトライの最大試行回数（デフォルト: 3）",
+                "default": 3,
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
               },
               "initialDelayMs": {
                 "title": "初回遅延",
@@ -6875,13 +6799,12 @@
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "maxAttempts": {
-                "title": "最大試行回数",
-                "description": "リトライの最大試行回数（デフォルト: 3）",
-                "default": 3,
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
+              "backoffMultiplier": {
+                "title": "バックオフ乗数",
+                "description": "リトライ間の指数バックオフの乗数（デフォルト: 2.0）",
+                "default": 2.0,
+                "type": "number",
+                "format": "double"
               },
               "maxDelayMs": {
                 "title": "最大遅延",
@@ -6903,33 +6826,47 @@
                   "format": "uint16",
                   "minimum": 0.0
                 }
+              },
+              "honorRetryAfter": {
+                "title": "Retry-After ヘッダーを尊重",
+                "description": "サーバーレスポンスの Retry-After ヘッダーを尊重するか（デフォルト: true）",
+                "default": true,
+                "type": "boolean"
               }
             }
           },
-          "TimeoutConfig": {
-            "title": "Timeout Configuration",
-            "description": "Configure connection and transfer timeouts for HTTP requests",
+          "RateLimitConfig": {
+            "title": "Rate Limit Configuration",
+            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
             "type": "object",
+            "required": [
+              "requests"
+            ],
             "properties": {
-              "connectionTimeout": {
-                "title": "接続タイムアウト",
-                "description": "接続確立の最大時間（秒）（デフォルト: 60）",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+              "requests": {
+                "title": "リクエスト数",
+                "description": "インターバル内に許容されるリクエストの最大数",
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "intervalMs": {
+                "title": "インターバル",
+                "description": "レート制限の時間間隔（ミリ秒）（デフォルト: 1000ms）",
+                "default": 1000,
+                "type": "integer",
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "transferTimeout": {
-                "title": "転送タイムアウト",
-                "description": "リクエスト全体を完了する最大時間（秒）（デフォルト: 90）",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
+              "timing": {
+                "title": "タイミング戦略",
+                "description": "インターバル内でリクエストを分配する方法（デフォルト: Burst）",
+                "default": "burst",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/TimingStrategy"
+                  }
+                ]
               }
             }
           },
@@ -6954,6 +6891,69 @@
                 ]
               }
             ]
+          },
+          "ObservabilityConfig": {
+            "title": "Observability Configuration",
+            "description": "Track additional metrics and diagnostics about HTTP requests",
+            "type": "object",
+            "properties": {
+              "trackDuration": {
+                "title": "処理時間を記録",
+                "description": "リクエストの合計処理時間を記録するか（デフォルト: true）",
+                "default": true,
+                "type": "boolean"
+              },
+              "durationAttribute": {
+                "title": "処理時間属性",
+                "description": "リクエスト処理時間（ミリ秒）を格納するフィーチャー属性名",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackFinalUrl": {
+                "title": "最終 URL を記録",
+                "description": "リダイレクト後の最終 URL を記録するか（デフォルト: false）",
+                "default": false,
+                "type": "boolean"
+              },
+              "finalUrlAttribute": {
+                "title": "最終 URL 属性",
+                "description": "リダイレクト後の最終 URL を格納するフィーチャー属性名",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackRetryCount": {
+                "title": "リトライ回数を記録",
+                "description": "リトライ試行回数を記録するか（デフォルト: true）",
+                "default": true,
+                "type": "boolean"
+              },
+              "retryCountAttribute": {
+                "title": "リトライ回数属性",
+                "description": "リトライ試行回数を格納するフィーチャー属性名",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackBytes": {
+                "title": "バイト数を記録",
+                "description": "レスポンスボディサイズをバイト単位で記録するか（デフォルト: false）",
+                "default": false,
+                "type": "boolean"
+              },
+              "bytesAttribute": {
+                "title": "バイト数属性",
+                "description": "レスポンスボディサイズを格納するフィーチャー属性名",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
           }
         }
       },
@@ -7123,19 +7123,6 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "onOverlap": {
-            "title": "重複時の処理",
-            "description": "複数のポリゴンが同じピクセルを覆う場合のピクセル重複解決戦略",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/OnOverlap"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "saveTo": {
             "title": "保存先",
             "description": "生成した画像を保存するパス式（任意）。指定しない場合はデフォルトのキャッシュディレクトリを使用。",
@@ -7161,6 +7148,19 @@
                 "type": "string"
               }
             }
+          },
+          "onOverlap": {
+            "title": "重複時の処理",
+            "description": "複数のポリゴンが同じピクセルを覆う場合のピクセル重複解決戦略",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/definitions/OnOverlap"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7325,19 +7325,6 @@
               "jsonQuery"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
@@ -7356,10 +7343,23 @@
                 "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
                 "type": "string"
               },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7377,28 +7377,11 @@
               "path"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
                   "fileUrl"
                 ]
-              },
-              "jsonQuery": {
-                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
-                "type": "string"
               },
               "path": {
                 "description": "Expression evaluating to the file path or URL containing JSON",
@@ -7421,10 +7404,27 @@
                   }
                 }
               },
+              "jsonQuery": {
+                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
+                "type": "string"
+              },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7540,6 +7540,27 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "description": "作成する JSON ファイルの出力パスまたは式",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "converter": {
             "description": "書き出し前にフィーチャーを変換するコンバーター式（任意）",
             "type": [
@@ -7556,27 +7577,6 @@
                 "type": "string",
                 "enum": [
                   "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "output": {
-            "description": "作成する JSON ファイルの出力パスまたは式",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
                 ]
               },
               "value": {
@@ -7620,16 +7620,16 @@
               "$ref": "#/definitions/Attribute"
             }
           },
+          "tolerance": {
+            "type": "number",
+            "format": "double"
+          },
           "overlaidListsAttrName": {
             "description": "オーバーレイされたリストを格納する属性名。デフォルトは \"overlaidLists\"。",
             "type": [
               "string",
               "null"
             ]
-          },
-          "tolerance": {
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -7668,14 +7668,6 @@
           "separateCharacter"
         ],
         "properties": {
-          "attribute": {
-            "description": "各リスト要素から取り出す属性名",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "list": {
             "description": "読み込むリスト属性",
             "allOf": [
@@ -7684,8 +7676,8 @@
               }
             ]
           },
-          "outputAttributeName": {
-            "description": "連結結果を格納する属性名",
+          "attribute": {
+            "description": "各リスト要素から取り出す属性名",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -7695,6 +7687,14 @@
           "separateCharacter": {
             "description": "連結された値の間の区切り文字",
             "type": "string"
+          },
+          "outputAttributeName": {
+            "description": "連結結果を格納する属性名",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7771,6 +7771,20 @@
           "listIndexToCopy"
         ],
         "properties": {
+          "listAttribute": {
+            "description": "読み込むリスト属性",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "listIndexToCopy": {
+            "description": "コピーするリスト要素のインデックス（0 始まり）",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          },
           "copiedAttributePrefix": {
             "description": "コピーした属性名に追加するプレフィックス（任意）",
             "default": null,
@@ -7786,20 +7800,6 @@
               "string",
               "null"
             ]
-          },
-          "listAttribute": {
-            "description": "読み込むリスト属性",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "listIndexToCopy": {
-            "description": "コピーするリスト要素のインデックス（0 始まり）",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0.0
           }
         },
         "definitions": {
@@ -7836,13 +7836,63 @@
           "output"
         ],
         "properties": {
-          "colonToUnderscore": {
-            "title": "コロンをアンダースコアに変換",
-            "description": "属性キーのコロン（XML 名前空間など）をアンダースコアに置換する",
-            "type": [
-              "boolean",
-              "null"
-            ]
+          "output": {
+            "title": "出力先",
+            "description": "生成する MVT タイルの出力ディレクトリパスまたは式",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "layerName": {
+            "title": "レイヤー名",
+            "description": "MVT タイル内のレイヤー名",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "最小ズームレベル",
+            "description": "タイルを生成する最小ズームレベル",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "最大ズームレベル",
+            "description": "タイルを生成する最大ズームレベル",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
           },
           "compressOutput": {
             "title": "出力を圧縮",
@@ -7869,6 +7919,22 @@
               }
             }
           },
+          "skipUnexposedAttributes": {
+            "title": "非公開属性をスキップ",
+            "description": "ダブルアンダースコアで始まる属性をスキップする",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "colonToUnderscore": {
+            "title": "コロンをアンダースコアに変換",
+            "description": "属性キーのコロン（XML 名前空間など）をアンダースコアに置換する",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "extent": {
             "title": "エクステント",
             "description": "MVT タイルの解像度。デフォルトは 4096。",
@@ -7879,77 +7945,11 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "layerName": {
-            "title": "レイヤー名",
-            "description": "MVT タイル内のレイヤー名",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "maxZoom": {
-            "title": "最大ズームレベル",
-            "description": "タイルを生成する最大ズームレベル",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "最小ズームレベル",
-            "description": "タイルを生成する最小ズームレベル",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "出力先",
-            "description": "生成する MVT タイルの出力ディレクトリパスまたは式",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "schemaKey": {
             "title": "スキーマキー",
             "description": "属性フィルタリングとキャストのためにデータとスキーマのフィーチャーを照合する属性キー。この属性は出力から除外される。",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "非公開属性をスキップ",
-            "description": "ダブルアンダースコアで始まる属性をスキップする",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -7978,6 +7978,39 @@
         "description": "基本フィーチャーと候補フィーチャーの間の空間的近傍を検索する設定",
         "type": "object",
         "properties": {
+          "numClosest": {
+            "description": "基本フィーチャーごとに検索する最近傍の数。1 以上必須。",
+            "default": 1,
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1.0
+          },
+          "maxDistance": {
+            "description": "照合の最大距離しきい値。None の場合は距離制限なし。単位は distanceMetric による: Euclidean は座標系の単位、Haversine はメートル。",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "distanceAttribute": {
+            "description": "最近傍までの計算距離を格納する属性名",
+            "default": "_neighbor_distance",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "neighborIndexAttribute": {
+            "description": "num_closest > 1 かつ merge_strategy が \"repeatBase\" の場合に近傍インデックス（0 始まりのランク）を格納する属性名。空文字列で出力を抑制する。",
+            "default": "_neighbor_index",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "attributePrefix": {
             "description": "衝突を避けるために転送する候補属性に付けるプレフィックス",
             "default": "_neighbor_",
@@ -7991,12 +8024,12 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "distanceAttribute": {
-            "description": "最近傍までの計算距離を格納する属性名",
-            "default": "_neighbor_distance",
+          "mergeStrategy": {
+            "description": "複数の近傍を出力にどのように表現するかを制御する",
+            "default": "closest",
             "allOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/definitions/MergeStrategy"
               }
             ]
           },
@@ -8008,70 +8041,11 @@
                 "$ref": "#/definitions/DistanceMetric"
               }
             ]
-          },
-          "maxDistance": {
-            "description": "照合の最大距離しきい値。None の場合は距離制限なし。単位は distanceMetric による: Euclidean は座標系の単位、Haversine はメートル。",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
-          "mergeStrategy": {
-            "description": "複数の近傍を出力にどのように表現するかを制御する",
-            "default": "closest",
-            "allOf": [
-              {
-                "$ref": "#/definitions/MergeStrategy"
-              }
-            ]
-          },
-          "neighborIndexAttribute": {
-            "description": "num_closest > 1 かつ merge_strategy が \"repeatBase\" の場合に近傍インデックス（0 始まりのランク）を格納する属性名。空文字列で出力を抑制する。",
-            "default": "_neighbor_index",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "numClosest": {
-            "description": "基本フィーチャーごとに検索する最近傍の数。1 以上必須。",
-            "default": 1,
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1.0
           }
         },
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "DistanceMetric": {
-            "description": "Distance metric for computing spatial proximity.",
-            "oneOf": [
-              {
-                "description": "X と Y 座標を使用した 2D ユークリッド距離。Z は無視される。",
-                "type": "string",
-                "enum": [
-                  "euclidean2d"
-                ]
-              },
-              {
-                "description": "X、Y、Z 座標を使用した 3D ユークリッド距離。",
-                "type": "string",
-                "enum": [
-                  "euclidean3d"
-                ]
-              },
-              {
-                "description": "X を経度（度）、Y を緯度（度）として扱う大圏距離。出力はメートル単位。WGS-84 入力を対象とする。\n\n注意: 距離は代表点（重心）間で計算される。正確な結果を得るには、入力フィーチャーが比較的小さい（例: 建物、地方道路）ことが望ましい。大きなジオメトリ（例: 国、大きな水域）は重心が空間範囲を適切に表さないため、不正確な距離が生じる可能性がある。",
-                "type": "string",
-                "enum": [
-                  "haversine"
-                ]
-              }
-            ]
           },
           "MergeStrategy": {
             "description": "Merge strategy for handling multiple neighbors.",
@@ -8095,6 +8069,32 @@
                 "type": "string",
                 "enum": [
                   "arrayAttributes"
+                ]
+              }
+            ]
+          },
+          "DistanceMetric": {
+            "description": "Distance metric for computing spatial proximity.",
+            "oneOf": [
+              {
+                "description": "X と Y 座標を使用した 2D ユークリッド距離。Z は無視される。",
+                "type": "string",
+                "enum": [
+                  "euclidean2d"
+                ]
+              },
+              {
+                "description": "X、Y、Z 座標を使用した 3D ユークリッド距離。",
+                "type": "string",
+                "enum": [
+                  "euclidean3d"
+                ]
+              },
+              {
+                "description": "X を経度（度）、Y を緯度（度）として扱う大圏距離。出力はメートル単位。WGS-84 入力を対象とする。\n\n注意: 距離は代表点（重心）間で計算される。正確な結果を得るには、入力フィーチャーが比較的小さい（例: 建物、地方道路）ことが望ましい。大きなジオメトリ（例: 国、大きな水域）は重心が空間範囲を適切に表さないため、不正確な距離が生じる可能性がある。",
+                "type": "string",
+                "enum": [
+                  "haversine"
                 ]
               }
             ]
@@ -8158,10 +8158,6 @@
         "description": "NullAttributeMapper のパラメータ",
         "type": "object",
         "properties": {
-          "defaultReplacement": {
-            "description": "マッピングにない属性のフォールバック置換値（scope = \"all\" の場合）",
-            "default": null
-          },
           "mappings": {
             "description": "属性ごとの置換ルール",
             "default": [],
@@ -8169,6 +8165,10 @@
             "items": {
               "$ref": "#/definitions/AttributeMapping"
             }
+          },
+          "defaultReplacement": {
+            "description": "マッピングにない属性のフォールバック置換値（scope = \"all\" の場合）",
+            "default": null
           },
           "nullDefinition": {
             "description": "「null」とみなす状態",
@@ -8208,6 +8208,9 @@
                 "description": "検査する属性名",
                 "type": "string"
               },
+              "replacement": {
+                "description": "属性が null 的な場合に書き込む値。null は属性を削除することを意味する。"
+              },
               "onMissing": {
                 "description": "属性が欠落しているが nullDefinition にない場合の処理",
                 "default": "skip",
@@ -8216,11 +8219,27 @@
                     "$ref": "#/definitions/OnMissing"
                   }
                 ]
-              },
-              "replacement": {
-                "description": "属性が null 的な場合に書き込む値。null は属性を削除することを意味する。"
               }
             }
+          },
+          "OnMissing": {
+            "description": "What to do when attribute is missing but not in nullDefinition",
+            "oneOf": [
+              {
+                "description": "変更しない",
+                "type": "string",
+                "enum": [
+                  "skip"
+                ]
+              },
+              {
+                "description": "属性を作成し、置換値を書き込む",
+                "type": "string",
+                "enum": [
+                  "create"
+                ]
+              }
+            ]
           },
           "NullKind": {
             "description": "Defines what states count as \"null\"",
@@ -8244,25 +8263,6 @@
                 "type": "string",
                 "enum": [
                   "emptyString"
-                ]
-              }
-            ]
-          },
-          "OnMissing": {
-            "description": "What to do when attribute is missing but not in nullDefinition",
-            "oneOf": [
-              {
-                "description": "変更しない",
-                "type": "string",
-                "enum": [
-                  "skip"
-                ]
-              },
-              {
-                "description": "属性を作成し、置換値を書き込む",
-                "type": "string",
-                "enum": [
-                  "create"
                 ]
               }
             ]
@@ -8314,67 +8314,11 @@
         "description": "頂点、面、法線、テクスチャ座標、マテリアル定義に対応した Wavefront OBJ 3D モデルファイルを読み込む設定",
         "type": "object",
         "properties": {
-          "dataset": {
-            "title": "ファイルパス",
-            "description": "入力ファイルのパスを返す式（例: \"model.obj\" や変数参照）",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "includeNormals": {
-            "title": "法線を含める",
-            "description": "出力ジオメトリに頂点法線データを含める",
+          "parseMaterials": {
+            "title": "マテリアルを解析",
+            "description": "OBJ ファイルで参照されている MTL ファイルからマテリアル定義の解析を有効にする",
             "default": true,
             "type": "boolean"
-          },
-          "includeTexcoords": {
-            "title": "テクスチャ座標を含める",
-            "description": "出力ジオメトリにテクスチャ座標（UV）データを含める",
-            "default": true,
-            "type": "boolean"
-          },
-          "inline": {
-            "title": "インラインコンテンツ",
-            "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "materialFile": {
             "title": "マテリアルファイル",
@@ -8402,23 +8346,79 @@
               }
             }
           },
+          "triangulate": {
+            "title": "三角形分割",
+            "description": "3 頂点を超えるポリゴンをファン三角形分割で三角形に変換する",
+            "default": false,
+            "type": "boolean"
+          },
           "mergeGroups": {
             "title": "グループをマージ",
             "description": "グループ/オブジェクトごとに個別フィーチャーを作成する代わりに、すべてのグループとオブジェクトを単一フィーチャーにマージする",
             "default": false,
             "type": "boolean"
           },
-          "parseMaterials": {
-            "title": "マテリアルを解析",
-            "description": "OBJ ファイルで参照されている MTL ファイルからマテリアル定義の解析を有効にする",
+          "includeNormals": {
+            "title": "法線を含める",
+            "description": "出力ジオメトリに頂点法線データを含める",
             "default": true,
             "type": "boolean"
           },
-          "triangulate": {
-            "title": "三角形分割",
-            "description": "3 頂点を超えるポリゴンをファン三角形分割で三角形に変換する",
-            "default": false,
+          "includeTexcoords": {
+            "title": "テクスチャ座標を含める",
+            "description": "出力ジオメトリにテクスチャ座標（UV）データを含める",
+            "default": true,
             "type": "boolean"
+          },
+          "dataset": {
+            "title": "ファイルパス",
+            "description": "入力ファイルのパスを返す式（例: \"model.obj\" や変数参照）",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "inline": {
+            "title": "インラインコンテンツ",
+            "description": "ファイルパスから読み込む代わりに、ファイル内容をテキストで返す式",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -8810,15 +8810,24 @@
         "title": "XmlAttributeExtractor パラメータ",
         "type": "object",
         "properties": {
-          "addNsprefixToFeatureTypes": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "cityCode": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "targetPackages": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "addNsprefixToFeatureTypes": {
+            "type": [
+              "boolean",
               "null"
             ]
           },
@@ -8842,15 +8851,6 @@
               "string",
               "null"
             ]
-          },
-          "targetPackages": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
           }
         }
       },
@@ -8934,10 +8934,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "ファイルインデックス属性",
-            "description": "ファイルインデックスを含む属性（デフォルト: \"fileIndex\"）",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "パーツ ID 属性",
+            "description": "BuildingPart ID を含む属性（デフォルト: \"featureId\"）",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -8954,10 +8954,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "パーツ ID 属性",
-            "description": "BuildingPart ID を含む属性（デフォルト: \"featureId\"）",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "ファイルインデックス属性",
+            "description": "ファイルインデックスを含む属性（デフォルト: \"fileIndex\"）",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -9095,6 +9095,16 @@
           "epsgCode"
         ],
         "properties": {
+          "errorAttribute": {
+            "title": "エラー属性名",
+            "description": "検証エラーメッセージを格納する属性名（デフォルト: \"_validation_error\"）",
+            "default": "_validation_error",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "epsgCode": {
             "title": "出力 EPSG コード",
             "description": "入力 EPSG 6697 からの座標変換先 EPSG コード。整数または文字列式で指定可能。",
@@ -9115,16 +9125,6 @@
                 "type": "string"
               }
             }
-          },
-          "errorAttribute": {
-            "title": "エラー属性名",
-            "description": "検証エラーメッセージを格納する属性名（デフォルト: \"_validation_error\"）",
-            "default": "_validation_error",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
           }
         },
         "definitions": {
@@ -9181,6 +9181,20 @@
         "description": "日本標準地域メッシュのメッシュコード抽出を設定する",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "メッシュタイプ",
+            "description": "日本標準メッシュタイプ: 1=80km、2=10km、3=1km、4=500m、5=250m、6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "メッシュコード属性名",
+            "description": "メッシュコードの出力属性名",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG コード",
             "description": "面積計算に使用する日本の平面直角座標系 EPSG コード",
@@ -9205,20 +9219,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "メッシュタイプ",
-            "description": "日本標準メッシュタイプ: 1=80km、2=10km、3=1km、4=500m、5=250m、6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "メッシュコード属性名",
-            "description": "メッシュコードの出力属性名",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -9336,17 +9336,6 @@
         "description": "洪水エリアポリゴンから TIN サーフェスを生成する設定。処理手順: 1. 属性でフィーチャーをグループ化（任意）2. グループ内のポリゴンを結合 3. ポリゴン境界に沿って一定間隔でサンプル点を抽出 4. ポリゴン内部にグリッド点を追加（任意）5. Delaunay 三角分割で TIN サーフェスを生成 6. 元のポリゴン内の三角形のみ保持",
         "type": "object",
         "properties": {
-          "groupBy": {
-            "description": "結合・三角分割前にフィーチャーをグループ化する属性名。この属性値が同じフィーチャーはまとめて処理される。指定しない場合は各フィーチャーを個別に処理する。",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "pointSpacing": {
             "description": "サンプル点間の間隔（メートル）（デフォルト: 50.0）。ポリゴン境界と任意の内部グリッドに沿ってこの間隔でサンプリングされる。",
             "type": [
@@ -9361,6 +9350,17 @@
             "type": [
               "boolean",
               "null"
+            ]
+          },
+          "groupBy": {
+            "description": "結合・三角分割前にフィーチャーをグループ化する属性名。この属性値が同じフィーチャーはまとめて処理される。指定しない場合は各フィーチャーを個別に処理する。",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -9559,21 +9559,6 @@
           "outputDir"
         ],
         "properties": {
-          "gmlIdAttribute": {
-            "description": "gml:id を保持する要素フィーチャーの属性名（デフォルト: \"gmlId\"）",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "measurements": {
-            "description": "gen:measureAttribute 要素として挿入する計測定義",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/MeasurementDef"
-            }
-          },
           "outputDir": {
             "description": "変更された CityGML ファイルの出力ディレクトリ式",
             "type": "object",
@@ -9595,6 +9580,14 @@
               }
             }
           },
+          "gmlIdAttribute": {
+            "description": "gml:id を保持する要素フィーチャーの属性名（デフォルト: \"gmlId\"）",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "pathAttribute": {
             "description": "ファイルパスを保持するパスフィーチャーの属性名（デフォルト: \"path\"）",
             "default": null,
@@ -9603,28 +9596,11 @@
               "null"
             ]
           },
-          "sourceEpsg": {
-            "description": "ラスタライズに使用する投影 CRS EPSG コード（UV 計算に必要）",
-            "default": null,
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
+          "measurements": {
+            "description": "gen:measureAttribute 要素として挿入する計測定義",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MeasurementDef"
             }
           },
           "textureImagePath": {
@@ -9651,6 +9627,30 @@
                 "type": "string"
               }
             }
+          },
+          "sourceEpsg": {
+            "description": "ラスタライズに使用する投影 CRS EPSG コード（UV 計算に必要）",
+            "default": null,
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         },
         "definitions": {
@@ -9663,12 +9663,12 @@
               "uom"
             ],
             "properties": {
-              "attribute": {
-                "description": "数値を保持するフィーチャー属性キー（例: \"totalSolarRadiation\"）",
-                "type": "string"
-              },
               "name": {
                 "description": "XML の name 属性値（例: \"年間予測日射量\"）",
+                "type": "string"
+              },
+              "attribute": {
+                "description": "数値を保持するフィーチャー属性キー（例: \"totalSolarRadiation\"）",
                 "type": "string"
               },
               "uom": {
@@ -9709,63 +9709,11 @@
               "type"
             ],
             "properties": {
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
+              "type": {
+                "type": "string",
+                "enum": [
+                  "time"
                 ]
-              },
-              "sourceEpsg": {
-                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "standardMeridian": {
-                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
-                "default": null,
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
               },
               "time": {
                 "description": "Time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
@@ -9788,60 +9736,6 @@
                   }
                 }
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "time"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "end",
-              "sourceEpsg",
-              "start",
-              "step",
-              "stepUnit",
-              "type"
-            ],
-            "properties": {
-              "end": {
-                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
-                ]
-              },
               "sourceEpsg": {
                 "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
                 "type": "object",
@@ -9886,8 +9780,62 @@
                   }
                 }
               },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
+                ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "end",
+              "sourceEpsg",
+              "start",
+              "step",
+              "stepUnit",
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "duration"
+                ]
+              },
               "start": {
                 "description": "Start time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "end": {
+                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
                 "type": "object",
                 "format": "code",
                 "required": [
@@ -9935,11 +9883,63 @@
                   }
                 ]
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "duration"
+              "sourceEpsg": {
+                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "standardMeridian": {
+                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
+                "default": null,
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
                 ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
               }
             }
           }
@@ -10004,9 +10004,9 @@
         "title": "SolidIntersectionTestPairCreator パラメータ",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "リストアイテム内の GML ID の属性名（デフォルト: \"gmlId\"）",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "ペア ID を格納する属性名（デフォルト: \"pair_id\"）",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10014,9 +10014,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "ペア ID を格納する属性名（デフォルト: \"pair_id\"）",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "リストアイテム内の GML ID の属性名（デフォルト: \"gmlId\"）",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10183,6 +10183,12 @@
         "description": "非共有エッジ検出の動作を設定する",
         "type": "object",
         "properties": {
+          "tolerance": {
+            "description": "エッジ照合の許容誤差（メートル）（デフォルト: 0.1）。この距離内のエッジは同一エッジとみなされる。",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          },
           "groupBy": {
             "description": "グループ化属性。指定した場合、エッジ検出は各グループ内で独立して実行される。これらの属性値が同じフィーチャーがグループ化される。",
             "default": null,
@@ -10193,12 +10199,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "tolerance": {
-            "description": "エッジ照合の許容誤差（メートル）（デフォルト: 0.1）。この距離内のエッジは同一エッジとみなされる。",
-            "default": 0.1,
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -10239,10 +10239,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "ファイルインデックス属性",
-            "description": "ファイルインデックスを含む属性（デフォルト: \"fileIndex\"）",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "パーツ ID 属性",
+            "description": "BuildingPart ID を含む属性（デフォルト: \"featureId\"）",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10259,10 +10259,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "パーツ ID 属性",
-            "description": "BuildingPart ID を含む属性（デフォルト: \"featureId\"）",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "ファイルインデックス属性",
+            "description": "ファイルインデックスを含む属性（デフォルト: \"fileIndex\"）",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10348,6 +10348,20 @@
         "description": "日本標準地域メッシュのメッシュコード抽出を設定する",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "メッシュタイプ",
+            "description": "日本標準メッシュタイプ: 1=80km、2=10km、3=1km、4=500m、5=250m、6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "メッシュコード属性名",
+            "description": "メッシュコードの出力属性名",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG コード",
             "description": "面積計算に使用する日本の平面直角座標系 EPSG コード",
@@ -10372,20 +10386,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "メッシュタイプ",
-            "description": "日本標準メッシュタイプ: 1=80km、2=10km、3=1km、4=500m、5=250m、6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "メッシュコード属性名",
-            "description": "メッシュコードの出力属性名",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -10535,9 +10535,9 @@
         "title": "SolidIntersectionTestPairCreator パラメータ",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "リストアイテム内の GML ID の属性名（デフォルト: \"gmlId\"）",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "ペア ID を格納する属性名（デフォルト: \"pair_id\"）",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10545,9 +10545,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "ペア ID を格納する属性名（デフォルト: \"pair_id\"）",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "リストアイテム内の GML ID の属性名（デフォルト: \"gmlId\"）",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10766,6 +10766,31 @@
         "title": "PythonScriptProcessor パラメータ",
         "type": "object",
         "properties": {
+          "script": {
+            "title": "インラインスクリプト",
+            "description": "インラインで実行する Python スクリプトコード",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "pythonFile": {
             "title": "Python ファイル",
             "description": "Python スクリプトファイルのパス（file://、http://、https://、gs:// などに対応）",
@@ -10798,31 +10823,6 @@
               "string",
               "null"
             ]
-          },
-          "script": {
-            "title": "インラインスクリプト",
-            "description": "インラインで実行する Python スクリプトコード",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "timeoutSeconds": {
             "title": "タイムアウト秒数",
@@ -10863,6 +10863,34 @@
           "ray"
         ],
         "properties": {
+          "ray": {
+            "description": "フィーチャー属性からレイデータを抽出する方法を定義する",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RayDefinition"
+              }
+            ]
+          },
+          "pairId": {
+            "description": "レイとジオメトリをグループ化するためのペア ID（int または string）に評価される式。一致する pairId を持つレイとジオメトリのみが互いにテストされる。",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "closestIntersectionOnly": {
             "description": "true（デフォルト）の場合、レイ-ジオメトリペアごとに最も近い交差点のみを返す。false の場合、すべての交差点を返す。",
             "default": null,
@@ -10887,8 +10915,8 @@
               }
             }
           },
-          "geomId": {
-            "description": "ジオメトリフィーチャーに評価されて ID 文字列を抽出する式。設定すると、交差フィーチャーにヒットしたジオメトリを識別する `geom_id` 属性が含まれる。",
+          "tolerance": {
+            "description": "交差計算の許容誤差（f64 に評価される）。指定しない場合はデフォルトの許容誤差が使用される。",
             "default": null,
             "type": [
               "object",
@@ -10944,36 +10972,8 @@
               }
             ]
           },
-          "pairId": {
-            "description": "レイとジオメトリをグループ化するためのペア ID（int または string）に評価される式。一致する pairId を持つレイとジオメトリのみが互いにテストされる。",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "ray": {
-            "description": "フィーチャー属性からレイデータを抽出する方法を定義する",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RayDefinition"
-              }
-            ]
-          },
-          "tolerance": {
-            "description": "交差計算の許容誤差（f64 に評価される）。指定しない場合はデフォルトの許容誤差が使用される。",
+          "geomId": {
+            "description": "ジオメトリフィーチャーに評価されて ID 文字列を抽出する式。設定すると、交差フィーチャーにヒットしたジオメトリを識別する `geom_id` 属性が含まれる。",
             "default": null,
             "type": [
               "object",
@@ -10998,28 +10998,6 @@
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "OutputGeometryType": {
-            "description": "Output geometry type for ray intersection results",
-            "oneOf": [
-              {
-                "description": "交差位置に点を出力する（デフォルト動作）",
-                "type": "string",
-                "enum": [
-                  "pointOfIntersection"
-                ]
-              },
-              {
-                "description": "レイの原点から交差点までの線分を出力する",
-                "type": "string",
-                "enum": [
-                  "lineSegmentToIntersection"
-                ]
-              }
-            ]
-          },
           "RayDefinition": {
             "description": "Defines how ray data is extracted from feature attributes.",
             "type": "object",
@@ -11032,30 +11010,6 @@
               "posZ"
             ],
             "properties": {
-              "dirX": {
-                "description": "レイの方向 X 成分を含む属性",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirY": {
-                "description": "レイの方向 Y 成分を含む属性",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirZ": {
-                "description": "レイの方向 Z 成分を含む属性",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
               "posX": {
                 "description": "レイの原点 X 座標を含む属性",
                 "allOf": [
@@ -11079,8 +11033,54 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "dirX": {
+                "description": "レイの方向 X 成分を含む属性",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirY": {
+                "description": "レイの方向 Y 成分を含む属性",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirZ": {
+                "description": "レイの方向 Z 成分を含む属性",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "OutputGeometryType": {
+            "description": "Output geometry type for ray intersection results",
+            "oneOf": [
+              {
+                "description": "交差位置に点を出力する（デフォルト動作）",
+                "type": "string",
+                "enum": [
+                  "pointOfIntersection"
+                ]
+              },
+              {
+                "description": "レイの原点から交差点までの線分を出力する",
+                "type": "string",
+                "enum": [
+                  "lineSegmentToIntersection"
+                ]
+              }
+            ]
           }
         }
       },
@@ -11163,6 +11163,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fromToVectors"
+                    ]
+                  },
                   "fromX": {
                     "description": "X component of the source direction vector",
                     "type": "object",
@@ -11282,12 +11288,6 @@
                         "type": "string"
                       }
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "fromToVectors"
-                    ]
                   }
                 }
               },
@@ -11302,25 +11302,11 @@
                   "type"
                 ],
                 "properties": {
-                  "angle": {
-                    "description": "Rotation angle in degrees",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "axisAngle"
+                    ]
                   },
                   "axisX": {
                     "description": "X component of the rotation axis",
@@ -11382,11 +11368,25 @@
                       }
                     }
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "axisAngle"
-                    ]
+                  "angle": {
+                    "description": "Rotation angle in degrees",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -11417,6 +11417,20 @@
         "description": "Shapefile アーカイブを地理的フィーチャーとして読み込む設定。必要な Shapefile コンポーネント（.shp、.dbf、.shx）を含む ZIP アーカイブを想定。",
         "type": "object",
         "properties": {
+          "encoding": {
+            "title": "文字エンコーディング",
+            "description": "DBF ファイルの属性データの文字エンコーディング。指定しない場合は .cpg ファイル（存在する場合）から判定し、なければ UTF-8 をデフォルトとする。\n\n対応するエンコーディング: - **UTF-8** - Unicode UTF-8（デフォルト、新しい Shapefile に推奨） - **Windows コードページ** - Windows-1250〜1258、Windows-874 - **ISO-8859 ファミリ** - ISO-8859-1（Latin-1）〜ISO-8859-16 - **アジア系** - Shift-JIS、EUC-JP、EUC-KR、Big5、GBK、GB18030 - **その他レガシー** - KOI8-R、KOI8-U、IBM866、Macintosh\n\nエンコーディングラベルは大文字小文字を区別せず、一般的な表記のバリエーションに対応（例: \"UTF-8\"、\"UTF8\"、\"utf8\" すべて有効）。\n\nUTF-16 はバイトレベルの処理要件により非対応。UTF-16 の Shapefile を読み込むとエラーと変換手順が返される。\n\n優先順位: encoding パラメータ > .cpg ファイル > UTF-8 デフォルト",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "force2d": {
+            "title": "2D に強制",
+            "description": "true の場合、すべてのジオメトリを 2D に強制する（Z 値を無視）",
+            "default": false,
+            "type": "boolean"
+          },
           "allowEmptyPath": {
             "title": "null パスを許可",
             "description": "true の場合、null に評価されるデータセット式はエラーの代わりにフィーチャーを 0 件生成する。パスが設定されない可能性がある省略可能な Shapefile 入力に便利。",
@@ -11447,20 +11461,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "文字エンコーディング",
-            "description": "DBF ファイルの属性データの文字エンコーディング。指定しない場合は .cpg ファイル（存在する場合）から判定し、なければ UTF-8 をデフォルトとする。\n\n対応するエンコーディング: - **UTF-8** - Unicode UTF-8（デフォルト、新しい Shapefile に推奨） - **Windows コードページ** - Windows-1250〜1258、Windows-874 - **ISO-8859 ファミリ** - ISO-8859-1（Latin-1）〜ISO-8859-16 - **アジア系** - Shift-JIS、EUC-JP、EUC-KR、Big5、GBK、GB18030 - **その他レガシー** - KOI8-R、KOI8-U、IBM866、Macintosh\n\nエンコーディングラベルは大文字小文字を区別せず、一般的な表記のバリエーションに対応（例: \"UTF-8\"、\"UTF8\"、\"utf8\" すべて有効）。\n\nUTF-16 はバイトレベルの処理要件により非対応。UTF-16 の Shapefile を読み込むとエラーと変換手順が返される。\n\n優先順位: encoding パラメータ > .cpg ファイル > UTF-8 デフォルト",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "force2d": {
-            "title": "2D に強制",
-            "description": "true の場合、すべてのジオメトリを 2D に強制する（Z 値を無視）",
-            "default": false,
-            "type": "boolean"
           },
           "inline": {
             "title": "インラインコンテンツ",
@@ -11514,16 +11514,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "フィーチャーをグループ化する属性（任意）。グループごとに別ファイルを作成する",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "作成する Shapefile の出力パスまたは式",
             "type": "object",
@@ -11543,6 +11533,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "フィーチャーをグループ化する属性（任意）。グループごとに別ファイルを作成する",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -11624,20 +11624,21 @@
         "description": "フィルターと候補ジオメトリ間の空間関係テストを設定する",
         "type": "object",
         "properties": {
-          "mergeFilterAttributes": {
-            "title": "フィルター属性をマージ",
-            "description": "true の場合、一致したフィルターフィーチャーの属性を候補にコピーする。passed ポートにルーティングされたフィーチャーにのみ適用。OR モード（pass_on_multiple_matches: true）では最初に一致したフィルターの属性のみマージ。AND モードでは一致したすべてのフィルターの属性を順番にマージし、複数のフィルターが同じキーを共有する場合は最後のフィルターの値が優先される。",
-            "default": false,
-            "type": "boolean"
-          },
-          "mergedAttributesPrefix": {
-            "title": "マージ属性プレフィックス",
-            "description": "衝突を避けるためにマージされたフィルター属性名に付加する任意のプレフィックス。例: \"filter_\" を指定するとフィルター属性 \"zone\" が \"filter_zone\" になる。",
-            "default": null,
-            "type": [
-              "string",
-              "null"
+          "predicate": {
+            "title": "空間述語",
+            "description": "フィルターと候補ジオメトリ間でテストする空間関係",
+            "default": "intersects",
+            "allOf": [
+              {
+                "$ref": "#/definitions/SpatialPredicate"
+              }
             ]
+          },
+          "passOnMultipleMatches": {
+            "title": "複数マッチ時に通過",
+            "description": "true の場合、いずれかのフィルターが一致すれば通過（OR 論理）。false の場合、すべてのフィルターが一致した場合のみ通過（AND 論理）。",
+            "default": true,
+            "type": "boolean"
           },
           "outputMatchCountAttribute": {
             "title": "マッチ数出力属性",
@@ -11652,27 +11653,23 @@
               }
             ]
           },
-          "passOnMultipleMatches": {
-            "title": "複数マッチ時に通過",
-            "description": "true の場合、いずれかのフィルターが一致すれば通過（OR 論理）。false の場合、すべてのフィルターが一致した場合のみ通過（AND 論理）。",
-            "default": true,
+          "mergeFilterAttributes": {
+            "title": "フィルター属性をマージ",
+            "description": "true の場合、一致したフィルターフィーチャーの属性を候補にコピーする。passed ポートにルーティングされたフィーチャーにのみ適用。OR モード（pass_on_multiple_matches: true）では最初に一致したフィルターの属性のみマージ。AND モードでは一致したすべてのフィルターの属性を順番にマージし、複数のフィルターが同じキーを共有する場合は最後のフィルターの値が優先される。",
+            "default": false,
             "type": "boolean"
           },
-          "predicate": {
-            "title": "空間述語",
-            "description": "フィルターと候補ジオメトリ間でテストする空間関係",
-            "default": "intersects",
-            "allOf": [
-              {
-                "$ref": "#/definitions/SpatialPredicate"
-              }
+          "mergedAttributesPrefix": {
+            "title": "マージ属性プレフィックス",
+            "description": "衝突を避けるためにマージされたフィルター属性名に付加する任意のプレフィックス。例: \"filter_\" を指定するとフィルター属性 \"zone\" が \"filter_zone\" になる。",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "SpatialPredicate": {
             "oneOf": [
               {
@@ -11739,6 +11736,9 @@
                 ]
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -11771,9 +11771,9 @@
           "sql"
         ],
         "properties": {
-          "databaseUrl": {
-            "title": "データベース URL",
-            "description": "データベース接続 URL（例: `sqlite:///tests/sqlite/sqlite.db`、`mysql://user:password@localhost:3306/db`、`postgresql://user:password@localhost:5432/db`）",
+          "sql": {
+            "title": "SQL クエリ",
+            "description": "データ取得のために実行する SQL クエリ式",
             "type": "object",
             "format": "code",
             "required": [
@@ -11793,9 +11793,9 @@
               }
             }
           },
-          "sql": {
-            "title": "SQL クエリ",
-            "description": "データ取得のために実行する SQL クエリ式",
+          "databaseUrl": {
+            "title": "データベース URL",
+            "description": "データベース接続 URL（例: `sqlite:///tests/sqlite/sqlite.db`、`mysql://user:password@localhost:3306/db`、`postgresql://user:password@localhost:5432/db`）",
             "type": "object",
             "format": "code",
             "required": [
@@ -11842,13 +11842,17 @@
           "calculations"
         ],
         "properties": {
-          "calculations": {
-            "title": "計算項目",
-            "description": "グループ化されたフィーチャーに対して実行する統計計算のリスト",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/Calculation"
-            }
+          "groupId": {
+            "title": "グループ ID",
+            "description": "グループ識別子を格納する属性（任意）。ID は group_by 属性の値を「|」で連結して形成される。",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "groupBy": {
             "title": "グループ化属性",
@@ -11861,17 +11865,13 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "groupId": {
-            "title": "グループ ID",
-            "description": "グループ識別子を格納する属性（任意）。ID は group_by 属性の値を「|」で連結して形成される。",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
+          "calculations": {
+            "title": "計算項目",
+            "description": "グループ化されたフィーチャーに対して実行する統計計算のリスト",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Calculation"
+            }
           }
         },
         "definitions": {
@@ -11885,6 +11885,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "新しい属性名",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "expr": {
                 "title": "実行する計算",
                 "type": "object",
@@ -11904,14 +11912,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "新しい属性名",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           }
@@ -11951,33 +11951,6 @@
           "minZ"
         ],
         "properties": {
-          "maxX": {
-            "title": "最大 X 属性",
-            "description": "最大 X 座標を含む属性名",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxY": {
-            "title": "最大 Y 属性",
-            "description": "最大 Y 座標を含む属性名",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxZ": {
-            "title": "最大 Z 属性",
-            "description": "最大 Z 座標を含む属性名",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "minX": {
             "title": "最小 X 属性",
             "description": "最小 X 座標を含む属性名",
@@ -11999,6 +11972,33 @@
           "minZ": {
             "title": "最小 Z 属性",
             "description": "最小 Z 座標を含む属性名",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxX": {
+            "title": "最大 X 属性",
+            "description": "最大 X 座標を含む属性名",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxY": {
+            "title": "最大 Y 属性",
+            "description": "最大 Y 座標を含む属性名",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxZ": {
+            "title": "最大 Z 属性",
+            "description": "最大 Z 座標を含む属性名",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -12138,69 +12138,6 @@
               }
             }
           },
-          "directionX": {
-            "title": "方向 X",
-            "description": "回転軸の方向ベクトルの X 成分",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionY": {
-            "title": "方向 Y",
-            "description": "回転軸の方向ベクトルの Y 成分",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionZ": {
-            "title": "方向 Z",
-            "description": "回転軸の方向ベクトルの Z 成分",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "originX": {
             "title": "原点 X",
             "description": "回転原点の X 座標",
@@ -12246,6 +12183,69 @@
           "originZ": {
             "title": "原点 Z",
             "description": "回転原点の Z 座標",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionX": {
+            "title": "方向 X",
+            "description": "回転軸の方向ベクトルの X 成分",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionY": {
+            "title": "方向 Y",
+            "description": "回転軸の方向ベクトルの Y 成分",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionZ": {
+            "title": "方向 Z",
+            "description": "回転軸の方向ベクトルの Z 成分",
             "type": "object",
             "format": "code",
             "required": [
@@ -12422,27 +12422,11 @@
               "source"
             ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
-              },
-              "elementsToExclude": {
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "source": {
+                "type": "string",
+                "enum": [
+                  "url"
+                ]
               },
               "elementsToMatch": {
                 "type": "object",
@@ -12463,11 +12447,27 @@
                   }
                 }
               },
-              "source": {
-                "type": "string",
-                "enum": [
-                  "url"
-                ]
+              "elementsToExclude": {
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               }
             }
           }
@@ -12520,19 +12520,19 @@
           "Attribute": {
             "type": "string"
           },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          },
           "ValidationType": {
             "type": "string",
             "enum": [
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }

--- a/engine/schema/actions_zh.json
+++ b/engine/schema/actions_zh.json
@@ -39,12 +39,6 @@
               }
             ]
           },
-          "multiplier": {
-            "description": "Multiplier to scale the area values (default: 1.0)",
-            "default": 1.0,
-            "type": "number",
-            "format": "double"
-          },
           "outputAttribute": {
             "description": "Name of the attribute to store the calculated area (default: \"area\")",
             "default": "area",
@@ -53,6 +47,12 @@
                 "$ref": "#/definitions/Attribute"
               }
             ]
+          },
+          "multiplier": {
+            "description": "Multiplier to scale the area values (default: 1.0)",
+            "default": 1.0,
+            "type": "number",
+            "format": "double"
           }
         },
         "definitions": {
@@ -93,6 +93,17 @@
         "description": "Configure how area overlay analysis is performed",
         "type": "object",
         "properties": {
+          "groupBy": {
+            "title": "Group By Attributes",
+            "description": "Optional attributes to group features by during overlay analysis",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "accumulationMode": {
             "title": "Accumulation Mode",
             "description": "Controls how attributes from input features are handled in output features",
@@ -110,17 +121,6 @@
               "string",
               "null"
             ]
-          },
-          "groupBy": {
-            "title": "Group By Attributes",
-            "description": "Optional attributes to group features by during overlay analysis",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
           },
           "outputAttribute": {
             "title": "Output Attribute",
@@ -141,15 +141,15 @@
           }
         },
         "definitions": {
+          "Attribute": {
+            "type": "string"
+          },
           "AccumulationMode": {
             "type": "string",
             "enum": [
               "useAttributesFromOneFeature",
               "dropIncomingAttributes"
             ]
-          },
-          "Attribute": {
-            "type": "string"
           }
         }
       },
@@ -212,14 +212,6 @@
               }
             }
           },
-          "calculationAttribute": {
-            "title": "Attribute to store calculation result",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "calculationValue": {
             "title": "Value to use for calculation",
             "type": [
@@ -227,6 +219,14 @@
               "null"
             ],
             "format": "int64"
+          },
+          "calculationAttribute": {
+            "title": "Attribute to store calculation result",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           },
           "method": {
             "title": "Method to use for aggregation",
@@ -244,6 +244,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "New attribute to create",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "attribute": {
                 "title": "Existing attribute to use",
                 "anyOf": [
@@ -277,14 +285,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "New attribute to create",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           },
@@ -388,6 +388,14 @@
           "rules"
         ],
         "properties": {
+          "rules": {
+            "title": "Conversion Rules",
+            "description": "List of rules defining how to map attributes using the conversion table",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/AttributeConversionTableRule"
+            }
+          },
           "dataset": {
             "title": "Dataset URI",
             "description": "Path or URI to external conversion table file",
@@ -413,15 +421,6 @@
               }
             }
           },
-          "format": {
-            "title": "Table Format",
-            "description": "Format of the conversion table (CSV, TSV, or JSON)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/ConversionTableFormat"
-              }
-            ]
-          },
           "inline": {
             "title": "Inline Table Data",
             "description": "Conversion table data provided directly as string content",
@@ -430,19 +429,17 @@
               "null"
             ]
           },
-          "rules": {
-            "title": "Conversion Rules",
-            "description": "List of rules defining how to map attributes using the conversion table",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/AttributeConversionTableRule"
-            }
+          "format": {
+            "title": "Table Format",
+            "description": "Format of the conversion table (CSV, TSV, or JSON)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/ConversionTableFormat"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "AttributeConversionTableRule": {
             "type": "object",
             "required": [
@@ -452,17 +449,6 @@
               "featureTo"
             ],
             "properties": {
-              "conversionTableKeys": {
-                "title": "Keys to match in conversion table",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "conversionTableTo": {
-                "title": "Attribute to convert to",
-                "type": "string"
-              },
               "featureFroms": {
                 "title": "Attributes to convert from",
                 "type": "array",
@@ -477,8 +463,22 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "conversionTableKeys": {
+                "title": "Keys to match in conversion table",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "conversionTableTo": {
+                "title": "Attribute to convert to",
+                "type": "string"
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
           },
           "ConversionTableFormat": {
             "type": "string",
@@ -647,15 +647,6 @@
           }
         },
         "definitions": {
-          "Method": {
-            "type": "string",
-            "enum": [
-              "convert",
-              "create",
-              "rename",
-              "remove"
-            ]
-          },
           "Operation": {
             "type": "object",
             "required": [
@@ -701,6 +692,15 @@
                 }
               }
             }
+          },
+          "Method": {
+            "type": "string",
+            "enum": [
+              "convert",
+              "create",
+              "rename",
+              "remove"
+            ]
           }
         }
       },
@@ -748,13 +748,6 @@
                   "null"
                 ]
               },
-              "childAttribute": {
-                "title": "Child attribute name",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
               "expr": {
                 "title": "Expression to evaluate",
                 "type": [
@@ -779,6 +772,27 @@
                   }
                 }
               },
+              "valueAttribute": {
+                "title": "Attribute name to get value from",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentAttribute": {
+                "title": "Parent attribute name",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "childAttribute": {
+                "title": "Child attribute name",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "multipleExpr": {
                 "title": "Expression to evaluate multiple attributes",
                 "type": [
@@ -801,20 +815,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "parentAttribute": {
-                "title": "Parent attribute name",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "valueAttribute": {
-                "title": "Attribute name to get value from",
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             }
           }
@@ -848,10 +848,6 @@
           "rangeTable"
         ],
         "properties": {
-          "defaultValue": {
-            "title": "Default Value",
-            "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
-          },
           "inputAttribute": {
             "title": "Input Attribute",
             "description": "The attribute to evaluate for range mapping",
@@ -869,6 +865,10 @@
             "items": {
               "$ref": "#/definitions/RangeEntry"
             }
+          },
+          "defaultValue": {
+            "title": "Default Value",
+            "description": "Value to use when input doesn't match any range (can be string, number, boolean, etc.)"
           }
         },
         "definitions": {
@@ -887,15 +887,15 @@
                 "type": "number",
                 "format": "double"
               },
-              "outputValue": {
-                "title": "Output Value",
-                "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
-              },
               "to": {
                 "title": "To (Maximum)",
                 "description": "The maximum value of the range (exclusive)",
                 "type": "number",
                 "format": "double"
+              },
+              "outputValue": {
+                "title": "Output Value",
+                "description": "The value to assign when input falls within this range (can be string, number, boolean, etc.)"
               }
             }
           }
@@ -923,13 +923,13 @@
         "description": "Configuration for extracting boundaries from geometries.",
         "type": "object",
         "properties": {
-          "exteriorOnly": {
-            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
+          "keepEmptyBoundaries": {
+            "description": "Whether to keep features with empty boundaries (default: false)",
             "default": false,
             "type": "boolean"
           },
-          "keepEmptyBoundaries": {
-            "description": "Whether to keep features with empty boundaries (default: false)",
+          "exteriorOnly": {
+            "description": "Whether to extract only exterior boundaries (ignoring holes) for polygons (default: false)",
             "default": false,
             "type": "boolean"
           }
@@ -956,18 +956,6 @@
         "title": "BoundsExtractor Parameters",
         "type": "object",
         "properties": {
-          "xmax": {
-            "title": "Maximum X Attribute",
-            "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "xmin": {
             "title": "Minimum X Attribute",
             "description": "Attribute name for storing the minimum X coordinate (defaults to \"xmin\")",
@@ -980,9 +968,9 @@
               }
             ]
           },
-          "ymax": {
-            "title": "Maximum Y Attribute",
-            "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
+          "xmax": {
+            "title": "Maximum X Attribute",
+            "description": "Attribute name for storing the maximum X coordinate (defaults to \"xmax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1004,9 +992,9 @@
               }
             ]
           },
-          "zmax": {
-            "title": "Maximum Z Attribute",
-            "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
+          "ymax": {
+            "title": "Maximum Y Attribute",
+            "description": "Attribute name for storing the maximum Y coordinate (defaults to \"ymax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1019,6 +1007,18 @@
           "zmin": {
             "title": "Minimum Z Attribute",
             "description": "Attribute name for storing the minimum Z coordinate (defaults to \"zmin\")",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "zmax": {
+            "title": "Maximum Z Attribute",
+            "description": "Attribute name for storing the maximum Z coordinate (defaults to \"zmax\")",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -1130,6 +1130,15 @@
           "renameValue"
         ],
         "properties": {
+          "renameType": {
+            "title": "Which Attributes to Rename",
+            "description": "Choose whether to rename all attributes or only selected ones",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RenameType"
+              }
+            ]
+          },
           "renameAction": {
             "title": "Rename Operation",
             "description": "The type of renaming operation to perform on the attribute names",
@@ -1139,13 +1148,12 @@
               }
             ]
           },
-          "renameType": {
-            "title": "Which Attributes to Rename",
-            "description": "Choose whether to rename all attributes or only selected ones",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RenameType"
-              }
+          "textToFind": {
+            "title": "Text Pattern to Find",
+            "description": "Regular expression pattern to match when using \"Replace Text\" operation",
+            "type": [
+              "string",
+              "null"
             ]
           },
           "renameValue": {
@@ -1163,17 +1171,29 @@
             "items": {
               "type": "string"
             }
-          },
-          "textToFind": {
-            "title": "Text Pattern to Find",
-            "description": "Regular expression pattern to match when using \"Replace Text\" operation",
-            "type": [
-              "string",
-              "null"
-            ]
           }
         },
         "definitions": {
+          "RenameType": {
+            "oneOf": [
+              {
+                "title": "All Attributes",
+                "description": "Rename all attributes in the feature",
+                "type": "string",
+                "enum": [
+                  "All"
+                ]
+              },
+              {
+                "title": "Selected Attributes",
+                "description": "Rename only specific attributes listed below",
+                "type": "string",
+                "enum": [
+                  "Selected"
+                ]
+              }
+            ]
+          },
           "RenameAction": {
             "oneOf": [
               {
@@ -1217,26 +1237,6 @@
                 ]
               }
             ]
-          },
-          "RenameType": {
-            "oneOf": [
-              {
-                "title": "All Attributes",
-                "description": "Rename all attributes in the feature",
-                "type": "string",
-                "enum": [
-                  "All"
-                ]
-              },
-              {
-                "title": "Selected Attributes",
-                "description": "Rename only specific attributes listed below",
-                "type": "string",
-                "enum": [
-                  "Selected"
-                ]
-              }
-            ]
           }
         }
       },
@@ -1262,22 +1262,6 @@
         "description": "Configure how the CSG builder pairs features from left and right ports",
         "type": "object",
         "properties": {
-          "createList": {
-            "title": "Create List",
-            "description": "When enabled, creates a list of attribute values from both children (left and right)",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "listAttributeName": {
-            "title": "List Attribute Name",
-            "description": "Name of the attribute to create the list from (required when create_list is true)",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "pairIdAttribute": {
             "title": "Pair ID Attribute",
             "description": "Expression to evaluate the pair ID used to match features from left and right ports",
@@ -1301,6 +1285,22 @@
                 "type": "string"
               }
             }
+          },
+          "createList": {
+            "title": "Create List",
+            "description": "When enabled, creates a list of attribute values from both children (left and right)",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "listAttributeName": {
+            "title": "List Attribute Name",
+            "description": "Name of the attribute to create the list from (required when create_list is true)",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -1445,6 +1445,42 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "title": "Output Path",
+            "description": "Directory path where the 3D tiles will be written",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "Minimum Zoom Level",
+            "description": "Minimum zoom level for tile generation (0-24)",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "Maximum Zoom Level",
+            "description": "Maximum zoom level for tile generation (0-24)",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
           "attachTexture": {
             "title": "Attach Textures",
             "description": "Whether to include texture information in the generated tiles",
@@ -1486,55 +1522,19 @@
               "null"
             ]
           },
-          "maxZoom": {
-            "title": "Maximum Zoom Level",
-            "description": "Maximum zoom level for tile generation (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "Minimum Zoom Level",
-            "description": "Minimum zoom level for tile generation (0-24)",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "Output Path",
-            "description": "Directory path where the 3D tiles will be written",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
+          "skipUnexposedAttributes": {
+            "title": "Skip unexposed Attributes",
+            "description": "Skip attributes with double underscore prefix",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "title": "Schema Key",
             "description": "Attribute key whose value identifies the schema type and determines the output filename: all features sharing the same value are written to the same file. This attribute is excluded from output.",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "Skip unexposed Attributes",
-            "description": "Skip attributes with double underscore prefix",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -1589,12 +1589,6 @@
               }
             }
           },
-          "flatten": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -1619,6 +1613,12 @@
                 "type": "string"
               }
             }
+          },
+          "flatten": {
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         }
       },
@@ -1647,29 +1647,6 @@
           "output"
         ],
         "properties": {
-          "epsgCode": {
-            "description": "EPSG code for coordinate reference system",
-            "default": null,
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "lodFilter": {
-            "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-            "default": null,
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            }
-          },
           "output": {
             "description": "Output file path expression",
             "type": "object",
@@ -1690,6 +1667,29 @@
                 "type": "string"
               }
             }
+          },
+          "lodFilter": {
+            "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+            "default": null,
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            }
+          },
+          "epsgCode": {
+            "description": "EPSG code for coordinate reference system",
+            "default": null,
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
           },
           "prettyPrint": {
             "description": "Whether to format output with indentation (default: true)",
@@ -1807,15 +1807,6 @@
           "mode"
         ],
         "properties": {
-          "defaultZValue": {
-            "title": "Default Z Value",
-            "description": "Z value to use for 2D geometries that have no Z coordinate.",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
           "mode": {
             "title": "Extraction Mode",
             "description": "How to extract coordinates from geometry vertices.",
@@ -1824,12 +1815,18 @@
                 "$ref": "#/definitions/CoordinateExtractionMode"
               }
             ]
+          },
+          "defaultZValue": {
+            "title": "Default Z Value",
+            "description": "Z value to use for 2D geometries that have no Z coordinate.",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "CoordinateExtractionMode": {
             "description": "Extraction mode: determines how coordinates are output.",
             "oneOf": [
@@ -1840,6 +1837,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "allCoordinates"
+                    ]
+                  },
                   "coordinatesListName": {
                     "title": "Coordinates List Name",
                     "description": "Name of the list attribute that will store coordinate objects (default: \"_indices\")",
@@ -1848,12 +1851,6 @@
                       {
                         "$ref": "#/definitions/Attribute"
                       }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "allCoordinates"
                     ]
                   }
                 }
@@ -1866,17 +1863,17 @@
                   "type"
                 ],
                 "properties": {
-                  "coordinateIndex": {
-                    "title": "Coordinate Index",
-                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
-                    "type": "integer",
-                    "format": "int64"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
                       "specifyCoordinate"
                     ]
+                  },
+                  "coordinateIndex": {
+                    "title": "Coordinate Index",
+                    "description": "Index of the coordinate to extract. 0 = first vertex, negative values count from end (-1 = last).",
+                    "type": "integer",
+                    "format": "int64"
                   },
                   "xAttribute": {
                     "title": "X Attribute Name",
@@ -1911,6 +1908,9 @@
                 }
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -1940,6 +1940,23 @@
           "format"
         ],
         "properties": {
+          "format": {
+            "title": "File Format",
+            "description": "Choose the delimiter format for the input file",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "encoding": {
+            "title": "Character Encoding",
+            "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -1964,45 +1981,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "Character Encoding",
-            "description": "Character encoding for the CSV/TSV file. If not specified, defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default) - **Shift-JIS** - Japanese encoding - **EUC-JP** - Japanese encoding - **Windows Code Pages** - Windows-1250 through Windows-1258 - **ISO-8859 family** - ISO-8859-1 through ISO-8859-16\n\nAll encoding labels are case-insensitive.",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "format": {
-            "title": "File Format",
-            "description": "Choose the delimiter format for the input file",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "Geometry Configuration",
-            "description": "Optional configuration for parsing geometry from CSV columns",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "headerRows": {
-            "title": "Header Row Count",
-            "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "uint",
-            "minimum": 0.0
           },
           "inline": {
             "title": "Inline Content",
@@ -2038,6 +2016,28 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "headerRows": {
+            "title": "Header Row Count",
+            "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint",
+            "minimum": 0.0
+          },
+          "geometry": {
+            "title": "Geometry Configuration",
+            "description": "Optional configuration for parsing geometry from CSV columns",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2152,26 +2152,6 @@
           "output"
         ],
         "properties": {
-          "format": {
-            "description": "File format: csv (comma) or tsv (tab)",
-            "allOf": [
-              {
-                "$ref": "#/definitions/CsvFormat"
-              }
-            ]
-          },
-          "geometry": {
-            "title": "Geometry Configuration",
-            "description": "Optional configuration for exporting geometry to CSV columns",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/GeometryExportConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "output": {
             "description": "Output path or expression for the CSV/TSV file to create",
             "type": "object",
@@ -2192,6 +2172,26 @@
                 "type": "string"
               }
             }
+          },
+          "format": {
+            "description": "File format: csv (comma) or tsv (tab)",
+            "allOf": [
+              {
+                "$ref": "#/definitions/CsvFormat"
+              }
+            ]
+          },
+          "geometry": {
+            "title": "Geometry Configuration",
+            "description": "Optional configuration for exporting geometry to CSV columns",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/GeometryExportConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -2290,6 +2290,28 @@
         "description": "Configuration for reading CZML files as geographic features.",
         "type": "object",
         "properties": {
+          "force2d": {
+            "title": "Force 2D",
+            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+            "default": false,
+            "type": "boolean"
+          },
+          "skipDocumentPacket": {
+            "title": "Skip Document Packet",
+            "description": "If true, skips the document packet (first packet with version/clock info)",
+            "default": true,
+            "type": "boolean"
+          },
+          "timeSampling": {
+            "title": "Time Sampling Strategy",
+            "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
+            "default": "preserveRaw",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TimeSamplingStrategy"
+              }
+            ]
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -2315,12 +2337,6 @@
               }
             }
           },
-          "force2d": {
-            "title": "Force 2D",
-            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -2345,22 +2361,6 @@
                 "type": "string"
               }
             }
-          },
-          "skipDocumentPacket": {
-            "title": "Skip Document Packet",
-            "description": "If true, skips the document packet (first packet with version/clock info)",
-            "default": true,
-            "type": "boolean"
-          },
-          "timeSampling": {
-            "title": "Time Sampling Strategy",
-            "description": "How to handle time-dynamic properties in CZML packets. Defaults to \"preserveRaw\" for lossless round-trip with CzmlWriter.",
-            "default": "preserveRaw",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TimeSamplingStrategy"
-              }
-            ]
           }
         },
         "definitions": {
@@ -2415,87 +2415,6 @@
           "output"
         ],
         "properties": {
-          "colorAttribute": {
-            "title": "Color Attribute",
-            "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "epoch": {
-            "title": "Epoch",
-            "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "groupBy": {
-            "title": "Group By Attributes",
-            "description": "Attributes used to group features into separate CZML files",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
-          "groupTimeseriesBy": {
-            "title": "Group Timeseries By",
-            "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "heightAttribute": {
-            "title": "Height Attribute",
-            "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "interpolationAlgorithm": {
-            "title": "Interpolation Algorithm",
-            "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
-            "default": "LINEAR",
-            "allOf": [
-              {
-                "$ref": "#/definitions/InterpolationAlgorithm"
-              }
-            ]
-          },
-          "interpolationDegree": {
-            "title": "Interpolation Degree",
-            "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
-            "default": 1,
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0.0
-          },
-          "opacity": {
-            "title": "Opacity",
-            "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
-            "default": 180,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
           "output": {
             "title": "Output File Path",
             "description": "Path where the CZML file will be written",
@@ -2518,9 +2437,90 @@
               }
             }
           },
+          "groupBy": {
+            "title": "Group By Attributes",
+            "description": "Attributes used to group features into separate CZML files",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
           "timeField": {
             "title": "Time Field",
             "description": "Attribute containing the timestamp for each feature. Supports two formats: - **ISO 8601 strings**: e.g., \"2024-01-01T00:00:00Z\", \"2024-01-01T12:30:45+09:00\" - **Numeric values**: Seconds as offset from epoch (e.g., \"0\", \"60\", \"120.5\")\n\nWhen set together with `groupTimeseriesBy`, features sharing the same group key are combined into a single CZML entity with time-tagged position samples for animation in Cesium.\n\n**Example workflow configuration:** ```yaml - action: CzmlWriter with: output: \"output.czml\" timeField: \"timestamp\" groupTimeseriesBy: \"vehicleId\" epoch: \"2024-01-01T00:00:00Z\"  # Optional for numeric times (auto-defaults to Unix epoch) ```",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "epoch": {
+            "title": "Epoch",
+            "description": "Reference time (ISO 8601 format) used as the base for numeric time offsets.\n\n**When to use:** - Optional but recommended when `timeField` contains numeric values (e.g., \"0\", \"60\", \"3600\") - Not needed when `timeField` contains ISO 8601 datetime strings\n\n**Format:** ISO 8601 datetime string with timezone - Examples: \"2024-01-01T00:00:00Z\", \"2024-06-15T09:00:00+09:00\"\n\n**Auto-detection:** If omitted and all time values are numeric, automatically defaults to Unix epoch \"1970-01-01T00:00:00Z\". For custom time ranges, explicitly set this parameter to your desired base time.\n\n**Example:** ```yaml epoch: \"2024-01-01T00:00:00Z\"  # Time value \"60\" means 2024-01-01T00:01:00Z ```",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "interpolationAlgorithm": {
+            "title": "Interpolation Algorithm",
+            "description": "Algorithm used by Cesium to interpolate between time-tagged samples.",
+            "default": "LINEAR",
+            "allOf": [
+              {
+                "$ref": "#/definitions/InterpolationAlgorithm"
+              }
+            ]
+          },
+          "interpolationDegree": {
+            "title": "Interpolation Degree",
+            "description": "Degree of interpolation (1 for LINEAR, 5 typical for LAGRANGE).",
+            "default": 1,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
+          "groupTimeseriesBy": {
+            "title": "Group Timeseries By",
+            "description": "Attribute used to group features into a single time-dynamic CZML entity. Features with the same value for this attribute are merged into one packet with time-tagged positions.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "colorAttribute": {
+            "title": "Color Attribute",
+            "description": "Attribute containing a hex color string (e.g., \"#ffd8c0\") for polygon fill. Used when polygon geometry is auto-converted from the feature geometry.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "opacity": {
+            "title": "Opacity",
+            "description": "Alpha value (0–255) for polygon fill color. Default: 180.",
+            "default": 180,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "heightAttribute": {
+            "title": "Height Attribute",
+            "description": "Attribute containing a numeric value for polygon extrusion height. When set, polygons are extruded from ground to this height value.",
             "anyOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -2598,14 +2598,6 @@
               }
             ]
           },
-          "outputAttribute": {
-            "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "outputFormat": {
             "description": "Desired output format (default: auto). Use `auto` to store as typed DateTime value (parser mode). Use other formats to output as string/number (formatter mode).",
             "default": "auto",
@@ -2613,6 +2605,14 @@
               {
                 "$ref": "#/definitions/DateTimeOutputFormat"
               }
+            ]
+          },
+          "outputAttribute": {
+            "description": "Write result to a different attribute (leave input untouched) Defaults to the same as `attribute`",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
@@ -2819,16 +2819,6 @@
         "description": "Configure how to dissolve features by grouping them based on shared attributes",
         "type": "object",
         "properties": {
-          "attributeAccumulation": {
-            "title": "Attribute Accumulation",
-            "description": "Strategy for handling attributes when dissolving features",
-            "default": "useOneFeature",
-            "allOf": [
-              {
-                "$ref": "#/definitions/AttributeAccumulationStrategy"
-              }
-            ]
-          },
           "groupBy": {
             "title": "Group By Attributes",
             "description": "List of attribute names to group features by before dissolving. Features with the same values for these attributes will be dissolved together",
@@ -2848,6 +2838,16 @@
               "null"
             ],
             "format": "double"
+          },
+          "attributeAccumulation": {
+            "title": "Attribute Accumulation",
+            "description": "Strategy for handling attributes when dissolving features",
+            "default": "useOneFeature",
+            "allOf": [
+              {
+                "$ref": "#/definitions/AttributeAccumulationStrategy"
+              }
+            ]
           }
         },
         "definitions": {
@@ -3089,15 +3089,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "CityGML属性键",
-            "description": "设置后，解析的CityGML属性将嵌套在此键下输出到要素中。为null时，属性在顶层输出。默认为null。",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "Dataset",
             "description": "解析为要读取的CityGML 2.0文件的路径表达式。",
@@ -3129,10 +3120,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "展平度量类型",
-            "description": "为true时，具有单个`uom`属性和数值文本内容的元素将被转换为数值，单位以兄弟键`{name}_uom`存储。默认为false。",
-            "default": false,
+          "keepAttributes": {
+            "title": "保留属性",
+            "description": "为false时，XML属性（如`@gml:id`、`@codeSpace`等`@`前缀条目）将从解析的要素中删除。默认为true。",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3141,11 +3132,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "保留属性",
-            "description": "为false时，XML属性（如`@gml:id`、`@codeSpace`等`@`前缀条目）将从解析的要素中删除。默认为true。",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "展平度量类型",
+            "description": "为true时，具有单个`uom`属性和数值文本内容的元素将被转换为数值，单位以兄弟键`{name}_uom`存储。默认为false。",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "CityGML属性键",
+            "description": "设置后，解析的CityGML属性将嵌套在此键下输出到要素中。为null时，属性在顶层输出。默认为null。",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3173,15 +3173,6 @@
           "dataset"
         ],
         "properties": {
-          "cityGmlAttributesKey": {
-            "title": "CityGML属性键",
-            "description": "设置后，解析的CityGML属性将嵌套在此键下输出到要素中。为null时，属性在顶层输出。默认为null。",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
           "dataset": {
             "title": "Dataset",
             "description": "解析为要读取的CityGML 3.0文件的路径表达式。",
@@ -3213,10 +3204,10 @@
               "type": "string"
             }
           },
-          "flattenMeasureTypes": {
-            "title": "展平度量类型",
-            "description": "为true时，具有单个`uom`属性和数值文本内容的元素将被转换为数值，单位以兄弟键`{name}_uom`存储。默认为false。",
-            "default": false,
+          "keepAttributes": {
+            "title": "保留属性",
+            "description": "为false时，XML属性（如`@gml:id`、`@codeSpace`等`@`前缀条目）将从解析的要素中删除。默认为true。",
+            "default": true,
             "type": "boolean"
           },
           "flattenSingleChildObjects": {
@@ -3225,11 +3216,20 @@
             "default": false,
             "type": "boolean"
           },
-          "keepAttributes": {
-            "title": "保留属性",
-            "description": "为false时，XML属性（如`@gml:id`、`@codeSpace`等`@`前缀条目）将从解析的要素中删除。默认为true。",
-            "default": true,
+          "flattenMeasureTypes": {
+            "title": "展平度量类型",
+            "description": "为true时，具有单个`uom`属性和数值文本内容的元素将被转换为数值，单位以兄弟键`{name}_uom`存储。默认为false。",
+            "default": false,
             "type": "boolean"
+          },
+          "cityGmlAttributesKey": {
+            "title": "CityGML属性键",
+            "description": "设置后，解析的CityGML属性将嵌套在此键下输出到要素中。为null时，属性在顶层输出。默认为null。",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3258,31 +3258,6 @@
           "dataset"
         ],
         "properties": {
-          "codelistsPath": {
-            "title": "Codelists Path",
-            "description": "Optional path to the codelists directory for resolving codelist values",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "dataset": {
             "title": "Dataset",
             "description": "Path or expression to the CityGML dataset file to be read",
@@ -3312,6 +3287,31 @@
               "boolean",
               "null"
             ]
+          },
+          "codelistsPath": {
+            "title": "Codelists Path",
+            "description": "Optional path to the codelists directory for resolving codelist values",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -3463,19 +3463,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "destPrefix": {
-            "title": "Destination Prefix",
-            "description": "Optional prefix to add to extracted file paths",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "extractArchive": {
-            "title": "Extract Archive",
-            "description": "Whether to extract archive files found in the dataset",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Expression to get the source dataset path or URL",
@@ -3497,6 +3484,19 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "Extract Archive",
+            "description": "Whether to extract archive files found in the dataset",
+            "type": "boolean"
+          },
+          "destPrefix": {
+            "title": "Destination Prefix",
+            "description": "Optional prefix to add to extracted file paths",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -3606,17 +3606,6 @@
           "joinType"
         ],
         "properties": {
-          "conflictResolution": {
-            "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ConflictResolution"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "joinType": {
             "description": "Join type: inner, left, or full",
             "allOf": [
@@ -3627,6 +3616,16 @@
           },
           "requestorAttribute": {
             "description": "Attributes from requestor features to use for matching (alternative to requestorAttributeValue)",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
             "type": [
               "array",
               "null"
@@ -3658,16 +3657,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "Attributes from supplier features to use for matching (alternative to supplierAttributeValue)",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "Expression to evaluate for supplier feature matching values (alternative to supplierAttribute)",
             "type": [
@@ -3690,30 +3679,20 @@
                 "type": "string"
               }
             }
+          },
+          "conflictResolution": {
+            "description": "Attribute conflict resolution strategy when both requestor and supplier have the same attribute",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ConflictResolution"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "ConflictResolution": {
-            "oneOf": [
-              {
-                "description": "Requestor attributes win on conflict",
-                "type": "string",
-                "enum": [
-                  "requestorWins"
-                ]
-              },
-              {
-                "description": "Supplier attributes win on conflict (default)",
-                "type": "string",
-                "enum": [
-                  "supplierWins"
-                ]
-              }
-            ]
-          },
           "JoinType": {
             "oneOf": [
               {
@@ -3735,6 +3714,27 @@
                 "type": "string",
                 "enum": [
                   "full"
+                ]
+              }
+            ]
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "ConflictResolution": {
+            "oneOf": [
+              {
+                "description": "Requestor attributes win on conflict",
+                "type": "string",
+                "enum": [
+                  "requestorWins"
+                ]
+              },
+              {
+                "description": "Supplier attributes win on conflict (default)",
+                "type": "string",
+                "enum": [
+                  "supplierWins"
                 ]
               }
             ]
@@ -3816,15 +3816,18 @@
         "description": "Configuration for merging requestor and supplier features based on matching attributes or expressions.",
         "type": "object",
         "properties": {
-          "completeGrouped": {
-            "description": "Whether to complete grouped features before processing the next group",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "requestorAttribute": {
             "description": "Attributes from requestor features to use for matching (alternative to requestor_attribute_value)",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
+            }
+          },
+          "supplierAttribute": {
+            "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
             "type": [
               "array",
               "null"
@@ -3856,16 +3859,6 @@
               }
             }
           },
-          "supplierAttribute": {
-            "description": "Attributes from supplier features to use for matching (alternative to supplier_attribute_value)",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "supplierAttributeValue": {
             "description": "Expression to evaluate for supplier feature matching values (alternative to supplier_attribute)",
             "type": [
@@ -3888,6 +3881,13 @@
                 "type": "string"
               }
             }
+          },
+          "completeGrouped": {
+            "description": "Whether to complete grouped features before processing the next group",
+            "type": [
+              "boolean",
+              "null"
+            ]
           }
         },
         "definitions": {
@@ -3927,27 +3927,11 @@
               "format"
             ],
             "properties": {
-              "dataset": {
-                "title": "Dataset",
-                "description": "Path or expression to the dataset file to be read",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "format": {
+                "type": "string",
+                "enum": [
+                  "csv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -3957,42 +3941,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "csv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4014,6 +3962,42 @@
                     "type": "string"
                   }
                 }
+              },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
+              "format": {
+                "type": "string",
+                "enum": [
+                  "tsv"
+                ]
               },
               "encoding": {
                 "title": "Character Encoding",
@@ -4023,42 +4007,6 @@
                   "null"
                 ]
               },
-              "format": {
-                "type": "string",
-                "enum": [
-                  "tsv"
-                ]
-              },
-              "headerRows": {
-                "title": "Header Row Count",
-                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              },
-              "offset": {
-                "description": "The offset of the first row to read",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint",
-                "minimum": 0.0
-              }
-            }
-          },
-          {
-            "title": "Common Reader Parameters",
-            "description": "Shared configuration for all feature reader formats.",
-            "type": "object",
-            "required": [
-              "dataset",
-              "format"
-            ],
-            "properties": {
               "dataset": {
                 "title": "Dataset",
                 "description": "Path or expression to the dataset file to be read",
@@ -4081,11 +4029,63 @@
                   }
                 }
               },
+              "offset": {
+                "description": "The offset of the first row to read",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              },
+              "headerRows": {
+                "title": "Header Row Count",
+                "description": "Number of consecutive rows that make up the header (default: 1). When 0, no header rows are read and column names are auto-generated as \"column1\", \"column2\", etc. When greater than 1, column names are formed by joining non-empty values from each header row with \"_\".",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint",
+                "minimum": 0.0
+              }
+            }
+          },
+          {
+            "title": "Common Reader Parameters",
+            "description": "Shared configuration for all feature reader formats.",
+            "type": "object",
+            "required": [
+              "dataset",
+              "format"
+            ],
+            "properties": {
               "format": {
                 "type": "string",
                 "enum": [
                   "json"
                 ]
+              },
+              "dataset": {
+                "title": "Dataset",
+                "description": "Path or expression to the dataset file to be read",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -4349,28 +4349,6 @@
               "output"
             ],
             "properties": {
-              "converter": {
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
               "format": {
                 "type": "string",
                 "enum": [
@@ -4397,6 +4375,28 @@
                     "type": "string"
                   }
                 }
+              },
+              "converter": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -4409,34 +4409,11 @@
               "output"
             ],
             "properties": {
-              "epsgCode": {
-                "description": "EPSG code for coordinate reference system",
-                "default": null,
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint32",
-                "minimum": 0.0
-              },
               "format": {
                 "type": "string",
                 "enum": [
                   "citygml"
                 ]
-              },
-              "lodFilter": {
-                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
-                "default": null,
-                "type": [
-                  "array",
-                  "null"
-                ],
-                "items": {
-                  "type": "integer",
-                  "format": "uint8",
-                  "minimum": 0.0
-                }
               },
               "output": {
                 "title": "Output path",
@@ -4458,6 +4435,29 @@
                     "type": "string"
                   }
                 }
+              },
+              "lodFilter": {
+                "description": "LOD levels to include (e.g., [0, 1, 2]). If empty, includes all LODs.",
+                "default": null,
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
+                }
+              },
+              "epsgCode": {
+                "description": "EPSG code for coordinate reference system",
+                "default": null,
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
               },
               "prettyPrint": {
                 "description": "Whether to format output with indentation (default: true)",
@@ -4497,11 +4497,6 @@
           "sourceDataset"
         ],
         "properties": {
-          "extractArchive": {
-            "title": "Extract Archive",
-            "description": "Whether to extract files from archives (zip files, etc.) or just list them",
-            "type": "boolean"
-          },
           "sourceDataset": {
             "title": "Source Dataset",
             "description": "Path or expression pointing to the source directory or archive file",
@@ -4523,6 +4518,11 @@
                 "type": "string"
               }
             }
+          },
+          "extractArchive": {
+            "title": "Extract Archive",
+            "description": "Whether to extract files from archives (zip files, etc.) or just list them",
+            "type": "boolean"
           }
         }
       },
@@ -4680,16 +4680,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "Optional attributes to group features by, creating separate files for each group",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "Output path or expression for the GeoJSON file to create",
             "type": "object",
@@ -4709,6 +4699,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "Optional attributes to group features by, creating separate files for each group",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -4739,6 +4739,32 @@
         "title": "GeoPackageReaderParam",
         "type": "object",
         "properties": {
+          "readMode": {
+            "default": "features",
+            "allOf": [
+              {
+                "$ref": "#/definitions/GeoPackageReadMode"
+              }
+            ]
+          },
+          "layerName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "includeMetadata": {
+            "default": false,
+            "type": "boolean"
+          },
+          "tileFormat": {
+            "default": "png",
+            "allOf": [
+              {
+                "$ref": "#/definitions/TileFormat"
+              }
+            ]
+          },
           "attributeFilter": {
             "default": null,
             "type": [
@@ -4754,6 +4780,17 @@
             ],
             "format": "uint",
             "minimum": 0.0
+          },
+          "force2D": {
+            "default": false,
+            "type": "boolean"
+          },
+          "spatialFilter": {
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "dataset": {
             "title": "File Path",
@@ -4780,14 +4817,6 @@
               }
             }
           },
-          "force2D": {
-            "default": false,
-            "type": "boolean"
-          },
-          "includeMetadata": {
-            "default": false,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -4812,35 +4841,6 @@
                 "type": "string"
               }
             }
-          },
-          "layerName": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "readMode": {
-            "default": "features",
-            "allOf": [
-              {
-                "$ref": "#/definitions/GeoPackageReadMode"
-              }
-            ]
-          },
-          "spatialFilter": {
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "tileFormat": {
-            "default": "png",
-            "allOf": [
-              {
-                "$ref": "#/definitions/TileFormat"
-              }
-            ]
           }
         },
         "definitions": {
@@ -4888,21 +4888,6 @@
           "output"
         ],
         "properties": {
-          "createSpatialIndex": {
-            "description": "Create RTree spatial index (default: true)",
-            "default": true,
-            "type": "boolean"
-          },
-          "geometryColumn": {
-            "description": "Geometry column name (default: \"geom\")",
-            "default": "geom",
-            "type": "string"
-          },
-          "geometryType": {
-            "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
-            "default": "GEOMETRY",
-            "type": "string"
-          },
           "output": {
             "description": "Output path for the GeoPackage file to create",
             "type": "object",
@@ -4924,10 +4909,15 @@
               }
             }
           },
-          "overwrite": {
-            "description": "Overwrite existing file (default: false)",
-            "default": false,
-            "type": "boolean"
+          "tableName": {
+            "description": "Table name to create (default: \"features\")",
+            "default": "features",
+            "type": "string"
+          },
+          "geometryColumn": {
+            "description": "Geometry column name (default: \"geom\")",
+            "default": "geom",
+            "type": "string"
           },
           "srsId": {
             "description": "Spatial Reference System ID (default: 4326 for WGS84)",
@@ -4935,10 +4925,20 @@
             "type": "integer",
             "format": "int32"
           },
-          "tableName": {
-            "description": "Table name to create (default: \"features\")",
-            "default": "features",
+          "geometryType": {
+            "description": "Geometry type for table (Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GEOMETRY for mixed)",
+            "default": "GEOMETRY",
             "type": "string"
+          },
+          "createSpatialIndex": {
+            "description": "Create RTree spatial index (default: true)",
+            "default": true,
+            "type": "boolean"
+          },
+          "overwrite": {
+            "description": "Overwrite existing file (default: false)",
+            "default": false,
+            "type": "boolean"
           }
         }
       },
@@ -5411,6 +5411,24 @@
         "title": "GltfReaderParam",
         "type": "object",
         "properties": {
+          "triangulate": {
+            "title": "Triangulate",
+            "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
+            "default": true,
+            "type": "boolean"
+          },
+          "mergeMeshes": {
+            "title": "Merge Meshes",
+            "description": "If true, combines all meshes from the glTF file into a single output feature",
+            "default": false,
+            "type": "boolean"
+          },
+          "includeNodes": {
+            "title": "Include Nodes",
+            "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
+            "default": true,
+            "type": "boolean"
+          },
           "dataset": {
             "title": "File Path",
             "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
@@ -5436,12 +5454,6 @@
               }
             }
           },
-          "includeNodes": {
-            "title": "Include Nodes",
-            "description": "If true, includes node hierarchy information from the glTF scene graph in feature attributes",
-            "default": true,
-            "type": "boolean"
-          },
           "inline": {
             "title": "Inline Content",
             "description": "Expression that returns the file content as text instead of reading from a file path",
@@ -5466,18 +5478,6 @@
                 "type": "string"
               }
             }
-          },
-          "mergeMeshes": {
-            "title": "Merge Meshes",
-            "description": "If true, combines all meshes from the glTF file into a single output feature",
-            "default": false,
-            "type": "boolean"
-          },
-          "triangulate": {
-            "title": "Triangulate",
-            "description": "If true, converts all primitives to triangles (reserved for future use - currently all primitives are processed as triangles)",
-            "default": true,
-            "type": "boolean"
           }
         }
       },
@@ -5505,20 +5505,6 @@
           "output"
         ],
         "properties": {
-          "attachTexture": {
-            "description": "Whether to attach texture information to the GLTF model",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "dracoCompression": {
-            "description": "Apply Draco compression to the geometry",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "output": {
             "description": "Output file path. When `schemaKey` is set, treated as a directory and each feature type is written to `<output>/<schemaKeyValue>.glb`; otherwise all features are written to this single file.",
             "type": "object",
@@ -5539,6 +5525,20 @@
                 "type": "string"
               }
             }
+          },
+          "attachTexture": {
+            "description": "Whether to attach texture information to the GLTF model",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "dracoCompression": {
+            "description": "Apply Draco compression to the geometry",
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "schemaKey": {
             "description": "Features are grouped by this attribute and written to separate files. The key is excluded from output attributes.",
@@ -5571,6 +5571,20 @@
           "unitSquareSize"
         ],
         "properties": {
+          "unitSquareSize": {
+            "title": "Unit Square Size",
+            "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
+            "type": "number",
+            "format": "double"
+          },
+          "keepSquareOnly": {
+            "title": "Keep Square Only",
+            "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "groupBy": {
             "title": "Group By Attributes",
             "description": "Attributes used to group features - each group gets its own grid origin",
@@ -5581,20 +5595,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "keepSquareOnly": {
-            "title": "Keep Square Only",
-            "description": "If true, only output complete grid squares (discard edge pieces). Default: false",
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
-          "unitSquareSize": {
-            "title": "Unit Square Size",
-            "description": "Side length of each grid cell (in the same units as the geometry coordinates)",
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -5631,12 +5631,78 @@
           "url"
         ],
         "properties": {
+          "url": {
+            "title": "URL",
+            "description": "The target URL for the HTTP request (supports expressions)",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "method": {
+            "title": "HTTP Method",
+            "description": "The HTTP method to use for the request",
+            "default": "GET",
+            "allOf": [
+              {
+                "$ref": "#/definitions/HttpMethod"
+              }
+            ]
+          },
           "authentication": {
             "title": "Authentication",
             "description": "Authentication method and credentials for the request",
             "anyOf": [
               {
                 "$ref": "#/definitions/Authentication"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "customHeaders": {
+            "title": "Custom Headers",
+            "description": "Additional HTTP headers to include in the request",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/HeaderParam"
+            }
+          },
+          "queryParameters": {
+            "title": "Query Parameters",
+            "description": "URL query parameters to append to the request",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/QueryParam"
+            }
+          },
+          "requestBody": {
+            "title": "Request Body",
+            "description": "The body content to send with the request",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5651,16 +5717,17 @@
               "null"
             ]
           },
-          "customHeaders": {
-            "title": "Custom Headers",
-            "description": "Additional HTTP headers to include in the request",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/HeaderParam"
-            }
+          "timeouts": {
+            "title": "Timeouts",
+            "description": "Connection and transfer timeout settings",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TimeoutConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "httpOptions": {
             "title": "HTTP Options",
@@ -5668,63 +5735,6 @@
             "anyOf": [
               {
                 "$ref": "#/definitions/HttpOptions"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "method": {
-            "title": "HTTP Method",
-            "description": "The HTTP method to use for the request",
-            "default": "GET",
-            "allOf": [
-              {
-                "$ref": "#/definitions/HttpMethod"
-              }
-            ]
-          },
-          "observability": {
-            "title": "Observability",
-            "description": "Track additional metrics and diagnostics",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/ObservabilityConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "queryParameters": {
-            "title": "Query Parameters",
-            "description": "URL query parameters to append to the request",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/QueryParam"
-            }
-          },
-          "rateLimit": {
-            "title": "Rate Limiting",
-            "description": "Rate limiting configuration to control request frequency",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RateLimitConfig"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "requestBody": {
-            "title": "Request Body",
-            "description": "The body content to send with the request",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/RequestBody"
               },
               {
                 "type": "null"
@@ -5755,386 +5765,32 @@
               }
             ]
           },
-          "timeouts": {
-            "title": "Timeouts",
-            "description": "Connection and transfer timeout settings",
+          "rateLimit": {
+            "title": "Rate Limiting",
+            "description": "Rate limiting configuration to control request frequency",
             "anyOf": [
               {
-                "$ref": "#/definitions/TimeoutConfig"
+                "$ref": "#/definitions/RateLimitConfig"
               },
               {
                 "type": "null"
               }
             ]
           },
-          "url": {
-            "title": "URL",
-            "description": "The target URL for the HTTP request (supports expressions)",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
+          "observability": {
+            "title": "Observability",
+            "description": "Track additional metrics and diagnostics",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/ObservabilityConfig"
               },
-              "value": {
-                "type": "string"
+              {
+                "type": "null"
               }
-            }
+            ]
           }
         },
         "definitions": {
-          "ApiKeyLocation": {
-            "title": "API Key Location",
-            "description": "Where to include the API key in the request",
-            "oneOf": [
-              {
-                "title": "Header",
-                "description": "Include API key in HTTP header",
-                "type": "string",
-                "enum": [
-                  "header"
-                ]
-              },
-              {
-                "title": "Query Parameter",
-                "description": "Include API key in URL query string",
-                "type": "string",
-                "enum": [
-                  "query"
-                ]
-              }
-            ]
-          },
-          "Authentication": {
-            "title": "Authentication",
-            "description": "Authentication method and credentials for HTTP requests",
-            "oneOf": [
-              {
-                "title": "Basic Authentication",
-                "description": "HTTP Basic authentication with username and password",
-                "type": "object",
-                "required": [
-                  "password",
-                  "type",
-                  "username"
-                ],
-                "properties": {
-                  "password": {
-                    "title": "Password",
-                    "description": "The password for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "basic"
-                    ]
-                  },
-                  "username": {
-                    "title": "Username",
-                    "description": "The username for basic authentication",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "title": "Bearer Token",
-                "description": "Bearer token authentication (OAuth 2.0)",
-                "type": "object",
-                "required": [
-                  "token",
-                  "type"
-                ],
-                "properties": {
-                  "token": {
-                    "title": "Token",
-                    "description": "The bearer token value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "bearer"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "API Key",
-                "description": "API key authentication in header or query parameter",
-                "type": "object",
-                "required": [
-                  "keyName",
-                  "keyValue",
-                  "type"
-                ],
-                "properties": {
-                  "keyName": {
-                    "title": "Key Name",
-                    "description": "The name of the API key parameter",
-                    "type": "string"
-                  },
-                  "keyValue": {
-                    "title": "Key Value",
-                    "description": "The API key value",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "location": {
-                    "title": "Location",
-                    "description": "Where to include the API key (header or query parameter)",
-                    "default": "header",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/ApiKeyLocation"
-                      }
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "apiKey"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "BinarySource": {
-            "title": "Binary Source",
-            "description": "Source of binary data for request body",
-            "oneOf": [
-              {
-                "title": "Base64 Encoded",
-                "description": "Binary data encoded as base64 string",
-                "type": "object",
-                "required": [
-                  "data",
-                  "type"
-                ],
-                "properties": {
-                  "data": {
-                    "title": "Data",
-                    "description": "Base64-encoded binary data (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "base64"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "From File",
-                "description": "Read binary data from a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path to the file to read (supports expressions)",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
-          "FormField": {
-            "title": "Form Field",
-            "description": "A name-value pair for URL-encoded form data",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "Field Name",
-                "description": "The name of the form field",
-                "type": "string"
-              },
-              "value": {
-                "title": "Field Value",
-                "description": "The value of the form field (supports expressions)",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
-          "HeaderParam": {
-            "title": "HTTP Header",
-            "description": "A custom HTTP header to include in the request",
-            "type": "object",
-            "required": [
-              "name",
-              "value"
-            ],
-            "properties": {
-              "name": {
-                "title": "Header Name",
-                "description": "The name of the HTTP header",
-                "type": "string"
-              },
-              "value": {
-                "title": "Header Value",
-                "description": "The value of the header (supports expressions)",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          },
           "HttpMethod": {
             "title": "HTTP Method",
             "description": "The HTTP request method to use",
@@ -6253,75 +5909,51 @@
               }
             ]
           },
-          "HttpOptions": {
-            "title": "HTTP Options",
-            "description": "Configure HTTP client behavior",
-            "type": "object",
-            "properties": {
-              "followRedirects": {
-                "title": "Follow Redirects",
-                "description": "Whether to automatically follow HTTP redirects (default: true)",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              },
-              "maxRedirects": {
-                "title": "Max Redirects",
-                "description": "Maximum number of redirects to follow (default: 10)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "userAgent": {
-                "title": "User Agent",
-                "description": "Custom User-Agent header value",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "verifySsl": {
-                "title": "Verify SSL",
-                "description": "Whether to verify SSL/TLS certificates (default: true)",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
-              }
-            }
-          },
-          "MultipartPart": {
-            "title": "Multipart Part",
-            "description": "A part in a multipart/form-data request",
+          "Authentication": {
+            "title": "Authentication",
+            "description": "Authentication method and credentials for HTTP requests",
             "oneOf": [
               {
-                "title": "Text Field",
-                "description": "A text field in the multipart form",
+                "title": "Basic Authentication",
+                "description": "HTTP Basic authentication with username and password",
                 "type": "object",
                 "required": [
-                  "name",
+                  "password",
                   "type",
-                  "value"
+                  "username"
                 ],
                 "properties": {
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the form field",
-                    "type": "string"
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "text"
+                      "basic"
                     ]
                   },
-                  "value": {
-                    "title": "Field Value",
-                    "description": "The value of the form field (supports expressions)",
+                  "username": {
+                    "title": "Username",
+                    "description": "The username for basic authentication",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "password": {
+                    "title": "Password",
+                    "description": "The password for basic authentication",
                     "type": "object",
                     "format": "code",
                     "required": [
@@ -6344,115 +5976,158 @@
                 }
               },
               {
-                "title": "File Upload",
-                "description": "A file upload in the multipart form",
+                "title": "Bearer Token",
+                "description": "Bearer token authentication (OAuth 2.0)",
                 "type": "object",
                 "required": [
-                  "name",
-                  "source",
+                  "token",
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "MIME type of the file",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "filename": {
-                    "title": "Filename",
-                    "description": "The filename to send in the Content-Disposition header",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "name": {
-                    "title": "Field Name",
-                    "description": "The name of the file upload field",
-                    "type": "string"
-                  },
-                  "source": {
-                    "title": "File Source",
-                    "description": "Source of the file data (base64 or file path)",
-                    "allOf": [
-                      {
-                        "$ref": "#/definitions/BinarySource"
-                      }
-                    ]
-                  },
                   "type": {
                     "type": "string",
                     "enum": [
-                      "file"
+                      "bearer"
+                    ]
+                  },
+                  "token": {
+                    "title": "Token",
+                    "description": "The bearer token value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "API Key",
+                "description": "API key authentication in header or query parameter",
+                "type": "object",
+                "required": [
+                  "keyName",
+                  "keyValue",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "apiKey"
+                    ]
+                  },
+                  "keyName": {
+                    "title": "Key Name",
+                    "description": "The name of the API key parameter",
+                    "type": "string"
+                  },
+                  "keyValue": {
+                    "title": "Key Value",
+                    "description": "The API key value",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "location": {
+                    "title": "Location",
+                    "description": "Where to include the API key (header or query parameter)",
+                    "default": "header",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/ApiKeyLocation"
+                      }
                     ]
                   }
                 }
               }
             ]
           },
-          "ObservabilityConfig": {
-            "title": "Observability Configuration",
-            "description": "Track additional metrics and diagnostics about HTTP requests",
+          "ApiKeyLocation": {
+            "title": "API Key Location",
+            "description": "Where to include the API key in the request",
+            "oneOf": [
+              {
+                "title": "Header",
+                "description": "Include API key in HTTP header",
+                "type": "string",
+                "enum": [
+                  "header"
+                ]
+              },
+              {
+                "title": "Query Parameter",
+                "description": "Include API key in URL query string",
+                "type": "string",
+                "enum": [
+                  "query"
+                ]
+              }
+            ]
+          },
+          "HeaderParam": {
+            "title": "HTTP Header",
+            "description": "A custom HTTP header to include in the request",
             "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
             "properties": {
-              "bytesAttribute": {
-                "title": "Bytes Attribute",
-                "description": "Feature attribute name to store the response body size",
-                "type": [
-                  "string",
-                  "null"
-                ]
+              "name": {
+                "title": "Header Name",
+                "description": "The name of the HTTP header",
+                "type": "string"
               },
-              "durationAttribute": {
-                "title": "Duration Attribute",
-                "description": "Feature attribute name to store request duration in milliseconds",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "finalUrlAttribute": {
-                "title": "Final URL Attribute",
-                "description": "Feature attribute name to store the final URL after redirects",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "retryCountAttribute": {
-                "title": "Retry Count Attribute",
-                "description": "Feature attribute name to store the number of retry attempts",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "trackBytes": {
-                "title": "Track Bytes",
-                "description": "Whether to track the response body size in bytes (default: false)",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackDuration": {
-                "title": "Track Duration",
-                "description": "Whether to track the total request duration (default: true)",
-                "default": true,
-                "type": "boolean"
-              },
-              "trackFinalUrl": {
-                "title": "Track Final URL",
-                "description": "Whether to track the final URL after redirects (default: false)",
-                "default": false,
-                "type": "boolean"
-              },
-              "trackRetryCount": {
-                "title": "Track Retry Count",
-                "description": "Whether to track the number of retry attempts (default: true)",
-                "default": true,
-                "type": "boolean"
+              "value": {
+                "title": "Header Value",
+                "description": "The value of the header (supports expressions)",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
               }
             }
           },
@@ -6494,41 +6169,6 @@
               }
             }
           },
-          "RateLimitConfig": {
-            "title": "Rate Limit Configuration",
-            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
-            "type": "object",
-            "required": [
-              "requests"
-            ],
-            "properties": {
-              "intervalMs": {
-                "title": "Interval",
-                "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
-                "default": 1000,
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "requests": {
-                "title": "Requests",
-                "description": "Maximum number of requests allowed within the interval",
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
-              },
-              "timing": {
-                "title": "Timing Strategy",
-                "description": "How to distribute requests within the interval (default: Burst)",
-                "default": "burst",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/TimingStrategy"
-                  }
-                ]
-              }
-            }
-          },
           "RequestBody": {
             "title": "Request Body",
             "description": "The body content to send with the HTTP request",
@@ -6542,6 +6182,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
                   "content": {
                     "title": "Content",
                     "description": "The text content to send (supports expressions)",
@@ -6571,12 +6217,6 @@
                       "string",
                       "null"
                     ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "text"
-                    ]
                   }
                 }
               },
@@ -6589,12 +6229,10 @@
                   "type"
                 ],
                 "properties": {
-                  "contentType": {
-                    "title": "Content Type",
-                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
-                    "type": [
-                      "string",
-                      "null"
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "binary"
                     ]
                   },
                   "source": {
@@ -6606,10 +6244,12 @@
                       }
                     ]
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "binary"
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "Content-Type header (e.g., application/octet-stream, image/png)",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
@@ -6623,6 +6263,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "formUrlEncoded"
+                    ]
+                  },
                   "fields": {
                     "title": "Form Fields",
                     "description": "List of form field name-value pairs",
@@ -6630,12 +6276,6 @@
                     "items": {
                       "$ref": "#/definitions/FormField"
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "formUrlEncoded"
-                    ]
                   }
                 }
               },
@@ -6648,6 +6288,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "multipart"
+                    ]
+                  },
                   "parts": {
                     "title": "Parts",
                     "description": "List of multipart form parts (text fields or file uploads)",
@@ -6655,34 +6301,315 @@
                     "items": {
                       "$ref": "#/definitions/MultipartPart"
                     }
-                  },
+                  }
+                }
+              }
+            ]
+          },
+          "BinarySource": {
+            "title": "Binary Source",
+            "description": "Source of binary data for request body",
+            "oneOf": [
+              {
+                "title": "Base64 Encoded",
+                "description": "Binary data encoded as base64 string",
+                "type": "object",
+                "required": [
+                  "data",
+                  "type"
+                ],
+                "properties": {
                   "type": {
                     "type": "string",
                     "enum": [
-                      "multipart"
+                      "base64"
+                    ]
+                  },
+                  "data": {
+                    "title": "Data",
+                    "description": "Base64-encoded binary data (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "From File",
+                "description": "Read binary data from a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path to the file to read (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "FormField": {
+            "title": "Form Field",
+            "description": "A name-value pair for URL-encoded form data",
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "title": "Field Name",
+                "description": "The name of the form field",
+                "type": "string"
+              },
+              "value": {
+                "title": "Field Value",
+                "description": "The value of the form field (supports expressions)",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "MultipartPart": {
+            "title": "Multipart Part",
+            "description": "A part in a multipart/form-data request",
+            "oneOf": [
+              {
+                "title": "Text Field",
+                "description": "A text field in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "text"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the form field",
+                    "type": "string"
+                  },
+                  "value": {
+                    "title": "Field Value",
+                    "description": "The value of the form field (supports expressions)",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "title": "File Upload",
+                "description": "A file upload in the multipart form",
+                "type": "object",
+                "required": [
+                  "name",
+                  "source",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "name": {
+                    "title": "Field Name",
+                    "description": "The name of the file upload field",
+                    "type": "string"
+                  },
+                  "source": {
+                    "title": "File Source",
+                    "description": "Source of the file data (base64 or file path)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/BinarySource"
+                      }
+                    ]
+                  },
+                  "filename": {
+                    "title": "Filename",
+                    "description": "The filename to send in the Content-Disposition header",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "contentType": {
+                    "title": "Content Type",
+                    "description": "MIME type of the file",
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 }
               }
             ]
           },
-          "ResponseConfig": {
-            "title": "Response Configuration",
-            "description": "Configure how HTTP response data is stored and processed",
+          "TimeoutConfig": {
+            "title": "Timeout Configuration",
+            "description": "Configure connection and transfer timeouts for HTTP requests",
             "type": "object",
             "properties": {
-              "autoDetectEncoding": {
-                "title": "Auto Detect Encoding",
-                "description": "Automatically detect character encoding from response headers",
+              "connectionTimeout": {
+                "title": "Connection Timeout",
+                "description": "Maximum time in seconds to establish a connection (default: 60)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "transferTimeout": {
+                "title": "Transfer Timeout",
+                "description": "Maximum time in seconds to complete the entire request (default: 90)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            }
+          },
+          "HttpOptions": {
+            "title": "HTTP Options",
+            "description": "Configure HTTP client behavior",
+            "type": "object",
+            "properties": {
+              "userAgent": {
+                "title": "User Agent",
+                "description": "Custom User-Agent header value",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "verifySsl": {
+                "title": "Verify SSL",
+                "description": "Whether to verify SSL/TLS certificates (default: true)",
                 "type": [
                   "boolean",
                   "null"
                 ]
               },
-              "errorAttribute": {
-                "title": "Error Attribute",
-                "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
-                "default": "_http_error",
+              "followRedirects": {
+                "title": "Follow Redirects",
+                "description": "Whether to automatically follow HTTP redirects (default: true)",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
+              "maxRedirects": {
+                "title": "Max Redirects",
+                "description": "Maximum number of redirects to follow (default: 10)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint8",
+                "minimum": 0.0
+              }
+            }
+          },
+          "ResponseConfig": {
+            "title": "Response Configuration",
+            "description": "Configure how HTTP response data is stored and processed",
+            "type": "object",
+            "properties": {
+              "responseBodyAttribute": {
+                "title": "Response Body Attribute",
+                "description": "Feature attribute name to store the response body (default: \"_response_body\")",
+                "default": "_response_body",
+                "type": "string"
+              },
+              "statusCodeAttribute": {
+                "title": "Status Code Attribute",
+                "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
+                "default": "_http_status_code",
                 "type": "string"
               },
               "headersAttribute": {
@@ -6691,33 +6618,11 @@
                 "default": "_headers",
                 "type": "string"
               },
-              "maxResponseSize": {
-                "title": "Max Response Size",
-                "description": "Maximum response body size in bytes (unlimited if not set)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "responseBodyAttribute": {
-                "title": "Response Body Attribute",
-                "description": "Feature attribute name to store the response body (default: \"_response_body\")",
-                "default": "_response_body",
+              "errorAttribute": {
+                "title": "Error Attribute",
+                "description": "Feature attribute name to store any error messages (default: \"_http_error\")",
+                "default": "_http_error",
                 "type": "string"
-              },
-              "responseEncoding": {
-                "title": "Response Encoding",
-                "description": "How to encode the response body (text, base64, or binary)",
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/ResponseEncoding"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
               },
               "responseHandling": {
                 "title": "Response Handling",
@@ -6731,13 +6636,114 @@
                   }
                 ]
               },
-              "statusCodeAttribute": {
-                "title": "Status Code Attribute",
-                "description": "Feature attribute name to store the HTTP status code (default: \"_http_status_code\")",
-                "default": "_http_status_code",
-                "type": "string"
+              "maxResponseSize": {
+                "title": "Max Response Size",
+                "description": "Maximum response body size in bytes (unlimited if not set)",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "responseEncoding": {
+                "title": "Response Encoding",
+                "description": "How to encode the response body (text, base64, or binary)",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/ResponseEncoding"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "autoDetectEncoding": {
+                "title": "Auto Detect Encoding",
+                "description": "Automatically detect character encoding from response headers",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             }
+          },
+          "ResponseHandling": {
+            "title": "Response Handling",
+            "description": "How to handle the HTTP response data",
+            "oneOf": [
+              {
+                "title": "Store in Attribute",
+                "description": "Store response body in a feature attribute",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "attribute"
+                    ]
+                  }
+                }
+              },
+              {
+                "title": "Save to File",
+                "description": "Save response body to a file",
+                "type": "object",
+                "required": [
+                  "path",
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "file"
+                    ]
+                  },
+                  "path": {
+                    "title": "File Path",
+                    "description": "Path where the response should be saved",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr",
+                          "string"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "storePathInAttribute": {
+                    "title": "Store Path in Attribute",
+                    "description": "Whether to store the file path in a feature attribute",
+                    "type": [
+                      "boolean",
+                      "null"
+                    ]
+                  },
+                  "pathAttribute": {
+                    "title": "Path Attribute Name",
+                    "description": "Attribute name for storing the file path",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            ]
           },
           "ResponseEncoding": {
             "title": "Response Encoding",
@@ -6769,100 +6775,18 @@
               }
             ]
           },
-          "ResponseHandling": {
-            "title": "Response Handling",
-            "description": "How to handle the HTTP response data",
-            "oneOf": [
-              {
-                "title": "Store in Attribute",
-                "description": "Store response body in a feature attribute",
-                "type": "object",
-                "required": [
-                  "type"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "attribute"
-                    ]
-                  }
-                }
-              },
-              {
-                "title": "Save to File",
-                "description": "Save response body to a file",
-                "type": "object",
-                "required": [
-                  "path",
-                  "type"
-                ],
-                "properties": {
-                  "path": {
-                    "title": "File Path",
-                    "description": "Path where the response should be saved",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr",
-                          "string"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "pathAttribute": {
-                    "title": "Path Attribute Name",
-                    "description": "Attribute name for storing the file path",
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "storePathInAttribute": {
-                    "title": "Store Path in Attribute",
-                    "description": "Whether to store the file path in a feature attribute",
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "file"
-                    ]
-                  }
-                }
-              }
-            ]
-          },
           "RetryConfig": {
             "title": "Retry Configuration",
             "description": "Configure automatic retry behavior for failed requests",
             "type": "object",
             "properties": {
-              "backoffMultiplier": {
-                "title": "Backoff Multiplier",
-                "description": "Multiplier for exponential backoff between retries (default: 2.0)",
-                "default": 2.0,
-                "type": "number",
-                "format": "double"
-              },
-              "honorRetryAfter": {
-                "title": "Honor Retry-After Header",
-                "description": "Whether to respect the Retry-After header from server responses (default: true)",
-                "default": true,
-                "type": "boolean"
+              "maxAttempts": {
+                "title": "Max Attempts",
+                "description": "Maximum number of retry attempts (default: 3)",
+                "default": 3,
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
               },
               "initialDelayMs": {
                 "title": "Initial Delay",
@@ -6872,13 +6796,12 @@
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "maxAttempts": {
-                "title": "Max Attempts",
-                "description": "Maximum number of retry attempts (default: 3)",
-                "default": 3,
-                "type": "integer",
-                "format": "uint32",
-                "minimum": 0.0
+              "backoffMultiplier": {
+                "title": "Backoff Multiplier",
+                "description": "Multiplier for exponential backoff between retries (default: 2.0)",
+                "default": 2.0,
+                "type": "number",
+                "format": "double"
               },
               "maxDelayMs": {
                 "title": "Max Delay",
@@ -6900,33 +6823,47 @@
                   "format": "uint16",
                   "minimum": 0.0
                 }
+              },
+              "honorRetryAfter": {
+                "title": "Honor Retry-After Header",
+                "description": "Whether to respect the Retry-After header from server responses (default: true)",
+                "default": true,
+                "type": "boolean"
               }
             }
           },
-          "TimeoutConfig": {
-            "title": "Timeout Configuration",
-            "description": "Configure connection and transfer timeouts for HTTP requests",
+          "RateLimitConfig": {
+            "title": "Rate Limit Configuration",
+            "description": "Control the rate of HTTP requests to avoid overwhelming the server",
             "type": "object",
+            "required": [
+              "requests"
+            ],
             "properties": {
-              "connectionTimeout": {
-                "title": "Connection Timeout",
-                "description": "Maximum time in seconds to establish a connection (default: 60)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+              "requests": {
+                "title": "Requests",
+                "description": "Maximum number of requests allowed within the interval",
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "intervalMs": {
+                "title": "Interval",
+                "description": "Time interval in milliseconds for the rate limit (default: 1000ms)",
+                "default": 1000,
+                "type": "integer",
                 "format": "uint64",
                 "minimum": 0.0
               },
-              "transferTimeout": {
-                "title": "Transfer Timeout",
-                "description": "Maximum time in seconds to complete the entire request (default: 90)",
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint64",
-                "minimum": 0.0
+              "timing": {
+                "title": "Timing Strategy",
+                "description": "How to distribute requests within the interval (default: Burst)",
+                "default": "burst",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/TimingStrategy"
+                  }
+                ]
               }
             }
           },
@@ -6951,6 +6888,69 @@
                 ]
               }
             ]
+          },
+          "ObservabilityConfig": {
+            "title": "Observability Configuration",
+            "description": "Track additional metrics and diagnostics about HTTP requests",
+            "type": "object",
+            "properties": {
+              "trackDuration": {
+                "title": "Track Duration",
+                "description": "Whether to track the total request duration (default: true)",
+                "default": true,
+                "type": "boolean"
+              },
+              "durationAttribute": {
+                "title": "Duration Attribute",
+                "description": "Feature attribute name to store request duration in milliseconds",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackFinalUrl": {
+                "title": "Track Final URL",
+                "description": "Whether to track the final URL after redirects (default: false)",
+                "default": false,
+                "type": "boolean"
+              },
+              "finalUrlAttribute": {
+                "title": "Final URL Attribute",
+                "description": "Feature attribute name to store the final URL after redirects",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackRetryCount": {
+                "title": "Track Retry Count",
+                "description": "Whether to track the number of retry attempts (default: true)",
+                "default": true,
+                "type": "boolean"
+              },
+              "retryCountAttribute": {
+                "title": "Retry Count Attribute",
+                "description": "Feature attribute name to store the number of retry attempts",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "trackBytes": {
+                "title": "Track Bytes",
+                "description": "Whether to track the response body size in bytes (default: false)",
+                "default": false,
+                "type": "boolean"
+              },
+              "bytesAttribute": {
+                "title": "Bytes Attribute",
+                "description": "Feature attribute name to store the response body size",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
           }
         }
       },
@@ -7120,19 +7120,6 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "onOverlap": {
-            "title": "On Overlap",
-            "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
-            "default": null,
-            "anyOf": [
-              {
-                "$ref": "#/definitions/OnOverlap"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "saveTo": {
             "title": "Save To",
             "description": "Optional path expression to save the generated image. If not provided, uses default cache directory.",
@@ -7158,6 +7145,19 @@
                 "type": "string"
               }
             }
+          },
+          "onOverlap": {
+            "title": "On Overlap",
+            "description": "Strategy for resolving pixel overlap when multiple polygons cover the same pixel.",
+            "default": null,
+            "anyOf": [
+              {
+                "$ref": "#/definitions/OnOverlap"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7322,19 +7322,6 @@
               "jsonQuery"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
@@ -7353,10 +7340,23 @@
                 "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
                 "type": "string"
               },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7374,28 +7374,11 @@
               "path"
             ],
             "properties": {
-              "attributePrefix": {
-                "description": "Optional prefix for flattened attribute names",
-                "default": null,
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "flattenQueryResult": {
-                "description": "If true, flatten JSON object keys into feature attributes",
-                "default": false,
-                "type": "boolean"
-              },
               "inputSource": {
                 "type": "string",
                 "enum": [
                   "fileUrl"
                 ]
-              },
-              "jsonQuery": {
-                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
-                "type": "string"
               },
               "path": {
                 "description": "Expression evaluating to the file path or URL containing JSON",
@@ -7418,10 +7401,27 @@
                   }
                 }
               },
+              "jsonQuery": {
+                "description": "JSONPath expression to select elements (e.g., \"$[*]\", \"$.results[*]\")",
+                "type": "string"
+              },
+              "flattenQueryResult": {
+                "description": "If true, flatten JSON object keys into feature attributes",
+                "default": false,
+                "type": "boolean"
+              },
               "recursivelyFlatten": {
                 "description": "If true, recursively flatten nested objects using dot-separated keys",
                 "default": false,
                 "type": "boolean"
+              },
+              "attributePrefix": {
+                "description": "Optional prefix for flattened attribute names",
+                "default": null,
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "rejectNoFragments": {
                 "description": "If true, reject features that produce no fragments",
@@ -7537,6 +7537,27 @@
           "output"
         ],
         "properties": {
+          "output": {
+            "description": "Output path or expression for the JSON file to create",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "converter": {
             "description": "Optional converter expression to transform features before writing",
             "type": [
@@ -7553,27 +7574,6 @@
                 "type": "string",
                 "enum": [
                   "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "output": {
-            "description": "Output path or expression for the JSON file to create",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
                 ]
               },
               "value": {
@@ -7617,16 +7617,16 @@
               "$ref": "#/definitions/Attribute"
             }
           },
+          "tolerance": {
+            "type": "number",
+            "format": "double"
+          },
           "overlaidListsAttrName": {
             "description": "Name of the attribute to store the overlaid lists. Defaults to \"overlaidLists\".",
             "type": [
               "string",
               "null"
             ]
-          },
-          "tolerance": {
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -7665,14 +7665,6 @@
           "separateCharacter"
         ],
         "properties": {
-          "attribute": {
-            "description": "Attribute name to extract from each list element",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "list": {
             "description": "List attribute to read from",
             "allOf": [
@@ -7681,8 +7673,8 @@
               }
             ]
           },
-          "outputAttributeName": {
-            "description": "Name of the attribute to store the concatenated result",
+          "attribute": {
+            "description": "Attribute name to extract from each list element",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -7692,6 +7684,14 @@
           "separateCharacter": {
             "description": "Character(s) to use as separator between concatenated values",
             "type": "string"
+          },
+          "outputAttributeName": {
+            "description": "Name of the attribute to store the concatenated result",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
           }
         },
         "definitions": {
@@ -7768,6 +7768,20 @@
           "listIndexToCopy"
         ],
         "properties": {
+          "listAttribute": {
+            "description": "List attribute to read from",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "listIndexToCopy": {
+            "description": "Index of the list element to copy (0-based)",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0.0
+          },
           "copiedAttributePrefix": {
             "description": "Optional prefix to add to copied attribute names",
             "default": null,
@@ -7783,20 +7797,6 @@
               "string",
               "null"
             ]
-          },
-          "listAttribute": {
-            "description": "List attribute to read from",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "listIndexToCopy": {
-            "description": "Index of the list element to copy (0-based)",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0.0
           }
         },
         "definitions": {
@@ -7833,13 +7833,63 @@
           "output"
         ],
         "properties": {
-          "colonToUnderscore": {
-            "title": "Colon to Underscore",
-            "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
-            "type": [
-              "boolean",
-              "null"
-            ]
+          "output": {
+            "title": "Output",
+            "description": "Output directory path or expression for the generated MVT tiles",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "layerName": {
+            "title": "Layer Name",
+            "description": "Name of the layer within the MVT tiles",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minZoom": {
+            "title": "Minimum Zoom",
+            "description": "Minimum zoom level to generate tiles for",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "maxZoom": {
+            "title": "Maximum Zoom",
+            "description": "Maximum zoom level to generate tiles for",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
           },
           "compressOutput": {
             "title": "Compress Output",
@@ -7866,6 +7916,22 @@
               }
             }
           },
+          "skipUnexposedAttributes": {
+            "title": "Skip Unexposed Attributes",
+            "description": "Skip attributes with double underscore prefix",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "colonToUnderscore": {
+            "title": "Colon to Underscore",
+            "description": "Replace colons in attribute keys (e.g., from XML Namespaces) with underscores",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "extent": {
             "title": "Extent",
             "description": "MVT tile resolution. Default is 4096.",
@@ -7876,77 +7942,11 @@
             "format": "uint32",
             "minimum": 0.0
           },
-          "layerName": {
-            "title": "Layer Name",
-            "description": "Name of the layer within the MVT tiles",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "maxZoom": {
-            "title": "Maximum Zoom",
-            "description": "Maximum zoom level to generate tiles for",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "minZoom": {
-            "title": "Minimum Zoom",
-            "description": "Minimum zoom level to generate tiles for",
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "output": {
-            "title": "Output",
-            "description": "Output directory path or expression for the generated MVT tiles",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "schemaKey": {
             "title": "Schema Key",
             "description": "Attribute key to match data and schema features for attribute filtering and casting. This attribute is excluded from output.",
             "type": [
               "string",
-              "null"
-            ]
-          },
-          "skipUnexposedAttributes": {
-            "title": "Skip Unexposed Attributes",
-            "description": "Skip attributes with double underscore prefix",
-            "type": [
-              "boolean",
               "null"
             ]
           }
@@ -7975,6 +7975,39 @@
         "description": "Configuration for finding spatial neighbors between base and candidate features.",
         "type": "object",
         "properties": {
+          "numClosest": {
+            "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
+            "default": 1,
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1.0
+          },
+          "maxDistance": {
+            "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "distanceAttribute": {
+            "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
+            "default": "_neighbor_distance",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "neighborIndexAttribute": {
+            "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
+            "default": "_neighbor_index",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "attributePrefix": {
             "description": "Prefix applied to transferred candidate attributes to avoid collisions.",
             "default": "_neighbor_",
@@ -7988,12 +8021,12 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "distanceAttribute": {
-            "description": "Name of the attribute to store the computed distance to the nearest neighbor.",
-            "default": "_neighbor_distance",
+          "mergeStrategy": {
+            "description": "Controls how multiple neighbors are represented on the output.",
+            "default": "closest",
             "allOf": [
               {
-                "$ref": "#/definitions/Attribute"
+                "$ref": "#/definitions/MergeStrategy"
               }
             ]
           },
@@ -8005,70 +8038,11 @@
                 "$ref": "#/definitions/DistanceMetric"
               }
             ]
-          },
-          "maxDistance": {
-            "description": "Maximum distance threshold for matching. If None, no distance limit is applied. Units depend on the distanceMetric: native units for Euclidean, meters for Haversine.",
-            "type": [
-              "number",
-              "null"
-            ],
-            "format": "double"
-          },
-          "mergeStrategy": {
-            "description": "Controls how multiple neighbors are represented on the output.",
-            "default": "closest",
-            "allOf": [
-              {
-                "$ref": "#/definitions/MergeStrategy"
-              }
-            ]
-          },
-          "neighborIndexAttribute": {
-            "description": "Name of the attribute to store the neighbor index (0-based rank) when num_closest > 1 and merge_strategy is \"repeatBase\". Set to empty string to suppress.",
-            "default": "_neighbor_index",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "numClosest": {
-            "description": "Number of closest neighbors to find per base feature. Must be >= 1.",
-            "default": 1,
-            "type": "integer",
-            "format": "uint",
-            "minimum": 1.0
           }
         },
         "definitions": {
           "Attribute": {
             "type": "string"
-          },
-          "DistanceMetric": {
-            "description": "Distance metric for computing spatial proximity.",
-            "oneOf": [
-              {
-                "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
-                "type": "string",
-                "enum": [
-                  "euclidean2d"
-                ]
-              },
-              {
-                "description": "3D Euclidean distance using X, Y, and Z coordinates.",
-                "type": "string",
-                "enum": [
-                  "euclidean3d"
-                ]
-              },
-              {
-                "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
-                "type": "string",
-                "enum": [
-                  "haversine"
-                ]
-              }
-            ]
           },
           "MergeStrategy": {
             "description": "Merge strategy for handling multiple neighbors.",
@@ -8092,6 +8066,32 @@
                 "type": "string",
                 "enum": [
                   "arrayAttributes"
+                ]
+              }
+            ]
+          },
+          "DistanceMetric": {
+            "description": "Distance metric for computing spatial proximity.",
+            "oneOf": [
+              {
+                "description": "2D Euclidean distance using X and Y coordinates. Z is ignored.",
+                "type": "string",
+                "enum": [
+                  "euclidean2d"
+                ]
+              },
+              {
+                "description": "3D Euclidean distance using X, Y, and Z coordinates.",
+                "type": "string",
+                "enum": [
+                  "euclidean3d"
+                ]
+              },
+              {
+                "description": "Great-circle distance treating X as longitude (degrees) and Y as latitude (degrees). Output is in meters. Intended for WGS-84 inputs.\n\nNote: Distance is computed between representative points (centroids). For accurate results, input features should be relatively small (e.g., buildings, local roads). Large geometries (e.g., countries, large water bodies) may produce inaccurate distances because their centroids may not represent their spatial extent well.",
+                "type": "string",
+                "enum": [
+                  "haversine"
                 ]
               }
             ]
@@ -8155,10 +8155,6 @@
         "description": "NullAttributeMapper parameters",
         "type": "object",
         "properties": {
-          "defaultReplacement": {
-            "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
-            "default": null
-          },
           "mappings": {
             "description": "Per-attribute replacement rules",
             "default": [],
@@ -8166,6 +8162,10 @@
             "items": {
               "$ref": "#/definitions/AttributeMapping"
             }
+          },
+          "defaultReplacement": {
+            "description": "Fallback replacement for attributes not in mappings (when scope = \"all\")",
+            "default": null
           },
           "nullDefinition": {
             "description": "Which states count as \"null\"",
@@ -8205,6 +8205,9 @@
                 "description": "Name of the attribute to inspect",
                 "type": "string"
               },
+              "replacement": {
+                "description": "Value to write when attribute is null-like null means remove the attribute"
+              },
               "onMissing": {
                 "description": "What to do when attribute is missing but not in nullDefinition",
                 "default": "skip",
@@ -8213,11 +8216,27 @@
                     "$ref": "#/definitions/OnMissing"
                   }
                 ]
-              },
-              "replacement": {
-                "description": "Value to write when attribute is null-like null means remove the attribute"
               }
             }
+          },
+          "OnMissing": {
+            "description": "What to do when attribute is missing but not in nullDefinition",
+            "oneOf": [
+              {
+                "description": "Leave unchanged",
+                "type": "string",
+                "enum": [
+                  "skip"
+                ]
+              },
+              {
+                "description": "Write replacement value, creating the attribute",
+                "type": "string",
+                "enum": [
+                  "create"
+                ]
+              }
+            ]
           },
           "NullKind": {
             "description": "Defines what states count as \"null\"",
@@ -8241,25 +8260,6 @@
                 "type": "string",
                 "enum": [
                   "emptyString"
-                ]
-              }
-            ]
-          },
-          "OnMissing": {
-            "description": "What to do when attribute is missing but not in nullDefinition",
-            "oneOf": [
-              {
-                "description": "Leave unchanged",
-                "type": "string",
-                "enum": [
-                  "skip"
-                ]
-              },
-              {
-                "description": "Write replacement value, creating the attribute",
-                "type": "string",
-                "enum": [
-                  "create"
                 ]
               }
             ]
@@ -8311,67 +8311,11 @@
         "description": "Configuration for reading Wavefront OBJ 3D model files with support for vertices, faces, normals, texture coordinates, and material definitions.",
         "type": "object",
         "properties": {
-          "dataset": {
-            "title": "File Path",
-            "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "includeNormals": {
-            "title": "Include Normals",
-            "description": "Include vertex normal data in the output geometry",
+          "parseMaterials": {
+            "title": "Parse Materials",
+            "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
             "default": true,
             "type": "boolean"
-          },
-          "includeTexcoords": {
-            "title": "Include Texture Coordinates",
-            "description": "Include texture coordinate (UV) data in the output geometry",
-            "default": true,
-            "type": "boolean"
-          },
-          "inline": {
-            "title": "Inline Content",
-            "description": "Expression that returns the file content as text instead of reading from a file path",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "materialFile": {
             "title": "Material File",
@@ -8399,23 +8343,79 @@
               }
             }
           },
+          "triangulate": {
+            "title": "Triangulate",
+            "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
+            "default": false,
+            "type": "boolean"
+          },
           "mergeGroups": {
             "title": "Merge Groups",
             "description": "Merge all groups and objects into a single feature instead of creating separate features per group/object",
             "default": false,
             "type": "boolean"
           },
-          "parseMaterials": {
-            "title": "Parse Materials",
-            "description": "Enable parsing of material definitions from MTL files referenced in the OBJ file",
+          "includeNormals": {
+            "title": "Include Normals",
+            "description": "Include vertex normal data in the output geometry",
             "default": true,
             "type": "boolean"
           },
-          "triangulate": {
-            "title": "Triangulate",
-            "description": "Convert polygons with more than 3 vertices into triangles using fan triangulation",
-            "default": false,
+          "includeTexcoords": {
+            "title": "Include Texture Coordinates",
+            "description": "Include texture coordinate (UV) data in the output geometry",
+            "default": true,
             "type": "boolean"
+          },
+          "dataset": {
+            "title": "File Path",
+            "description": "Expression that returns the path to the input file (e.g., \"data.csv\" or variable reference)",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "inline": {
+            "title": "Inline Content",
+            "description": "Expression that returns the file content as text instead of reading from a file path",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         }
       },
@@ -8807,15 +8807,24 @@
         "title": "XmlAttributeExtractorParam",
         "type": "object",
         "properties": {
-          "addNsprefixToFeatureTypes": {
-            "type": [
-              "boolean",
-              "null"
-            ]
-          },
           "cityCode": {
             "type": [
               "string",
+              "null"
+            ]
+          },
+          "targetPackages": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "addNsprefixToFeatureTypes": {
+            "type": [
+              "boolean",
               "null"
             ]
           },
@@ -8839,15 +8848,6 @@
               "string",
               "null"
             ]
-          },
-          "targetPackages": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "type": "string"
-            }
           }
         }
       },
@@ -8931,10 +8931,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "File Index Attribute",
-            "description": "Attribute containing the file index (default: \"fileIndex\")",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "Part ID Attribute",
+            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -8951,10 +8951,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "Part ID Attribute",
-            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "File Index Attribute",
+            "description": "Attribute containing the file index (default: \"fileIndex\")",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -9092,6 +9092,16 @@
           "epsgCode"
         ],
         "properties": {
+          "errorAttribute": {
+            "title": "Error Attribute Name",
+            "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
+            "default": "_validation_error",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
           "epsgCode": {
             "title": "Target EPSG Code",
             "description": "EPSG code for coordinate transformation from source EPSG 6697. Accepts integer or string expression.",
@@ -9112,16 +9122,6 @@
                 "type": "string"
               }
             }
-          },
-          "errorAttribute": {
-            "title": "Error Attribute Name",
-            "description": "Attribute name to store validation error messages (default: \"_validation_error\")",
-            "default": "_validation_error",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
           }
         },
         "definitions": {
@@ -9178,6 +9178,20 @@
         "description": "Configure mesh code extraction for Japanese standard regional mesh",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "Mesh Type",
+            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "Mesh Code Attribute Name",
+            "description": "Output attribute name for the mesh code",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG Code",
             "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -9202,20 +9216,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "Mesh Type",
-            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "Mesh Code Attribute Name",
-            "description": "Output attribute name for the mesh code",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -9333,17 +9333,6 @@
         "description": "Configuration for generating TIN surfaces from flood area polygons. This processor converts polygons to triangulated surfaces by: 1. Optionally grouping features by an attribute (e.g., udxDirs) 2. Combining all polygons in each group 3. Sampling points along polygon boundaries at regular intervals 4. Optionally adding interior grid points within polygons 5. Performing Delaunay triangulation to create a TIN surface 6. Filtering triangles to keep only those inside the original polygons",
         "type": "object",
         "properties": {
-          "groupBy": {
-            "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "pointSpacing": {
             "description": "Spacing between sampled points in meters (default: 50.0). Points are sampled along polygon boundaries and optionally on an interior grid at this spacing interval.",
             "type": [
@@ -9358,6 +9347,17 @@
             "type": [
               "boolean",
               "null"
+            ]
+          },
+          "groupBy": {
+            "description": "Attribute name to group features by before combining and triangulating. Features with the same value for this attribute will be processed together. If not specified, each feature is processed individually.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -9556,21 +9556,6 @@
           "outputDir"
         ],
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
-            "default": null,
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "measurements": {
-            "description": "Measurement definitions to insert as gen:measureAttribute elements",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/MeasurementDef"
-            }
-          },
           "outputDir": {
             "description": "Output directory expression for modified CityGML files",
             "type": "object",
@@ -9592,6 +9577,14 @@
               }
             }
           },
+          "gmlIdAttribute": {
+            "description": "Attribute name on element features holding gml:id (default: \"gmlId\")",
+            "default": null,
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "pathAttribute": {
             "description": "Attribute name on path features holding the file path (default: \"path\")",
             "default": null,
@@ -9600,28 +9593,11 @@
               "null"
             ]
           },
-          "sourceEpsg": {
-            "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
-            "default": null,
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
+          "measurements": {
+            "description": "Measurement definitions to insert as gen:measureAttribute elements",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MeasurementDef"
             }
           },
           "textureImagePath": {
@@ -9648,6 +9624,30 @@
                 "type": "string"
               }
             }
+          },
+          "sourceEpsg": {
+            "description": "The projected CRS EPSG code used for rasterization (needed for UV computation)",
+            "default": null,
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
           }
         },
         "definitions": {
@@ -9660,12 +9660,12 @@
               "uom"
             ],
             "properties": {
-              "attribute": {
-                "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
-                "type": "string"
-              },
               "name": {
                 "description": "XML name attribute value (e.g. \"年間予測日射量\")",
+                "type": "string"
+              },
+              "attribute": {
+                "description": "Feature attribute key holding the numeric value (e.g. \"totalSolarRadiation\")",
                 "type": "string"
               },
               "uom": {
@@ -9706,63 +9706,11 @@
               "type"
             ],
             "properties": {
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
+              "type": {
+                "type": "string",
+                "enum": [
+                  "time"
                 ]
-              },
-              "sourceEpsg": {
-                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "standardMeridian": {
-                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
-                "default": null,
-                "type": [
-                  "object",
-                  "null"
-                ],
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
               },
               "time": {
                 "description": "Time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
@@ -9785,60 +9733,6 @@
                   }
                 }
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "time"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
-            "required": [
-              "end",
-              "sourceEpsg",
-              "start",
-              "step",
-              "stepUnit",
-              "type"
-            ],
-            "properties": {
-              "end": {
-                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr",
-                      "string"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
-              },
-              "outputBelowHorizon": {
-                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
-                "default": false,
-                "type": "boolean"
-              },
-              "outputType": {
-                "description": "Output type: unit normal vector or altitude/azimuth angles",
-                "default": "unitNormalVector",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/OutputType"
-                  }
-                ]
-              },
               "sourceEpsg": {
                 "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
                 "type": "object",
@@ -9883,8 +9777,62 @@
                   }
                 }
               },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
+                ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "end",
+              "sourceEpsg",
+              "start",
+              "step",
+              "stepUnit",
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "duration"
+                ]
+              },
               "start": {
                 "description": "Start time expression evaluating to RFC 3339 format (e.g., \"2025-01-11T00:00:00Z\") or date-only format (e.g., \"2025-01-11\" or \"2025-01-11+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr",
+                      "string"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "end": {
+                "description": "End time expression evaluating to RFC 3339 format (e.g., \"2025-01-12T00:00:00Z\") or date-only format (e.g., \"2025-01-12\" or \"2025-01-12+09:00\"). When hours, minutes, and seconds are omitted they default to zero.",
                 "type": "object",
                 "format": "code",
                 "required": [
@@ -9932,11 +9880,63 @@
                   }
                 ]
               },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "duration"
+              "sourceEpsg": {
+                "description": "Source EPSG code expression (required). Evaluates to int (e.g., 6677 for Japan Plane IX).",
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "standardMeridian": {
+                "description": "Standard meridian in degrees (optional). If not provided, computed as round(longitude / 15) * 15.",
+                "default": null,
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "outputType": {
+                "description": "Output type: unit normal vector or altitude/azimuth angles",
+                "default": "unitNormalVector",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/OutputType"
+                  }
                 ]
+              },
+              "outputBelowHorizon": {
+                "description": "Whether to output sun positions below the horizon (altitude < 0). Default: false.",
+                "default": false,
+                "type": "boolean"
               }
             }
           }
@@ -10001,9 +10001,9 @@
         "title": "SolidIntersectionTestPairCreatorParam",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10011,9 +10011,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10180,6 +10180,12 @@
         "description": "Configure unshared edge detection behavior",
         "type": "object",
         "properties": {
+          "tolerance": {
+            "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
+            "default": 0.1,
+            "type": "number",
+            "format": "double"
+          },
           "groupBy": {
             "description": "Group By Attributes. When specified, edge detection is performed independently within each group. Features with the same values for these attributes are grouped together.",
             "default": null,
@@ -10190,12 +10196,6 @@
             "items": {
               "$ref": "#/definitions/Attribute"
             }
-          },
-          "tolerance": {
-            "description": "Tolerance for edge matching in meters (default: 0.1) Edges within this distance are considered the same edge",
-            "default": 0.1,
-            "type": "number",
-            "format": "double"
           }
         },
         "definitions": {
@@ -10236,10 +10236,10 @@
               }
             ]
           },
-          "fileIndexAttribute": {
-            "title": "File Index Attribute",
-            "description": "Attribute containing the file index (default: \"fileIndex\")",
-            "default": "fileIndex",
+          "partIdAttribute": {
+            "title": "Part ID Attribute",
+            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
+            "default": "featureId",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10256,10 +10256,10 @@
               }
             ]
           },
-          "partIdAttribute": {
-            "title": "Part ID Attribute",
-            "description": "Attribute containing the BuildingPart ID (default: \"featureId\")",
-            "default": "featureId",
+          "fileIndexAttribute": {
+            "title": "File Index Attribute",
+            "description": "Attribute containing the file index (default: \"fileIndex\")",
+            "default": "fileIndex",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -10345,6 +10345,20 @@
         "description": "Configure mesh code extraction for Japanese standard regional mesh",
         "type": "object",
         "properties": {
+          "meshType": {
+            "title": "Mesh Type",
+            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
+            "default": 3,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0.0
+          },
+          "meshcodeAttr": {
+            "title": "Mesh Code Attribute Name",
+            "description": "Output attribute name for the mesh code",
+            "default": "_meshcode",
+            "type": "string"
+          },
           "epsgCode": {
             "title": "EPSG Code",
             "description": "Japanese Plane Rectangular Coordinate System EPSG code for area calculation",
@@ -10369,20 +10383,6 @@
                 "type": "string"
               }
             }
-          },
-          "meshType": {
-            "title": "Mesh Type",
-            "description": "Japanese standard mesh type: 1=80km, 2=10km, 3=1km, 4=500m, 5=250m, 6=125m",
-            "default": 3,
-            "type": "integer",
-            "format": "uint8",
-            "minimum": 0.0
-          },
-          "meshcodeAttr": {
-            "title": "Mesh Code Attribute Name",
-            "description": "Output attribute name for the mesh code",
-            "default": "_meshcode",
-            "type": "string"
           }
         }
       },
@@ -10532,9 +10532,9 @@
         "title": "SolidIntersectionTestPairCreatorParam",
         "type": "object",
         "properties": {
-          "gmlIdAttribute": {
-            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
-            "default": "gmlId",
+          "pairIdAttribute": {
+            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
+            "default": "pair_id",
             "type": "string"
           },
           "listAttribute": {
@@ -10542,9 +10542,9 @@
             "default": "list",
             "type": "string"
           },
-          "pairIdAttribute": {
-            "description": "Attribute name to store the pair ID (default: \"pair_id\")",
-            "default": "pair_id",
+          "gmlIdAttribute": {
+            "description": "Attribute name for the GML ID within the list items (default: \"gmlId\")",
+            "default": "gmlId",
             "type": "string"
           }
         }
@@ -10763,6 +10763,31 @@
         "title": "PythonScriptProcessorParam",
         "type": "object",
         "properties": {
+          "script": {
+            "title": "Inline Script",
+            "description": "Python script code to execute inline",
+            "type": [
+              "object",
+              "null"
+            ],
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr",
+                  "string"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "pythonFile": {
             "title": "Python File",
             "description": "Path to a Python script file (supports file://, http://, https://, gs://, etc.)",
@@ -10795,31 +10820,6 @@
               "string",
               "null"
             ]
-          },
-          "script": {
-            "title": "Inline Script",
-            "description": "Python script code to execute inline",
-            "type": [
-              "object",
-              "null"
-            ],
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr",
-                  "string"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
           },
           "timeoutSeconds": {
             "title": "Timeout Seconds",
@@ -10860,6 +10860,34 @@
           "ray"
         ],
         "properties": {
+          "ray": {
+            "description": "Defines how to extract ray data from feature attributes",
+            "allOf": [
+              {
+                "$ref": "#/definitions/RayDefinition"
+              }
+            ]
+          },
+          "pairId": {
+            "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
           "closestIntersectionOnly": {
             "description": "When true (default), return only the closest intersection point per ray-geometry pair. When false, return all intersection points.",
             "default": null,
@@ -10884,8 +10912,8 @@
               }
             }
           },
-          "geomId": {
-            "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
+          "tolerance": {
+            "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
             "default": null,
             "type": [
               "object",
@@ -10941,36 +10969,8 @@
               }
             ]
           },
-          "pairId": {
-            "description": "Expression that evaluates to a pair ID (int or string) for grouping rays with geometries. Only rays and geometries with matching pairId values are tested against each other.",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "ray": {
-            "description": "Defines how to extract ray data from feature attributes",
-            "allOf": [
-              {
-                "$ref": "#/definitions/RayDefinition"
-              }
-            ]
-          },
-          "tolerance": {
-            "description": "Tolerance for intersection calculations (evaluates to f64). If not specified, a default tolerance is used.",
+          "geomId": {
+            "description": "Expression evaluated on geometry features to extract an ID string. When set, intersection features will include a `geom_id` attribute identifying which geometry was hit.",
             "default": null,
             "type": [
               "object",
@@ -10995,28 +10995,6 @@
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
-          "OutputGeometryType": {
-            "description": "Output geometry type for ray intersection results",
-            "oneOf": [
-              {
-                "description": "Output a point at the intersection location (default behavior)",
-                "type": "string",
-                "enum": [
-                  "pointOfIntersection"
-                ]
-              },
-              {
-                "description": "Output a line segment from ray origin to intersection point",
-                "type": "string",
-                "enum": [
-                  "lineSegmentToIntersection"
-                ]
-              }
-            ]
-          },
           "RayDefinition": {
             "description": "Defines how ray data is extracted from feature attributes.",
             "type": "object",
@@ -11029,30 +11007,6 @@
               "posZ"
             ],
             "properties": {
-              "dirX": {
-                "description": "Attribute containing ray direction X component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirY": {
-                "description": "Attribute containing ray direction Y component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
-              "dirZ": {
-                "description": "Attribute containing ray direction Z component",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
-              },
               "posX": {
                 "description": "Attribute containing ray origin X coordinate",
                 "allOf": [
@@ -11076,8 +11030,54 @@
                     "$ref": "#/definitions/Attribute"
                   }
                 ]
+              },
+              "dirX": {
+                "description": "Attribute containing ray direction X component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirY": {
+                "description": "Attribute containing ray direction Y component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
+              "dirZ": {
+                "description": "Attribute containing ray direction Z component",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
               }
             }
+          },
+          "Attribute": {
+            "type": "string"
+          },
+          "OutputGeometryType": {
+            "description": "Output geometry type for ray intersection results",
+            "oneOf": [
+              {
+                "description": "Output a point at the intersection location (default behavior)",
+                "type": "string",
+                "enum": [
+                  "pointOfIntersection"
+                ]
+              },
+              {
+                "description": "Output a line segment from ray origin to intersection point",
+                "type": "string",
+                "enum": [
+                  "lineSegmentToIntersection"
+                ]
+              }
+            ]
           }
         }
       },
@@ -11160,6 +11160,12 @@
                   "type"
                 ],
                 "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fromToVectors"
+                    ]
+                  },
                   "fromX": {
                     "description": "X component of the source direction vector",
                     "type": "object",
@@ -11279,12 +11285,6 @@
                         "type": "string"
                       }
                     }
-                  },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "fromToVectors"
-                    ]
                   }
                 }
               },
@@ -11299,25 +11299,11 @@
                   "type"
                 ],
                 "properties": {
-                  "angle": {
-                    "description": "Rotation angle in degrees",
-                    "type": "object",
-                    "format": "code",
-                    "required": [
-                      "type",
-                      "value"
-                    ],
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "flowExpr"
-                        ]
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "axisAngle"
+                    ]
                   },
                   "axisX": {
                     "description": "X component of the rotation axis",
@@ -11379,11 +11365,25 @@
                       }
                     }
                   },
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "axisAngle"
-                    ]
+                  "angle": {
+                    "description": "Rotation angle in degrees",
+                    "type": "object",
+                    "format": "code",
+                    "required": [
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "flowExpr"
+                        ]
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }
@@ -11414,6 +11414,20 @@
         "description": "Configuration for reading Shapefile archives as geographic features. Expects a ZIP archive containing the required Shapefile components (.shp, .dbf, .shx).",
         "type": "object",
         "properties": {
+          "encoding": {
+            "title": "Character Encoding",
+            "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "force2d": {
+            "title": "Force 2D",
+            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
+            "default": false,
+            "type": "boolean"
+          },
           "allowEmptyPath": {
             "title": "Allow Null Path",
             "description": "If true, a dataset expression that evaluates to null produces zero features instead of an error. This is useful for optional shapefile inputs where the path may not be configured.",
@@ -11444,20 +11458,6 @@
                 "type": "string"
               }
             }
-          },
-          "encoding": {
-            "title": "Character Encoding",
-            "description": "Character encoding for attribute data in the DBF file. If not specified, encoding is determined from the .cpg file (if present), otherwise defaults to UTF-8.\n\nSupported encodings include: - **UTF-8** - Unicode UTF-8 (default, recommended for all new shapefiles) - **Windows Code Pages** - Windows-1250 through Windows-1258, Windows-874 - **ISO-8859 family** - ISO-8859-1 (Latin-1) through ISO-8859-16 - **Asian encodings** - Shift-JIS, EUC-JP, EUC-KR, Big5, GBK, GB18030 - **Other legacy encodings** - KOI8-R, KOI8-U, IBM866, Macintosh\n\nAll encoding labels are case-insensitive and support common variations (e.g., \"UTF-8\", \"UTF8\", \"utf8\" all work).\n\nUTF-16 is not supported due to byte-level handling requirements. If a UTF-16 shapefile is encountered, an error with conversion instructions is returned.\n\nExamples: - `\"UTF-8\"` - Modern standard - `\"Windows-1252\"` - Common for Western European legacy data - `\"ISO-8859-1\"` - Latin-1, common in older shapefiles - `\"Shift-JIS\"` - Japanese data\n\nPriority order: encoding parameter > .cpg file > UTF-8 default",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "force2d": {
-            "title": "Force 2D",
-            "description": "If true, forces all geometries to be 2D (ignoring Z values)",
-            "default": false,
-            "type": "boolean"
           },
           "inline": {
             "title": "Inline Content",
@@ -11511,16 +11511,6 @@
           "output"
         ],
         "properties": {
-          "groupBy": {
-            "description": "Optional attributes to group features by, creating separate files for each group",
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/definitions/Attribute"
-            }
-          },
           "output": {
             "description": "Output path or expression for the Shapefile to create",
             "type": "object",
@@ -11540,6 +11530,16 @@
               "value": {
                 "type": "string"
               }
+            }
+          },
+          "groupBy": {
+            "description": "Optional attributes to group features by, creating separate files for each group",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/definitions/Attribute"
             }
           }
         },
@@ -11621,20 +11621,21 @@
         "description": "Configure spatial relationship testing between filter and candidate geometries",
         "type": "object",
         "properties": {
-          "mergeFilterAttributes": {
-            "title": "Merge Filter Attributes",
-            "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
-            "default": false,
-            "type": "boolean"
-          },
-          "mergedAttributesPrefix": {
-            "title": "Merged Attributes Prefix",
-            "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
-            "default": null,
-            "type": [
-              "string",
-              "null"
+          "predicate": {
+            "title": "Spatial Predicate",
+            "description": "The spatial relationship to test between filter and candidate geometries",
+            "default": "intersects",
+            "allOf": [
+              {
+                "$ref": "#/definitions/SpatialPredicate"
+              }
             ]
+          },
+          "passOnMultipleMatches": {
+            "title": "Pass on Multiple Matches",
+            "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
+            "default": true,
+            "type": "boolean"
           },
           "outputMatchCountAttribute": {
             "title": "Output Match Count Attribute",
@@ -11649,27 +11650,23 @@
               }
             ]
           },
-          "passOnMultipleMatches": {
-            "title": "Pass on Multiple Matches",
-            "description": "If true, pass if ANY filter matches (OR logic). If false, pass only if ALL filters match (AND logic).",
-            "default": true,
+          "mergeFilterAttributes": {
+            "title": "Merge Filter Attributes",
+            "description": "If true, copy attributes from matched filter feature(s) onto the candidate. Only applies to features routed to the passed port. In OR mode (pass_on_multiple_matches: true), only the first matching filter's attributes are merged. In AND mode, attributes from all matched filters are merged in order; if multiple filters share a key, the last filter's value wins.",
+            "default": false,
             "type": "boolean"
           },
-          "predicate": {
-            "title": "Spatial Predicate",
-            "description": "The spatial relationship to test between filter and candidate geometries",
-            "default": "intersects",
-            "allOf": [
-              {
-                "$ref": "#/definitions/SpatialPredicate"
-              }
+          "mergedAttributesPrefix": {
+            "title": "Merged Attributes Prefix",
+            "description": "Optional prefix applied to merged filter attribute names to avoid collisions. For example, a prefix of \"filter_\" turns a filter attribute \"zone\" into \"filter_zone\".",
+            "default": null,
+            "type": [
+              "string",
+              "null"
             ]
           }
         },
         "definitions": {
-          "Attribute": {
-            "type": "string"
-          },
           "SpatialPredicate": {
             "oneOf": [
               {
@@ -11736,6 +11733,9 @@
                 ]
               }
             ]
+          },
+          "Attribute": {
+            "type": "string"
           }
         }
       },
@@ -11768,9 +11768,9 @@
           "sql"
         ],
         "properties": {
-          "databaseUrl": {
-            "title": "Database URL",
-            "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
+          "sql": {
+            "title": "SQL Query",
+            "description": "SQL query expression to execute for retrieving data",
             "type": "object",
             "format": "code",
             "required": [
@@ -11790,9 +11790,9 @@
               }
             }
           },
-          "sql": {
-            "title": "SQL Query",
-            "description": "SQL query expression to execute for retrieving data",
+          "databaseUrl": {
+            "title": "Database URL",
+            "description": "Database connection URL (e.g. `sqlite:///tests/sqlite/sqlite.db`, `mysql://user:password@localhost:3306/db`, `postgresql://user:password@localhost:5432/db`)",
             "type": "object",
             "format": "code",
             "required": [
@@ -11839,13 +11839,17 @@
           "calculations"
         ],
         "properties": {
-          "calculations": {
-            "title": "Calculations",
-            "description": "List of statistical calculations to perform on grouped features",
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/Calculation"
-            }
+          "groupId": {
+            "title": "Group id",
+            "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "groupBy": {
             "title": "Group by",
@@ -11858,17 +11862,13 @@
               "$ref": "#/definitions/Attribute"
             }
           },
-          "groupId": {
-            "title": "Group id",
-            "description": "Optional attribute to store the group identifier. The ID will be formed by concatenating the values of the group_by attributes separated by '|'.",
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              },
-              {
-                "type": "null"
-              }
-            ]
+          "calculations": {
+            "title": "Calculations",
+            "description": "List of statistical calculations to perform on grouped features",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Calculation"
+            }
           }
         },
         "definitions": {
@@ -11882,6 +11882,14 @@
               "newAttribute"
             ],
             "properties": {
+              "newAttribute": {
+                "title": "New attribute name",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Attribute"
+                  }
+                ]
+              },
               "expr": {
                 "title": "Calculation to perform",
                 "type": "object",
@@ -11901,14 +11909,6 @@
                     "type": "string"
                   }
                 }
-              },
-              "newAttribute": {
-                "title": "New attribute name",
-                "allOf": [
-                  {
-                    "$ref": "#/definitions/Attribute"
-                  }
-                ]
               }
             }
           }
@@ -11948,33 +11948,6 @@
           "minZ"
         ],
         "properties": {
-          "maxX": {
-            "title": "Maximum X Attribute",
-            "description": "Name of attribute containing the maximum X coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxY": {
-            "title": "Maximum Y Attribute",
-            "description": "Name of attribute containing the maximum Y coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
-          "maxZ": {
-            "title": "Maximum Z Attribute",
-            "description": "Name of attribute containing the maximum Z coordinate",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Attribute"
-              }
-            ]
-          },
           "minX": {
             "title": "Minimum X Attribute",
             "description": "Name of attribute containing the minimum X coordinate",
@@ -11996,6 +11969,33 @@
           "minZ": {
             "title": "Minimum Z Attribute",
             "description": "Name of attribute containing the minimum Z coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxX": {
+            "title": "Maximum X Attribute",
+            "description": "Name of attribute containing the maximum X coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxY": {
+            "title": "Maximum Y Attribute",
+            "description": "Name of attribute containing the maximum Y coordinate",
+            "allOf": [
+              {
+                "$ref": "#/definitions/Attribute"
+              }
+            ]
+          },
+          "maxZ": {
+            "title": "Maximum Z Attribute",
+            "description": "Name of attribute containing the maximum Z coordinate",
             "allOf": [
               {
                 "$ref": "#/definitions/Attribute"
@@ -12135,69 +12135,6 @@
               }
             }
           },
-          "directionX": {
-            "title": "Direction X",
-            "description": "X component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionY": {
-            "title": "Direction Y",
-            "description": "Y component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
-          "directionZ": {
-            "title": "Direction Z",
-            "description": "Z component of the rotation axis direction vector",
-            "type": "object",
-            "format": "code",
-            "required": [
-              "type",
-              "value"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "flowExpr"
-                ]
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          },
           "originX": {
             "title": "Origin X",
             "description": "X coordinate of the rotation origin point",
@@ -12243,6 +12180,69 @@
           "originZ": {
             "title": "Origin Z",
             "description": "Z coordinate of the rotation origin point",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionX": {
+            "title": "Direction X",
+            "description": "X component of the rotation axis direction vector",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionY": {
+            "title": "Direction Y",
+            "description": "Y component of the rotation axis direction vector",
+            "type": "object",
+            "format": "code",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "flowExpr"
+                ]
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "directionZ": {
+            "title": "Direction Z",
+            "description": "Z component of the rotation axis direction vector",
             "type": "object",
             "format": "code",
             "required": [
@@ -12419,27 +12419,11 @@
               "source"
             ],
             "properties": {
-              "attribute": {
-                "$ref": "#/definitions/Attribute"
-              },
-              "elementsToExclude": {
-                "type": "object",
-                "format": "code",
-                "required": [
-                  "type",
-                  "value"
-                ],
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "flowExpr"
-                    ]
-                  },
-                  "value": {
-                    "type": "string"
-                  }
-                }
+              "source": {
+                "type": "string",
+                "enum": [
+                  "url"
+                ]
               },
               "elementsToMatch": {
                 "type": "object",
@@ -12460,11 +12444,27 @@
                   }
                 }
               },
-              "source": {
-                "type": "string",
-                "enum": [
-                  "url"
-                ]
+              "elementsToExclude": {
+                "type": "object",
+                "format": "code",
+                "required": [
+                  "type",
+                  "value"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "flowExpr"
+                    ]
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              },
+              "attribute": {
+                "$ref": "#/definitions/Attribute"
               }
             }
           }
@@ -12517,19 +12517,19 @@
           "Attribute": {
             "type": "string"
           },
+          "XmlInputType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "text"
+            ]
+          },
           "ValidationType": {
             "type": "string",
             "enum": [
               "syntax",
               "syntaxAndNamespace",
               "syntaxAndSchema"
-            ]
-          },
-          "XmlInputType": {
-            "type": "string",
-            "enum": [
-              "file",
-              "text"
             ]
           }
         }

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.64"
+version = "0.2.65"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.254"
+version = "0.1.255"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Overview

Enables the `preserve_order` feature on schemars so that generated action parameter schemas keep the Rust struct declaration order in their `properties` objects, instead of being alphabetized by schemars' internal BTreeMap.

## What changed

- `engine/Cargo.toml`: one-line feature addition (`preserve_order`) on schemars — this swaps its internal map to an insertion-ordered IndexMap
- All regenerated artifacts (`actions.json`, 5 language files, mdbook `action.md`): **key ordering changes only** — verified programmatically that content is identical to the previous generation for every action in all 6 schema files
- 62 actions now expose non-alphabetical (declaration) parameter order

## Why

This is a precursor to the action quality improvement PRs (see `engine/dev-docs/action-review-findings.md`). The Action Standard §3.5 requires parameters to be ordered by usability — required first, common optional next, edge-case optional last — which is impossible while the generator alphabetizes properties. Landing this separately keeps the mechanical reordering diff out of the content PRs.

## Verification

- Programmatic diff of old vs new JSON (order-insensitive) — identical content for all 155 actions × 6 files
- `cargo make clippy` — clean workspace-wide