### PR TITLE
feat(engine): migrate GeoJSON Reader to new geometry behind feature flag

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "futures",
  "once_cell",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "approx",
  "async-trait",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "Inflector",
  "approx",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "bytes",
  "clap",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "approx",
  "bvh",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "bytes",
  "futures",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "bytes",
  "futures",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "ahash",
  "bytes",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.436"
+version = "0.0.437"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "futures",
  "once_cell",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "approx",
  "async-trait",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "Inflector",
  "approx",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "bytes",
  "clap",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "approx",
  "bvh",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "bytes",
  "futures",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "bytes",
  "futures",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "ahash",
  "bytes",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.435"
+version = "0.0.436"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.436"
+version = "0.0.437"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.435"
+version = "0.0.436"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-source/src/file/geojson.rs
+++ b/engine/runtime/action-source/src/file/geojson.rs
@@ -102,7 +102,6 @@ impl Source for GeoJsonReader {
         Ok(vec![])
     }
 
-    #[cfg(not(feature = "new-geometry"))]
     async fn start(
         &mut self,
         ctx: NodeContext,

--- a/engine/runtime/action-source/src/file/reader/geojson.rs
+++ b/engine/runtime/action-source/src/file/reader/geojson.rs
@@ -4,7 +4,6 @@ use reearth_flow_runtime::node::{IngestionMessage, Port, FEATURES_PORT};
 use reearth_flow_types::Feature;
 use tokio::sync::mpsc::Sender;
 
-#[cfg(not(feature = "new-geometry"))]
 pub(crate) async fn read_geojson(
     content: &Bytes,
     sender: Sender<(Port, IngestionMessage)>,

--- a/engine/runtime/types/src/conversion.rs
+++ b/engine/runtime/types/src/conversion.rs
@@ -1,2 +1,8 @@
+// The GeoJSON <-> Feature conversion depends on the feature geometry type, so it
+// splits by world: `geojson.rs` (old) vs `geojson_next.rs` (new-geometry).
+#[cfg(not(feature = "new-geometry"))]
+pub mod geojson;
+#[cfg(feature = "new-geometry")]
+#[path = "conversion/geojson_next.rs"]
 pub mod geojson;
 pub mod nusamai;

--- a/engine/runtime/types/src/conversion/geojson_next.rs
+++ b/engine/runtime/types/src/conversion/geojson_next.rs
@@ -4,7 +4,6 @@
 
 use std::sync::Arc;
 
-use nusamai_projection::crs::{EPSG_WGS84_GEOGRAPHIC_2D, EPSG_WGS84_GEOGRAPHIC_3D};
 use reearth_flow_geometry::types::conversion::{is_2d_geojson_value, is_3d_geojson_value};
 use reearth_flow_geometry::{
     collection::{Collection2D, Collection3D},
@@ -12,13 +11,18 @@ use reearth_flow_geometry::{
     line_string::{LineString2D, LineString3D},
     point::{Point2D, Point3D},
     polygon::{Polygon2D, Polygon3D},
-    Euclidean2DGeometry, Euclidean3DGeometry, Geometry,
+    Euclidean2DGeometry, Euclidean3DGeometry, Geometry, GeometryCollection,
 };
 
 use crate::{
     error::{Error, Result},
     Attribute, Attributes, Feature,
 };
+
+// WGS84 geographic CRS codes, defined here so this new-geometry module carries no
+// dependency on nusamai-projection (which is slated for removal after the migration).
+const EPSG_WGS84_GEOGRAPHIC_2D: u16 = 4326;
+const EPSG_WGS84_GEOGRAPHIC_3D: u16 = 4979;
 
 impl TryFrom<geojson::Feature> for Feature {
     type Error = Error;
@@ -68,15 +72,23 @@ fn wgs84_3d() -> CoordinateFrame {
 }
 
 fn geojson_value_to_geometry(value: geojson::Value) -> Result<Geometry> {
-    // Every coordinate must be uniformly 2D or uniformly 3D. Anything else
-    // (mixed dimensions, degenerate/short coords, GeometryCollection) is rejected
-    // rather than indexed into blindly, which would panic.
-    if is_2d_geojson_value(&value) {
-        Ok(Geometry::Euclidean2D(value_to_2d(value)?))
-    } else if is_3d_geojson_value(&value) {
-        Ok(Geometry::Euclidean3D(value_to_3d(value)?))
-    } else {
-        Err(unsupported(&value))
+    match value {
+        // A heterogeneous collection: each member converts on its own, so members
+        // may differ in dimension / coordinate frame.
+        geojson::Value::GeometryCollection(geometries) => {
+            let members = geometries
+                .into_iter()
+                .map(|g| geojson_value_to_geometry(g.value))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(Geometry::GeometryCollection(GeometryCollection::new(
+                members,
+            )))
+        }
+        // A single geometry's coordinates must be uniformly 2D or 3D; mixed or
+        // degenerate coordinates are rejected rather than indexed into blindly.
+        value if is_2d_geojson_value(&value) => Ok(Geometry::Euclidean2D(value_to_2d(value)?)),
+        value if is_3d_geojson_value(&value) => Ok(Geometry::Euclidean3D(value_to_3d(value)?)),
+        _ => Err(mixed_dimensions()),
     }
 }
 
@@ -102,7 +114,7 @@ fn value_to_2d(value: geojson::Value) -> Result<Euclidean2DGeometry> {
                 Euclidean2DGeometry::Polygon(Box::new(polygon_2d(rings)))
             })))
         }
-        other => Err(unsupported(&other)),
+        _ => Err(mixed_dimensions()),
     }
 }
 
@@ -128,20 +140,15 @@ fn value_to_3d(value: geojson::Value) -> Result<Euclidean3DGeometry> {
                 Euclidean3DGeometry::Polygon(Box::new(polygon_3d(rings)))
             })))
         }
-        other => Err(unsupported(&other)),
+        _ => Err(mixed_dimensions()),
     }
 }
 
-fn unsupported(value: &geojson::Value) -> Error {
-    match value {
-        geojson::Value::GeometryCollection(_) => {
-            Error::unsupported_feature("GeoJSON GeometryCollection is not supported")
-        }
-        _ => Error::unsupported_feature(
-            "GeoJSON geometry has mixed or unsupported coordinate dimensions \
-             (every coordinate must be uniformly 2D or 3D)",
-        ),
-    }
+fn mixed_dimensions() -> Error {
+    Error::unsupported_feature(
+        "GeoJSON geometry has mixed or unsupported coordinate dimensions \
+         (every coordinate must be uniformly 2D or 3D)",
+    )
 }
 
 fn collection_2d(members: impl IntoIterator<Item = Euclidean2DGeometry>) -> Euclidean2DGeometry {
@@ -192,7 +199,7 @@ mod tests {
         line_string::{LineString2D, LineString3D},
         point::{Point2D, Point3D},
         polygon::{Polygon2D, Polygon3D},
-        Euclidean2DGeometry, Euclidean3DGeometry, Geometry,
+        Euclidean2DGeometry, Euclidean3DGeometry, Geometry, GeometryCollection,
     };
 
     use super::*;
@@ -429,16 +436,52 @@ mod tests {
         );
     }
 
-    // A GeoJSON GeometryCollection is not supported by the reader (parity with the old world).
+    // A GeometryCollection converts to the new GeometryCollection; its members may
+    // differ in dimension (each carries its own coordinate frame).
     #[test]
-    fn geometry_collection_is_unsupported() {
+    fn geometry_collection_converts_with_mixed_dimension_members() {
         let gj = geojson_feature(geojson::Value::GeometryCollection(vec![
             geojson::Geometry::new(geojson::Value::Point(vec![0.0, 0.0])),
+            geojson::Geometry::new(geojson::Value::Point(vec![1.0, 1.0, 2.0])),
         ]));
 
-        let result: Result<Feature> = gj.try_into();
+        let feature: Feature = gj.try_into().unwrap();
 
-        assert!(result.is_err());
+        assert_eq!(
+            *feature.geometry,
+            Geometry::GeometryCollection(GeometryCollection::new([
+                Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
+                    crs(4326),
+                    [0.0, 0.0],
+                ))),
+                Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+                    crs(4979),
+                    [1.0, 1.0, 2.0],
+                ))),
+            ]))
+        );
+    }
+
+    // A nested GeometryCollection recurses.
+    #[test]
+    fn nested_geometry_collection_converts() {
+        let inner = geojson::Value::GeometryCollection(vec![geojson::Geometry::new(
+            geojson::Value::Point(vec![3.0, 4.0]),
+        )]);
+        let gj = geojson_feature(geojson::Value::GeometryCollection(vec![
+            geojson::Geometry::new(inner),
+        ]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            *feature.geometry,
+            Geometry::GeometryCollection(GeometryCollection::new([Geometry::GeometryCollection(
+                GeometryCollection::new([Geometry::Euclidean2D(Euclidean2DGeometry::Point(
+                    Point2D::new(crs(4326), [3.0, 4.0])
+                ),)])
+            ),]))
+        );
     }
 
     // Mixed-dimension coordinates are rejected, not panicked on.

--- a/engine/runtime/types/src/conversion/geojson_next.rs
+++ b/engine/runtime/types/src/conversion/geojson_next.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use nusamai_projection::crs::{EPSG_WGS84_GEOGRAPHIC_2D, EPSG_WGS84_GEOGRAPHIC_3D};
-use reearth_flow_geometry::types::conversion::is_2d_geojson_value;
+use reearth_flow_geometry::types::conversion::{is_2d_geojson_value, is_3d_geojson_value};
 use reearth_flow_geometry::{
     collection::{Collection2D, Collection3D},
     coordinate::{CoordinateFrame, EpsgCode},
@@ -68,12 +68,15 @@ fn wgs84_3d() -> CoordinateFrame {
 }
 
 fn geojson_value_to_geometry(value: geojson::Value) -> Result<Geometry> {
+    // Every coordinate must be uniformly 2D or uniformly 3D. Anything else
+    // (mixed dimensions, degenerate/short coords, GeometryCollection) is rejected
+    // rather than indexed into blindly, which would panic.
     if is_2d_geojson_value(&value) {
         Ok(Geometry::Euclidean2D(value_to_2d(value)?))
-    } else {
-        // GeometryCollection and mixed-dimension values fall here; unsupported ones
-        // error in `value_to_3d`, matching the old reader.
+    } else if is_3d_geojson_value(&value) {
         Ok(Geometry::Euclidean3D(value_to_3d(value)?))
+    } else {
+        Err(unsupported(&value))
     }
 }
 
@@ -130,11 +133,15 @@ fn value_to_3d(value: geojson::Value) -> Result<Euclidean3DGeometry> {
 }
 
 fn unsupported(value: &geojson::Value) -> Error {
-    let name = match value {
-        geojson::Value::GeometryCollection(_) => "GeometryCollection",
-        _ => "geometry",
-    };
-    Error::unsupported_feature(format!("unsupported GeoJSON {name}"))
+    match value {
+        geojson::Value::GeometryCollection(_) => {
+            Error::unsupported_feature("GeoJSON GeometryCollection is not supported")
+        }
+        _ => Error::unsupported_feature(
+            "GeoJSON geometry has mixed or unsupported coordinate dimensions \
+             (every coordinate must be uniformly 2D or 3D)",
+        ),
+    }
 }
 
 fn collection_2d(members: impl IntoIterator<Item = Euclidean2DGeometry>) -> Euclidean2DGeometry {
@@ -428,6 +435,29 @@ mod tests {
         let gj = geojson_feature(geojson::Value::GeometryCollection(vec![
             geojson::Geometry::new(geojson::Value::Point(vec![0.0, 0.0])),
         ]));
+
+        let result: Result<Feature> = gj.try_into();
+
+        assert!(result.is_err());
+    }
+
+    // Mixed-dimension coordinates are rejected, not panicked on.
+    #[test]
+    fn mixed_dimension_multi_point_is_unsupported() {
+        let gj = geojson_feature(geojson::Value::MultiPoint(vec![
+            vec![0.0, 0.0],      // 2D
+            vec![1.0, 1.0, 1.0], // 3D
+        ]));
+
+        let result: Result<Feature> = gj.try_into();
+
+        assert!(result.is_err());
+    }
+
+    // A degenerate coordinate (fewer than 2 elements) is rejected, not panicked on.
+    #[test]
+    fn degenerate_coordinate_is_unsupported() {
+        let gj = geojson_feature(geojson::Value::Point(vec![0.0]));
 
         let result: Result<Feature> = gj.try_into();
 

--- a/engine/runtime/types/src/conversion/geojson_next.rs
+++ b/engine/runtime/types/src/conversion/geojson_next.rs
@@ -1,0 +1,467 @@
+//! GeoJSON -> `Feature` conversion for the new-geometry world. Builds
+//! `reearth_flow_geometry::Geometry` (per-leaf `CoordinateFrame`) rather than the
+//! old `GeometryValue` wrapper.
+
+use std::sync::Arc;
+
+use nusamai_projection::crs::{EPSG_WGS84_GEOGRAPHIC_2D, EPSG_WGS84_GEOGRAPHIC_3D};
+use reearth_flow_geometry::types::conversion::is_2d_geojson_value;
+use reearth_flow_geometry::{
+    collection::{Collection2D, Collection3D},
+    coordinate::{CoordinateFrame, EpsgCode},
+    line_string::{LineString2D, LineString3D},
+    point::{Point2D, Point3D},
+    polygon::{Polygon2D, Polygon3D},
+    Euclidean2DGeometry, Euclidean3DGeometry, Geometry,
+};
+
+use crate::{
+    error::{Error, Result},
+    Attribute, Attributes, Feature,
+};
+
+impl TryFrom<geojson::Feature> for Feature {
+    type Error = Error;
+
+    fn try_from(geom: geojson::Feature) -> Result<Self> {
+        let attributes = geom
+            .properties
+            .as_ref()
+            .map(geojson_object_to_attributes)
+            .unwrap_or_default();
+        let geometry = match geom.geometry {
+            Some(g) => geojson_value_to_geometry(g.value)?,
+            None => Geometry::None,
+        };
+        Ok(Feature {
+            id: geom.id.map_or_else(uuid::Uuid::new_v4, geojson_id_to_uuid),
+            attributes: Arc::new(attributes),
+            geometry: Arc::new(geometry),
+        })
+    }
+}
+
+/// A GeoJSON string id that is a valid UUID is preserved; anything else gets a fresh UUID.
+fn geojson_id_to_uuid(id: geojson::feature::Id) -> uuid::Uuid {
+    match id {
+        geojson::feature::Id::String(v) => {
+            uuid::Uuid::parse_str(&v).unwrap_or_else(|_| uuid::Uuid::new_v4())
+        }
+        geojson::feature::Id::Number(_) => uuid::Uuid::new_v4(),
+    }
+}
+
+fn geojson_object_to_attributes(obj: &geojson::JsonObject) -> Attributes {
+    obj.iter()
+        .map(|(k, v)| (Attribute::new(k), v.clone().into()))
+        .collect()
+}
+
+/// WGS84 geographic frame for 2D coordinates (lon, lat).
+fn wgs84_2d() -> CoordinateFrame {
+    CoordinateFrame::Crs(EpsgCode::new(EPSG_WGS84_GEOGRAPHIC_2D))
+}
+
+/// WGS84 geographic frame for 3D coordinates (lon, lat, height).
+fn wgs84_3d() -> CoordinateFrame {
+    CoordinateFrame::Crs(EpsgCode::new(EPSG_WGS84_GEOGRAPHIC_3D))
+}
+
+fn geojson_value_to_geometry(value: geojson::Value) -> Result<Geometry> {
+    if is_2d_geojson_value(&value) {
+        Ok(Geometry::Euclidean2D(value_to_2d(value)?))
+    } else {
+        // GeometryCollection and mixed-dimension values fall here; unsupported ones
+        // error in `value_to_3d`, matching the old reader.
+        Ok(Geometry::Euclidean3D(value_to_3d(value)?))
+    }
+}
+
+fn value_to_2d(value: geojson::Value) -> Result<Euclidean2DGeometry> {
+    match value {
+        geojson::Value::Point(p) => Ok(Euclidean2DGeometry::Point(point_2d(&p))),
+        geojson::Value::MultiPoint(ps) => Ok(collection_2d(
+            ps.iter().map(|p| Euclidean2DGeometry::Point(point_2d(p))),
+        )),
+        geojson::Value::LineString(coords) => {
+            Ok(Euclidean2DGeometry::LineString(line_string_2d(&coords)))
+        }
+        geojson::Value::MultiLineString(lines) => {
+            Ok(collection_2d(lines.iter().map(|l| {
+                Euclidean2DGeometry::LineString(line_string_2d(l))
+            })))
+        }
+        geojson::Value::Polygon(rings) => {
+            Ok(Euclidean2DGeometry::Polygon(Box::new(polygon_2d(&rings))))
+        }
+        geojson::Value::MultiPolygon(polys) => {
+            Ok(collection_2d(polys.iter().map(|rings| {
+                Euclidean2DGeometry::Polygon(Box::new(polygon_2d(rings)))
+            })))
+        }
+        other => Err(unsupported(&other)),
+    }
+}
+
+fn value_to_3d(value: geojson::Value) -> Result<Euclidean3DGeometry> {
+    match value {
+        geojson::Value::Point(p) => Ok(Euclidean3DGeometry::Point(point_3d(&p))),
+        geojson::Value::MultiPoint(ps) => Ok(collection_3d(
+            ps.iter().map(|p| Euclidean3DGeometry::Point(point_3d(p))),
+        )),
+        geojson::Value::LineString(coords) => {
+            Ok(Euclidean3DGeometry::LineString(line_string_3d(&coords)))
+        }
+        geojson::Value::MultiLineString(lines) => {
+            Ok(collection_3d(lines.iter().map(|l| {
+                Euclidean3DGeometry::LineString(line_string_3d(l))
+            })))
+        }
+        geojson::Value::Polygon(rings) => {
+            Ok(Euclidean3DGeometry::Polygon(Box::new(polygon_3d(&rings))))
+        }
+        geojson::Value::MultiPolygon(polys) => {
+            Ok(collection_3d(polys.iter().map(|rings| {
+                Euclidean3DGeometry::Polygon(Box::new(polygon_3d(rings)))
+            })))
+        }
+        other => Err(unsupported(&other)),
+    }
+}
+
+fn unsupported(value: &geojson::Value) -> Error {
+    let name = match value {
+        geojson::Value::GeometryCollection(_) => "GeometryCollection",
+        _ => "geometry",
+    };
+    Error::unsupported_feature(format!("unsupported GeoJSON {name}"))
+}
+
+fn collection_2d(members: impl IntoIterator<Item = Euclidean2DGeometry>) -> Euclidean2DGeometry {
+    Euclidean2DGeometry::Collection(Collection2D::new(members))
+}
+
+fn collection_3d(members: impl IntoIterator<Item = Euclidean3DGeometry>) -> Euclidean3DGeometry {
+    Euclidean3DGeometry::Collection(Collection3D::new(members))
+}
+
+fn point_2d(p: &[f64]) -> Point2D {
+    Point2D::new(wgs84_2d(), [p[0], p[1]])
+}
+
+fn point_3d(p: &[f64]) -> Point3D {
+    Point3D::new(wgs84_3d(), [p[0], p[1], p[2]])
+}
+
+fn line_string_2d(coords: &[Vec<f64>]) -> LineString2D {
+    LineString2D::from_coords(wgs84_2d(), coords.iter().map(|c| [c[0], c[1]]))
+}
+
+fn line_string_3d(coords: &[Vec<f64>]) -> LineString3D {
+    LineString3D::from_coords(wgs84_3d(), coords.iter().map(|c| [c[0], c[1], c[2]]))
+}
+
+fn polygon_2d(rings: &[Vec<Vec<f64>>]) -> Polygon2D {
+    let mut rings = rings
+        .iter()
+        .map(|r| r.iter().map(|c| [c[0], c[1]]).collect::<Vec<_>>());
+    let exterior = rings.next().unwrap_or_default();
+    Polygon2D::from_rings(wgs84_2d(), exterior, rings)
+}
+
+fn polygon_3d(rings: &[Vec<Vec<f64>>]) -> Polygon3D {
+    let mut rings = rings
+        .iter()
+        .map(|r| r.iter().map(|c| [c[0], c[1], c[2]]).collect::<Vec<_>>());
+    let exterior = rings.next().unwrap_or_default();
+    Polygon3D::from_rings(wgs84_3d(), exterior, rings)
+}
+
+#[cfg(test)]
+mod tests {
+    use reearth_flow_geometry::{
+        collection::{Collection2D, Collection3D},
+        coordinate::{CoordinateFrame, EpsgCode},
+        line_string::{LineString2D, LineString3D},
+        point::{Point2D, Point3D},
+        polygon::{Polygon2D, Polygon3D},
+        Euclidean2DGeometry, Euclidean3DGeometry, Geometry,
+    };
+
+    use super::*;
+    use crate::{Attribute, AttributeValue};
+
+    fn crs(code: u16) -> CoordinateFrame {
+        CoordinateFrame::Crs(EpsgCode::new(code))
+    }
+
+    fn geojson_feature(value: geojson::Value) -> geojson::Feature {
+        geojson::Feature {
+            bbox: None,
+            geometry: Some(geojson::Geometry::new(value)),
+            id: None,
+            properties: None,
+            foreign_members: None,
+        }
+    }
+
+    // A 2D GeoJSON Point becomes a Euclidean2D Point in the WGS84 geographic frame.
+    #[test]
+    fn point_2d_converts_to_euclidean_2d_wgs84() {
+        let gj = geojson_feature(geojson::Value::Point(vec![139.7, 35.6]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            *feature.geometry,
+            Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
+                crs(4326),
+                [139.7, 35.6],
+            )))
+        );
+    }
+
+    // A 3D GeoJSON Point becomes a Euclidean3D Point in the WGS84 3D geographic frame.
+    #[test]
+    fn point_3d_converts_to_euclidean_3d_wgs84() {
+        let gj = geojson_feature(geojson::Value::Point(vec![139.7, 35.6, 12.5]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            *feature.geometry,
+            Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
+                crs(4979),
+                [139.7, 35.6, 12.5],
+            )))
+        );
+    }
+
+    #[test]
+    fn line_string_2d_converts() {
+        let gj = geojson_feature(geojson::Value::LineString(vec![
+            vec![0.0, 0.0],
+            vec![1.0, 2.0],
+        ]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            *feature.geometry,
+            Geometry::Euclidean2D(Euclidean2DGeometry::LineString(LineString2D::from_coords(
+                crs(4326),
+                [[0.0, 0.0], [1.0, 2.0]],
+            )))
+        );
+    }
+
+    #[test]
+    fn line_string_3d_converts() {
+        let gj = geojson_feature(geojson::Value::LineString(vec![
+            vec![0.0, 0.0, 1.0],
+            vec![1.0, 2.0, 3.0],
+        ]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            *feature.geometry,
+            Geometry::Euclidean3D(Euclidean3DGeometry::LineString(LineString3D::from_coords(
+                crs(4979),
+                [[0.0, 0.0, 1.0], [1.0, 2.0, 3.0]],
+            )))
+        );
+    }
+
+    // A 2D Polygon keeps its exterior ring and interior holes.
+    #[test]
+    fn polygon_2d_with_hole_converts() {
+        let exterior = vec![
+            vec![0.0, 0.0],
+            vec![4.0, 0.0],
+            vec![4.0, 4.0],
+            vec![0.0, 0.0],
+        ];
+        let hole = vec![
+            vec![1.0, 1.0],
+            vec![2.0, 1.0],
+            vec![1.0, 2.0],
+            vec![1.0, 1.0],
+        ];
+        let gj = geojson_feature(geojson::Value::Polygon(vec![exterior, hole]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            *feature.geometry,
+            Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
+                Polygon2D::from_rings(
+                    crs(4326),
+                    [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 0.0]],
+                    [[[1.0, 1.0], [2.0, 1.0], [1.0, 2.0], [1.0, 1.0]]],
+                )
+            )))
+        );
+    }
+
+    // A 3D Polygon exterior ring keeps z.
+    #[test]
+    fn polygon_3d_converts() {
+        let exterior = vec![
+            vec![0.0, 0.0, 1.0],
+            vec![4.0, 0.0, 1.0],
+            vec![4.0, 4.0, 1.0],
+            vec![0.0, 0.0, 1.0],
+        ];
+        let gj = geojson_feature(geojson::Value::Polygon(vec![exterior]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            *feature.geometry,
+            Geometry::Euclidean3D(Euclidean3DGeometry::Polygon(Box::new(
+                Polygon3D::from_rings(
+                    crs(4979),
+                    [
+                        [0.0, 0.0, 1.0],
+                        [4.0, 0.0, 1.0],
+                        [4.0, 4.0, 1.0],
+                        [0.0, 0.0, 1.0]
+                    ],
+                    std::iter::empty::<Vec<[f64; 3]>>(),
+                )
+            )))
+        );
+    }
+
+    // MultiPoint (2D) becomes a Collection of Points (the new geometry has no Multi* leaf).
+    #[test]
+    fn multi_point_2d_converts_to_collection() {
+        let gj = geojson_feature(geojson::Value::MultiPoint(vec![
+            vec![0.0, 0.0],
+            vec![1.0, 1.0],
+        ]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            *feature.geometry,
+            Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([
+                Euclidean2DGeometry::Point(Point2D::new(crs(4326), [0.0, 0.0])),
+                Euclidean2DGeometry::Point(Point2D::new(crs(4326), [1.0, 1.0])),
+            ])))
+        );
+    }
+
+    // MultiPoint (3D) becomes a 3D Collection of Points.
+    #[test]
+    fn multi_point_3d_converts_to_collection() {
+        let gj = geojson_feature(geojson::Value::MultiPoint(vec![
+            vec![0.0, 0.0, 5.0],
+            vec![1.0, 1.0, 6.0],
+        ]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            *feature.geometry,
+            Geometry::Euclidean3D(Euclidean3DGeometry::Collection(Collection3D::new([
+                Euclidean3DGeometry::Point(Point3D::new(crs(4979), [0.0, 0.0, 5.0])),
+                Euclidean3DGeometry::Point(Point3D::new(crs(4979), [1.0, 1.0, 6.0])),
+            ])))
+        );
+    }
+
+    // MultiLineString (2D) becomes a Collection of LineStrings.
+    #[test]
+    fn multi_line_string_2d_converts_to_collection() {
+        let gj = geojson_feature(geojson::Value::MultiLineString(vec![
+            vec![vec![0.0, 0.0], vec![1.0, 1.0]],
+            vec![vec![2.0, 2.0], vec![3.0, 3.0]],
+        ]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            *feature.geometry,
+            Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([
+                Euclidean2DGeometry::LineString(LineString2D::from_coords(
+                    crs(4326),
+                    [[0.0, 0.0], [1.0, 1.0]],
+                )),
+                Euclidean2DGeometry::LineString(LineString2D::from_coords(
+                    crs(4326),
+                    [[2.0, 2.0], [3.0, 3.0]],
+                )),
+            ])))
+        );
+    }
+
+    // MultiPolygon (2D) becomes a Collection of Polygons.
+    #[test]
+    fn multi_polygon_2d_converts_to_collection() {
+        let poly = vec![vec![
+            vec![0.0, 0.0],
+            vec![1.0, 0.0],
+            vec![0.0, 1.0],
+            vec![0.0, 0.0],
+        ]];
+        let gj = geojson_feature(geojson::Value::MultiPolygon(vec![poly]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            *feature.geometry,
+            Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([
+                Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+                    crs(4326),
+                    [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
+                    std::iter::empty::<Vec<[f64; 2]>>(),
+                ))),
+            ])))
+        );
+    }
+
+    // A GeoJSON GeometryCollection is not supported by the reader (parity with the old world).
+    #[test]
+    fn geometry_collection_is_unsupported() {
+        let gj = geojson_feature(geojson::Value::GeometryCollection(vec![
+            geojson::Geometry::new(geojson::Value::Point(vec![0.0, 0.0])),
+        ]));
+
+        let result: Result<Feature> = gj.try_into();
+
+        assert!(result.is_err());
+    }
+
+    // Feature properties are carried over as attributes.
+    #[test]
+    fn properties_become_attributes() {
+        let mut props = geojson::JsonObject::new();
+        props.insert(
+            "name".to_string(),
+            serde_json::Value::String("bldg-1".to_string()),
+        );
+        let mut gj = geojson_feature(geojson::Value::Point(vec![0.0, 0.0]));
+        gj.properties = Some(props);
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(
+            feature.attributes.get(&Attribute::new("name")),
+            Some(&AttributeValue::String("bldg-1".to_string()))
+        );
+    }
+
+    // A string feature id that is a valid UUID is preserved.
+    #[test]
+    fn string_id_parses_as_uuid() {
+        let id = "550e8400-e29b-41d4-a716-446655440000";
+        let mut gj = geojson_feature(geojson::Value::Point(vec![0.0, 0.0]));
+        gj.id = Some(geojson::feature::Id::String(id.to_string()));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        assert_eq!(feature.id, uuid::Uuid::parse_str(id).unwrap());
+    }
+}


### PR DESCRIPTION
## What
Migrates the **GeoJSON Reader** to the new-geometry representation, behind the `new-geometry` feature flag. First source reader ported.

## Approach (sibling route)
- The GeoJSON → `Feature` conversion is split by world via a module swap in `conversion.rs`: old `geojson.rs` under `not(new-geometry)`, new `geojson_next.rs` under `new-geometry`.
- The reader wiring (`GeoJsonReader::start`, `read_geojson`) is now **shared** across both worlds, since it is identical once the conversion exists. Only the `try_into()` target differs, and that is flag-selected.

## Behavior (parity with old reader)
- Builds `reearth_flow_geometry::Geometry` with per-leaf WGS84 `CoordinateFrame` (EPSG 4326 for 2D, 4979 for 3D).
- `Multi*` map to `Collection`; `GeometryCollection` stays unsupported (matches the old `_ => Err`).
- Properties → attributes and string-UUID id parsing preserved.

## Testing
- 13 new unit tests (net-new: the old reader direction had none), run under `--features new-geometry`.
- New-world clippy clean (`-p reearth-flow-cli -p reearth-flow-worker --features new-geometry -- -D warnings`).
- Default world unchanged: old geojson tests + reader integration test (`test_proximity_search_with_geojson`) still green.
- Per the migration's CI model, the new world is compile+clippy-only; these unit tests run locally.

## Notes
- The old conversion is retained for the default world; the reader falls back to it when the flag is off.
- Future cleanup (on flag removal): delete old `geojson.rs`, promote `geojson_next.rs` to a plain `pub mod geojson;`. The shared reader needs no unwinding.