### PR TITLE
test(web): record video for manually created e2e session contexts

### DIFF
--- a/ui/e2e/fixtures/session.ts
+++ b/ui/e2e/fixtures/session.ts
@@ -25,8 +25,6 @@ export type EditorSession = {
 export async function newEditorSession(
   browser: Browser,
 ): Promise<EditorSession> {
-  // Manually created contexts don't inherit `use.video` from the config, so
-  // recording must be enabled here explicitly.
   const context = await browser.newContext({
     storageState: STORAGE_STATE,
     baseURL: process.env.FLOW_DASHBOARD_E2E_BASEURL,
@@ -64,20 +62,18 @@ export async function teardownSession(
       await deployments.goto();
       await deployments
         .deleteDeploymentIfExists(opts.deploymentDescription)
-        .catch(() => {});
+        .catch(() => { });
     }
     if (opts.projectName) {
       await projects.goto();
-      await projects.deleteProjectIfExists(opts.projectName).catch(() => {});
+      await projects.deleteProjectIfExists(opts.projectName).catch(() => { });
     }
     for (const name of opts.assetNames ?? []) {
       if (!name) continue;
       await assets.goto();
-      await assets.deleteAssetIfExists(name).catch(() => {});
+      await assets.deleteAssetIfExists(name).catch(() => { });
     }
   } finally {
-    // The video file is only fully written once the context is closed, so it
-    // has to be attached afterwards (it lands in the suite's Tear down section).
     await context.close();
     if (video) {
       const videoPath = await video.path().catch(() => undefined);
@@ -85,7 +81,7 @@ export async function teardownSession(
         await test
           .info()
           .attach("video", { path: videoPath, contentType: "video/webm" })
-          .catch(() => {});
+          .catch(() => { });
       }
     }
   }

--- a/ui/e2e/fixtures/session.ts
+++ b/ui/e2e/fixtures/session.ts
@@ -1,4 +1,11 @@
-import type { Browser, BrowserContext, Page } from "@playwright/test";
+import path from "path";
+
+import {
+  test,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
 
 import { AssetsPage } from "../pages/assetsPage";
 import { DeploymentsPage } from "../pages/deploymentsPage";
@@ -18,11 +25,17 @@ export type EditorSession = {
 export async function newEditorSession(
   browser: Browser,
 ): Promise<EditorSession> {
+  // Manually created contexts don't inherit `use.video` from the config, so
+  // recording must be enabled here explicitly.
   const context = await browser.newContext({
     storageState: STORAGE_STATE,
     baseURL: process.env.FLOW_DASHBOARD_E2E_BASEURL,
     viewport: { width: 1920, height: 1080 },
     locale: "en-US",
+    recordVideo: {
+      dir: path.join(__dirname, "../test-results/session-videos"),
+      size: { width: 1920, height: 1080 },
+    },
   });
   const page = await context.newPage();
   return {
@@ -44,7 +57,8 @@ export async function teardownSession(
   } = {},
 ) {
   if (!session) return;
-  const { context, assets, projects, deployments } = session;
+  const { context, page, assets, projects, deployments } = session;
+  const video = page.video();
   try {
     if (opts.deploymentDescription) {
       await deployments.goto();
@@ -62,6 +76,17 @@ export async function teardownSession(
       await assets.deleteAssetIfExists(name).catch(() => {});
     }
   } finally {
+    // The video file is only fully written once the context is closed, so it
+    // has to be attached afterwards (it lands in the suite's Tear down section).
     await context.close();
+    if (video) {
+      const videoPath = await video.path().catch(() => undefined);
+      if (videoPath) {
+        await test
+          .info()
+          .attach("video", { path: videoPath, contentType: "video/webm" })
+          .catch(() => {});
+      }
+    }
   }
 }

--- a/ui/e2e/fixtures/session.ts
+++ b/ui/e2e/fixtures/session.ts
@@ -62,16 +62,16 @@ export async function teardownSession(
       await deployments.goto();
       await deployments
         .deleteDeploymentIfExists(opts.deploymentDescription)
-        .catch(() => { });
+        .catch(() => {});
     }
     if (opts.projectName) {
       await projects.goto();
-      await projects.deleteProjectIfExists(opts.projectName).catch(() => { });
+      await projects.deleteProjectIfExists(opts.projectName).catch(() => {});
     }
     for (const name of opts.assetNames ?? []) {
       if (!name) continue;
       await assets.goto();
-      await assets.deleteAssetIfExists(name).catch(() => { });
+      await assets.deleteAssetIfExists(name).catch(() => {});
     }
   } finally {
     await context.close();
@@ -81,7 +81,7 @@ export async function teardownSession(
         await test
           .info()
           .attach("video", { path: videoPath, contentType: "video/webm" })
-          .catch(() => { });
+          .catch(() => {});
       }
     }
   }


### PR DESCRIPTION
# Overview
Contexts created via browser.newContext() in newEditorSession don't inherit `use.video` from the Playwright config, so the UI-built pipeline suites had no video attachments in the Allure report. Enable recordVideo explicitly and attach the video on session teardown.

## What I've done

## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
