### PR TITLE
feat(engine): file-level srsName/EPSG implementation in new CityGML reader and cesium writer

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "futures",
  "once_cell",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "approx",
  "async-trait",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "Inflector",
  "approx",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "bytes",
  "clap",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "approx",
  "bvh",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "bytes",
  "futures",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "bytes",
  "futures",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "ahash",
  "bytes",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.435"
+version = "0.0.436"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/citygml_parser/appearance.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/appearance.rs
@@ -786,7 +786,7 @@ fn target_key(reference: &str, base: &Url) -> Option<SurfaceKey> {
 
 #[cfg(test)]
 mod tests {
-    use crate::citygml_parser::parser::Parser;
+    use crate::citygml_parser::parser::{Parser, ParserOutput};
     use crate::citygml_parser::resolver::resolve_root;
     use reearth_flow_geometry::appearance::{
         Appearance, Material, Sampler, Side, ThemeId, UvSet, UvSource, WrapMode,
@@ -817,7 +817,14 @@ mod tests {
         parser
             .parse(xml.as_bytes(), &Url::parse("file:///dir/test.gml").unwrap())
             .unwrap();
-        let (pending, raw_registry, geom_registry, appearance_members, srs, _ns) = parser.finish();
+        let ParserOutput {
+            pending,
+            raw_registry,
+            geom_registry,
+            appearance_members,
+            srs_by_file: srs,
+            ..
+        } = parser.finish();
         let appearance = super::build_index(&appearance_members, &raw_registry);
         assert!(!appearance.is_empty(), "appearance should be indexed");
         let feature = pending.into_iter().next().expect("one feature");
@@ -1461,7 +1468,14 @@ mod tests {
         parser
             .parse(xml.as_bytes(), &Url::parse("file:///dir/test.gml").unwrap())
             .unwrap();
-        let (pending, raw_registry, geom_registry, appearance_members, srs, _ns) = parser.finish();
+        let ParserOutput {
+            pending,
+            raw_registry,
+            geom_registry,
+            appearance_members,
+            srs_by_file: srs,
+            ..
+        } = parser.finish();
         let appearance = super::build_index(&appearance_members, &raw_registry);
         let feature = pending.into_iter().next().expect("one feature");
         let geom = resolve_root(&feature.geoms[0].node, &geom_registry, &appearance, &srs)
@@ -1697,7 +1711,14 @@ mod tests {
         parser
             .parse(xml.as_bytes(), &Url::parse("file:///dir/test.gml").unwrap())
             .unwrap();
-        let (pending, raw_registry, geom_registry, appearance_members, srs, _ns) = parser.finish();
+        let ParserOutput {
+            pending,
+            raw_registry,
+            geom_registry,
+            appearance_members,
+            srs_by_file: srs,
+            ..
+        } = parser.finish();
         let appearance = super::build_index(&appearance_members, &raw_registry);
         let feature = pending.into_iter().next().expect("one feature");
         let geom = resolve_root(&feature.geoms[0].node, &geom_registry, &appearance, &srs)
@@ -1799,7 +1820,14 @@ mod tests {
                 &Url::parse("file:///dir/b.gml").unwrap(),
             )
             .unwrap();
-        let (pending, raw_registry, geom_registry, appearance_members, srs, _ns) = parser.finish();
+        let ParserOutput {
+            pending,
+            raw_registry,
+            geom_registry,
+            appearance_members,
+            srs_by_file: srs,
+            ..
+        } = parser.finish();
         let appearance = super::build_index(&appearance_members, &raw_registry);
         let features: Vec<_> = pending.into_iter().collect();
         assert_eq!(features.len(), 2);

--- a/engine/runtime/action-processor/src/citygml_parser/appearance.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/appearance.rs
@@ -817,11 +817,11 @@ mod tests {
         parser
             .parse(xml.as_bytes(), &Url::parse("file:///dir/test.gml").unwrap())
             .unwrap();
-        let (pending, raw_registry, geom_registry, appearance_members, _ns) = parser.finish();
+        let (pending, raw_registry, geom_registry, appearance_members, srs, _ns) = parser.finish();
         let appearance = super::build_index(&appearance_members, &raw_registry);
         assert!(!appearance.is_empty(), "appearance should be indexed");
         let feature = pending.into_iter().next().expect("one feature");
-        let geom = resolve_root(&feature.geoms[0].node, &geom_registry, &appearance)
+        let geom = resolve_root(&feature.geoms[0].node, &geom_registry, &appearance, &srs)
             .expect("geometry resolves");
         match geom {
             Euclidean3DGeometry::Collection(c) => match c.members().first().expect("one member") {
@@ -1461,10 +1461,10 @@ mod tests {
         parser
             .parse(xml.as_bytes(), &Url::parse("file:///dir/test.gml").unwrap())
             .unwrap();
-        let (pending, raw_registry, geom_registry, appearance_members, _ns) = parser.finish();
+        let (pending, raw_registry, geom_registry, appearance_members, srs, _ns) = parser.finish();
         let appearance = super::build_index(&appearance_members, &raw_registry);
         let feature = pending.into_iter().next().expect("one feature");
-        let geom = resolve_root(&feature.geoms[0].node, &geom_registry, &appearance)
+        let geom = resolve_root(&feature.geoms[0].node, &geom_registry, &appearance, &srs)
             .expect("geometry resolves");
         match geom {
             Euclidean3DGeometry::TriangularMesh(m) => *m,
@@ -1697,10 +1697,10 @@ mod tests {
         parser
             .parse(xml.as_bytes(), &Url::parse("file:///dir/test.gml").unwrap())
             .unwrap();
-        let (pending, raw_registry, geom_registry, appearance_members, _ns) = parser.finish();
+        let (pending, raw_registry, geom_registry, appearance_members, srs, _ns) = parser.finish();
         let appearance = super::build_index(&appearance_members, &raw_registry);
         let feature = pending.into_iter().next().expect("one feature");
-        let geom = resolve_root(&feature.geoms[0].node, &geom_registry, &appearance)
+        let geom = resolve_root(&feature.geoms[0].node, &geom_registry, &appearance, &srs)
             .expect("geometry resolves");
         match geom {
             Euclidean3DGeometry::PolygonMesh(m) => *m,
@@ -1799,14 +1799,24 @@ mod tests {
                 &Url::parse("file:///dir/b.gml").unwrap(),
             )
             .unwrap();
-        let (pending, raw_registry, geom_registry, appearance_members, _ns) = parser.finish();
+        let (pending, raw_registry, geom_registry, appearance_members, srs, _ns) = parser.finish();
         let appearance = super::build_index(&appearance_members, &raw_registry);
         let features: Vec<_> = pending.into_iter().collect();
         assert_eq!(features.len(), 2);
-        let a = resolve_root(&features[0].geoms[0].node, &geom_registry, &appearance)
-            .expect("file a resolves");
-        let b = resolve_root(&features[1].geoms[0].node, &geom_registry, &appearance)
-            .expect("file b resolves");
+        let a = resolve_root(
+            &features[0].geoms[0].node,
+            &geom_registry,
+            &appearance,
+            &srs,
+        )
+        .expect("file a resolves");
+        let b = resolve_root(
+            &features[1].geoms[0].node,
+            &geom_registry,
+            &appearance,
+            &srs,
+        )
+        .expect("file b resolves");
         assert_eq!(diffuse(&a), [1.0, 0.0, 0.0], "file a keeps its own colour");
         assert_eq!(diffuse(&b), [0.0, 0.0, 1.0], "file b keeps its own colour");
     }

--- a/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
@@ -20,8 +20,7 @@ use super::parser::{raw_gml_id, RawChild, RawNode};
 use super::resolver::{
     FaceIds, GeomNode, GeomRegistry, GmlGeometryType, LeafIds, Role, Unresolved,
 };
-use super::srsname::parse_epsg;
-use super::utils::{local_name, srs_name_attr, GML_NS_311_ID, GML_NS_ID};
+use super::utils::{local_name, GML_NS_311_ID, GML_NS_ID};
 
 /// A geometry carved from a feature, tagged with the LOD of the property it came
 /// from (`None` for `tin`) and the `gml:id`s of its enclosing elements (nearest
@@ -140,26 +139,6 @@ fn strip(
     }
 }
 
-/// Error on a geometry-level `srsName` naming a CRS other than the file's: the
-/// reader can't honour a per-geometry override, so the geometry is left
-/// mis-referenced. A redundant restatement of the file CRS is silent.
-fn check_local_srs(node: &RawNode, frame: &CoordinateFrame) {
-    let Some(srs_name) = srs_name_attr(&node.attrs) else {
-        return;
-    };
-    let file_epsg = match frame {
-        CoordinateFrame::Crs(epsg) => Some(*epsg),
-        _ => None,
-    };
-    if file_epsg.is_some() && parse_epsg(srs_name) == file_epsg {
-        return;
-    }
-    tracing::error!(
-        srs_name,
-        "citygml geometry: local srsName is not honoured; geometry left in the file CRS"
-    );
-}
-
 /// Borrow a node's `gml:id`, if any.
 fn gml_id_ref(node: &RawNode) -> Option<&str> {
     node.attrs
@@ -214,7 +193,6 @@ fn geometry_node(
         );
         return None;
     };
-    check_local_srs(node, frame);
     let id = raw_gml_id(node);
     let file = node.source_url.as_str().to_string();
     let geom = if ty.is_inline() {

--- a/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
@@ -20,7 +20,8 @@ use super::parser::{raw_gml_id, RawChild, RawNode};
 use super::resolver::{
     FaceIds, GeomNode, GeomRegistry, GmlGeometryType, LeafIds, Role, Unresolved,
 };
-use super::utils::{local_name, GML_NS_311_ID, GML_NS_ID};
+use super::srsname::parse_epsg;
+use super::utils::{local_name, srs_name_attr, GML_NS_311_ID, GML_NS_ID};
 
 /// A geometry carved from a feature, tagged with the LOD of the property it came
 /// from (`None` for `tin`) and the `gml:id`s of its enclosing elements (nearest
@@ -139,6 +140,26 @@ fn strip(
     }
 }
 
+/// Error on a geometry-level `srsName` naming a CRS other than the file's: the
+/// reader can't honour a per-geometry override, so the geometry is left
+/// mis-referenced. A redundant restatement of the file CRS is silent.
+fn check_local_srs(node: &RawNode, frame: &CoordinateFrame) {
+    let Some(srs_name) = srs_name_attr(&node.attrs) else {
+        return;
+    };
+    let file_epsg = match frame {
+        CoordinateFrame::Crs(epsg) => Some(*epsg),
+        _ => None,
+    };
+    if file_epsg.is_some() && parse_epsg(srs_name) == file_epsg {
+        return;
+    }
+    tracing::error!(
+        srs_name,
+        "citygml geometry: local srsName is not honoured; geometry left in the file CRS"
+    );
+}
+
 /// Borrow a node's `gml:id`, if any.
 fn gml_id_ref(node: &RawNode) -> Option<&str> {
     node.attrs
@@ -193,6 +214,7 @@ fn geometry_node(
         );
         return None;
     };
+    check_local_srs(node, frame);
     let id = raw_gml_id(node);
     let file = node.source_url.as_str().to_string();
     let geom = if ty.is_inline() {

--- a/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
@@ -427,10 +427,9 @@ fn parse_ordinates(text: &str) -> Option<Vec<f64>> {
         .collect()
 }
 
-/// Parse a `gml:posList` into `[x, y, z]` triples, swapping the leading
-/// latitude/longitude pair into `x, y` order. A list with any unparseable token,
-/// or whose ordinate count is not a multiple of 3, is skipped whole rather than
-/// producing misaligned coordinates.
+/// Parse a `gml:posList` into ordinate triples, in the source's own axis order.
+/// A list with any unparseable token, or whose ordinate count is not a multiple
+/// of 3, is skipped whole rather than producing misaligned coordinates.
 fn parse_pos_list(text: &str) -> Vec<[f64; 3]> {
     let Some(values) = parse_ordinates(text) else {
         tracing::warn!("citygml geometry: invalid gml:posList content, skipped");
@@ -440,10 +439,10 @@ fn parse_pos_list(text: &str) -> Vec<[f64; 3]> {
         tracing::warn!("citygml geometry: gml:posList length not a multiple of 3, skipped");
         return Vec::new();
     }
-    values.chunks_exact(3).map(|c| [c[1], c[0], c[2]]).collect()
+    values.chunks_exact(3).map(|c| [c[0], c[1], c[2]]).collect()
 }
 
-/// Parse a single `gml:pos` into one `[x, y, z]`, swapping latitude/longitude.
+/// Parse a single `gml:pos` into one ordinate triple, in the source's own axis order.
 fn parse_pos(text: &str) -> Option<[f64; 3]> {
     let Some(values) = parse_ordinates(text) else {
         tracing::warn!("citygml geometry: invalid gml:pos content, skipped");
@@ -452,7 +451,7 @@ fn parse_pos(text: &str) -> Option<[f64; 3]> {
     if values.len() != 3 {
         return None;
     }
-    Some([values[1], values[0], values[2]])
+    Some([values[0], values[1], values[2]])
 }
 
 /// Extract the LOD digit from a `lod<N>…` property name.
@@ -668,8 +667,7 @@ mod tests {
         match only_member(&geometry) {
             Euclidean3DGeometry::LineString(ls) => {
                 assert_eq!(ls.coords().len(), 3);
-                // posList is lat/lon; stored x/y, so the pair is swapped.
-                assert_eq!(ls.coords()[0], [1.0, 0.0, 0.0]);
+                assert_eq!(ls.coords()[0], [0.0, 1.0, 0.0]);
             }
             other => panic!("expected LineString, got {other:?}"),
         }
@@ -686,7 +684,7 @@ mod tests {
         match only_member(&geometry) {
             Euclidean3DGeometry::Polygon(p) => {
                 assert_eq!(p.exterior().len(), 4);
-                assert_eq!(p.exterior()[0], [2.0, 1.0, 0.0]); // swapped
+                assert_eq!(p.exterior()[0], [1.0, 2.0, 0.0]);
                 assert_eq!(p.interiors().count(), 0);
             }
             other => panic!("expected Polygon, got {other:?}"),
@@ -826,7 +824,7 @@ mod tests {
         assert_eq!(geoms.len(), 1);
         assert_eq!(geoms[0].lod, Some(0));
         match resolve_root_bare(&geoms[0].node, &registry).unwrap() {
-            Euclidean3DGeometry::Point(p) => assert_eq!(p.position(), [2.0, 1.0, 5.0]),
+            Euclidean3DGeometry::Point(p) => assert_eq!(p.position(), [1.0, 2.0, 5.0]),
             other => panic!("expected Point, got {other:?}"),
         }
     }

--- a/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
@@ -9,6 +9,7 @@
 
 use std::sync::Arc;
 
+use reearth_flow_geometry::coordinate::CoordinateFrame;
 use reearth_flow_geometry::line_string::LineString3D;
 use reearth_flow_geometry::point::Point3D;
 use reearth_flow_geometry::polygon::Polygon3D;
@@ -17,7 +18,7 @@ use reearth_flow_geometry::Euclidean3DGeometry;
 
 use super::parser::{raw_gml_id, RawChild, RawNode};
 use super::resolver::{
-    FaceIds, GeomNode, GeomRegistry, GmlGeometryType, LeafIds, Role, Unresolved, FRAME,
+    FaceIds, GeomNode, GeomRegistry, GmlGeometryType, LeafIds, Role, Unresolved,
 };
 use super::utils::{local_name, GML_NS_311_ID, GML_NS_ID};
 
@@ -54,11 +55,12 @@ fn owner_chain(mut owner: Option<&Owner>) -> Vec<String> {
 /// hoisted.
 pub(super) fn split_geometry(
     node: &Arc<RawNode>,
+    frame: &CoordinateFrame,
     registry: &mut GeomRegistry,
     track_owners: bool,
 ) -> (Arc<RawNode>, Vec<PendingGeom>) {
     let mut geoms = Vec::new();
-    let stripped = strip(node, None, registry, &mut geoms, track_owners);
+    let stripped = strip(node, frame, None, registry, &mut geoms, track_owners);
     (stripped, geoms)
 }
 
@@ -67,6 +69,7 @@ pub(super) fn split_geometry(
 /// `gml:id`s above `node`.
 fn strip(
     node: &Arc<RawNode>,
+    frame: &CoordinateFrame,
     owner: Option<&Owner>,
     registry: &mut GeomRegistry,
     geoms: &mut Vec<PendingGeom>,
@@ -95,7 +98,7 @@ fn strip(
         let lod = lod.filter(|_| is_geometry_property(e));
 
         if let Some(lod) = lod {
-            if let Some(gnode) = property_geometry(e, registry) {
+            if let Some(gnode) = property_geometry(e, frame, registry) {
                 let owner_ids = if track_owners {
                     owner_chain(owner)
                 } else {
@@ -111,7 +114,7 @@ fn strip(
                 new_children = Some(node.children[..i].to_vec());
             }
         } else {
-            let stripped_child = strip(e, owner, registry, geoms, track_owners);
+            let stripped_child = strip(e, frame, owner, registry, geoms, track_owners);
             match new_children {
                 None => {
                     if !Arc::ptr_eq(&stripped_child, e) {
@@ -160,11 +163,15 @@ fn is_geometry_property(prop: &RawNode) -> bool {
 
 /// Parse the single geometry element (or `xlink:href`) inside a `lod<N>…` / `tin`
 /// property into a [`GeomNode`].
-fn property_geometry(prop: &RawNode, registry: &mut GeomRegistry) -> Option<GeomNode> {
+fn property_geometry(
+    prop: &RawNode,
+    frame: &CoordinateFrame,
+    registry: &mut GeomRegistry,
+) -> Option<GeomNode> {
     for child in &prop.children {
         match child {
             RawChild::Ref(key) => return Some(GeomNode::Ref(key.clone())),
-            RawChild::Element(e) => return geometry_node(e, registry),
+            RawChild::Element(e) => return geometry_node(e, frame, registry),
             RawChild::Text(_) => {}
         }
     }
@@ -174,7 +181,11 @@ fn property_geometry(prop: &RawNode, registry: &mut GeomRegistry) -> Option<Geom
 /// Convert a geometry element into a [`GeomNode`]: an inline leaf is parsed to a
 /// concrete geometry, a container is left [`Unresolved`]. A node with a `gml:id`
 /// is moved into `registry` and replaced by a [`GeomNode::Ref`].
-fn geometry_node(node: &RawNode, registry: &mut GeomRegistry) -> Option<GeomNode> {
+fn geometry_node(
+    node: &RawNode,
+    frame: &CoordinateFrame,
+    registry: &mut GeomRegistry,
+) -> Option<GeomNode> {
     let Some(ty) = geometry_type(local_name(&node.name.0)) else {
         tracing::warn!(
             element = local_name(&node.name.0),
@@ -185,14 +196,14 @@ fn geometry_node(node: &RawNode, registry: &mut GeomRegistry) -> Option<GeomNode
     let id = raw_gml_id(node);
     let file = node.source_url.as_str().to_string();
     let geom = if ty.is_inline() {
-        let (geometry, faces) = build_leaf(node, &ty)?;
+        let (geometry, faces) = build_leaf(node, &ty, frame)?;
         GeomNode::Resolved(geometry, LeafIds { file, faces })
     } else {
         GeomNode::Unresolved(Unresolved {
             ty,
             id: id.clone(),
             file,
-            members: collect_members(node, registry),
+            members: collect_members(node, frame, registry),
         })
     };
     Some(register(node, id, geom, registry))
@@ -218,7 +229,11 @@ fn register(
 
 /// Collect a container's members, tagging each with the role of the property that
 /// owns it.
-fn collect_members(node: &RawNode, registry: &mut GeomRegistry) -> Vec<(Role, GeomNode)> {
+fn collect_members(
+    node: &RawNode,
+    frame: &CoordinateFrame,
+    registry: &mut GeomRegistry,
+) -> Vec<(Role, GeomNode)> {
     let mut members = Vec::new();
     for prop in element_children(node) {
         let role = property_role(local_name(&prop.name.0));
@@ -226,7 +241,7 @@ fn collect_members(node: &RawNode, registry: &mut GeomRegistry) -> Vec<(Role, Ge
             match child {
                 RawChild::Ref(key) => members.push((role, GeomNode::Ref(key.clone()))),
                 RawChild::Element(inner) => {
-                    if let Some(g) = geometry_node(inner, registry) {
+                    if let Some(g) = geometry_node(inner, frame, registry) {
                         members.push((role, g));
                     }
                 }
@@ -240,30 +255,39 @@ fn collect_members(node: &RawNode, registry: &mut GeomRegistry) -> Vec<(Role, Ge
 /// Parse an inline geometry leaf into a concrete geometry and the per-face gml:ids
 /// captured alongside it, dispatching on its type. Container types and unsupported
 /// leaves yield `None`.
-fn build_leaf(node: &RawNode, ty: &GmlGeometryType) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
+fn build_leaf(
+    node: &RawNode,
+    ty: &GmlGeometryType,
+    frame: &CoordinateFrame,
+) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
     match ty {
-        GmlGeometryType::Point => build_point(node),
-        GmlGeometryType::LineString => build_line_string(node),
+        GmlGeometryType::Point => build_point(node, frame),
+        GmlGeometryType::LineString => build_line_string(node, frame),
         // TODO: gml:Curve support is deferred. Its segments may be arcs or splines,
         // which cannot be handled by sweeping control points into a straight chain.
         GmlGeometryType::Curve => {
             tracing::warn!("citygml geometry: gml:Curve is not supported yet, skipped");
             None
         }
-        GmlGeometryType::LinearRing => build_ring_polygon(node),
-        GmlGeometryType::Polygon => build_polygon(node),
-        GmlGeometryType::TriangulatedSurface | GmlGeometryType::Tin => build_triangulated(node),
+        GmlGeometryType::LinearRing => build_ring_polygon(node, frame),
+        GmlGeometryType::Polygon => build_polygon(node, frame),
+        GmlGeometryType::TriangulatedSurface | GmlGeometryType::Tin => {
+            build_triangulated(node, frame)
+        }
         _ => None,
     }
 }
 
 /// Build a `Point` from the element's first coordinate; `None` if it carries none.
 /// A point has no faces, so no gml:ids are captured.
-fn build_point(node: &RawNode) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
+fn build_point(
+    node: &RawNode,
+    frame: &CoordinateFrame,
+) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
     let coords = gather_coords(node);
     coords.first().map(|&c| {
         (
-            Euclidean3DGeometry::Point(Point3D::new(FRAME, c)),
+            Euclidean3DGeometry::Point(Point3D::new(frame.clone(), c)),
             Vec::new(),
         )
     })
@@ -271,23 +295,29 @@ fn build_point(node: &RawNode) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
 
 /// Build a `LineString` from the element's coordinates; `None` if it carries none.
 /// A line has no faces, so no gml:ids are captured.
-fn build_line_string(node: &RawNode) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
+fn build_line_string(
+    node: &RawNode,
+    frame: &CoordinateFrame,
+) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
     let coords = gather_coords(node);
     if coords.is_empty() {
         return None;
     }
-    let line = Euclidean3DGeometry::LineString(LineString3D::from_coords(FRAME, coords));
+    let line = Euclidean3DGeometry::LineString(LineString3D::from_coords(frame.clone(), coords));
     Some((line, Vec::new()))
 }
 
 /// Build a single-ring `Polygon` from a `LinearRing`'s coordinates; `None` if it
 /// carries none. The one face's sole ring id is the `LinearRing`'s own gml:id.
-fn build_ring_polygon(node: &RawNode) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
+fn build_ring_polygon(
+    node: &RawNode,
+    frame: &CoordinateFrame,
+) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
     let exterior = gather_coords(node);
     if exterior.is_empty() {
         return None;
     }
-    let polygon = Polygon3D::from_rings(FRAME, exterior, Vec::<Vec<[f64; 3]>>::new());
+    let polygon = Polygon3D::from_rings(frame.clone(), exterior, Vec::<Vec<[f64; 3]>>::new());
     let face = FaceIds {
         surface: None,
         rings: vec![raw_gml_id(node)],
@@ -296,8 +326,11 @@ fn build_ring_polygon(node: &RawNode) -> Option<(Euclidean3DGeometry, Vec<FaceId
 }
 
 /// Build a `Polygon` from an element's exterior and interior ring properties.
-fn build_polygon(node: &RawNode) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
-    let (polygon, face) = polygon_from_rings(node)?;
+fn build_polygon(
+    node: &RawNode,
+    frame: &CoordinateFrame,
+) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
+    let (polygon, face) = polygon_from_rings(node, frame)?;
     Some((Euclidean3DGeometry::Polygon(Box::new(polygon)), vec![face]))
 }
 
@@ -306,7 +339,10 @@ fn build_polygon(node: &RawNode) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> 
 /// `FaceIds` per triangle, in triangle order: each face's surface id the whole
 /// surface's own gml:id (a texture drapes the surface, not a single triangle) and
 /// its sole ring id the triangle's exterior `LinearRing` gml:id.
-fn build_triangulated(node: &RawNode) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
+fn build_triangulated(
+    node: &RawNode,
+    frame: &CoordinateFrame,
+) -> Option<(Euclidean3DGeometry, Vec<FaceIds>)> {
     let surface = raw_gml_id(node);
     let mut soup: Vec<[f64; 3]> = Vec::new();
     let mut face_ids: Vec<FaceIds> = Vec::new();
@@ -327,8 +363,10 @@ fn build_triangulated(node: &RawNode) -> Option<(Euclidean3DGeometry, Vec<FaceId
     if soup.is_empty() {
         return None;
     }
-    let mesh =
-        Euclidean3DGeometry::TriangularMesh(Box::new(TriangularMesh3D::from_soup(FRAME, soup)));
+    let mesh = Euclidean3DGeometry::TriangularMesh(Box::new(TriangularMesh3D::from_soup(
+        frame.clone(),
+        soup,
+    )));
     Some((mesh, face_ids))
 }
 
@@ -343,7 +381,7 @@ fn triangle_ring_id(triangle: &RawNode) -> Option<String> {
 /// Build a polygon from an element's `exterior` / `interior` ring properties,
 /// capturing the element's own gml:id as the face's surface id and each
 /// `LinearRing`'s gml:id in exterior-first, holes-next order.
-fn polygon_from_rings(node: &RawNode) -> Option<(Polygon3D, FaceIds)> {
+fn polygon_from_rings(node: &RawNode, frame: &CoordinateFrame) -> Option<(Polygon3D, FaceIds)> {
     let mut exterior: Option<Ring> = None;
     let mut interiors: Vec<Ring> = Vec::new();
     for prop in element_children(node) {
@@ -373,7 +411,7 @@ fn polygon_from_rings(node: &RawNode) -> Option<(Polygon3D, FaceIds)> {
             ring.coords
         })
         .collect();
-    let polygon = Polygon3D::from_rings(FRAME, exterior.coords, interior_coords);
+    let polygon = Polygon3D::from_rings(frame.clone(), exterior.coords, interior_coords);
     let face = FaceIds {
         surface: raw_gml_id(node),
         rings,
@@ -551,7 +589,7 @@ mod tests {
         let url = Url::parse("file:///test.gml").unwrap();
         let mut parser = Parser::new();
         parser.parse(xml.as_bytes(), &url).unwrap();
-        let (pending, _raw, geom_registry, _app, _ns) = parser.finish();
+        let (pending, _raw, geom_registry, _app, _srs, _ns) = parser.finish();
         let feature = pending.into_iter().next().expect("one feature");
         (feature.root, feature.geoms, geom_registry)
     }
@@ -939,7 +977,7 @@ mod tests {
         parser
             .parse(xml.as_bytes(), &Url::parse("file:///test.gml").unwrap())
             .unwrap();
-        let (_pending, _raw, geom_registry, _app, _ns) = parser.finish();
+        let (_pending, _raw, geom_registry, _app, _srs, _ns) = parser.finish();
         let node = geom_registry
             .get(&("file:///test.gml".to_string(), "poly1".to_string()))
             .expect("polygon registered under its GML 3.1 gml:id");

--- a/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
@@ -567,7 +567,7 @@ fn text_content(node: &RawNode) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::citygml_parser::parser::Parser;
+    use crate::citygml_parser::parser::{Parser, ParserOutput};
     use crate::citygml_parser::resolver::resolve_root_bare;
     use url::Url;
 
@@ -589,7 +589,11 @@ mod tests {
         let url = Url::parse("file:///test.gml").unwrap();
         let mut parser = Parser::new();
         parser.parse(xml.as_bytes(), &url).unwrap();
-        let (pending, _raw, geom_registry, _app, _srs, _ns) = parser.finish();
+        let ParserOutput {
+            pending,
+            geom_registry,
+            ..
+        } = parser.finish();
         let feature = pending.into_iter().next().expect("one feature");
         (feature.root, feature.geoms, geom_registry)
     }
@@ -977,7 +981,7 @@ mod tests {
         parser
             .parse(xml.as_bytes(), &Url::parse("file:///test.gml").unwrap())
             .unwrap();
-        let (_pending, _raw, geom_registry, _app, _srs, _ns) = parser.finish();
+        let ParserOutput { geom_registry, .. } = parser.finish();
         let node = geom_registry
             .get(&("file:///test.gml".to_string(), "poly1".to_string()))
             .expect("polygon registered under its GML 3.1 gml:id");

--- a/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/geometry_next.rs
@@ -16,11 +16,9 @@ use reearth_flow_geometry::polygon::Polygon3D;
 use reearth_flow_geometry::triangular_mesh::TriangularMesh3D;
 use reearth_flow_geometry::Euclidean3DGeometry;
 
-use super::parser::{raw_gml_id, RawChild, RawNode};
-use super::resolver::{
-    FaceIds, GeomNode, GeomRegistry, GmlGeometryType, LeafIds, Role, Unresolved,
-};
-use super::utils::{local_name, GML_NS_311_ID, GML_NS_ID};
+use super::parser::{raw_gml_id, Parser, RawChild, RawNode};
+use super::resolver::{FaceIds, GeomNode, GmlGeometryType, LeafIds, Role, Unresolved};
+use super::utils::{frame_for, local_name, GML_NS_311_ID, GML_NS_ID};
 
 /// A geometry carved from a feature, tagged with the LOD of the property it came
 /// from (`None` for `tin`) and the `gml:id`s of its enclosing elements (nearest
@@ -48,94 +46,172 @@ fn owner_chain(mut owner: Option<&Owner>) -> Vec<String> {
     ids
 }
 
-/// Strip every geometry property from `node`, returning the geometry-free
-/// attribute tree and the geometries carved out of it. Geometries carrying a
-/// `gml:id` are registered in `registry` as reference targets. `track_owners`
-/// records each geometry's enclosing `gml:id`s, needed only when children will be
-/// hoisted.
-pub(super) fn split_geometry(
-    node: &Arc<RawNode>,
-    frame: &CoordinateFrame,
-    registry: &mut GeomRegistry,
-    track_owners: bool,
-) -> (Arc<RawNode>, Vec<PendingGeom>) {
-    let mut geoms = Vec::new();
-    let stripped = strip(node, frame, None, registry, &mut geoms, track_owners);
-    (stripped, geoms)
-}
+impl Parser {
+    /// Strip every geometry property from `node`, returning the geometry-free
+    /// attribute tree and the geometries carved out of it. Geometries carrying a
+    /// `gml:id` are registered as `xlink` reference targets.
+    pub(super) fn split_geometry(
+        &mut self,
+        node: &Arc<RawNode>,
+    ) -> (Arc<RawNode>, Vec<PendingGeom>) {
+        let mut geoms = Vec::new();
+        let stripped = self.strip(node, None, &mut geoms);
+        (stripped, geoms)
+    }
 
-/// Recursively rebuild `node` without its geometry-property children, collecting
-/// the parsed geometries into `geoms`. `owner` is the chain of enclosing
-/// `gml:id`s above `node`.
-fn strip(
-    node: &Arc<RawNode>,
-    frame: &CoordinateFrame,
-    owner: Option<&Owner>,
-    registry: &mut GeomRegistry,
-    geoms: &mut Vec<PendingGeom>,
-    track_owners: bool,
-) -> Arc<RawNode> {
-    let here = gml_id_ref(node).map(|id| Owner { id, parent: owner });
-    let owner = here.as_ref().or(owner);
-    let mut new_children: Option<Vec<RawChild>> = None;
+    /// Recursively rebuild `node` without its geometry-property children, collecting
+    /// the parsed geometries into `geoms`. `owner` is the chain of enclosing
+    /// `gml:id`s above `node`.
+    fn strip(
+        &mut self,
+        node: &Arc<RawNode>,
+        owner: Option<&Owner>,
+        geoms: &mut Vec<PendingGeom>,
+    ) -> Arc<RawNode> {
+        let here = gml_id_ref(node).map(|id| Owner { id, parent: owner });
+        let owner = here.as_ref().or(owner);
+        let mut new_children: Option<Vec<RawChild>> = None;
 
-    for (i, child) in node.children.iter().enumerate() {
-        let RawChild::Element(e) = child else {
-            if let Some(ref mut nc) = new_children {
-                nc.push(child.clone());
-            }
-            continue;
-        };
-
-        let ln = local_name(&e.name.0);
-        let lod = if ln == "tin" {
-            Some(None)
-        } else {
-            extract_lod(ln).map(Some)
-        };
-        // A name match alone is not enough: keep an element that merely shares the
-        // `lod<N>…` / `tin` naming but wraps no geometry, rather than stripping it.
-        let lod = lod.filter(|_| is_geometry_property(e));
-
-        if let Some(lod) = lod {
-            if let Some(gnode) = property_geometry(e, frame, registry) {
-                let owner_ids = if track_owners {
-                    owner_chain(owner)
-                } else {
-                    Vec::new()
-                };
-                geoms.push(PendingGeom {
-                    lod,
-                    node: gnode,
-                    owner_ids,
-                });
-            }
-            if new_children.is_none() {
-                new_children = Some(node.children[..i].to_vec());
-            }
-        } else {
-            let stripped_child = strip(e, frame, owner, registry, geoms, track_owners);
-            match new_children {
-                None => {
-                    if !Arc::ptr_eq(&stripped_child, e) {
-                        let mut nc = node.children[..i].to_vec();
-                        nc.push(RawChild::Element(stripped_child));
-                        new_children = Some(nc);
-                    }
+        for (i, child) in node.children.iter().enumerate() {
+            let RawChild::Element(e) = child else {
+                if let Some(ref mut nc) = new_children {
+                    nc.push(child.clone());
                 }
-                Some(ref mut nc) => nc.push(RawChild::Element(stripped_child)),
+                continue;
+            };
+
+            let ln = local_name(&e.name.0);
+            let lod = if ln == "tin" {
+                Some(None)
+            } else {
+                extract_lod(ln).map(Some)
+            };
+            // A name match alone is not enough: keep an element that merely shares
+            // the `lod<N>…` / `tin` naming but wraps no geometry, rather than
+            // stripping it.
+            let lod = lod.filter(|_| is_geometry_property(e));
+
+            if let Some(lod) = lod {
+                if let Some(gnode) = self.property_geometry(e) {
+                    let owner_ids = if self.track_owners {
+                        owner_chain(owner)
+                    } else {
+                        Vec::new()
+                    };
+                    geoms.push(PendingGeom {
+                        lod,
+                        node: gnode,
+                        owner_ids,
+                    });
+                }
+                if new_children.is_none() {
+                    new_children = Some(node.children[..i].to_vec());
+                }
+            } else {
+                let stripped_child = self.strip(e, owner, geoms);
+                match new_children {
+                    None => {
+                        if !Arc::ptr_eq(&stripped_child, e) {
+                            let mut nc = node.children[..i].to_vec();
+                            nc.push(RawChild::Element(stripped_child));
+                            new_children = Some(nc);
+                        }
+                    }
+                    Some(ref mut nc) => nc.push(RawChild::Element(stripped_child)),
+                }
             }
+        }
+
+        match new_children {
+            None => Arc::clone(node),
+            Some(children) => Arc::new(RawNode {
+                name: node.name.clone(),
+                attrs: node.attrs.clone(),
+                children,
+                source_url: Arc::clone(&node.source_url),
+            }),
         }
     }
 
-    match new_children {
-        None => Arc::clone(node),
-        Some(children) => Arc::new(RawNode {
-            name: node.name.clone(),
-            attrs: node.attrs.clone(),
-            children,
-            source_url: Arc::clone(&node.source_url),
-        }),
+    /// Parse the single geometry element (or `xlink:href`) inside a `lod<N>…` /
+    /// `tin` property into a [`GeomNode`].
+    fn property_geometry(&mut self, prop: &RawNode) -> Option<GeomNode> {
+        for child in &prop.children {
+            match child {
+                RawChild::Ref(key) => return Some(GeomNode::Ref(key.clone())),
+                RawChild::Element(e) => return self.geometry_node(e),
+                RawChild::Text(_) => {}
+            }
+        }
+        None
+    }
+
+    /// Convert a geometry element into a [`GeomNode`]: an inline leaf is parsed to a
+    /// concrete geometry, tagged with its source file's frame; a container is left
+    /// [`Unresolved`]. A node with a `gml:id` is registered and replaced by a
+    /// [`GeomNode::Ref`].
+    fn geometry_node(&mut self, node: &RawNode) -> Option<GeomNode> {
+        let Some(ty) = geometry_type(local_name(&node.name.0)) else {
+            tracing::warn!(
+                element = local_name(&node.name.0),
+                "citygml geometry: unrecognized element, skipped"
+            );
+            return None;
+        };
+        let id = raw_gml_id(node);
+        let file = node.source_url.as_str().to_string();
+        let geom = if ty.is_inline() {
+            let (geometry, faces) = build_leaf(node, &ty, &self.frame(node))?;
+            GeomNode::Resolved(geometry, LeafIds { file, faces })
+        } else {
+            GeomNode::Unresolved(Unresolved {
+                ty,
+                id: id.clone(),
+                file,
+                members: self.collect_members(node),
+            })
+        };
+        Some(self.register(node, id, geom))
+    }
+
+    /// Register a geometry as an `xlink` target if it has a `gml:id`, returning a
+    /// [`GeomNode::Ref`] in its place; otherwise return it unchanged.
+    fn register(&mut self, node: &RawNode, id: Option<String>, geom: GeomNode) -> GeomNode {
+        match id {
+            Some(id) => {
+                let key = (node.source_url.as_str().to_string(), id);
+                self.geom_registry.insert(key.clone(), geom);
+                GeomNode::Ref(key)
+            }
+            None => geom,
+        }
+    }
+
+    /// Collect a container's members, tagging each with the role of the property
+    /// that owns it.
+    fn collect_members(&mut self, node: &RawNode) -> Vec<(Role, GeomNode)> {
+        let mut members = Vec::new();
+        for prop in element_children(node) {
+            let role = property_role(local_name(&prop.name.0));
+            for child in &prop.children {
+                match child {
+                    RawChild::Ref(key) => members.push((role, GeomNode::Ref(key.clone()))),
+                    RawChild::Element(inner) => {
+                        if let Some(g) = self.geometry_node(inner) {
+                            members.push((role, g));
+                        }
+                    }
+                    RawChild::Text(_) => {}
+                }
+            }
+        }
+        members
+    }
+
+    /// The coordinate frame geometry from `node` is expressed in: the CRS of the
+    /// file the node was parsed from, or `Euclidean` when that file declared none.
+    fn frame(&self, node: &RawNode) -> CoordinateFrame {
+        frame_for(node.source_url.as_str(), &self.srs_by_file)
     }
 }
 
@@ -149,7 +225,7 @@ fn gml_id_ref(node: &RawNode) -> Option<&str> {
 
 /// Whether a `lod<N>…` / `tin`-named element actually wraps a geometry: its first
 /// non-text child is a recognized GML geometry element or an `xlink:href`
-/// reference. Mirrors [`property_geometry`]'s child selection.
+/// reference. Mirrors [`Parser::property_geometry`]'s child selection.
 fn is_geometry_property(prop: &RawNode) -> bool {
     for child in &prop.children {
         match child {
@@ -159,97 +235,6 @@ fn is_geometry_property(prop: &RawNode) -> bool {
         }
     }
     false
-}
-
-/// Parse the single geometry element (or `xlink:href`) inside a `lod<N>…` / `tin`
-/// property into a [`GeomNode`].
-fn property_geometry(
-    prop: &RawNode,
-    frame: &CoordinateFrame,
-    registry: &mut GeomRegistry,
-) -> Option<GeomNode> {
-    for child in &prop.children {
-        match child {
-            RawChild::Ref(key) => return Some(GeomNode::Ref(key.clone())),
-            RawChild::Element(e) => return geometry_node(e, frame, registry),
-            RawChild::Text(_) => {}
-        }
-    }
-    None
-}
-
-/// Convert a geometry element into a [`GeomNode`]: an inline leaf is parsed to a
-/// concrete geometry, a container is left [`Unresolved`]. A node with a `gml:id`
-/// is moved into `registry` and replaced by a [`GeomNode::Ref`].
-fn geometry_node(
-    node: &RawNode,
-    frame: &CoordinateFrame,
-    registry: &mut GeomRegistry,
-) -> Option<GeomNode> {
-    let Some(ty) = geometry_type(local_name(&node.name.0)) else {
-        tracing::warn!(
-            element = local_name(&node.name.0),
-            "citygml geometry: unrecognized element, skipped"
-        );
-        return None;
-    };
-    let id = raw_gml_id(node);
-    let file = node.source_url.as_str().to_string();
-    let geom = if ty.is_inline() {
-        let (geometry, faces) = build_leaf(node, &ty, frame)?;
-        GeomNode::Resolved(geometry, LeafIds { file, faces })
-    } else {
-        GeomNode::Unresolved(Unresolved {
-            ty,
-            id: id.clone(),
-            file,
-            members: collect_members(node, frame, registry),
-        })
-    };
-    Some(register(node, id, geom, registry))
-}
-
-/// Register a geometry as an `xlink` target if it has a `gml:id`, returning a
-/// [`GeomNode::Ref`] in its place; otherwise return it unchanged.
-fn register(
-    node: &RawNode,
-    id: Option<String>,
-    geom: GeomNode,
-    registry: &mut GeomRegistry,
-) -> GeomNode {
-    match id {
-        Some(id) => {
-            let key = (node.source_url.as_str().to_string(), id);
-            registry.insert(key.clone(), geom);
-            GeomNode::Ref(key)
-        }
-        None => geom,
-    }
-}
-
-/// Collect a container's members, tagging each with the role of the property that
-/// owns it.
-fn collect_members(
-    node: &RawNode,
-    frame: &CoordinateFrame,
-    registry: &mut GeomRegistry,
-) -> Vec<(Role, GeomNode)> {
-    let mut members = Vec::new();
-    for prop in element_children(node) {
-        let role = property_role(local_name(&prop.name.0));
-        for child in &prop.children {
-            match child {
-                RawChild::Ref(key) => members.push((role, GeomNode::Ref(key.clone()))),
-                RawChild::Element(inner) => {
-                    if let Some(g) = geometry_node(inner, frame, registry) {
-                        members.push((role, g));
-                    }
-                }
-                RawChild::Text(_) => {}
-            }
-        }
-    }
-    members
 }
 
 /// Parse an inline geometry leaf into a concrete geometry and the per-face gml:ids
@@ -568,7 +553,7 @@ fn text_content(node: &RawNode) -> &str {
 mod tests {
     use super::*;
     use crate::citygml_parser::parser::{Parser, ParserOutput};
-    use crate::citygml_parser::resolver::resolve_root_bare;
+    use crate::citygml_parser::resolver::{resolve_root_bare, GeomRegistry};
     use url::Url;
 
     /// Parse one CityGML feature wrapping `inner`, returning its stripped attribute

--- a/engine/runtime/action-processor/src/citygml_parser/mod.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/mod.rs
@@ -15,5 +15,7 @@ pub mod parser;
 pub mod pipeline;
 #[cfg(feature = "new-geometry")]
 pub(crate) mod resolver;
+#[cfg(feature = "new-geometry")]
+mod srsname;
 pub(crate) mod utils;
 pub(crate) mod xlink;

--- a/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
@@ -771,6 +771,31 @@ mod tests {
     }
 
     #[test]
+    fn parse_records_srs_from_envelope() {
+        let xml = br#"
+<core:CityModel
+  xmlns:core="http://www.opengis.net/citygml/3.0"
+  xmlns:bldg="http://www.opengis.net/citygml/building/3.0"
+  xmlns:gml="http://www.opengis.net/gml/3.2">
+  <gml:boundedBy>
+    <gml:Envelope srsName="urn:ogc:def:crs:EPSG::6697"/>
+  </gml:boundedBy>
+  <core:cityObjectMember>
+    <bldg:Building gml:id="bldg001"/>
+  </core:cityObjectMember>
+</core:CityModel>"#;
+
+        let mut parser = Parser::new();
+        parser.parse(xml, &dummy_url()).unwrap();
+        let ParserOutput { srs_by_file, .. } = parser.finish();
+
+        assert_eq!(
+            srs_by_file.get(&dummy_url().to_string()),
+            Some(&EpsgCode::new(6697))
+        );
+    }
+
+    #[test]
     fn parse_errors_on_truncated_citygml() {
         let xml = br#"
 <core:CityModel

--- a/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
@@ -36,6 +36,22 @@ pub(crate) enum RawChild {
 
 pub(crate) type RawRegistry = HashMap<RawNodeKey, Arc<RawNode>>;
 
+/// Everything [`Parser::finish`] hands off to pass-2 reference resolution.
+pub(super) struct ParserOutput {
+    /// The features awaiting geometry resolution.
+    pub(super) pending: Vec<PendingFeature>,
+    /// Attribute trees, keyed for `xlink:href` lookup.
+    pub(super) raw_registry: RawRegistry,
+    /// Parsed geometry nodes, keyed for `xlink:href` lookup.
+    pub(super) geom_registry: GeomRegistry,
+    /// Retained appearance member roots.
+    pub(super) appearance_members: Vec<Arc<RawNode>>,
+    /// Each file's CRS, parsed from its `gml:boundedBy/gml:Envelope/@srsName`.
+    pub(super) srs_by_file: HashMap<String, EpsgCode>,
+    /// Interned namespace URIs.
+    pub(super) ns_registry: NamespaceRegistry,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ParseError {
     #[error("XML error: {0}")]
@@ -215,27 +231,16 @@ impl Parser {
         Ok(())
     }
 
-    /// Consume the parser and return the pending features, the attribute and
-    /// geometry registries, the retained appearance member roots, each file's CRS,
-    /// and the namespace registry for pass-2 resolution.
-    pub(super) fn finish(
-        self,
-    ) -> (
-        Vec<PendingFeature>,
-        RawRegistry,
-        GeomRegistry,
-        Vec<Arc<RawNode>>,
-        HashMap<String, EpsgCode>,
-        NamespaceRegistry,
-    ) {
-        (
-            self.pending,
-            self.raw_registry,
-            self.geom_registry,
-            self.appearance_members,
-            self.srs_by_file,
-            self.ns_registry,
-        )
+    /// Consume the parser and hand off its state for pass-2 resolution.
+    pub(super) fn finish(self) -> ParserOutput {
+        ParserOutput {
+            pending: self.pending,
+            raw_registry: self.raw_registry,
+            geom_registry: self.geom_registry,
+            appearance_members: self.appearance_members,
+            srs_by_file: self.srs_by_file,
+            ns_registry: self.ns_registry,
+        }
     }
 }
 
@@ -659,7 +664,7 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (pending, _, _, _, _, _) = parser.finish();
+        let ParserOutput { pending, .. } = parser.finish();
 
         assert_eq!(pending.len(), 2);
         assert_eq!(raw_gml_id(&pending[0].root), Some("bldg001".to_string()));
@@ -681,7 +686,11 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (pending, raw_reg, _, _, _, _) = parser.finish();
+        let ParserOutput {
+            pending,
+            raw_registry: raw_reg,
+            ..
+        } = parser.finish();
         assert_eq!(raw_gml_id(&pending[0].root), Some("bldg001".to_string()));
         assert!(raw_reg.contains_key(&(dummy_url().to_string(), "bldg001".to_string())));
     }
@@ -702,7 +711,10 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (_, raw_reg, _, _, _, _) = parser.finish();
+        let ParserOutput {
+            raw_registry: raw_reg,
+            ..
+        } = parser.finish();
 
         let url = dummy_url().to_string();
         assert!(raw_reg.contains_key(&(url.clone(), "bldg001".to_string())));
@@ -727,7 +739,10 @@ mod tests {
         let mut parser = Parser::new();
         parser.parse(xml, &url_a).unwrap();
         parser.parse(xml, &url_b).unwrap();
-        let (_, raw_reg, _, _, _, _) = parser.finish();
+        let ParserOutput {
+            raw_registry: raw_reg,
+            ..
+        } = parser.finish();
 
         assert_eq!(raw_reg.len(), 2);
         assert!(raw_reg.contains_key(&(url_a.to_string(), "shared001".to_string())));
@@ -756,7 +771,7 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (pending, _, _, _, _, _) = parser.finish();
+        let ParserOutput { pending, .. } = parser.finish();
         assert_eq!(pending.len(), 1);
     }
 
@@ -789,7 +804,7 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (pending, _, _, _, _, _) = parser.finish();
+        let ParserOutput { pending, .. } = parser.finish();
         assert_eq!(pending.len(), 1);
     }
 
@@ -853,7 +868,7 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (pending, _, _, _, _, _) = parser.finish();
+        let ParserOutput { pending, .. } = parser.finish();
 
         assert_eq!(
             pending[0]

--- a/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
@@ -14,9 +14,8 @@ use super::geometry;
 use super::resolver::GeomRegistry;
 use super::srsname;
 use super::utils::{
-    frame_for, gml_id_attr, local_name as utils_local_name, srs_name_attr, xlink_href_attr,
-    NamespaceRegistry, NsId, QName, XmlChild, XmlNode, EMPTY_NS_ID, GML_NS_311_ID, GML_NS_ID,
-    XLINK_NS_ID,
+    gml_id_attr, local_name as utils_local_name, srs_name_attr, xlink_href_attr, NamespaceRegistry,
+    NsId, QName, XmlChild, XmlNode, EMPTY_NS_ID, GML_NS_311_ID, GML_NS_ID, XLINK_NS_ID,
 };
 
 pub(super) type RawNodeKey = (String, String); // (file_url, gml_id)
@@ -73,7 +72,7 @@ pub enum ParseError {
 /// the state for pass-2 reference resolution.
 pub struct Parser {
     raw_registry: RawRegistry,
-    geom_registry: GeomRegistry,
+    pub(super) geom_registry: GeomRegistry,
     /// The `app:appearanceMember` roots, retained for pass-2 indexing once every
     /// `gml:id` is known, so a surface data or appearance reached by `xlink:href`
     /// resolves.
@@ -82,10 +81,10 @@ pub struct Parser {
     pending: Vec<PendingFeature>,
     /// Whether to record each geometry's enclosing `gml:id`s, needed only when
     /// `flatten` will hoist children into separate features.
-    track_owners: bool,
+    pub(super) track_owners: bool,
     /// Each file's CRS, parsed from its `gml:boundedBy/gml:Envelope/@srsName`; a
     /// file with no entry declared no (or an unrecognized) srsName.
-    srs_by_file: HashMap<String, EpsgCode>,
+    pub(super) srs_by_file: HashMap<String, EpsgCode>,
 }
 
 impl Default for Parser {
@@ -157,13 +156,7 @@ impl Parser {
                                 _ => None,
                             })
                         {
-                            let frame = frame_for(source_url_arc.as_str(), &self.srs_by_file);
-                            let (stripped, geoms) = geometry::split_geometry(
-                                &feature_node,
-                                &frame,
-                                &mut self.geom_registry,
-                                self.track_owners,
-                            );
+                            let (stripped, geoms) = self.split_geometry(&feature_node);
                             collect_ids(&stripped, source_url_arc.as_str(), &mut self.raw_registry);
                             collect_nested_appearances(&stripped, &mut self.appearance_members);
                             self.pending.push(PendingFeature {

--- a/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
@@ -246,8 +246,8 @@ impl Parser {
 }
 
 /// The EPSG code declared by a `gml:boundedBy` element's `gml:Envelope/@srsName`.
-/// New-geometry only tracks EPSG CRSes; a present-but-unrecognized srsName is
-/// warned and treated as no declaration.
+/// New-geometry only tracks EPSG CRSes; a present-but-unrecognized srsName is an
+/// error and is treated as no declaration.
 fn envelope_epsg(bounded_by: &RawNode) -> Option<EpsgCode> {
     bounded_by.children.iter().find_map(|child| {
         let RawChild::Element(node) = child else {
@@ -259,7 +259,7 @@ fn envelope_epsg(bounded_by: &RawNode) -> Option<EpsgCode> {
         let srs_name = srs_name_attr(&node.attrs)?;
         let epsg = srsname::parse_epsg(srs_name);
         if epsg.is_none() {
-            tracing::warn!(
+            tracing::error!(
                 srs_name,
                 "citygml: gml:Envelope srsName is not a recognized EPSG CRS, ignored"
             );

--- a/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
@@ -6,14 +6,16 @@ use indexmap::IndexMap;
 use quick_xml::events::Event;
 use quick_xml::name::ResolveResult;
 use quick_xml::NsReader;
+use reearth_flow_geometry::coordinate::EpsgCode;
 use reearth_flow_types::{Attribute, AttributeValue, Attributes, CitygmlFeatureExt, Feature};
 use url::Url;
 
 use super::geometry;
 use super::resolver::GeomRegistry;
 use super::utils::{
-    gml_id_attr, local_name as utils_local_name, xlink_href_attr, NamespaceRegistry, NsId, QName,
-    XmlChild, XmlNode, EMPTY_NS_ID, GML_NS_311_ID, GML_NS_ID, XLINK_NS_ID,
+    frame_for, gml_id_attr, local_name as utils_local_name, parse_epsg_from_srs_name,
+    srs_name_attr, xlink_href_attr, NamespaceRegistry, NsId, QName, XmlChild, XmlNode, EMPTY_NS_ID,
+    GML_NS_311_ID, GML_NS_ID, XLINK_NS_ID,
 };
 
 pub(super) type RawNodeKey = (String, String); // (file_url, gml_id)
@@ -64,6 +66,9 @@ pub struct Parser {
     /// Whether to record each geometry's enclosing `gml:id`s, needed only when
     /// `flatten` will hoist children into separate features.
     track_owners: bool,
+    /// Each file's CRS, parsed from its `gml:boundedBy/gml:Envelope/@srsName`; a
+    /// file with no entry declared no (or an unrecognized) srsName.
+    srs_by_file: HashMap<String, EpsgCode>,
 }
 
 impl Default for Parser {
@@ -97,6 +102,7 @@ impl Parser {
             ns_registry: NamespaceRegistry::new(),
             pending: Vec::new(),
             track_owners,
+            srs_by_file: HashMap::new(),
         }
     }
 
@@ -134,8 +140,10 @@ impl Parser {
                                 _ => None,
                             })
                         {
+                            let frame = frame_for(source_url_arc.as_str(), &self.srs_by_file);
                             let (stripped, geoms) = geometry::split_geometry(
                                 &feature_node,
+                                &frame,
                                 &mut self.geom_registry,
                                 self.track_owners,
                             );
@@ -161,6 +169,19 @@ impl Parser {
                         )?);
                         collect_ids(&member, source_url_arc.as_str(), &mut self.raw_registry);
                         self.appearance_members.push(member);
+                    } else if ln == "boundedBy" {
+                        let bounded_by = parse_element(
+                            &mut reader,
+                            &mut buf,
+                            name,
+                            attrs,
+                            &source_url_arc,
+                            &mut self.ns_registry,
+                        )?;
+                        if let Some(epsg) = envelope_epsg(&bounded_by) {
+                            self.srs_by_file
+                                .insert(source_url_arc.as_str().to_string(), epsg);
+                        }
                     } else {
                         skip_element(&mut reader, &mut buf, &mut self.ns_registry)?;
                     }
@@ -195,8 +216,8 @@ impl Parser {
     }
 
     /// Consume the parser and return the pending features, the attribute and
-    /// geometry registries, the retained appearance member roots, and the namespace
-    /// registry for pass-2 resolution.
+    /// geometry registries, the retained appearance member roots, each file's CRS,
+    /// and the namespace registry for pass-2 resolution.
     pub(super) fn finish(
         self,
     ) -> (
@@ -204,6 +225,7 @@ impl Parser {
         RawRegistry,
         GeomRegistry,
         Vec<Arc<RawNode>>,
+        HashMap<String, EpsgCode>,
         NamespaceRegistry,
     ) {
         (
@@ -211,9 +233,32 @@ impl Parser {
             self.raw_registry,
             self.geom_registry,
             self.appearance_members,
+            self.srs_by_file,
             self.ns_registry,
         )
     }
+}
+
+/// The EPSG code from a `gml:boundedBy` element's `gml:Envelope/@srsName`, if
+/// present and recognized.
+fn envelope_epsg(bounded_by: &RawNode) -> Option<EpsgCode> {
+    bounded_by.children.iter().find_map(|child| {
+        let RawChild::Element(node) = child else {
+            return None;
+        };
+        if local_name(&node.name.0) != "Envelope" {
+            return None;
+        }
+        let srs_name = srs_name_attr(&node.attrs)?;
+        let epsg = parse_epsg_from_srs_name(srs_name);
+        if epsg.is_none() {
+            tracing::warn!(
+                srs_name,
+                "citygml: gml:Envelope srsName is not a recognized EPSG URI, ignored"
+            );
+        }
+        epsg
+    })
 }
 
 /// A top-level city object awaiting pass-2 resolution: its attribute tree, with
@@ -614,7 +659,7 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (pending, _, _, _, _) = parser.finish();
+        let (pending, _, _, _, _, _) = parser.finish();
 
         assert_eq!(pending.len(), 2);
         assert_eq!(raw_gml_id(&pending[0].root), Some("bldg001".to_string()));
@@ -636,7 +681,7 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (pending, raw_reg, _, _, _) = parser.finish();
+        let (pending, raw_reg, _, _, _, _) = parser.finish();
         assert_eq!(raw_gml_id(&pending[0].root), Some("bldg001".to_string()));
         assert!(raw_reg.contains_key(&(dummy_url().to_string(), "bldg001".to_string())));
     }
@@ -657,7 +702,7 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (_, raw_reg, _, _, _) = parser.finish();
+        let (_, raw_reg, _, _, _, _) = parser.finish();
 
         let url = dummy_url().to_string();
         assert!(raw_reg.contains_key(&(url.clone(), "bldg001".to_string())));
@@ -682,7 +727,7 @@ mod tests {
         let mut parser = Parser::new();
         parser.parse(xml, &url_a).unwrap();
         parser.parse(xml, &url_b).unwrap();
-        let (_, raw_reg, _, _, _) = parser.finish();
+        let (_, raw_reg, _, _, _, _) = parser.finish();
 
         assert_eq!(raw_reg.len(), 2);
         assert!(raw_reg.contains_key(&(url_a.to_string(), "shared001".to_string())));
@@ -711,7 +756,7 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (pending, _, _, _, _) = parser.finish();
+        let (pending, _, _, _, _, _) = parser.finish();
         assert_eq!(pending.len(), 1);
     }
 
@@ -744,7 +789,7 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (pending, _, _, _, _) = parser.finish();
+        let (pending, _, _, _, _, _) = parser.finish();
         assert_eq!(pending.len(), 1);
     }
 
@@ -808,7 +853,7 @@ mod tests {
 
         let mut parser = Parser::new();
         parser.parse(xml, &dummy_url()).unwrap();
-        let (pending, _, _, _, _) = parser.finish();
+        let (pending, _, _, _, _, _) = parser.finish();
 
         assert_eq!(
             pending[0]

--- a/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/parser_next.rs
@@ -12,10 +12,11 @@ use url::Url;
 
 use super::geometry;
 use super::resolver::GeomRegistry;
+use super::srsname;
 use super::utils::{
-    frame_for, gml_id_attr, local_name as utils_local_name, parse_epsg_from_srs_name,
-    srs_name_attr, xlink_href_attr, NamespaceRegistry, NsId, QName, XmlChild, XmlNode, EMPTY_NS_ID,
-    GML_NS_311_ID, GML_NS_ID, XLINK_NS_ID,
+    frame_for, gml_id_attr, local_name as utils_local_name, srs_name_attr, xlink_href_attr,
+    NamespaceRegistry, NsId, QName, XmlChild, XmlNode, EMPTY_NS_ID, GML_NS_311_ID, GML_NS_ID,
+    XLINK_NS_ID,
 };
 
 pub(super) type RawNodeKey = (String, String); // (file_url, gml_id)
@@ -244,8 +245,9 @@ impl Parser {
     }
 }
 
-/// The EPSG code from a `gml:boundedBy` element's `gml:Envelope/@srsName`, if
-/// present and recognized.
+/// The EPSG code declared by a `gml:boundedBy` element's `gml:Envelope/@srsName`.
+/// New-geometry only tracks EPSG CRSes; a present-but-unrecognized srsName is
+/// warned and treated as no declaration.
 fn envelope_epsg(bounded_by: &RawNode) -> Option<EpsgCode> {
     bounded_by.children.iter().find_map(|child| {
         let RawChild::Element(node) = child else {
@@ -255,11 +257,11 @@ fn envelope_epsg(bounded_by: &RawNode) -> Option<EpsgCode> {
             return None;
         }
         let srs_name = srs_name_attr(&node.attrs)?;
-        let epsg = parse_epsg_from_srs_name(srs_name);
+        let epsg = srsname::parse_epsg(srs_name);
         if epsg.is_none() {
             tracing::warn!(
                 srs_name,
-                "citygml: gml:Envelope srsName is not a recognized EPSG URI, ignored"
+                "citygml: gml:Envelope srsName is not a recognized EPSG CRS, ignored"
             );
         }
         epsg

--- a/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
@@ -165,7 +165,7 @@ mod build_next {
     use crate::citygml_parser::{
         appearance::{self, AppearanceIndex},
         codespace, flatten, geometry,
-        parser::{self, Parser, RawRegistry},
+        parser::{self, Parser, ParserOutput, RawRegistry},
         resolver::{self, GeomRegistry},
         utils::{gml_id_attr, NamespaceRegistry},
         xlink,
@@ -185,8 +185,14 @@ mod build_next {
         _flatten_single_child_objects: bool,
         _flatten_measure_types: bool,
     ) -> Vec<Feature> {
-        let (pending, raw_registry, geom_registry, appearance_members, srs_by_file, ns_registry) =
-            parser.finish();
+        let ParserOutput {
+            pending,
+            raw_registry,
+            geom_registry,
+            appearance_members,
+            srs_by_file,
+            ns_registry,
+        } = parser.finish();
         let appearance = appearance::build_index(&appearance_members, &raw_registry);
         assemble_features(
             pending,
@@ -324,14 +330,14 @@ mod build_next {
             parser
                 .parse(xml.as_bytes(), &Url::parse("file:///test.gml").unwrap())
                 .unwrap();
-            let (
+            let ParserOutput {
                 pending,
                 raw_registry,
                 geom_registry,
                 appearance_members,
                 srs_by_file,
                 ns_registry,
-            ) = parser.finish();
+            } = parser.finish();
             let appearance = appearance::build_index(&appearance_members, &raw_registry);
             let tags: HashSet<String> = extract_tags.iter().map(|s| s.to_string()).collect();
             assemble_features(

--- a/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
@@ -156,6 +156,7 @@ pub use build_next::build_features;
 mod build_next {
     use std::collections::{HashMap, HashSet};
 
+    use reearth_flow_geometry::coordinate::EpsgCode;
     use reearth_flow_geometry::{Geometry, GeometryCollection};
     use reearth_flow_types::{
         AttributeValue, Attributes, Feature, CITYGML_PARENT_GML_ID_KEY, CITYGML_ROOT_GML_ID_KEY,
@@ -184,7 +185,7 @@ mod build_next {
         _flatten_single_child_objects: bool,
         _flatten_measure_types: bool,
     ) -> Vec<Feature> {
-        let (pending, raw_registry, geom_registry, appearance_members, ns_registry) =
+        let (pending, raw_registry, geom_registry, appearance_members, srs_by_file, ns_registry) =
             parser.finish();
         let appearance = appearance::build_index(&appearance_members, &raw_registry);
         assemble_features(
@@ -192,6 +193,7 @@ mod build_next {
             &raw_registry,
             &geom_registry,
             &appearance,
+            &srs_by_file,
             &ns_registry,
             extract_tags,
         )
@@ -205,6 +207,7 @@ mod build_next {
         raw_registry: &RawRegistry,
         geom_registry: &GeomRegistry,
         appearance: &AppearanceIndex,
+        srs_by_file: &HashMap<String, EpsgCode>,
         ns_registry: &NamespaceRegistry,
         extract_tags: &HashSet<String>,
     ) -> Vec<Feature> {
@@ -224,7 +227,7 @@ mod build_next {
 
             if extract_tags.is_empty() {
                 let mut feature = parser::to_feature(&feature_root);
-                attach_geometry(&mut feature, &geoms, geom_registry, appearance);
+                attach_geometry(&mut feature, &geoms, geom_registry, appearance, srs_by_file);
                 out.push(feature);
             } else {
                 let root_gml_id = gml_id_attr(&feature_root.attrs);
@@ -263,6 +266,7 @@ mod build_next {
                             gs.iter().copied(),
                             geom_registry,
                             appearance,
+                            srs_by_file,
                         );
                     }
                     out.push(feature);
@@ -279,12 +283,13 @@ mod build_next {
         geoms: impl IntoIterator<Item = &'a geometry::PendingGeom>,
         registry: &GeomRegistry,
         appearance: &AppearanceIndex,
+        srs_by_file: &HashMap<String, EpsgCode>,
     ) {
         // TODO: carry each geometry's LOD and gml:id in the collection's per-member attributes.
         let members: Vec<Geometry> = geoms
             .into_iter()
             .filter_map(|pending| {
-                resolver::resolve_root(&pending.node, registry, appearance)
+                resolver::resolve_root(&pending.node, registry, appearance, srs_by_file)
                     .map(Geometry::Euclidean3D)
             })
             .collect();
@@ -319,8 +324,14 @@ mod build_next {
             parser
                 .parse(xml.as_bytes(), &Url::parse("file:///test.gml").unwrap())
                 .unwrap();
-            let (pending, raw_registry, geom_registry, appearance_members, ns_registry) =
-                parser.finish();
+            let (
+                pending,
+                raw_registry,
+                geom_registry,
+                appearance_members,
+                srs_by_file,
+                ns_registry,
+            ) = parser.finish();
             let appearance = appearance::build_index(&appearance_members, &raw_registry);
             let tags: HashSet<String> = extract_tags.iter().map(|s| s.to_string()).collect();
             assemble_features(
@@ -328,6 +339,7 @@ mod build_next {
                 &raw_registry,
                 &geom_registry,
                 &appearance,
+                &srs_by_file,
                 &ns_registry,
                 &tags,
             )

--- a/engine/runtime/action-processor/src/citygml_parser/resolver.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/resolver.rs
@@ -8,7 +8,7 @@
 use std::collections::{HashMap, HashSet};
 
 use reearth_flow_geometry::collection::Collection3D;
-use reearth_flow_geometry::coordinate::CoordinateFrame;
+use reearth_flow_geometry::coordinate::{CoordinateFrame, EpsgCode};
 use reearth_flow_geometry::line_string::LineString3D;
 use reearth_flow_geometry::polygon::Polygon3D;
 use reearth_flow_geometry::polygon_mesh::PolygonMesh3D;
@@ -17,10 +17,7 @@ use reearth_flow_geometry::Euclidean3DGeometry;
 
 use super::appearance::AppearanceIndex;
 use super::parser::RawNodeKey;
-
-/// The coordinate frame all resolved geometry is expressed in; CityGML `srsName`
-/// / EPSG handling happens downstream.
-pub(super) const FRAME: CoordinateFrame = CoordinateFrame::Euclidean;
+use super::utils::frame_for;
 
 /// A node in a CityGML geometry tree during pass-2 resolution: a geometry already
 /// built in pass 1, a reference still to be looked up, or a container still to be
@@ -175,17 +172,25 @@ pub(super) fn resolve_root(
     node: &GeomNode,
     registry: &GeomRegistry,
     appearance: &AppearanceIndex,
+    srs_by_file: &HashMap<String, EpsgCode>,
 ) -> Option<Euclidean3DGeometry> {
-    resolve(node, registry, appearance, &[], &mut HashSet::new())
+    resolve(
+        node,
+        registry,
+        appearance,
+        srs_by_file,
+        &[],
+        &mut HashSet::new(),
+    )
 }
 
-/// Resolve a top-level geometry node with no appearance attached.
+/// Resolve a top-level geometry node with no appearance attached and no known CRS.
 #[cfg(test)]
 pub(super) fn resolve_root_bare(
     node: &GeomNode,
     registry: &GeomRegistry,
 ) -> Option<Euclidean3DGeometry> {
-    resolve_root(node, registry, &AppearanceIndex::default())
+    resolve_root(node, registry, &AppearanceIndex::default(), &HashMap::new())
 }
 
 /// Resolve one node. `enclosing` is the chain of enclosing container ids, each
@@ -197,6 +202,7 @@ fn resolve(
     node: &GeomNode,
     registry: &GeomRegistry,
     appearance: &AppearanceIndex,
+    srs_by_file: &HashMap<String, EpsgCode>,
     enclosing: &[(&str, &str)],
     in_progress: &mut HashSet<RawNodeKey>,
 ) -> Option<Euclidean3DGeometry> {
@@ -207,10 +213,22 @@ fn resolve(
             appearance,
             enclosing,
         )),
-        GeomNode::Ref(key) => resolve_ref(key, registry, appearance, enclosing, in_progress),
-        GeomNode::Unresolved(unresolved) => {
-            construct(unresolved, registry, appearance, enclosing, in_progress)
-        }
+        GeomNode::Ref(key) => resolve_ref(
+            key,
+            registry,
+            appearance,
+            srs_by_file,
+            enclosing,
+            in_progress,
+        ),
+        GeomNode::Unresolved(unresolved) => construct(
+            unresolved,
+            registry,
+            appearance,
+            srs_by_file,
+            enclosing,
+            in_progress,
+        ),
     }
 }
 
@@ -253,6 +271,7 @@ fn resolve_ref(
     key: &RawNodeKey,
     registry: &GeomRegistry,
     appearance: &AppearanceIndex,
+    srs_by_file: &HashMap<String, EpsgCode>,
     enclosing: &[(&str, &str)],
     in_progress: &mut HashSet<RawNodeKey>,
 ) -> Option<Euclidean3DGeometry> {
@@ -261,7 +280,14 @@ fn resolve_ref(
         return None;
     }
     let resolved = match registry.get(key) {
-        Some(target) => resolve(target, registry, appearance, enclosing, in_progress),
+        Some(target) => resolve(
+            target,
+            registry,
+            appearance,
+            srs_by_file,
+            enclosing,
+            in_progress,
+        ),
         None => {
             tracing::warn!(
                 id = key.1,
@@ -278,11 +304,15 @@ fn resolve_ref(
 /// type. Members that fail to resolve are dropped, so a container survives with
 /// whatever members did resolve. This container's own gml:id is prepended to
 /// `enclosing` for its members, so an appearance bound to the container reaches
-/// them.
+/// them. The container's own frame is `node.file`'s CRS, so a container welded
+/// here (a mesh, a solid, a ring-polygon) is tagged with the CRS of the file its
+/// own element lives in, regardless of what file any `xlink:href` member resolved
+/// from.
 fn construct(
     node: &Unresolved,
     registry: &GeomRegistry,
     appearance: &AppearanceIndex,
+    srs_by_file: &HashMap<String, EpsgCode>,
     enclosing: &[(&str, &str)],
     in_progress: &mut HashSet<RawNodeKey>,
 ) -> Option<Euclidean3DGeometry> {
@@ -294,10 +324,19 @@ fn construct(
         .members
         .iter()
         .filter_map(|(role, child)| {
-            resolve(child, registry, appearance, &member_enclosing, in_progress).map(|g| (*role, g))
+            resolve(
+                child,
+                registry,
+                appearance,
+                srs_by_file,
+                &member_enclosing,
+                in_progress,
+            )
+            .map(|g| (*role, g))
         })
         .collect();
 
+    let frame = frame_for(&node.file, srs_by_file);
     match node.ty {
         GmlGeometryType::MultiPoint
         | GmlGeometryType::MultiCurve
@@ -312,12 +351,12 @@ fn construct(
         GmlGeometryType::OrientableCurve | GmlGeometryType::OrientableSurface => {
             members.into_iter().next().map(|(_, geometry)| geometry)
         }
-        GmlGeometryType::Ring => ring(members),
+        GmlGeometryType::Ring => ring(members, &frame),
         GmlGeometryType::CompositeSurface
         | GmlGeometryType::Shell
         | GmlGeometryType::Surface
-        | GmlGeometryType::PolyhedralSurface => surface_mesh(members),
-        GmlGeometryType::Solid => solid(members),
+        | GmlGeometryType::PolyhedralSurface => surface_mesh(members, &frame),
+        GmlGeometryType::Solid => solid(members, &frame),
         _ => {
             tracing::warn!("citygml geometry: inline type deferred to pass 2, skipped");
             None
@@ -334,7 +373,10 @@ fn collection(members: Vec<(Role, Euclidean3DGeometry)>) -> Euclidean3DGeometry 
 
 /// Concatenate curve members into one open exterior ring, yielding a single-ring
 /// `Polygon`.
-fn ring(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometry> {
+fn ring(
+    members: Vec<(Role, Euclidean3DGeometry)>,
+    frame: &CoordinateFrame,
+) -> Option<Euclidean3DGeometry> {
     let mut exterior: Vec<[f64; 3]> = Vec::new();
     for (_, geometry) in members {
         match into_line_string(geometry) {
@@ -345,7 +387,7 @@ fn ring(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometry
     if exterior.is_empty() {
         return None;
     }
-    let polygon = Polygon3D::from_rings(FRAME, exterior, Vec::<Vec<[f64; 3]>>::new());
+    let polygon = Polygon3D::from_rings(frame.clone(), exterior, Vec::<Vec<[f64; 3]>>::new());
     Some(Euclidean3DGeometry::Polygon(Box::new(polygon)))
 }
 
@@ -355,7 +397,10 @@ fn ring(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometry
 /// welded into a single mesh, carrying each member polygon's appearance across.
 /// Mesh members mixed with other members are not yet supported and are skipped
 /// with a warning.
-fn surface_mesh(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometry> {
+fn surface_mesh(
+    members: Vec<(Role, Euclidean3DGeometry)>,
+    frame: &CoordinateFrame,
+) -> Option<Euclidean3DGeometry> {
     if members.len() == 1
         && matches!(
             members[0].1,
@@ -380,20 +425,23 @@ fn surface_mesh(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3D
     if faces.is_empty() {
         return None;
     }
-    build_mesh(faces).map(|mesh| Euclidean3DGeometry::PolygonMesh(Box::new(mesh)))
+    build_mesh(faces, frame).map(|mesh| Euclidean3DGeometry::PolygonMesh(Box::new(mesh)))
 }
 
 /// Pair an exterior boundary with any interior void boundaries into a `Solid`.
-fn solid(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometry> {
+fn solid(
+    members: Vec<(Role, Euclidean3DGeometry)>,
+    frame: &CoordinateFrame,
+) -> Option<Euclidean3DGeometry> {
     let mut exterior: Option<Shell> = None;
     let mut interiors: Vec<Shell> = Vec::new();
     for (role, geometry) in members {
         match role {
-            Role::Exterior if exterior.is_none() => exterior = into_shell(geometry),
+            Role::Exterior if exterior.is_none() => exterior = into_shell(geometry, frame),
             Role::Exterior => {
                 tracing::warn!("citygml geometry: solid with multiple exteriors, extra skipped")
             }
-            Role::Interior => interiors.extend(into_shell(geometry)),
+            Role::Interior => interiors.extend(into_shell(geometry, frame)),
             Role::Member => {
                 tracing::warn!("citygml geometry: unexpected solid member role, skipped")
             }
@@ -401,13 +449,15 @@ fn solid(members: Vec<(Role, Euclidean3DGeometry)>) -> Option<Euclidean3DGeometr
     }
     let exterior = exterior?;
     Some(Euclidean3DGeometry::Solid(Box::new(Solid::new(
-        FRAME, exterior, interiors,
+        frame.clone(),
+        exterior,
+        interiors,
     ))))
 }
 
-/// Weld independent faces into one polygon mesh in [`FRAME`].
-fn build_mesh(faces: Vec<Polygon3D>) -> Option<PolygonMesh3D> {
-    match PolygonMesh3D::from_polygons(FRAME, &faces) {
+/// Weld independent faces into one polygon mesh in `frame`.
+fn build_mesh(faces: Vec<Polygon3D>, frame: &CoordinateFrame) -> Option<PolygonMesh3D> {
+    match PolygonMesh3D::from_polygons(frame.clone(), &faces) {
         Ok(mesh) => Some(mesh),
         Err(e) => {
             tracing::warn!("citygml geometry: failed to weld mesh: {e}");
@@ -431,12 +481,12 @@ fn into_line_string(geometry: Euclidean3DGeometry) -> Option<LineString3D> {
 /// `Shell` boundary has already been assembled into a mesh by [`surface_mesh`], so
 /// this just unwraps it; a bare `Polygon` boundary is welded into a single-face
 /// mesh.
-fn into_shell(geometry: Euclidean3DGeometry) -> Option<Shell> {
+fn into_shell(geometry: Euclidean3DGeometry, frame: &CoordinateFrame) -> Option<Shell> {
     match geometry {
         Euclidean3DGeometry::PolygonMesh(mesh) => Some(Shell::PolygonMesh(mesh.into_data())),
         Euclidean3DGeometry::TriangularMesh(mesh) => Some(Shell::TriangularMesh(mesh.into_data())),
         Euclidean3DGeometry::Polygon(polygon) => {
-            build_mesh(vec![*polygon]).map(|mesh| Shell::PolygonMesh(mesh.into_data()))
+            build_mesh(vec![*polygon], frame).map(|mesh| Shell::PolygonMesh(mesh.into_data()))
         }
         _ => {
             tracing::warn!("citygml geometry: cannot use as a solid boundary, skipped");
@@ -449,6 +499,8 @@ fn into_shell(geometry: Euclidean3DGeometry) -> Option<Shell> {
 mod tests {
     use super::*;
     use reearth_flow_geometry::point::Point3D;
+
+    const FRAME: CoordinateFrame = CoordinateFrame::Euclidean;
 
     fn key(id: &str) -> RawNodeKey {
         ("file:///test.gml".to_string(), id.to_string())

--- a/engine/runtime/action-processor/src/citygml_parser/resolver.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/resolver.rs
@@ -304,10 +304,8 @@ fn resolve_ref(
 /// type. Members that fail to resolve are dropped, so a container survives with
 /// whatever members did resolve. This container's own gml:id is prepended to
 /// `enclosing` for its members, so an appearance bound to the container reaches
-/// them. The container's own frame is `node.file`'s CRS, so a container welded
-/// here (a mesh, a solid, a ring-polygon) is tagged with the CRS of the file its
-/// own element lives in, regardless of what file any `xlink:href` member resolved
-/// from.
+/// them. The container's frame is `node.file`'s CRS; a member from a file in a
+/// different CRS is dropped with error rather than folded in.
 fn construct(
     node: &Unresolved,
     registry: &GeomRegistry,
@@ -320,10 +318,17 @@ fn construct(
     member_enclosing.extend(node.id.as_deref().map(|id| (node.file.as_str(), id)));
     member_enclosing.extend_from_slice(enclosing);
 
+    let frame = frame_for(&node.file, srs_by_file);
     let members: Vec<(Role, Euclidean3DGeometry)> = node
         .members
         .iter()
         .filter_map(|(role, child)| {
+            if frame_for(source_file(child), srs_by_file) != frame {
+                tracing::error!(
+                    "citygml geometry: member srsName disagrees with its parent, skipped"
+                );
+                return None;
+            }
             resolve(
                 child,
                 registry,
@@ -336,7 +341,6 @@ fn construct(
         })
         .collect();
 
-    let frame = frame_for(&node.file, srs_by_file);
     match node.ty {
         GmlGeometryType::MultiPoint
         | GmlGeometryType::MultiCurve
@@ -361,6 +365,15 @@ fn construct(
             tracing::warn!("citygml geometry: inline type deferred to pass 2, skipped");
             None
         }
+    }
+}
+
+/// The source file URL a child node's coordinates belong to.
+fn source_file(node: &GeomNode) -> &str {
+    match node {
+        GeomNode::Resolved(_, ids) => &ids.file,
+        GeomNode::Ref(key) => &key.0,
+        GeomNode::Unresolved(unresolved) => &unresolved.file,
     }
 }
 
@@ -460,7 +473,7 @@ fn build_mesh(faces: Vec<Polygon3D>, frame: &CoordinateFrame) -> Option<PolygonM
     match PolygonMesh3D::from_polygons(frame.clone(), &faces) {
         Ok(mesh) => Some(mesh),
         Err(e) => {
-            tracing::warn!("citygml geometry: failed to weld mesh: {e}");
+            tracing::error!("citygml geometry: failed to weld mesh: {e}");
             None
         }
     }
@@ -542,6 +555,48 @@ mod tests {
             file: String::new(),
             members,
         })
+    }
+
+    fn crs(code: u16) -> CoordinateFrame {
+        CoordinateFrame::Crs(EpsgCode::new(code))
+    }
+
+    fn triangle_in(frame: CoordinateFrame) -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Polygon(Box::new(Polygon3D::from_rings(
+            frame,
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+            Vec::<Vec<[f64; 3]>>::new(),
+        )))
+    }
+
+    fn point_in(frame: CoordinateFrame) -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Point(Point3D::new(frame, [1.0, 2.0, 3.0]))
+    }
+
+    fn resolved_in(file: &str, geometry: Euclidean3DGeometry) -> GeomNode {
+        GeomNode::Resolved(
+            geometry,
+            LeafIds {
+                file: file.to_string(),
+                faces: Vec::new(),
+            },
+        )
+    }
+
+    fn node_in(file: &str, ty: GmlGeometryType, members: Vec<(Role, GeomNode)>) -> GeomNode {
+        GeomNode::Unresolved(Unresolved {
+            ty,
+            id: None,
+            file: file.to_string(),
+            members,
+        })
+    }
+
+    fn srs(pairs: &[(&str, u16)]) -> HashMap<String, EpsgCode> {
+        pairs
+            .iter()
+            .map(|(file, code)| (file.to_string(), EpsgCode::new(*code)))
+            .collect()
     }
 
     fn collection_len(geometry: &Euclidean3DGeometry) -> usize {
@@ -692,5 +747,59 @@ mod tests {
         );
         let geometry = resolve_root_bare(&GeomNode::Ref(key("a")), &registry).unwrap();
         assert_eq!(collection_len(&geometry), 0);
+    }
+
+    fn resolve_root_srs(node: &GeomNode, srs: &HashMap<String, EpsgCode>) -> Euclidean3DGeometry {
+        resolve_root(node, &GeomRegistry::new(), &AppearanceIndex::default(), srs).unwrap()
+    }
+
+    #[test]
+    fn member_in_disagreeing_crs_is_dropped_from_weld() {
+        // The face from a different-CRS file is dropped; the rest still weld.
+        let n = node_in(
+            "a.gml",
+            GmlGeometryType::CompositeSurface,
+            vec![
+                (Role::Member, resolved_in("a.gml", triangle_in(crs(6668)))),
+                (Role::Member, resolved_in("a.gml", triangle_in(crs(6668)))),
+                (Role::Member, resolved_in("b.gml", triangle_in(crs(6697)))),
+            ],
+        );
+        match resolve_root_srs(&n, &srs(&[("a.gml", 6668), ("b.gml", 6697)])) {
+            Euclidean3DGeometry::PolygonMesh(mesh) => assert_eq!(mesh.num_faces(), 2),
+            other => panic!("expected PolygonMesh, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn member_in_same_crs_from_another_file_is_kept() {
+        // Same CRS from a different file still welds.
+        let n = node_in(
+            "a.gml",
+            GmlGeometryType::CompositeSurface,
+            vec![
+                (Role::Member, resolved_in("a.gml", triangle_in(crs(6668)))),
+                (Role::Member, resolved_in("c.gml", triangle_in(crs(6668)))),
+            ],
+        );
+        match resolve_root_srs(&n, &srs(&[("a.gml", 6668), ("c.gml", 6668)])) {
+            Euclidean3DGeometry::PolygonMesh(mesh) => assert_eq!(mesh.num_faces(), 2),
+            other => panic!("expected PolygonMesh, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disagreeing_member_is_gated_for_non_welded_types_too() {
+        // The gate is uniform: a non-welded MultiPoint member is gated too.
+        let n = node_in(
+            "a.gml",
+            GmlGeometryType::MultiPoint,
+            vec![
+                (Role::Member, resolved_in("a.gml", point_in(crs(6668)))),
+                (Role::Member, resolved_in("b.gml", point_in(crs(6697)))),
+            ],
+        );
+        let geometry = resolve_root_srs(&n, &srs(&[("a.gml", 6668), ("b.gml", 6697)]));
+        assert_eq!(collection_len(&geometry), 1);
     }
 }

--- a/engine/runtime/action-processor/src/citygml_parser/srsname.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/srsname.rs
@@ -1,0 +1,115 @@
+//! Parsing a GML `srsName` CRS reference to an [`EpsgCode`].
+
+use reearth_flow_geometry::coordinate::EpsgCode;
+
+/// The two OGC-standard encodings a CRS `srsName` can take, each an identifier
+/// of the form `objectType`/`authority`/`version`/`code`.
+enum SrsEncoding {
+    /// OGC 07-092r3, e.g. `urn:ogc:def:crs:EPSG::6697`.
+    Urn,
+    /// OGC 09-048r3, e.g. `http://www.opengis.net/def/crs/EPSG/0/6697`.
+    HttpUri,
+}
+
+impl SrsEncoding {
+    /// The encoding of `srs_name` paired with its identifier body — the part
+    /// after the fixed prefix — or `None` if it is neither standard encoding.
+    fn detect(srs_name: &str) -> Option<(Self, &str)> {
+        if let Some(body) = srs_name.strip_prefix("urn:ogc:def:") {
+            Some((Self::Urn, body))
+        } else if let Some(body) = srs_name
+            .strip_prefix("http://www.opengis.net/def/")
+            .or_else(|| srs_name.strip_prefix("https://www.opengis.net/def/"))
+        {
+            Some((Self::HttpUri, body))
+        } else {
+            None
+        }
+    }
+
+    fn separator(&self) -> char {
+        match self {
+            Self::Urn => ':',
+            Self::HttpUri => '/',
+        }
+    }
+}
+
+/// A CRS reference decomposed from a `srsName` into its OGC identifier parts.
+struct CrsRef<'a> {
+    object_type: &'a str,
+    authority: &'a str,
+    code: &'a str,
+}
+
+impl<'a> CrsRef<'a> {
+    fn parse(srs_name: &'a str) -> Option<Self> {
+        let (encoding, body) = SrsEncoding::detect(srs_name)?;
+        let mut parts = body.split(encoding.separator());
+        let object_type = parts.next()?;
+        let authority = parts.next()?;
+        let _version = parts.next()?;
+        let code = parts.next()?;
+        // Exactly four segments; a fifth means a compound or malformed reference.
+        parts.next().is_none().then_some(Self {
+            object_type,
+            authority,
+            code,
+        })
+    }
+
+    fn epsg_code(&self) -> Option<EpsgCode> {
+        if self.object_type.eq_ignore_ascii_case("crs")
+            && self.authority.eq_ignore_ascii_case("EPSG")
+        {
+            self.code.parse::<u16>().ok().map(EpsgCode::new)
+        } else {
+            None
+        }
+    }
+}
+
+/// The EPSG code a CRS `srsName` references, or `None` if it isn't an EPSG CRS.
+pub(super) fn parse_epsg(srs_name: &str) -> Option<EpsgCode> {
+    CrsRef::parse(srs_name)?.epsg_code()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn code(srs_name: &str) -> Option<u16> {
+        parse_epsg(srs_name).map(|e| e.get())
+    }
+
+    #[test]
+    fn ogc_http_uri() {
+        assert_eq!(code("http://www.opengis.net/def/crs/EPSG/0/6697"), Some(6697));
+        assert_eq!(code("https://www.opengis.net/def/crs/EPSG/0/4326"), Some(4326));
+    }
+
+    #[test]
+    fn ogc_urn() {
+        assert_eq!(code("urn:ogc:def:crs:EPSG::6697"), Some(6697));
+        assert_eq!(code("urn:ogc:def:crs:EPSG:9.9.1:6697"), Some(6697));
+    }
+
+    #[test]
+    fn non_epsg_authority_rejected() {
+        // Trailing number belongs to the OGC authority, not EPSG.
+        assert_eq!(code("http://www.opengis.net/def/crs/OGC/0/84"), None);
+        assert_eq!(code("http://www.opengis.net/def/crs/OGC/1.3/CRS84"), None);
+    }
+
+    #[test]
+    fn non_crs_object_type_rejected() {
+        assert_eq!(code("urn:ogc:def:coordinateOperation:EPSG::1234"), None);
+    }
+
+    #[test]
+    fn compound_and_malformed_rejected() {
+        assert_eq!(code("urn:ogc:def:crs,crs:EPSG::6697,crs:EPSG::5773"), None);
+        assert_eq!(code("EPSG:6697"), None); // legacy short form is not an OGC identifier
+        assert_eq!(code("nonsense"), None);
+    }
+}

--- a/engine/runtime/action-processor/src/citygml_parser/srsname.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/srsname.rs
@@ -84,8 +84,14 @@ mod tests {
 
     #[test]
     fn ogc_http_uri() {
-        assert_eq!(code("http://www.opengis.net/def/crs/EPSG/0/6697"), Some(6697));
-        assert_eq!(code("https://www.opengis.net/def/crs/EPSG/0/4326"), Some(4326));
+        assert_eq!(
+            code("http://www.opengis.net/def/crs/EPSG/0/6697"),
+            Some(6697)
+        );
+        assert_eq!(
+            code("https://www.opengis.net/def/crs/EPSG/0/4326"),
+            Some(4326)
+        );
     }
 
     #[test]

--- a/engine/runtime/action-processor/src/citygml_parser/utils.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/utils.rs
@@ -99,24 +99,13 @@ pub(super) fn xlink_href_attr(attrs: &[(QName, String)]) -> Option<&str> {
         .map(|(_, v)| v.as_str())
 }
 
+/// The `srsName` attribute of an element, if present.
 #[cfg(feature = "new-geometry")]
 pub(super) fn srs_name_attr(attrs: &[(QName, String)]) -> Option<&str> {
     attrs
         .iter()
         .find(|((q, _), _)| local_name(q) == "srsName")
         .map(|(_, v)| v.as_str())
-}
-
-/// Parse the trailing EPSG code from a `srsName` URI, e.g.
-/// `http://www.opengis.net/def/crs/EPSG/0/6697` -> `6697`. `None` if the URI's
-/// last path segment isn't a plain number.
-#[cfg(feature = "new-geometry")]
-pub(super) fn parse_epsg_from_srs_name(srs_name: &str) -> Option<EpsgCode> {
-    srs_name
-        .rsplit('/')
-        .next()
-        .and_then(|code| code.parse::<u16>().ok())
-        .map(EpsgCode::new)
 }
 
 /// The frame for geometry parsed from `file`: `Crs` if `srs_by_file` has an entry

--- a/engine/runtime/action-processor/src/citygml_parser/utils.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/utils.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use reearth_flow_geometry::coordinate::{CoordinateFrame, EpsgCode};
 use url::Url;
 
 pub(super) const GML_NS_32: &str = "http://www.opengis.net/gml/3.2";
@@ -95,6 +96,33 @@ pub(super) fn xlink_href_attr(attrs: &[(QName, String)]) -> Option<&str> {
         .iter()
         .find(|((q, ns), _)| local_name(q) == "href" && *ns == XLINK_NS_ID)
         .map(|(_, v)| v.as_str())
+}
+
+pub(super) fn srs_name_attr(attrs: &[(QName, String)]) -> Option<&str> {
+    attrs
+        .iter()
+        .find(|((q, _), _)| local_name(q) == "srsName")
+        .map(|(_, v)| v.as_str())
+}
+
+/// Parse the trailing EPSG code from a `srsName` URI, e.g.
+/// `http://www.opengis.net/def/crs/EPSG/0/6697` -> `6697`. `None` if the URI's
+/// last path segment isn't a plain number.
+pub(super) fn parse_epsg_from_srs_name(srs_name: &str) -> Option<EpsgCode> {
+    srs_name
+        .rsplit('/')
+        .next()
+        .and_then(|code| code.parse::<u16>().ok())
+        .map(EpsgCode::new)
+}
+
+/// The frame for geometry parsed from `file`: `Crs` if `srs_by_file` has an entry
+/// for it, `Euclidean` (no known CRS) otherwise.
+pub(super) fn frame_for(file: &str, srs_by_file: &HashMap<String, EpsgCode>) -> CoordinateFrame {
+    match srs_by_file.get(file) {
+        Some(&epsg) => CoordinateFrame::Crs(epsg),
+        None => CoordinateFrame::Euclidean,
+    }
 }
 
 #[cfg(test)]

--- a/engine/runtime/action-processor/src/citygml_parser/utils.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/utils.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+#[cfg(feature = "new-geometry")]
 use reearth_flow_geometry::coordinate::{CoordinateFrame, EpsgCode};
 use url::Url;
 
@@ -98,6 +99,7 @@ pub(super) fn xlink_href_attr(attrs: &[(QName, String)]) -> Option<&str> {
         .map(|(_, v)| v.as_str())
 }
 
+#[cfg(feature = "new-geometry")]
 pub(super) fn srs_name_attr(attrs: &[(QName, String)]) -> Option<&str> {
     attrs
         .iter()
@@ -108,6 +110,7 @@ pub(super) fn srs_name_attr(attrs: &[(QName, String)]) -> Option<&str> {
 /// Parse the trailing EPSG code from a `srsName` URI, e.g.
 /// `http://www.opengis.net/def/crs/EPSG/0/6697` -> `6697`. `None` if the URI's
 /// last path segment isn't a plain number.
+#[cfg(feature = "new-geometry")]
 pub(super) fn parse_epsg_from_srs_name(srs_name: &str) -> Option<EpsgCode> {
     srs_name
         .rsplit('/')
@@ -118,6 +121,7 @@ pub(super) fn parse_epsg_from_srs_name(srs_name: &str) -> Option<EpsgCode> {
 
 /// The frame for geometry parsed from `file`: `Crs` if `srs_by_file` has an entry
 /// for it, `Euclidean` (no known CRS) otherwise.
+#[cfg(feature = "new-geometry")]
 pub(super) fn frame_for(file: &str, srs_by_file: &HashMap<String, EpsgCode>) -> CoordinateFrame {
     match srs_by_file.get(file) {
         Some(&epsg) => CoordinateFrame::Crs(epsg),

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
@@ -5,8 +5,6 @@ use reearth_flow_geometry::polygon_mesh::PolygonMesh3D;
 use reearth_flow_geometry::solid::Shell;
 use reearth_flow_geometry::{Euclidean3DGeometry, Geometry};
 
-/// JGD2011 — temporary until the new-geometry CityGML reader parses srsName/EPSG.
-const ASSUMED_SOURCE_CRS: EpsgCode = EpsgCode::new(6697);
 /// WGS84, 3D geographic (lat, lon, height) — used for the tileset's bounding region.
 const WGS84_GEOGRAPHIC: EpsgCode = EpsgCode::new(4979);
 /// WGS84, geocentric (ECEF) — used for glTF vertex positions.
@@ -94,9 +92,9 @@ fn collect_geometry(geometry: &Geometry, out: &mut Vec<PolygonMesh3D>) {
 }
 
 /// Recurse through `Collection` members and unpack a `Solid`'s boundary
-/// shells, collecting every `PolygonMesh` found. A `Solid` shell has no
-/// `Coordinate` of its own, so a placeholder frame is used — this writer
-/// reprojects raw vertex buffers directly and ignores it anyway.
+/// shells, collecting every `PolygonMesh` found. A `Solid` shell is a
+/// coordinate-free mesh; its frame lives on the enclosing `Solid`, so each
+/// unpacked shell is re-paired with the solid's frame for reprojection.
 fn collect_euclidean3d(geometry: &Euclidean3DGeometry, out: &mut Vec<PolygonMesh3D>) {
     match geometry {
         Euclidean3DGeometry::Collection(c) => {
@@ -109,7 +107,7 @@ fn collect_euclidean3d(geometry: &Euclidean3DGeometry, out: &mut Vec<PolygonMesh
             for shell in std::iter::once(solid.exterior()).chain(solid.interiors()) {
                 match shell {
                     Shell::PolygonMesh(data) => {
-                        out.push(PolygonMesh3D::new(CoordinateFrame::Euclidean, data.clone()))
+                        out.push(PolygonMesh3D::new(solid.frame().clone(), data.clone()))
                     }
                     Shell::TriangularMesh(_) => tracing::warn!(
                         "Cesium3DTilesWriter: a Solid shell is a TriangularMesh; \
@@ -124,8 +122,23 @@ fn collect_euclidean3d(geometry: &Euclidean3DGeometry, out: &mut Vec<PolygonMesh
     }
 }
 
+/// The EPSG source CRS a mesh's coordinates are reprojected from. A mesh
+/// tagged with anything but a concrete `Crs` (e.g. `Euclidean`, meaning the
+/// reader found no srsName) cannot be placed on the globe, so it is skipped.
+fn source_crs(frame: &CoordinateFrame) -> Option<EpsgCode> {
+    match frame {
+        CoordinateFrame::Crs(epsg) => Some(*epsg),
+        other => {
+            tracing::warn!("Cesium3DTilesWriter: mesh has no geographic CRS ({other:?}); skipping");
+            None
+        }
+    }
+}
+
 /// Triangulate and reproject one `PolygonMesh`.
 fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ReprojectCaches) -> Option<ExtractedMesh> {
+    let source_crs = source_crs(mesh.frame())?;
+
     let mut triangulation_cache = TriangulationCache::new();
     let result = mesh.triangulate_with_normals(&mut triangulation_cache);
     let (mesh, polygon_normals, polygon_tris) =
@@ -134,7 +147,7 @@ fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ReprojectCaches) -> Option<
     let mut geographic_vertices = mesh.vertices().to_vec();
     if let Err(e) = transform_coords_3d(
         &mut caches.geographic,
-        ASSUMED_SOURCE_CRS,
+        source_crs,
         WGS84_GEOGRAPHIC,
         &mut geographic_vertices,
     ) {
@@ -145,7 +158,7 @@ fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ReprojectCaches) -> Option<
     let mut ecef_vertices = mesh.vertices().to_vec();
     if let Err(e) = transform_coords_3d(
         &mut caches.geocentric,
-        ASSUMED_SOURCE_CRS,
+        source_crs,
         WGS84_GEOCENTRIC,
         &mut ecef_vertices,
     ) {

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
@@ -7,7 +7,7 @@ use reearth_flow_geometry::{Euclidean3DGeometry, Geometry};
 
 /// JGD2011 — temporary until the new-geometry CityGML reader parses srsName/EPSG.
 const ASSUMED_SOURCE_CRS: EpsgCode = EpsgCode::new(6697);
-/// WGS84, 3D geographic (lon, lat, height) — used for the tileset's bounding region.
+/// WGS84, 3D geographic (lat, lon, height) — used for the tileset's bounding region.
 const WGS84_GEOGRAPHIC: EpsgCode = EpsgCode::new(4979);
 /// WGS84, geocentric (ECEF) — used for glTF vertex positions.
 const WGS84_GEOCENTRIC: EpsgCode = EpsgCode::new(4978);
@@ -24,7 +24,7 @@ pub(super) struct ReprojectCaches {
 pub(super) struct ExtractedMesh {
     /// Vertex positions in ECEF (WGS84 geocentric), metres.
     pub(super) ecef_vertices: Vec<[f64; 3]>,
-    /// The same vertices in WGS84 geographic (lon, lat, height); degrees/metres.
+    /// The same vertices in WGS84 geographic (lat, lon, height); degrees/metres.
     pub(super) geographic_vertices: Vec<[f64; 3]>,
     /// Triangle index triples, parallel to both vertex arrays above.
     pub(super) indices: Vec<[u32; 3]>,

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/quadtree.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/quadtree.rs
@@ -61,9 +61,10 @@ pub(super) struct GeoBox {
 }
 
 impl GeoBox {
-    /// The bounding box of `points` (lon, lat, height triples); `None` if empty.
+    /// The bounding box of `points` (lat, lon, height triples — WGS84/EPSG:4979's
+    /// own axis order); `None` if empty.
     pub(super) fn of(points: &[[f64; 3]]) -> Option<Self> {
-        points.iter().fold(None, |acc, &[lon, lat, height]| {
+        points.iter().fold(None, |acc, &[lat, lon, height]| {
             Some(match acc {
                 None => GeoBox {
                     west: lon,

--- a/engine/runtime/geometry/src/ops/reproject/ffi.rs
+++ b/engine/runtime/geometry/src/ops/reproject/ffi.rs
@@ -7,9 +7,8 @@ use std::ptr;
 use crate::coordinate::EpsgCode;
 use proj_sys::{
     proj_context_create, proj_context_destroy, proj_context_errno, proj_context_errno_string,
-    proj_create_crs_to_crs, proj_destroy, proj_errno, proj_errno_reset,
-    proj_normalize_for_visualization, proj_trans, PJ, PJ_CONTEXT, PJ_COORD, PJ_DIRECTION_PJ_FWD,
-    PJ_XYZT,
+    proj_create_crs_to_crs, proj_destroy, proj_errno, proj_errno_reset, proj_trans, PJ, PJ_CONTEXT,
+    PJ_COORD, PJ_DIRECTION_PJ_FWD, PJ_XYZT,
 };
 
 use crate::error::{Error, Result};
@@ -122,22 +121,7 @@ impl Entry {
                 )));
             }
 
-            let pj_norm = proj_normalize_for_visualization(ctx, pj);
-            proj_destroy(pj);
-            if pj_norm.is_null() {
-                let msg = ctx_errno_string(ctx);
-                proj_context_destroy(ctx);
-                return Err(Error::projection(format!(
-                    "failed to normalize transform EPSG:{from}->EPSG:{to}: {msg}"
-                )));
-            }
-
-            Ok(Self {
-                from,
-                to,
-                ctx,
-                pj: pj_norm,
-            })
+            Ok(Self { from, to, ctx, pj })
         }
     }
 }

--- a/engine/runtime/geometry/src/ops/reproject/mod.rs
+++ b/engine/runtime/geometry/src/ops/reproject/mod.rs
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn transform_round_trip_3d() {
         let mut cache = ReprojectionCache::new();
-        let p = [139.767, 35.681, 100.0];
+        let p = [35.681, 139.767, 100.0];
         let ecef = cache
             .transform(EpsgCode::new(4979), EpsgCode::new(4978), p)
             .unwrap();
@@ -105,13 +105,14 @@ mod tests {
     }
 
     #[test]
-    fn transform_axis_order_is_lon_lat() {
+    fn transform_uses_each_crs_own_axis_order() {
         let mut cache = ReprojectionCache::new();
+        // EPSG:4326 is officially (lat, lon); EPSG:3857 is (x, y) easting/northing.
         let out = cache
             .transform(
                 EpsgCode::new(4326),
                 EpsgCode::new(3857),
-                [139.767, 35.681, 0.0],
+                [35.681, 139.767, 0.0],
             )
             .unwrap();
         assert_relative_eq!(out[0], 1.5558e7, epsilon = 1e4);
@@ -131,7 +132,7 @@ mod tests {
     #[test]
     fn point3d_reproject_updates_position_and_frame() {
         let mut cache = ReprojectionCache::new();
-        let start = [139.767, 35.681, 100.0];
+        let start = [35.681, 139.767, 100.0];
         let expected = cache
             .transform(EpsgCode::new(4979), EpsgCode::new(4978), start)
             .unwrap();
@@ -151,11 +152,11 @@ mod tests {
             .transform(
                 EpsgCode::new(4326),
                 EpsgCode::new(3857),
-                [139.767, 35.681, 0.0],
+                [35.681, 139.767, 0.0],
             )
             .unwrap();
 
-        let mut p = Point2D::new(CoordinateFrame::Crs(EpsgCode::new(4326)), [139.767, 35.681]);
+        let mut p = Point2D::new(CoordinateFrame::Crs(EpsgCode::new(4326)), [35.681, 139.767]);
         p.reproject(EpsgCode::new(3857), &mut cache).unwrap();
         assert_eq!(
             p,
@@ -166,7 +167,7 @@ mod tests {
     #[test]
     fn linestring2d_reproject_carries_elevation() {
         let mut cache = ReprojectionCache::new();
-        let raw = [[139.7, 35.6, 10.0], [139.8, 35.7, 20.0]];
+        let raw = [[35.6, 139.7, 10.0], [35.7, 139.8, 20.0]];
         let expected: Vec<[f64; 3]> = raw
             .iter()
             .map(|&[x, y, z]| {
@@ -193,8 +194,8 @@ mod tests {
     #[test]
     fn collection_reproject_dispatches_to_each_member() {
         let mut cache = ReprojectionCache::new();
-        let a = [139.7, 35.6, 1.0];
-        let b = [140.0, 35.9, 2.0];
+        let a = [35.6, 139.7, 1.0];
+        let b = [35.9, 140.0, 2.0];
         let ea = cache
             .transform(EpsgCode::new(4979), EpsgCode::new(4978), a)
             .unwrap();

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -122,6 +122,12 @@ impl PolygonMesh3DData {
 }
 
 impl PolygonMesh3D {
+    /// The coordinate frame the mesh data is expressed in.
+    #[inline]
+    pub fn frame(&self) -> &CoordinateFrame {
+        &self.frame
+    }
+
     /// Borrow the appearance, if any.
     #[inline]
     pub fn appearance(&self) -> &Option<Appearance> {

--- a/engine/runtime/geometry/src/solid/mod.rs
+++ b/engine/runtime/geometry/src/solid/mod.rs
@@ -61,6 +61,12 @@ pub struct Solid {
 }
 
 impl Solid {
+    /// The coordinate frame this solid's shells are expressed in.
+    #[inline]
+    pub fn frame(&self) -> &CoordinateFrame {
+        &self.frame
+    }
+
     /// The exterior boundary shell.
     #[inline]
     pub fn exterior(&self) -> &Shell {


### PR DESCRIPTION
# Overview

This PR implements file-level EPSG code parsing in CityGML reader and properly use EPSG and drops hard-coded EPSG:6697 in Cesium writer. It also removed the axis customization and use the order defined in EPSG.

## Changes

- `mesh.rs`: reproject each mesh from its own source CRS instead of a hard-coded JGD2011, skipping meshes with no geographic CRS
- `mesh.rs`: reproject a solid's boundary shells using the parent solid's CRS (shells carry no CRS of their own)
- `parser_next.rs`, `resolver.rs`: read each file's CRS from its envelope srsName and tag every geometry produced from it
- `resolver.rs`: drop a container member whose CRS disagrees with its parent's, reported as an error, rather than welding coordinates from two CRS into one geometry
- `srsname.rs`: parse an OGC srsName into an EPSG code (URN and OGC-URL forms; reject non-EPSG, compound, legacy short forms)
- `geometry_next.rs`, `reproject/ffi.rs`, `quadtree.rs`: keep coordinates in each CRS's declared axis order (no lon/lat swap or viz normalization)
- `parser_next.rs`: report an unrecognized envelope srsName as an error instead of a warning
- `parser_next.rs`: return parser results as a named `ParserOutput` struct (was a 5-tuple), carrying the file CRS to pass 2
- `solid/mod.rs`, `polygon_mesh/mod.rs`: expose each geometry's coordinate frame so the writer can read its source CRS

## Notes

### srsName parsing

[Some PLATEAU files](https://github.com/reearth/reearth-flow/blob/fc14093ab9156981ac61b39b964ecb39b644f4fc/engine/testing/data/testcases/quality-check/plateau4/09-brid-tun-ubld/C02/udx/brid/input.gml#L1366) use `srsName="EPSG:6668"`, instead of the full URL form. They are not handled by nusamai-projection. I could not find documentation for this style. Maybe it is CURIEs (https://docs.ogc.org/pol/09-048r6.html) but it should require surrounding brackets. Therefore the short form remains unimplemented before we understand the standard completely.

Note that the `EPSG:6668` is actually used to override root-level srsName in several PLATEAU GML files, but they are all not effective (only for representing lod0 2D-like data but 6697 already gives same horizontal projection). This seems to be a duplication caused by the tools generating those GML files, not necessary. So toplevel parsing should be fine with existing GML files.

### srsName override

In the example above, the root geometry element is overriden to EPSG:6668. Currently the parser is implemented that if parent and child srsNames disagree, geometry get dropped with an error message, while this currently applies to only xlink:href geometry thus unlikely to trigger error in PLATEAU data, for the 6668 example, the acceptance of them (as a result, correctly holding 6668 for these geometry) relies on the fact that these tag is specified on the toplevel geometry tag.

However, according to citygml spec, srsname is an attribute on the geometry nodes, NOT on the coordinates. Therefore, theoretically writing geometry like `<gml:MultiSurface> <gml:SurfaceMember srsName="EPSG:6668">` specifically means "we want multisurface to be in 6697 but its child to be 6668", which flow new geometry should not support (right now).

### Unimplemented

- non-toplevel srsName are ignored (no error log)
- urn srsName is not handled in new geometry representation though parsed (error log)
- per feature boundedby/envelope not parsed (no error log, could contain srsname)