### PR TITLE
feat(engine): new geometry winding

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4094,7 +4094,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.72"
+version = "0.2.73"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "futures",
  "once_cell",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "approx",
  "async-trait",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "Inflector",
  "approx",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "bytes",
  "clap",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "approx",
  "bvh",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "bytes",
  "futures",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "bytes",
  "futures",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "ahash",
  "bytes",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.437"
+version = "0.0.438"
 dependencies = [
  "async-trait",
  "axum",
@@ -8046,7 +8046,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.262"
+version = "0.1.263"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.437"
+version = "0.0.438"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
@@ -1,6 +1,8 @@
 use reearth_flow_geometry::coordinate::{CoordinateFrame, EpsgCode};
 use reearth_flow_geometry::ops::reproject::transform_coords_3d;
-use reearth_flow_geometry::ops::{triangulation::Cache as TriangulationCache, ReprojectionCache};
+use reearth_flow_geometry::ops::{
+    triangulation::Cache as TriangulationCache, Reproject, ReprojectionCache,
+};
 use reearth_flow_geometry::polygon_mesh::PolygonMesh3D;
 use reearth_flow_geometry::solid::Shell;
 use reearth_flow_geometry::{Euclidean3DGeometry, Geometry};
@@ -136,21 +138,11 @@ fn source_crs(frame: &CoordinateFrame) -> Option<EpsgCode> {
 }
 
 /// Triangulate and reproject one `PolygonMesh`.
-///
-/// Reprojection into ECEF (a right-handed frame) carries the source winding into
-/// its canonical, CCW-outward orientation on its own: a reflected source frame
-/// (lat/northing-first) reprojects with a reversed orientation that cancels its
-/// reflected winding. So the reprojected triangles are already CCW-front for glTF,
-/// and the flat normals are recomputed from that ECEF geometry rather than carried
-/// from the source frame (where they point inward for a reflected frame and would
-/// need a separate source-to-ECEF rotation).
 fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ReprojectCaches) -> Option<ExtractedMesh> {
     let source_crs = source_crs(mesh.frame())?;
 
-    let mut triangulation_cache = TriangulationCache::new();
-    let result = mesh.triangulate_with_normals(&mut triangulation_cache);
-    let (mesh, polygon_tris) = (result.mesh, result.polygon_tris);
-
+    // WGS84 geographic vertices for the bounding region, taken before the mesh
+    // is moved into ECEF.
     let mut geographic_vertices = mesh.vertices().to_vec();
     if let Err(e) = transform_coords_3d(
         &mut caches.geographic,
@@ -162,73 +154,21 @@ fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ReprojectCaches) -> Option<
         return None;
     }
 
-    let mut ecef_vertices = mesh.vertices().to_vec();
-    if let Err(e) = transform_coords_3d(
-        &mut caches.geocentric,
-        source_crs,
-        WGS84_GEOCENTRIC,
-        &mut ecef_vertices,
-    ) {
+    if let Err(e) = mesh.reproject(WGS84_GEOCENTRIC, &mut caches.geocentric) {
         tracing::warn!("Cesium3DTilesWriter: failed to reproject to ECEF: {e:?}");
         return None;
     }
 
-    let indices: Vec<[u32; 3]> = mesh.triangles().collect();
-    let polygon_normals = ecef_polygon_normals(&ecef_vertices, &indices, &polygon_tris);
+    let mut triangulation_cache = TriangulationCache::new();
+    let result = mesh.triangulate_with_normals(&mut triangulation_cache);
 
     Some(ExtractedMesh {
-        ecef_vertices,
+        ecef_vertices: result.mesh.vertices().to_vec(),
         geographic_vertices,
-        indices,
-        polygon_normals,
-        polygon_tris,
+        indices: result.mesh.triangles().collect(),
+        polygon_normals: result.polygon_normals,
+        polygon_tris: result.polygon_tris,
     })
-}
-
-/// One outward unit normal per source polygon, taken from the first ECEF triangle
-/// of each; a degenerate polygon (zero triangles) gets a placeholder that is never
-/// repeated into the output. `polygon_tris` gives each polygon's triangle count in
-/// polygon order, and `triangles` are grouped by polygon in that same order.
-fn ecef_polygon_normals(
-    vertices: &[[f64; 3]],
-    triangles: &[[u32; 3]],
-    polygon_tris: &[u32],
-) -> Vec<[f64; 3]> {
-    let mut normals = Vec::with_capacity(polygon_tris.len());
-    let mut base = 0usize;
-    for &count in polygon_tris {
-        let normal = if count == 0 {
-            [0.0, 0.0, 1.0]
-        } else {
-            let [a, b, c] = triangles[base];
-            face_normal(
-                vertices[a as usize],
-                vertices[b as usize],
-                vertices[c as usize],
-            )
-        };
-        normals.push(normal);
-        base += count as usize;
-    }
-    normals
-}
-
-/// Unit right-hand-rule normal of triangle `a, b, c`; `+Z` when the triangle is
-/// degenerate.
-fn face_normal(a: [f64; 3], b: [f64; 3], c: [f64; 3]) -> [f64; 3] {
-    let u = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
-    let v = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
-    let n = [
-        u[1] * v[2] - u[2] * v[1],
-        u[2] * v[0] - u[0] * v[2],
-        u[0] * v[1] - u[1] * v[0],
-    ];
-    let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
-    if len > 0.0 {
-        [n[0] / len, n[1] / len, n[2] / len]
-    } else {
-        [0.0, 0.0, 1.0]
-    }
 }
 
 #[cfg(test)]
@@ -241,38 +181,11 @@ mod tests {
         a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
     }
 
-    #[test]
-    fn face_normal_of_ccw_xy_triangle_points_up() {
-        let n = face_normal([0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]);
-        assert_eq!(n, [0.0, 0.0, 1.0]);
-    }
-
-    #[test]
-    fn face_normal_of_degenerate_triangle_falls_back_to_up() {
-        let n = face_normal([0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]);
-        assert_eq!(n, [0.0, 0.0, 1.0]);
-    }
-
-    #[test]
-    fn ecef_polygon_normals_groups_by_polygon_and_placeholders_degenerate() {
-        // Polygon 0: one triangle in the z = 1 plane, CCW -> +Z normal.
-        // Polygon 1: zero triangles (degenerate) -> placeholder, not read from `triangles`.
-        let vertices = vec![[0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [0.0, 1.0, 1.0]];
-        let triangles = vec![[0u32, 1, 2]];
-        let polygon_tris = vec![1u32, 0];
-
-        let normals = ecef_polygon_normals(&vertices, &triangles, &polygon_tris);
-
-        assert_eq!(normals.len(), 2);
-        assert_eq!(normals[0], [0.0, 0.0, 1.0]);
-        assert_eq!(normals[1], [0.0, 0.0, 1.0]);
-    }
-
     // A face whose canonical orientation is outward, stored in a lat-first frame
     // (EPSG:4979, orientation sign -1), must emit an ECEF normal that points away
-    // from the earth's centre. This fails if the normal is carried from the source
-    // frame (where it points inward for a reflected frame) instead of recomputed
-    // from the reprojected ECEF geometry.
+    // from the earth's centre. Triangulating in ECEF gives this for free: the
+    // reflected source winding is cancelled by the reprojection, so the
+    // right-hand-rule normal comes out outward.
     #[test]
     fn outward_face_in_lat_first_frame_emits_outward_ecef_normal() {
         // Vertices stored (lat, lon, height). In real ENU at this location the ring

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
@@ -163,7 +163,13 @@ fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ExtractCaches) -> Option<Ex
         return None;
     }
 
-    let result = mesh.triangulate_with_normals(&mut caches.triangulation);
+    let result = match mesh.triangulate_with_normals(&mut caches.triangulation) {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::warn!("Cesium3DTilesWriter: failed to triangulate mesh: {e:?}");
+            return None;
+        }
+    };
 
     Some(ExtractedMesh {
         ecef_vertices: result.mesh.vertices().to_vec(),

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
@@ -136,13 +136,20 @@ fn source_crs(frame: &CoordinateFrame) -> Option<EpsgCode> {
 }
 
 /// Triangulate and reproject one `PolygonMesh`.
+///
+/// Reprojection into ECEF (a right-handed frame) carries the source winding into
+/// its canonical, CCW-outward orientation on its own: a reflected source frame
+/// (lat/northing-first) reprojects with a reversed orientation that cancels its
+/// reflected winding. So the reprojected triangles are already CCW-front for glTF,
+/// and the flat normals are recomputed from that ECEF geometry rather than carried
+/// from the source frame (where they point inward for a reflected frame and would
+/// need a separate source-to-ECEF rotation).
 fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ReprojectCaches) -> Option<ExtractedMesh> {
     let source_crs = source_crs(mesh.frame())?;
 
     let mut triangulation_cache = TriangulationCache::new();
     let result = mesh.triangulate_with_normals(&mut triangulation_cache);
-    let (mesh, polygon_normals, polygon_tris) =
-        (result.mesh, result.polygon_normals, result.polygon_tris);
+    let (mesh, polygon_tris) = (result.mesh, result.polygon_tris);
 
     let mut geographic_vertices = mesh.vertices().to_vec();
     if let Err(e) = transform_coords_3d(
@@ -166,11 +173,131 @@ fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ReprojectCaches) -> Option<
         return None;
     }
 
+    let indices: Vec<[u32; 3]> = mesh.triangles().collect();
+    let polygon_normals = ecef_polygon_normals(&ecef_vertices, &indices, &polygon_tris);
+
     Some(ExtractedMesh {
         ecef_vertices,
         geographic_vertices,
-        indices: mesh.triangles().collect(),
+        indices,
         polygon_normals,
         polygon_tris,
     })
+}
+
+/// One outward unit normal per source polygon, taken from the first ECEF triangle
+/// of each; a degenerate polygon (zero triangles) gets a placeholder that is never
+/// repeated into the output. `polygon_tris` gives each polygon's triangle count in
+/// polygon order, and `triangles` are grouped by polygon in that same order.
+fn ecef_polygon_normals(
+    vertices: &[[f64; 3]],
+    triangles: &[[u32; 3]],
+    polygon_tris: &[u32],
+) -> Vec<[f64; 3]> {
+    let mut normals = Vec::with_capacity(polygon_tris.len());
+    let mut base = 0usize;
+    for &count in polygon_tris {
+        let normal = if count == 0 {
+            [0.0, 0.0, 1.0]
+        } else {
+            let [a, b, c] = triangles[base];
+            face_normal(
+                vertices[a as usize],
+                vertices[b as usize],
+                vertices[c as usize],
+            )
+        };
+        normals.push(normal);
+        base += count as usize;
+    }
+    normals
+}
+
+/// Unit right-hand-rule normal of triangle `a, b, c`; `+Z` when the triangle is
+/// degenerate.
+fn face_normal(a: [f64; 3], b: [f64; 3], c: [f64; 3]) -> [f64; 3] {
+    let u = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+    let v = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+    let n = [
+        u[1] * v[2] - u[2] * v[1],
+        u[2] * v[0] - u[0] * v[2],
+        u[0] * v[1] - u[1] * v[0],
+    ];
+    let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+    if len > 0.0 {
+        [n[0] / len, n[1] / len, n[2] / len]
+    } else {
+        [0.0, 0.0, 1.0]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reearth_flow_geometry::polygon_mesh::{PolygonMesh3D, PolygonMesh3DData};
+
+    use super::*;
+
+    fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+        a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+    }
+
+    #[test]
+    fn face_normal_of_ccw_xy_triangle_points_up() {
+        let n = face_normal([0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]);
+        assert_eq!(n, [0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn face_normal_of_degenerate_triangle_falls_back_to_up() {
+        let n = face_normal([0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]);
+        assert_eq!(n, [0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn ecef_polygon_normals_groups_by_polygon_and_placeholders_degenerate() {
+        // Polygon 0: one triangle in the z = 1 plane, CCW -> +Z normal.
+        // Polygon 1: zero triangles (degenerate) -> placeholder, not read from `triangles`.
+        let vertices = vec![[0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [0.0, 1.0, 1.0]];
+        let triangles = vec![[0u32, 1, 2]];
+        let polygon_tris = vec![1u32, 0];
+
+        let normals = ecef_polygon_normals(&vertices, &triangles, &polygon_tris);
+
+        assert_eq!(normals.len(), 2);
+        assert_eq!(normals[0], [0.0, 0.0, 1.0]);
+        assert_eq!(normals[1], [0.0, 0.0, 1.0]);
+    }
+
+    // A face whose canonical orientation is outward, stored in a lat-first frame
+    // (EPSG:4979, orientation sign -1), must emit an ECEF normal that points away
+    // from the earth's centre. This fails if the normal is carried from the source
+    // frame (where it points inward for a reflected frame) instead of recomputed
+    // from the reprojected ECEF geometry.
+    #[test]
+    fn outward_face_in_lat_first_frame_emits_outward_ecef_normal() {
+        // Vertices stored (lat, lon, height). In real ENU at this location the ring
+        // A -> B -> C turns counter-clockwise seen from above (an upward, outward
+        // face); its right-hand-rule normal in stored order points the opposite way,
+        // and reprojection into right-handed ECEF flips it back to outward.
+        let a = [35.0, 139.0, 0.0];
+        let b = [35.0, 139.001, 0.0];
+        let c = [35.001, 139.0, 0.0];
+        let data = PolygonMesh3DData::from_parts(vec![a, b, c], [[0u32, 1, 2]]).unwrap();
+        let mesh = PolygonMesh3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), data);
+        let geometry = Geometry::Euclidean3D(Euclidean3DGeometry::PolygonMesh(Box::new(mesh)));
+
+        let mut caches = ReprojectCaches::default();
+        let extracted = extract(&geometry, &mut caches).expect("mesh extracts");
+
+        assert_eq!(extracted.polygon_normals.len(), 1);
+        // The ECEF position of a point on the ellipsoid surface is itself an outward
+        // radial direction, so an outward normal has a positive dot with it.
+        let normal = extracted.polygon_normals[0];
+        for &vertex in &extracted.ecef_vertices {
+            assert!(
+                dot(normal, vertex) > 0.0,
+                "normal {normal:?} should point outward at {vertex:?}"
+            );
+        }
+    }
 }

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
@@ -12,13 +12,19 @@ const WGS84_GEOGRAPHIC: EpsgCode = EpsgCode::new(4979);
 /// WGS84, geocentric (ECEF) — used for glTF vertex positions.
 const WGS84_GEOCENTRIC: EpsgCode = EpsgCode::new(4978);
 
-/// One `ReprojectionCache` per target CRS: each cache only ever sees a
-/// single (from, to) pair, so its cached PROJ transform is never evicted
-/// (a cache handed both target CRSes would thrash between them every call).
+/// Per-file scratch shared across every mesh, so repeated extraction amortizes
+/// its PROJ setup and earcut allocations.
+///
+/// One `ReprojectionCache` per target CRS: each only ever sees a single
+/// (from, to) pair, so its cached PROJ transform is never evicted (a cache
+/// handed both target CRSes would thrash between them every call). The
+/// triangulation cache reuses earcut's arenas and index/vertex scratch across
+/// meshes.
 #[derive(Default)]
-pub(super) struct ReprojectCaches {
+pub(super) struct ExtractCaches {
     geographic: ReprojectionCache,
     geocentric: ReprojectionCache,
+    triangulation: TriangulationCache,
 }
 
 pub(super) struct ExtractedMesh {
@@ -41,7 +47,7 @@ pub(super) struct ExtractedMesh {
 ///
 /// Returns `None` when nothing was found, or everything found failed to
 /// triangulate/reproject (each failure is `tracing::warn!`ed individually).
-pub(super) fn extract(geometry: &Geometry, caches: &mut ReprojectCaches) -> Option<ExtractedMesh> {
+pub(super) fn extract(geometry: &Geometry, caches: &mut ExtractCaches) -> Option<ExtractedMesh> {
     let mut meshes = Vec::new();
     collect_geometry(geometry, &mut meshes);
 
@@ -138,11 +144,9 @@ fn source_crs(frame: &CoordinateFrame) -> Option<EpsgCode> {
 }
 
 /// Triangulate and reproject one `PolygonMesh`.
-fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ReprojectCaches) -> Option<ExtractedMesh> {
+fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ExtractCaches) -> Option<ExtractedMesh> {
     let source_crs = source_crs(mesh.frame())?;
 
-    // WGS84 geographic vertices for the bounding region, taken before the mesh
-    // is moved into ECEF.
     let mut geographic_vertices = mesh.vertices().to_vec();
     if let Err(e) = transform_coords_3d(
         &mut caches.geographic,
@@ -159,8 +163,7 @@ fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ReprojectCaches) -> Option<
         return None;
     }
 
-    let mut triangulation_cache = TriangulationCache::new();
-    let result = mesh.triangulate_with_normals(&mut triangulation_cache);
+    let result = mesh.triangulate_with_normals(&mut caches.triangulation);
 
     Some(ExtractedMesh {
         ecef_vertices: result.mesh.vertices().to_vec(),
@@ -199,7 +202,7 @@ mod tests {
         let mesh = PolygonMesh3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), data);
         let geometry = Geometry::Euclidean3D(Euclidean3DGeometry::PolygonMesh(Box::new(mesh)));
 
-        let mut caches = ReprojectCaches::default();
+        let mut caches = ExtractCaches::default();
         let extracted = extract(&geometry, &mut caches).expect("mesh extracts");
 
         assert_eq!(extracted.polygon_normals.len(), 1);

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
@@ -92,12 +92,10 @@ pub fn build(
     options: MetadataOptions,
     max_zoom: u8,
 ) -> crate::errors::Result<BuiltTileset> {
-    let mut reproject_caches = mesh::ReprojectCaches::default();
+    let mut caches = mesh::ExtractCaches::default();
     let extracted: Vec<(&Feature, mesh::ExtractedMesh)> = features
         .iter()
-        .filter_map(|feature| {
-            mesh::extract(&feature.geometry, &mut reproject_caches).map(|m| (feature, m))
-        })
+        .filter_map(|feature| mesh::extract(&feature.geometry, &mut caches).map(|m| (feature, m)))
         .collect();
 
     if extracted.is_empty() {

--- a/engine/runtime/geometry/src/coordinate.rs
+++ b/engine/runtime/geometry/src/coordinate.rs
@@ -16,7 +16,7 @@
 //! [`CoordinateFrame::orientation_sign`] is the sign function that is used to determine
 //! the orientation of a ring, and is given by the following rules:
 //!    1. CRS frame: for geographic CRSs and projected CRSs the sign is determined by the
-//!       CRS's axis order and directions. A geocentric (ECEF) CRS is right-handed in 
+//!       CRS's axis order and directions. A geocentric (ECEF) CRS is right-handed in
 //!       `(X, Y, Z)` order, so `+1`.
 //!    2. Euclidean frame: the sign is always `+1`.
 //!    3. Tangent frame: the sign is derived from the base frame.

--- a/engine/runtime/geometry/src/coordinate.rs
+++ b/engine/runtime/geometry/src/coordinate.rs
@@ -1,4 +1,27 @@
-//! Per-leaf coordinate frame.
+//! Per-leaf coordinate frame, and the axis-order and orientation conventions
+//! that follow from it.
+//!
+//! # Axis order conventions
+//!
+//! When a geometry has a CRS frame, its coordinate axes are in the order declared by
+//! the CRS authority. When a geometry lives in a general Euclidean frame, its axes are
+//! in `(x, y[, z])` order. Otherwise, a geometry lives in a tangent plane anchored in
+//! a base frame, and its axes inherited from the base frame.
+//!
+//! # Orientation sign
+//!
+//! For CRS coordinate systems, a north-first order is a reflection of an east-first one,
+//! so the sign of every face normal depends on the frame.
+//! [`CoordinateFrame::orientation_sign`] is the sign function that is used to determine
+//! the orientation of a ring, and is given by the following rules:
+//!    1. CRS frame: the sign is determined by the CRS's axis order and directions.
+//!    2. Euclidean frame: the sign is always `+1`.
+//!    3. Tangent frame: the sign is derived from the base frame.
+//!
+//! The canonical orientation of a ring is then defined as
+//! `right_hand_rule(ring) * CoordinateFrame::orientation_sign(frame)`. This product is
+//! invariant under reprojection: reordering the coordinate axes flips `right_hand_rule(ring)`
+//! and `CoordinateFrame::orientation_sign(frame)` together.
 
 use std::fmt;
 
@@ -53,10 +76,7 @@ pub enum CoordinateFrame {
     /// Bare Euclidean space with no geo-referencing.
     #[default]
     Euclidean,
-    /// A 2D plane embedded in 3D, anchored in a base frame. Boxed: a
-    /// `TangentPlane` is ~72 bytes against the 2-byte `EpsgCode`, and `Tangent`
-    /// is the rare frame, so boxing it keeps `CoordinateFrame` — embedded in every
-    /// geometry leaf — pointer-sized for the common `Crs` / `Euclidean` cases.
+    /// A 2D plane embedded in 3D, anchored in a base frame.
     Tangent(Box<TangentPlane>),
 }
 
@@ -71,6 +91,27 @@ impl CoordinateFrame {
             CoordinateFrame::Tangent(_) => Err(Error::projection(
                 "cannot reproject a Tangent-plane geometry",
             )),
+        }
+    }
+
+    /// The orientation sign of this frame: `+1` when its coordinates are
+    /// right-handed in canonical `(East, North[, Up])` order, `-1` when reflected.
+    /// A stored winding times this sign is the canonical orientation.
+    ///
+    /// `Crs` frames read the sign from the CRS's declared axis directions and
+    /// therefore error on an unknown CRS or one whose axes are not axis-aligned.
+    /// `Euclidean` coordinates are right-handed by construction, so their sign is
+    /// `+1`. A `Tangent` frame's in-plane axes are expressed in its base frame, so
+    /// its sign is the base frame's: `+1` for a Euclidean base, the CRS's sign for
+    /// a `Crs` base.
+    pub fn orientation_sign(&self) -> Result<i8> {
+        match self {
+            CoordinateFrame::Crs(epsg) => crate::ops::axis_order_sign(*epsg),
+            CoordinateFrame::Euclidean => Ok(1),
+            CoordinateFrame::Tangent(tangent) => match tangent.base {
+                BaseFrame::Crs(epsg) => crate::ops::axis_order_sign(epsg),
+                BaseFrame::Euclidean => Ok(1),
+            },
         }
     }
 }
@@ -102,4 +143,51 @@ pub struct TangentPlane {
     pub u: [f64; 3],
     /// Orthonormal in-plane axis.
     pub v: [f64; 3],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crs_sign_follows_axis_order() {
+        assert_eq!(
+            CoordinateFrame::Crs(EpsgCode::new(4326))
+                .orientation_sign()
+                .unwrap(),
+            -1
+        );
+        assert_eq!(
+            CoordinateFrame::Crs(EpsgCode::new(3857))
+                .orientation_sign()
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn euclidean_is_right_handed() {
+        assert_eq!(CoordinateFrame::Euclidean.orientation_sign().unwrap(), 1);
+    }
+
+    #[test]
+    fn tangent_sign_follows_its_base() {
+        let euclidean_base = CoordinateFrame::Tangent(Box::new(TangentPlane {
+            base: BaseFrame::Euclidean,
+            origin: [0.0, 0.0, 0.0],
+            u: [1.0, 0.0, 0.0],
+            v: [0.0, 1.0, 0.0],
+        }));
+        assert_eq!(euclidean_base.orientation_sign().unwrap(), 1);
+
+        // EPSG:6697 is lat-first (sign -1), so a tangent plane anchored in it is
+        // reflected too.
+        let reflected_base = CoordinateFrame::Tangent(Box::new(TangentPlane {
+            base: BaseFrame::Crs(EpsgCode::new(6697)),
+            origin: [0.0, 0.0, 0.0],
+            u: [1.0, 0.0, 0.0],
+            v: [0.0, 1.0, 0.0],
+        }));
+        assert_eq!(reflected_base.orientation_sign().unwrap(), -1);
+    }
 }

--- a/engine/runtime/geometry/src/coordinate.rs
+++ b/engine/runtime/geometry/src/coordinate.rs
@@ -10,11 +10,14 @@
 //!
 //! # Orientation sign
 //!
-//! For CRS coordinate systems, a north-first order is a reflection of an east-first one,
-//! so the sign of every face normal depends on the frame.
+//! For CRS coordinate systems, the stored axis basis is either right-handed or a
+//! reflection of one (for example, a north-first order reflects an east-first one), so
+//! the sign of every face normal depends on the frame.
 //! [`CoordinateFrame::orientation_sign`] is the sign function that is used to determine
 //! the orientation of a ring, and is given by the following rules:
-//!    1. CRS frame: the sign is determined by the CRS's axis order and directions.
+//!    1. CRS frame: for geographic CRSs and projected CRSs the sign is determined by the
+//!       CRS's axis order and directions. A geocentric (ECEF) CRS is right-handed in 
+//!       `(X, Y, Z)` order, so `+1`.
 //!    2. Euclidean frame: the sign is always `+1`.
 //!    3. Tangent frame: the sign is derived from the base frame.
 //!

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -11,6 +11,7 @@
 pub mod reproject;
 pub mod triangulation;
 
+pub(crate) use reproject::axis_order_sign;
 pub use reproject::{Reproject, ReprojectionCache};
 
 /// Returned by an operation a given geometry type does not support. Carries the

--- a/engine/runtime/geometry/src/ops/reproject/ffi.rs
+++ b/engine/runtime/geometry/src/ops/reproject/ffi.rs
@@ -297,6 +297,9 @@ unsafe fn axis_sign_from_cs(ctx: *mut PJ_CONTEXT, cs: *const PJ, epsg: EpsgCode)
 
 /// Map a PROJ axis direction to its `(row, sign)` in the canonical
 /// `(East, North, Up)` basis, or `None` if it is not aligned to an axis.
+///
+/// Geocentric (ECEF) axes are treated as a right-handed basis in `X, Y, Z`
+/// order, so a geocentric CRS resolves to orientation sign `+1`.
 fn canonical_axis(direction: &str) -> Option<(usize, f64)> {
     match direction.to_ascii_lowercase().as_str() {
         "east" => Some((0, 1.0)),
@@ -305,6 +308,9 @@ fn canonical_axis(direction: &str) -> Option<(usize, f64)> {
         "south" => Some((1, -1.0)),
         "up" => Some((2, 1.0)),
         "down" => Some((2, -1.0)),
+        "geocentricx" => Some((0, 1.0)),
+        "geocentricy" => Some((1, 1.0)),
+        "geocentricz" => Some((2, 1.0)),
         _ => None,
     }
 }
@@ -333,6 +339,11 @@ mod tests {
     fn easting_first_projected_is_positive() {
         assert_eq!(sign(3857), 1); // Web Mercator (easting, northing)
         assert_eq!(sign(32633), 1); // UTM 33N (easting, northing)
+    }
+
+    #[test]
+    fn geocentric_is_positive() {
+        assert_eq!(sign(4978), 1); // WGS84 geocentric (ECEF), right-handed X/Y/Z
     }
 
     #[test]

--- a/engine/runtime/geometry/src/ops/reproject/ffi.rs
+++ b/engine/runtime/geometry/src/ops/reproject/ffi.rs
@@ -1,14 +1,15 @@
 //! PROJ-backed coordinate transformation for the reprojection ops.
 
 use std::ffi::{CStr, CString};
-use std::os::raw::c_int;
+use std::os::raw::{c_char, c_int};
 use std::ptr;
 
 use crate::coordinate::EpsgCode;
 use proj_sys::{
     proj_context_create, proj_context_destroy, proj_context_errno, proj_context_errno_string,
-    proj_create_crs_to_crs, proj_destroy, proj_errno, proj_errno_reset, proj_trans, PJ, PJ_CONTEXT,
-    PJ_COORD, PJ_DIRECTION_PJ_FWD, PJ_XYZT,
+    proj_create, proj_create_crs_to_crs, proj_crs_get_coordinate_system, proj_crs_get_sub_crs,
+    proj_cs_get_axis_count, proj_cs_get_axis_info, proj_destroy, proj_errno, proj_errno_reset,
+    proj_trans, PJ, PJ_CONTEXT, PJ_COORD, PJ_DIRECTION_PJ_FWD, PJ_XYZT,
 };
 
 use crate::error::{Error, Result};
@@ -141,4 +142,174 @@ unsafe fn errno_string(ctx: *mut PJ_CONTEXT, errno: c_int) -> String {
 // SAFETY: `ctx` must be a valid, non-null PROJ context.
 unsafe fn ctx_errno_string(ctx: *mut PJ_CONTEXT) -> String {
     errno_string(ctx, proj_context_errno(ctx))
+}
+
+/// The orientation sign of `epsg`: `+1` when the CRS's declared axis basis is
+/// right-handed in canonical `(East, North[, Up])` order, `-1` when reflected.
+/// Errors when the CRS is unknown or its axes are not aligned to those directions.
+pub(crate) fn axis_order_sign(epsg: EpsgCode) -> Result<i8> {
+    // SAFETY: each PROJ object is null-checked before use and every path frees
+    // the objects it created; the axis-direction strings are owned by `cs` and
+    // read while it is alive.
+    unsafe {
+        let ctx = proj_context_create();
+        if ctx.is_null() {
+            return Err(Error::projection("proj_context_create returned null"));
+        }
+        let def = CString::new(format!("EPSG:{epsg}")).map_err(Error::projection)?;
+        let crs = proj_create(ctx, def.as_ptr());
+        if crs.is_null() {
+            let msg = ctx_errno_string(ctx);
+            proj_context_destroy(ctx);
+            return Err(Error::projection(format!(
+                "failed to create CRS EPSG:{epsg}: {msg}"
+            )));
+        }
+        let result = axis_sign_for_crs(ctx, crs, epsg);
+
+        proj_destroy(crs);
+        proj_context_destroy(ctx);
+        result
+    }
+}
+
+/// The orientation sign of a CRS, descending into a compound CRS's horizontal
+/// sub-CRS (index 0) when the CRS has no single coordinate system of its own.
+// SAFETY: `ctx` and `crs` must be valid, non-null PROJ objects.
+unsafe fn axis_sign_for_crs(ctx: *mut PJ_CONTEXT, crs: *const PJ, epsg: EpsgCode) -> Result<i8> {
+    let cs = proj_crs_get_coordinate_system(ctx, crs);
+    if !cs.is_null() {
+        let result = axis_sign_from_cs(ctx, cs, epsg);
+        proj_destroy(cs);
+        return result;
+    }
+
+    let horizontal = proj_crs_get_sub_crs(ctx, crs, 0);
+    if horizontal.is_null() {
+        return Err(Error::projection(format!(
+            "EPSG:{epsg} has no coordinate system: {}",
+            ctx_errno_string(ctx)
+        )));
+    }
+    let cs = proj_crs_get_coordinate_system(ctx, horizontal);
+    let result = if cs.is_null() {
+        Err(Error::projection(format!(
+            "EPSG:{epsg} horizontal sub-CRS has no coordinate system: {}",
+            ctx_errno_string(ctx)
+        )))
+    } else {
+        let sign = axis_sign_from_cs(ctx, cs, epsg);
+        proj_destroy(cs);
+        sign
+    };
+    proj_destroy(horizontal);
+    result
+}
+
+/// The orientation sign of a coordinate system, from its axis directions.
+// SAFETY: `ctx` and `cs` must be valid, non-null PROJ objects.
+unsafe fn axis_sign_from_cs(ctx: *mut PJ_CONTEXT, cs: *const PJ, epsg: EpsgCode) -> Result<i8> {
+    let n = proj_cs_get_axis_count(ctx, cs);
+    if !(2..=3).contains(&n) {
+        return Err(Error::projection(format!(
+            "EPSG:{epsg} has an unsupported axis count ({n})"
+        )));
+    }
+    let n = n as usize;
+
+    // Each axis contributes a canonical unit column vector; the sign of the
+    // determinant of those columns is the frame's orientation sign.
+    let mut axes: Vec<[f64; 3]> = Vec::with_capacity(n);
+    for i in 0..n {
+        let mut direction: *const c_char = ptr::null();
+        let ok = proj_cs_get_axis_info(
+            ctx,
+            cs,
+            i as c_int,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            &mut direction,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        );
+        if ok == 0 || direction.is_null() {
+            return Err(Error::projection(format!(
+                "EPSG:{epsg} axis {i} has no direction"
+            )));
+        }
+        let dir = CStr::from_ptr(direction).to_string_lossy();
+        let (row, sign) = canonical_axis(dir.as_ref()).ok_or_else(|| {
+            Error::projection(format!(
+                "EPSG:{epsg} axis {i} direction `{dir}` is not axis-aligned"
+            ))
+        })?;
+        let mut axis = [0.0f64; 3];
+        axis[row] = sign;
+        axes.push(axis);
+    }
+
+    let det = if n == 2 {
+        axes[0][0] * axes[1][1] - axes[0][1] * axes[1][0]
+    } else {
+        let (a, b, c) = (axes[0], axes[1], axes[2]);
+        a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0])
+            + a[2] * (b[0] * c[1] - b[1] * c[0])
+    };
+    if det > 0.0 {
+        Ok(1)
+    } else if det < 0.0 {
+        Ok(-1)
+    } else {
+        Err(Error::projection(format!(
+            "EPSG:{epsg} axes are not orthonormal in the (East, North, Up) basis"
+        )))
+    }
+}
+
+/// Map a PROJ axis direction to its `(row, sign)` in the canonical
+/// `(East, North, Up)` basis, or `None` if it is not aligned to an axis.
+fn canonical_axis(direction: &str) -> Option<(usize, f64)> {
+    match direction.to_ascii_lowercase().as_str() {
+        "east" => Some((0, 1.0)),
+        "west" => Some((0, -1.0)),
+        "north" => Some((1, 1.0)),
+        "south" => Some((1, -1.0)),
+        "up" => Some((2, 1.0)),
+        "down" => Some((2, -1.0)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sign(code: u16) -> i8 {
+        axis_order_sign(EpsgCode::new(code)).unwrap()
+    }
+
+    #[test]
+    fn latitude_first_geographic_is_negative() {
+        assert_eq!(sign(4326), -1); // WGS84 2D (lat, lon)
+        assert_eq!(sign(4979), -1); // WGS84 3D (lat, lon, height)
+        assert_eq!(sign(6697), -1); // JGD2011 + height (lat, lon, height)
+    }
+
+    #[test]
+    fn northing_first_projected_is_negative() {
+        assert_eq!(sign(6669), -1); // JGD2011 plane rectangular I (northing, easting)
+    }
+
+    #[test]
+    fn easting_first_projected_is_positive() {
+        assert_eq!(sign(3857), 1); // Web Mercator (easting, northing)
+        assert_eq!(sign(32633), 1); // UTM 33N (easting, northing)
+    }
+
+    #[test]
+    fn unknown_crs_errors() {
+        assert!(axis_order_sign(EpsgCode::new(1)).is_err());
+    }
 }

--- a/engine/runtime/geometry/src/ops/reproject/ffi.rs
+++ b/engine/runtime/geometry/src/ops/reproject/ffi.rs
@@ -1,8 +1,12 @@
 //! PROJ-backed coordinate transformation for the reprojection ops.
 
+use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int};
 use std::ptr;
+use std::sync::OnceLock;
+
+use parking_lot::RwLock;
 
 use crate::coordinate::EpsgCode;
 use proj_sys::{
@@ -144,10 +148,33 @@ unsafe fn ctx_errno_string(ctx: *mut PJ_CONTEXT) -> String {
     errno_string(ctx, proj_context_errno(ctx))
 }
 
+/// Process-wide memoization of computed orientation signs, keyed by EPSG code.
+/// The sign is a fixed property of a CRS, so a value cached once stays valid for
+/// the life of the process. Only successful lookups are cached; an unknown or
+/// unsupported CRS is a rare error path not worth memoizing.
+fn sign_cache() -> &'static RwLock<HashMap<EpsgCode, i8>> {
+    static CACHE: OnceLock<RwLock<HashMap<EpsgCode, i8>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
 /// The orientation sign of `epsg`: `+1` when the CRS's declared axis basis is
 /// right-handed in canonical `(East, North[, Up])` order, `-1` when reflected.
 /// Errors when the CRS is unknown or its axes are not aligned to those directions.
+///
+/// Memoized per EPSG code: the first call for a CRS pays the PROJ lookup, later
+/// calls read the cached sign.
 pub(crate) fn axis_order_sign(epsg: EpsgCode) -> Result<i8> {
+    if let Some(&sign) = sign_cache().read().get(&epsg) {
+        return Ok(sign);
+    }
+    let sign = axis_order_sign_uncached(epsg)?;
+    sign_cache().write().insert(epsg, sign);
+    Ok(sign)
+}
+
+/// Compute the orientation sign of `epsg` directly from PROJ, without consulting
+/// or populating the cache.
+fn axis_order_sign_uncached(epsg: EpsgCode) -> Result<i8> {
     // SAFETY: each PROJ object is null-checked before use and every path frees
     // the objects it created; the axis-direction strings are owned by `cs` and
     // read while it is alive.
@@ -311,5 +338,15 @@ mod tests {
     #[test]
     fn unknown_crs_errors() {
         assert!(axis_order_sign(EpsgCode::new(1)).is_err());
+    }
+
+    #[test]
+    fn sign_is_memoized_per_code() {
+        let code = EpsgCode::new(32633);
+        let computed = axis_order_sign(code).unwrap();
+        // The first call stored the sign under this code, and a second call
+        // returns the same value from the cache rather than recomputing it.
+        assert_eq!(sign_cache().read().get(&code), Some(&computed));
+        assert_eq!(axis_order_sign(code).unwrap(), computed);
     }
 }

--- a/engine/runtime/geometry/src/ops/reproject/mod.rs
+++ b/engine/runtime/geometry/src/ops/reproject/mod.rs
@@ -5,6 +5,7 @@ use crate::error::{Error, Result};
 
 mod ffi;
 
+pub(crate) use ffi::axis_order_sign;
 pub use ffi::ReprojectionCache;
 
 /// Reproject a geometry's coordinates to a target CRS.

--- a/engine/runtime/geometry/src/ops/triangulation.rs
+++ b/engine/runtime/geometry/src/ops/triangulation.rs
@@ -27,11 +27,6 @@ impl Cache {
 /// count, both in polygon order.
 pub struct Triangulated<M> {
     pub mesh: M,
-    /// Each source polygon's right-hand-rule flat normal, in the mesh's own
-    /// coordinate frame. In a right-handed frame (Euclidean, or a reprojected
-    /// frame such as ECEF) this is the outward normal of a canonically-oriented
-    /// face; a caller that needs an outward render normal should triangulate in
-    /// such a frame.
     pub polygon_normals: Vec<[f64; 3]>,
     pub polygon_tris: Vec<u32>,
 }
@@ -246,21 +241,14 @@ impl Projector {
 /// Newell's-method unit normal of a planar ring, following the winding by the
 /// right-hand rule; `None` if degenerate (fewer than three vertices, or a
 /// near-zero normal). Ported from `earcut::utils3d`.
-///
-/// The ring is centered on its first vertex before summing so the `prev + p`
-/// term stays small even when the coordinates have a large magnitude (e.g. raw
-/// ECEF metres), which keeps the method well-conditioned. Centering is a pure
-/// translation and leaves the normal unchanged.
 pub(crate) fn normal(vertices: &[[f64; 3]]) -> Option<[f64; 3]> {
+    let (&last, _) = vertices.split_last()?;
     if vertices.len() < 3 {
         return None;
     }
-    let origin = vertices[0];
-    let centered = |p: [f64; 3]| [p[0] - origin[0], p[1] - origin[1], p[2] - origin[2]];
     let mut sum = [0.0f64; 3];
-    let mut prev = centered(vertices[vertices.len() - 1]);
-    for &v in vertices {
-        let [x, y, z] = centered(v);
+    let mut prev = last;
+    for &[x, y, z] in vertices {
         // sum += (prev - p) x (prev + p)
         let a = [prev[0] - x, prev[1] - y, prev[2] - z];
         let b = [prev[0] + x, prev[1] + y, prev[2] + z];

--- a/engine/runtime/geometry/src/ops/triangulation.rs
+++ b/engine/runtime/geometry/src/ops/triangulation.rs
@@ -27,6 +27,11 @@ impl Cache {
 /// count, both in polygon order.
 pub struct Triangulated<M> {
     pub mesh: M,
+    /// Each source polygon's right-hand-rule flat normal, in the mesh's own
+    /// coordinate frame. In a right-handed frame (Euclidean, or a reprojected
+    /// frame such as ECEF) this is the outward normal of a canonically-oriented
+    /// face; a caller that needs an outward render normal should triangulate in
+    /// such a frame.
     pub polygon_normals: Vec<[f64; 3]>,
     pub polygon_tris: Vec<u32>,
 }
@@ -241,14 +246,21 @@ impl Projector {
 /// Newell's-method unit normal of a planar ring, following the winding by the
 /// right-hand rule; `None` if degenerate (fewer than three vertices, or a
 /// near-zero normal). Ported from `earcut::utils3d`.
+///
+/// The ring is centered on its first vertex before summing so the `prev + p`
+/// term stays small even when the coordinates have a large magnitude (e.g. raw
+/// ECEF metres), which keeps the method well-conditioned. Centering is a pure
+/// translation and leaves the normal unchanged.
 pub(crate) fn normal(vertices: &[[f64; 3]]) -> Option<[f64; 3]> {
-    let (&last, _) = vertices.split_last()?;
     if vertices.len() < 3 {
         return None;
     }
+    let origin = vertices[0];
+    let centered = |p: [f64; 3]| [p[0] - origin[0], p[1] - origin[1], p[2] - origin[2]];
     let mut sum = [0.0f64; 3];
-    let mut prev = last;
-    for &[x, y, z] in vertices {
+    let mut prev = centered(vertices[vertices.len() - 1]);
+    for &v in vertices {
+        let [x, y, z] = centered(v);
         // sum += (prev - p) x (prev + p)
         let a = [prev[0] - x, prev[1] - y, prev[2] - z];
         let b = [prev[0] + x, prev[1] + y, prev[2] + z];

--- a/engine/runtime/geometry/src/polygon/mod.rs
+++ b/engine/runtime/geometry/src/polygon/mod.rs
@@ -27,7 +27,10 @@ pub struct Polygon2D {
     /// Coordinate frame these coords are expressed in.
     frame: CoordinateFrame,
     /// Exterior ring, then all interior rings (holes), concatenated. A valid polygon
-    /// has each ring closed (first == last), with the exterior wound CCW and interiors CW.
+    /// has each ring closed (first == last), with the exterior wound counter-clockwise
+    /// and interiors clockwise in canonical orientation (see [`crate::coordinate`]:
+    /// winding is judged after applying the frame's orientation sign, not in stored
+    /// coordinate order).
     coords: Box<[[f64; 2]]>,
     /// Start index in `coords` of each interior ring; empty when there are no
     /// holes. exterior = `coords[0 .. first interior start (or end)]`;
@@ -47,10 +50,11 @@ pub struct Polygon2D {
 pub struct Polygon3D {
     /// Coordinate frame these coords are expressed in.
     frame: CoordinateFrame,
-    /// Exterior ring, then all interior rings (holes), concatenated. Its normal is
-    /// determined by the right-hand rule with respect to the exterior. A valid
-    /// polygon has each ring closed (first == last), with exterior and interior rings
-    /// wound opposite to each other.
+    /// Exterior ring, then all interior rings (holes), concatenated. Its canonical
+    /// outward normal is the exterior's right-hand-rule normal times the frame's
+    /// orientation sign (see [`crate::coordinate`]). A valid polygon has each ring
+    /// closed (first == last), with exterior and interior rings wound opposite to
+    /// each other.
     coords: Box<[[f64; 3]]>,
     /// Start index in `coords` of each interior ring; empty when there are no holes.
     interior_offsets: Box<[u32]>,

--- a/engine/runtime/geometry/src/polygon/validation.rs
+++ b/engine/runtime/geometry/src/polygon/validation.rs
@@ -81,12 +81,16 @@ impl Validate for Polygon2D {
     }
 
     fn check_orientation(&self, _params: &ValidationParams) -> ValidationReport {
-        // Flow orients 2D faces counter-clockwise: the exterior ring must wind
-        // CCW, each hole clockwise.
+        // Flow orients 2D faces counter-clockwise in canonical orientation: the
+        // exterior ring must wind CCW, each hole clockwise, after applying the
+        // frame's orientation sign. An undeterminable frame skips the check.
         ValidationReport::ran(|r| {
-            check_ring_orientation_2d(&self.frame, self.exterior(), true, r);
+            let Ok(sign) = self.frame.orientation_sign() else {
+                return;
+            };
+            check_ring_orientation_2d(&self.frame, sign, self.exterior(), true, r);
             for hole in self.interiors() {
-                check_ring_orientation_2d(&self.frame, hole, false, r);
+                check_ring_orientation_2d(&self.frame, sign, hole, false, r);
             }
         })
     }
@@ -143,7 +147,7 @@ impl Validate for Polygon3D {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::CoordinateFrame;
+    use crate::coordinate::{CoordinateFrame, EpsgCode};
     use crate::polygon::Polygon2D;
     use crate::validation_next::{validate_one, ValidationParams, ValidationResult};
 
@@ -276,6 +280,29 @@ mod tests {
         let cw = [[0.0, 0.0], [0.0, 4.0], [4.0, 4.0], [4.0, 0.0], [0.0, 0.0]];
         let p = Polygon2D::from_rings(CoordinateFrame::Euclidean, cw, Vec::<Vec<[f64; 2]>>::new());
         assert_eq!(failures(&p, ValidationType::Orientation).len(), 1);
+    }
+
+    #[test]
+    fn winding_is_judged_in_canonical_orientation() {
+        // EPSG:6697 is lat-first (orientation sign -1), so canonical winding is the
+        // raw winding flipped. The CCW `square()` is therefore canonically clockwise
+        // and misoriented as an exterior, while its reversed (raw CW) ring is
+        // canonically counter-clockwise and valid.
+        let reflected = CoordinateFrame::Crs(EpsgCode::new(6697));
+        let ccw_raw =
+            Polygon2D::from_rings(reflected.clone(), square(), Vec::<Vec<[f64; 2]>>::new());
+        assert_eq!(failures(&ccw_raw, ValidationType::Orientation).len(), 1);
+
+        let cw_raw = [[0.0, 0.0], [0.0, 4.0], [4.0, 4.0], [4.0, 0.0], [0.0, 0.0]];
+        let p = Polygon2D::from_rings(reflected, cw_raw, Vec::<Vec<[f64; 2]>>::new());
+        assert_eq!(
+            validate_one(
+                &p,
+                ValidationType::Orientation,
+                &ValidationParams::default()
+            ),
+            ValidationResult::Success
+        );
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -32,8 +32,10 @@ pub struct PolygonMesh2D {
     /// `Some`, `z.len() == vertices.len()`. `None` = pure 2D.
     z: Option<Box<[f64]>>,
     /// All rings of all faces concatenated; each face is its exterior ring then
-    /// its hole rings. A valid face has the exterior wound CCW and interiors CW.
-    /// Width from `vertices.len() - 1`.
+    /// its hole rings. A valid face has the exterior wound counter-clockwise and
+    /// interiors clockwise in canonical orientation (see [`crate::coordinate`]:
+    /// winding is judged after applying the frame's orientation sign, not in stored
+    /// coordinate order). Width from `vertices.len() - 1`.
     face_indices: IndexBuffer<1>,
     /// Internal face boundaries into `face_indices`: `len() = n_faces - 1`, no
     /// leading 0. `face_offsets[i]` is where face `i+1` begins; face `i` spans
@@ -62,8 +64,9 @@ pub struct PolygonMesh2D {
 pub struct PolygonMesh3DData {
     vertices: Vec<[f64; 3]>,
     /// All rings of all faces concatenated; each face is its exterior ring then
-    /// its hole rings. Each face's normal is determined by the right-hand rule
-    /// with respect to exterior. A valid face has exterior and interior rings wound
+    /// its hole rings. Each face's canonical outward normal is its exterior's
+    /// right-hand-rule normal times the frame's orientation sign (see
+    /// [`crate::coordinate`]). A valid face has exterior and interior rings wound
     /// opposite to each other. Width from `vertices.len() - 1`.
     face_indices: IndexBuffer<1>,
     /// Internal face boundaries into `face_indices`: `len() = n_faces - 1`, no

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -283,19 +283,27 @@ impl PolygonMesh3D {
     /// polygon's flat normal and its output triangle count, in polygon order
     /// (see [`PolygonMesh3DData::triangulate`]), for a caller that wants to
     /// attach flat normals as a mesh attribute without this crate's geometry
-    /// types ever carrying a normal field themselves. The normals follow the
-    /// right-hand rule in this mesh's frame; reproject the mesh into a
-    /// right-handed render frame (e.g. ECEF) first for outward render normals.
+    /// types ever carrying a normal field themselves.
+    ///
+    /// Each normal is the polygon's canonical outward normal (see
+    /// [`crate::coordinate`]). Errors when the frame's orientation sign cannot
+    /// be determined (e.g. an unknown or non-axis-aligned CRS).
     pub fn triangulate_with_normals(
         &mut self,
         cache: &mut Cache,
-    ) -> Triangulated<TriangularMesh3D> {
+    ) -> crate::error::Result<Triangulated<TriangularMesh3D>> {
+        let sign = self.frame.orientation_sign()? as f64;
         let result = self.data.triangulate(cache);
-        Triangulated {
+        let polygon_normals = result
+            .polygon_normals
+            .into_iter()
+            .map(|[x, y, z]| [x * sign, y * sign, z * sign])
+            .collect();
+        Ok(Triangulated {
             mesh: TriangularMesh3D::new(self.frame.clone(), result.mesh),
-            polygon_normals: result.polygon_normals,
+            polygon_normals,
             polygon_tris: result.polygon_tris,
-        }
+        })
     }
 }
 
@@ -358,7 +366,7 @@ fn push_open_ring(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::CoordinateFrame;
+    use crate::coordinate::{CoordinateFrame, EpsgCode};
 
     #[test]
     fn polygon_mesh2d_box_spans_vertex_pool() {
@@ -442,6 +450,40 @@ mod tests {
         };
         assert_eq!(tm.num_triangles(), 2);
         assert_eq!(g.bounding_box().unwrap(), mesh_box);
+    }
+
+    #[test]
+    fn triangulate_with_normals_orients_normal_by_frame_sign() {
+        // A quad wound CCW in the z = 0 plane: its right-hand-rule normal is +Z.
+        let vertices = vec![
+            [0.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [2.0, 2.0, 0.0],
+            [0.0, 2.0, 0.0],
+        ];
+        let build = |frame| {
+            PolygonMesh3D::from_parts(frame, vertices.clone(), vec![vec![0u32, 1, 2, 3]]).unwrap()
+        };
+
+        // A right-handed (Euclidean) frame keeps the raw +Z as the outward normal.
+        let mut mesh = build(CoordinateFrame::Euclidean);
+        assert_eq!(
+            mesh.triangulate_with_normals(&mut Cache::new())
+                .unwrap()
+                .polygon_normals,
+            vec![[0.0, 0.0, 1.0]]
+        );
+
+        // EPSG:6697 is lat-first (orientation sign -1), so the same winding is
+        // canonically the opposite orientation: the normal comes out flipped,
+        // without the caller reprojecting into a right-handed frame first.
+        let mut mesh = build(CoordinateFrame::Crs(EpsgCode::new(6697)));
+        assert_eq!(
+            mesh.triangulate_with_normals(&mut Cache::new())
+                .unwrap()
+                .polygon_normals,
+            vec![[0.0, 0.0, -1.0]]
+        );
     }
 
     #[test]

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -283,7 +283,9 @@ impl PolygonMesh3D {
     /// polygon's flat normal and its output triangle count, in polygon order
     /// (see [`PolygonMesh3DData::triangulate`]), for a caller that wants to
     /// attach flat normals as a mesh attribute without this crate's geometry
-    /// types ever carrying a normal field themselves.
+    /// types ever carrying a normal field themselves. The normals follow the
+    /// right-hand rule in this mesh's frame; reproject the mesh into a
+    /// right-handed render frame (e.g. ECEF) first for outward render normals.
     pub fn triangulate_with_normals(
         &mut self,
         cache: &mut Cache,

--- a/engine/runtime/geometry/src/polygon_mesh/validation.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/validation.rs
@@ -292,15 +292,19 @@ impl Validate for PolygonMesh2D {
 
     fn check_orientation(&self, _params: &ValidationParams) -> ValidationReport {
         // Each face's exterior ring must wind counter-clockwise, its holes
-        // clockwise.
+        // clockwise, in canonical orientation (after applying the frame's
+        // orientation sign). An undeterminable frame skips the check.
         ValidationReport::ran(|r| {
+            let Ok(sign) = self.frame.orientation_sign() else {
+                return;
+            };
             for_each_ring(
                 &self.face_indices,
                 &self.face_offsets,
                 &self.interior_offsets,
                 |ring, is_exterior| {
                     let coords = ring_coords(&self.vertices, ring);
-                    check_ring_orientation_2d(&self.frame, &coords, is_exterior, r);
+                    check_ring_orientation_2d(&self.frame, sign, &coords, is_exterior, r);
                 },
             );
         })

--- a/engine/runtime/geometry/src/solid/validation.rs
+++ b/engine/runtime/geometry/src/solid/validation.rs
@@ -169,14 +169,21 @@ impl Validate for Solid {
     }
 
     fn check_shell_orientation(&self, _params: &ValidationParams) -> ValidationReport {
-        // The exterior shell must enclose positive volume (outward normals); each
-        // void shell negative volume (normals into the void).
+        // In canonical orientation the exterior shell must enclose positive volume
+        // (outward normals) and each void shell negative volume (normals into the
+        // void); a signed volume in a reflected frame carries the opposite sign, so
+        // it is judged after applying the frame's orientation sign (see
+        // [`crate::coordinate`]). An undeterminable frame skips the check.
         ValidationReport::ran(|r| {
-            if self.exterior().signed_volume() <= 0.0 {
+            let Ok(sign) = self.frame.orientation_sign() else {
+                return;
+            };
+            let sign = sign as f64;
+            if self.exterior().signed_volume() * sign <= 0.0 {
                 r.push(self.exterior().to_geometry(&self.frame));
             }
             for void in self.interiors() {
-                if void.signed_volume() >= 0.0 {
+                if void.signed_volume() * sign >= 0.0 {
                     r.push(void.to_geometry(&self.frame));
                 }
             }
@@ -187,6 +194,7 @@ impl Validate for Solid {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::coordinate::EpsgCode;
     use crate::triangular_mesh::TriangularMesh3DData;
     use crate::validation_next::{validate_one, ValidationParams, ValidationResult};
 
@@ -273,5 +281,18 @@ mod tests {
             vec![tetra_outward().into()],
         );
         assert_eq!(failure_count(&bad, ValidationType::ShellOrientation), 1);
+    }
+
+    #[test]
+    fn reflected_frame_inverts_shell_orientation() {
+        // EPSG:6697 is lat-first (orientation sign -1), so a shell's signed volume
+        // carries the opposite sign there: the raw-outward tetra encloses negative
+        // volume and is canonically inward (misoriented as an exterior), while the
+        // raw-inward tetra is canonically outward and valid.
+        let reflected = CoordinateFrame::Crs(EpsgCode::new(6697));
+        let outward = Solid::from_exterior(reflected.clone(), tetra_outward());
+        assert_eq!(failure_count(&outward, ValidationType::ShellOrientation), 1);
+        let inward = Solid::from_exterior(reflected, tetra_inward());
+        assert!(is_success(&inward, ValidationType::ShellOrientation));
     }
 }

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -28,8 +28,10 @@ pub struct TriangularMesh2D {
     /// Optional per-vertex elevation, parallel to `vertices`. INVARIANT: when
     /// `Some`, `z.len() == vertices.len()`. `None` = pure 2D.
     z: Option<Box<[f64]>>,
-    /// Flat triangle index list; width from `vertices.len() - 1`. Each triangle
-    /// uses CCW winding (positive signed area); triangles carry no interior rings.
+    /// Flat triangle index list; width from `vertices.len() - 1`. Each triangle is
+    /// wound counter-clockwise in canonical orientation (see [`crate::coordinate`]:
+    /// judged after applying the frame's orientation sign, not by the raw signed
+    /// area of the stored coordinates); triangles carry no interior rings.
     indices: IndexBuffer<3>,
     /// Optional materials / themes / per-face binding, incl. per-theme UV parallel
     /// to the corner buffers; `None` = bare.
@@ -48,8 +50,9 @@ pub struct TriangularMesh2D {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct TriangularMesh3DData {
     vertices: Vec<[f64; 3]>,
-    /// Flat triangle index list; width from `vertices.len() - 1`. Winding orients
-    /// each triangle's normal by the right-hand rule.
+    /// Flat triangle index list; width from `vertices.len() - 1`. Each triangle's
+    /// canonical outward normal is its right-hand-rule normal times the frame's
+    /// orientation sign (see [`crate::coordinate`]).
     indices: IndexBuffer<3>,
     /// Optional materials / themes / per-face binding, incl. per-theme UV parallel
     /// to the corner buffers; `None` = bare.

--- a/engine/runtime/geometry/src/triangular_mesh/validation.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/validation.rs
@@ -68,15 +68,20 @@ impl Validate for TriangularMesh2D {
     }
 
     fn check_orientation(&self, _params: &ValidationParams) -> ValidationReport {
-        // Each triangle should wind counter-clockwise.
+        // Each triangle should wind counter-clockwise in canonical orientation
+        // (after applying the frame's orientation sign). An undeterminable frame
+        // skips the check.
         ValidationReport::ran(|r| {
+            let Ok(sign) = self.frame.orientation_sign() else {
+                return;
+            };
             for [a, b, c] in self.triangles() {
                 let ring = [
                     self.vertices[a as usize],
                     self.vertices[b as usize],
                     self.vertices[c as usize],
                 ];
-                check_ring_orientation_2d(&self.frame, &ring, true, r);
+                check_ring_orientation_2d(&self.frame, sign, &ring, true, r);
             }
         })
     }
@@ -138,7 +143,7 @@ impl Validate for TriangularMesh3D {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::coordinate::CoordinateFrame;
+    use crate::coordinate::{CoordinateFrame, EpsgCode};
     use crate::validation_next::{validate_one, ValidationParams, ValidationResult};
 
     // Each helper runs just `check` (and its prerequisites) on the mesh, not the
@@ -175,6 +180,28 @@ mod tests {
         )
         .unwrap();
         assert_eq!(failures(&m, ValidationType::Orientation).len(), 1);
+    }
+
+    #[test]
+    fn triangle_winding_is_judged_in_canonical_orientation() {
+        // EPSG:6697 is lat-first (orientation sign -1), so the raw-CCW triangle is
+        // canonically clockwise and misoriented, while the raw-CW triangle is
+        // canonically counter-clockwise and valid.
+        let reflected = CoordinateFrame::Crs(EpsgCode::new(6697));
+        let ccw_raw = TriangularMesh2D::from_parts(
+            reflected.clone(),
+            vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            [0u32, 1, 2],
+        )
+        .unwrap();
+        assert_eq!(failures(&ccw_raw, ValidationType::Orientation).len(), 1);
+        let cw_raw = TriangularMesh2D::from_parts(
+            reflected,
+            vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            [0u32, 2, 1],
+        )
+        .unwrap();
+        assert!(is_success(&cw_raw, ValidationType::Orientation));
     }
 
     fn quad() -> Vec<[f64; 3]> {

--- a/engine/runtime/geometry/src/validation_next.rs
+++ b/engine/runtime/geometry/src/validation_next.rs
@@ -725,17 +725,21 @@ fn signed_area_2d(ring: &[[f64; 2]]) -> f64 {
 }
 
 /// Report a [`ValidationType::Orientation`] problem when a 2D ring winds the
-/// wrong way. Flow's convention is counter-clockwise: an exterior ring must be
-/// counter-clockwise, a hole clockwise. A zero-area (degenerate / collinear) ring
-/// has no meaningful winding and is left to the degeneracy check. The position is
-/// the offending ring.
+/// wrong way. Flow's convention is counter-clockwise in canonical orientation: an
+/// exterior ring must be counter-clockwise, a hole clockwise, after the stored
+/// signed area is multiplied by the frame's orientation sign (see
+/// [`crate::coordinate`]). `sign` is that orientation sign, computed once for the
+/// whole geometry by the caller. A zero-area (degenerate / collinear) ring has no
+/// meaningful winding and is left to the degeneracy check. The position is the
+/// offending ring.
 pub(crate) fn check_ring_orientation_2d(
     frame: &CoordinateFrame,
+    sign: i8,
     ring: &[[f64; 2]],
     is_exterior: bool,
     report: &mut ValidationReport,
 ) {
-    let area = signed_area_2d(ring);
+    let area = signed_area_2d(ring) * sign as f64;
     let wrong = if is_exterior { area < 0.0 } else { area > 0.0 };
     if wrong {
         report.push(Geometry::Euclidean2D(Euclidean2DGeometry::LineString(

--- a/engine/runtime/types/src/conversion/geojson_next.rs
+++ b/engine/runtime/types/src/conversion/geojson_next.rs
@@ -61,12 +61,12 @@ fn geojson_object_to_attributes(obj: &geojson::JsonObject) -> Attributes {
         .collect()
 }
 
-/// WGS84 geographic frame for 2D coordinates (lon, lat).
+/// WGS84 geographic frame for 2D coordinates, stored (lat, lon) per EPSG:4326.
 fn wgs84_2d() -> CoordinateFrame {
     CoordinateFrame::Crs(EpsgCode::new(EPSG_WGS84_GEOGRAPHIC_2D))
 }
 
-/// WGS84 geographic frame for 3D coordinates (lon, lat, height).
+/// WGS84 geographic frame for 3D coordinates, stored (lat, lon, height) per EPSG:4979.
 fn wgs84_3d() -> CoordinateFrame {
     CoordinateFrame::Crs(EpsgCode::new(EPSG_WGS84_GEOGRAPHIC_3D))
 }
@@ -159,26 +159,31 @@ fn collection_3d(members: impl IntoIterator<Item = Euclidean3DGeometry>) -> Eucl
     Euclidean3DGeometry::Collection(Collection3D::new(members))
 }
 
+// GeoJSON coordinates are (lon, lat[, height]) per RFC 7946, but the WGS84 frames
+// they are tagged with declare (lat, lon[, height]) axis order, so the horizontal
+// pair is swapped on read. The swap also flips ring winding, which the frame's
+// orientation sign accounts for, keeping the canonical orientation intact.
+
 fn point_2d(p: &[f64]) -> Point2D {
-    Point2D::new(wgs84_2d(), [p[0], p[1]])
+    Point2D::new(wgs84_2d(), [p[1], p[0]])
 }
 
 fn point_3d(p: &[f64]) -> Point3D {
-    Point3D::new(wgs84_3d(), [p[0], p[1], p[2]])
+    Point3D::new(wgs84_3d(), [p[1], p[0], p[2]])
 }
 
 fn line_string_2d(coords: &[Vec<f64>]) -> LineString2D {
-    LineString2D::from_coords(wgs84_2d(), coords.iter().map(|c| [c[0], c[1]]))
+    LineString2D::from_coords(wgs84_2d(), coords.iter().map(|c| [c[1], c[0]]))
 }
 
 fn line_string_3d(coords: &[Vec<f64>]) -> LineString3D {
-    LineString3D::from_coords(wgs84_3d(), coords.iter().map(|c| [c[0], c[1], c[2]]))
+    LineString3D::from_coords(wgs84_3d(), coords.iter().map(|c| [c[1], c[0], c[2]]))
 }
 
 fn polygon_2d(rings: &[Vec<Vec<f64>>]) -> Polygon2D {
     let mut rings = rings
         .iter()
-        .map(|r| r.iter().map(|c| [c[0], c[1]]).collect::<Vec<_>>());
+        .map(|r| r.iter().map(|c| [c[1], c[0]]).collect::<Vec<_>>());
     let exterior = rings.next().unwrap_or_default();
     Polygon2D::from_rings(wgs84_2d(), exterior, rings)
 }
@@ -186,7 +191,7 @@ fn polygon_2d(rings: &[Vec<Vec<f64>>]) -> Polygon2D {
 fn polygon_3d(rings: &[Vec<Vec<f64>>]) -> Polygon3D {
     let mut rings = rings
         .iter()
-        .map(|r| r.iter().map(|c| [c[0], c[1], c[2]]).collect::<Vec<_>>());
+        .map(|r| r.iter().map(|c| [c[1], c[0], c[2]]).collect::<Vec<_>>());
     let exterior = rings.next().unwrap_or_default();
     Polygon3D::from_rings(wgs84_3d(), exterior, rings)
 }
@@ -219,7 +224,7 @@ mod tests {
         }
     }
 
-    // A 2D GeoJSON Point becomes a Euclidean2D Point in the WGS84 geographic frame.
+    // A 2D GeoJSON Point (lon, lat) becomes a Euclidean2D Point stored (lat, lon).
     #[test]
     fn point_2d_converts_to_euclidean_2d_wgs84() {
         let gj = geojson_feature(geojson::Value::Point(vec![139.7, 35.6]));
@@ -230,12 +235,12 @@ mod tests {
             *feature.geometry,
             Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
                 crs(4326),
-                [139.7, 35.6],
+                [35.6, 139.7],
             )))
         );
     }
 
-    // A 3D GeoJSON Point becomes a Euclidean3D Point in the WGS84 3D geographic frame.
+    // A 3D GeoJSON Point (lon, lat, h) becomes a Euclidean3D Point stored (lat, lon, h).
     #[test]
     fn point_3d_converts_to_euclidean_3d_wgs84() {
         let gj = geojson_feature(geojson::Value::Point(vec![139.7, 35.6, 12.5]));
@@ -246,7 +251,7 @@ mod tests {
             *feature.geometry,
             Geometry::Euclidean3D(Euclidean3DGeometry::Point(Point3D::new(
                 crs(4979),
-                [139.7, 35.6, 12.5],
+                [35.6, 139.7, 12.5],
             )))
         );
     }
@@ -264,7 +269,7 @@ mod tests {
             *feature.geometry,
             Geometry::Euclidean2D(Euclidean2DGeometry::LineString(LineString2D::from_coords(
                 crs(4326),
-                [[0.0, 0.0], [1.0, 2.0]],
+                [[0.0, 0.0], [2.0, 1.0]],
             )))
         );
     }
@@ -282,7 +287,7 @@ mod tests {
             *feature.geometry,
             Geometry::Euclidean3D(Euclidean3DGeometry::LineString(LineString3D::from_coords(
                 crs(4979),
-                [[0.0, 0.0, 1.0], [1.0, 2.0, 3.0]],
+                [[0.0, 0.0, 1.0], [2.0, 1.0, 3.0]],
             )))
         );
     }
@@ -311,11 +316,42 @@ mod tests {
             Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
                 Polygon2D::from_rings(
                     crs(4326),
-                    [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 0.0]],
-                    [[[1.0, 1.0], [2.0, 1.0], [1.0, 2.0], [1.0, 1.0]]],
+                    [[0.0, 0.0], [0.0, 4.0], [4.0, 4.0], [0.0, 0.0]],
+                    [[[1.0, 1.0], [1.0, 2.0], [2.0, 1.0], [1.0, 1.0]]],
                 )
             )))
         );
+    }
+
+    /// Shoelace signed area of a closed ring in its stored coordinate order.
+    fn signed_area(ring: &[[f64; 2]]) -> f64 {
+        ring.windows(2)
+            .map(|w| w[0][0] * w[1][1] - w[1][0] * w[0][1])
+            .sum::<f64>()
+            / 2.0
+    }
+
+    // A GeoJSON exterior wound CCW in (lon, lat) is stored CW in the (lat, lon) frame:
+    // the axis swap flips the raw winding, and the frame's orientation sign (-1 for
+    // EPSG:4326) flips it back, so the canonical orientation stays CCW.
+    #[test]
+    fn ccw_geojson_exterior_is_stored_clockwise() {
+        // (0,0) -> (4,0) -> (4,4) -> (0,0): CCW in (lon, lat), positive area.
+        let exterior = vec![
+            vec![0.0, 0.0],
+            vec![4.0, 0.0],
+            vec![4.0, 4.0],
+            vec![0.0, 0.0],
+        ];
+        let gj = geojson_feature(geojson::Value::Polygon(vec![exterior]));
+
+        let feature: Feature = gj.try_into().unwrap();
+
+        let Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(polygon)) = &*feature.geometry
+        else {
+            panic!("expected a 2D polygon");
+        };
+        assert!(signed_area(polygon.exterior()) < 0.0);
     }
 
     // A 3D Polygon exterior ring keeps z.
@@ -338,7 +374,7 @@ mod tests {
                     crs(4979),
                     [
                         [0.0, 0.0, 1.0],
-                        [4.0, 0.0, 1.0],
+                        [0.0, 4.0, 1.0],
                         [4.0, 4.0, 1.0],
                         [0.0, 0.0, 1.0]
                     ],
@@ -429,7 +465,7 @@ mod tests {
             Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([
                 Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
                     crs(4326),
-                    [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
+                    [[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 0.0]],
                     std::iter::empty::<Vec<[f64; 2]>>(),
                 ))),
             ])))
@@ -467,7 +503,7 @@ mod tests {
     fn nested_geometry_collection_converts() {
         let inner = geojson::Value::GeometryCollection(vec![geojson::Geometry::new(
             geojson::Value::Point(vec![3.0, 4.0]),
-        )]);
+        )]); // (lon, lat) -> stored (lat, lon) = [4.0, 3.0]
         let gj = geojson_feature(geojson::Value::GeometryCollection(vec![
             geojson::Geometry::new(inner),
         ]));
@@ -478,7 +514,7 @@ mod tests {
             *feature.geometry,
             Geometry::GeometryCollection(GeometryCollection::new([Geometry::GeometryCollection(
                 GeometryCollection::new([Geometry::Euclidean2D(Euclidean2DGeometry::Point(
-                    Point2D::new(crs(4326), [3.0, 4.0])
+                    Point2D::new(crs(4326), [4.0, 3.0])
                 ),)])
             ),]))
         );

--- a/engine/runtime/types/src/conversion/geojson_next.rs
+++ b/engine/runtime/types/src/conversion/geojson_next.rs
@@ -160,7 +160,7 @@ fn collection_3d(members: impl IntoIterator<Item = Euclidean3DGeometry>) -> Eucl
 }
 
 // GeoJSON coordinates are (lon, lat[, height]) per RFC 7946, but the WGS84 frames
-// they are tagged with declare (lat, lon[, height]) axis order, so the horizontal
+// they are tagged with declared (lat, lon[, height]) axis order, so the horizontal
 // pair is swapped on read. The swap also flips ring winding, which the frame's
 // orientation sign accounts for, keeping the canonical orientation intact.
 

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.72"
+version = "0.2.73"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.262"
+version = "0.1.263"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This is a follow up PR of #2246, which introduced the changes in the Flow's internal coordinate frame handling. It contains the doc describing the new conventions and makes the corresponding fixes for the  new geometry world.

## Doc updates
The new convention is written in `engine/runtime/geometry/src/coordinate.rs`. Each leaf type doc is also updated.

## New functions introduced
- Added the `ops::axis_order_sign(epsg)` function to return the sign of the CRS coordinate of `epsg`. The result is stored in cache to avoid repeating the expensive PROJ's database look up.
- Added the `orientation_sign()` function that wraps `ops::axis_order_sign(epsg)`.

## Fixes
- `GeoJsonReader` is fixed to respect the new convention.
- `triangulate_with_normals()` is fixed so that the output normal vector follows the new convention. 3DTilesWriter is then fixed to reproject vertices first, before triangulation, so that the returned normal vector is meaningful.

## Side fix
Triangulation is fixed to reuse cache in `3DTilesWriter`.