### PR TITLE
feat(engine): 2D predicates and ovelay for new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4094,7 +4094,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.75"
+version = "0.2.76"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "futures",
  "once_cell",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "approx",
  "async-trait",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "Inflector",
  "approx",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "bytes",
  "clap",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "approx",
  "bvh",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5100,7 +5100,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5182,7 +5182,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "bytes",
  "futures",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "bytes",
  "futures",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "ahash",
  "bytes",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.441"
+version = "0.0.442"
 dependencies = [
  "async-trait",
  "axum",
@@ -8047,7 +8047,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.265"
+version = "0.1.266"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -5043,6 +5043,7 @@ dependencies = [
  "num-traits",
  "nusamai-projection",
  "parking_lot",
+ "pretty_assertions",
  "proj-sys",
  "rayon",
  "reearth-flow-common",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.441"
+version = "0.0.442"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/geometry/Cargo.toml
+++ b/engine/runtime/geometry/Cargo.toml
@@ -46,3 +46,6 @@ serde_json.workspace = true
 smallvec.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+pretty_assertions.workspace = true

--- a/engine/runtime/geometry/src/algorithm/relate/geomgraph/edge_end.rs
+++ b/engine/runtime/geometry/src/algorithm/relate/geomgraph/edge_end.rs
@@ -123,12 +123,13 @@ impl<T: GeoFloat, Z: GeoFloat> EdgeEndKey<T, Z> {
             (Some(q1), Some(q2)) if q1 > q2 => Ordering::Greater,
             (Some(q1), Some(q2)) if q1 < q2 => Ordering::Less,
             _ => {
-                match RobustKernel::orient(
-                    other.coord_0,
-                    other.coord_1,
-                    self.coord_0,
-                    Some(self.coord_1),
-                ) {
+                // JTS `EdgeEnd::compareDirection`: same-quadrant ties break on
+                // the 2D orientation of this end's direction point against the
+                // other end's ray. Passing `Some(coord_1)` here routed through
+                // `orient3d` with `z = 0`, which is always `Collinear` for 2D
+                // input and wrongly bundled every same-quadrant pair of edge
+                // ends (e.g. the N and E edges at a shared corner).
+                match RobustKernel::orient(other.coord_0, other.coord_1, self.coord_1, None) {
                     Orientation::Clockwise => Ordering::Less,
                     Orientation::CounterClockwise => Ordering::Greater,
                     Orientation::Collinear => Ordering::Equal,

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -33,6 +33,7 @@ pub mod csg;
 pub mod index;
 pub mod line_string;
 pub mod ops;
+pub mod overlay;
 pub mod point;
 pub mod point_cloud;
 pub mod polygon;

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -37,6 +37,7 @@ pub mod point;
 pub mod point_cloud;
 pub mod polygon;
 pub mod polygon_mesh;
+pub mod predicates;
 pub mod solid;
 pub mod triangular_mesh;
 #[cfg(feature = "new-geometry")]

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -34,6 +34,20 @@ pub struct LineString3D {
     coords: Box<[[f64; 3]]>,
 }
 
+impl LineString2D {
+    /// The coordinate frame these coords are expressed in.
+    #[inline]
+    pub fn frame(&self) -> &CoordinateFrame {
+        &self.frame
+    }
+
+    /// The chain's vertices in order.
+    #[inline]
+    pub fn coords(&self) -> &[[f64; 2]] {
+        &self.coords
+    }
+}
+
 impl LineString3D {
     /// The chain's vertices in order.
     #[inline]

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -114,6 +114,32 @@ impl Aabb {
         }
     }
 
+    /// Whether two boxes overlap. Contact (shared face, edge, or corner) counts
+    /// as overlap — the test is inclusive on every axis, matching the closed-set
+    /// semantics the predicate kernels expect from a quick-reject.
+    ///
+    /// Same-embedding boxes compare directly; a 2D box mixed with a 3D one is
+    /// placed in the `z = 0` plane first (as in [`union`](Aabb::union)), so the
+    /// mixed case never spuriously rejects on the `z` axis.
+    pub fn intersects(&self, other: &Aabb) -> bool {
+        if let (
+            Aabb::D2 {
+                min: amin,
+                max: amax,
+            },
+            Aabb::D2 {
+                min: bmin,
+                max: bmax,
+            },
+        ) = (self, other)
+        {
+            return (0..2).all(|i| amin[i] <= bmax[i] && bmin[i] <= amax[i]);
+        }
+        let (amin, amax) = self.as_3d();
+        let (bmin, bmax) = other.as_3d();
+        (0..3).all(|i| amin[i] <= bmax[i] && bmin[i] <= amax[i])
+    }
+
     /// The smallest box containing both. Two 2D boxes stay 2D; a 2D box mixed
     /// with a 3D one is promoted into the `z = 0` plane and the result is 3D.
     pub fn union(self, other: Aabb) -> Aabb {
@@ -291,6 +317,52 @@ mod tests {
                 max: [3.0, 1.0]
             })
         );
+    }
+
+    #[test]
+    fn intersects_overlapping_and_disjoint_2d() {
+        let a = Aabb::D2 {
+            min: [0.0, 0.0],
+            max: [2.0, 2.0],
+        };
+        let overlap = Aabb::D2 {
+            min: [1.0, 1.0],
+            max: [3.0, 3.0],
+        };
+        let disjoint = Aabb::D2 {
+            min: [3.0, 3.0],
+            max: [4.0, 4.0],
+        };
+        // Touching along an edge counts (inclusive).
+        let touching = Aabb::D2 {
+            min: [2.0, 0.0],
+            max: [4.0, 2.0],
+        };
+        assert!(a.intersects(&overlap));
+        assert!(a.intersects(&touching));
+        assert!(!a.intersects(&disjoint));
+        // Symmetric.
+        assert!(overlap.intersects(&a));
+    }
+
+    #[test]
+    fn intersects_mixed_dim_uses_z_zero_plane() {
+        let flat = Aabb::D2 {
+            min: [0.0, 0.0],
+            max: [2.0, 2.0],
+        };
+        // A 3D box straddling z = 0 overlaps the z = 0 plane.
+        let through_plane = Aabb::D3 {
+            min: [1.0, 1.0, -1.0],
+            max: [3.0, 3.0, 1.0],
+        };
+        // A 3D box entirely above z = 0 does not.
+        let above_plane = Aabb::D3 {
+            min: [1.0, 1.0, 1.0],
+            max: [3.0, 3.0, 2.0],
+        };
+        assert!(flat.intersects(&through_plane));
+        assert!(!flat.intersects(&above_plane));
     }
 
     #[test]

--- a/engine/runtime/geometry/src/overlay/mod.rs
+++ b/engine/runtime/geometry/src/overlay/mod.rs
@@ -41,6 +41,12 @@
 //!   degenerate slivers are dropped, collinear vertices are removed, and
 //!   chained overlays can drift. Segment intersection points are f64-rounded
 //!   robust-kernel constructions (no grid snap).
+//! - An exact pre-pass guards the backend: when each operand's members have
+//!   pairwise disjoint bounding boxes, the operands are first related with
+//!   the exact [`relate`](crate::predicates::relate()) kernel, and a
+//!   relationship that alone determines the result (disjoint, boundary-only
+//!   touch, containment, equality) bypasses the backend instead of trusting
+//!   its snapped output near zero-area configurations.
 //! - Output is pure 2D: any per-vertex elevation on the inputs is ignored and
 //!   dropped, and appearance does not propagate.
 
@@ -57,7 +63,9 @@ use i_overlay::string::clip::ClipRule;
 
 use crate::coordinate::CoordinateFrame;
 use crate::line_string::LineString2D;
+use crate::ops::Aabb;
 use crate::polygon::Polygon2D;
+use crate::predicates::relate::relate_leaves;
 use crate::predicates::view::{flatten_2d, require_common_frame_leaves, Leaf2D};
 use crate::predicates::{flatten_2d_pair, PredicateError, Result};
 use crate::{Euclidean2DGeometry, Geometry};
@@ -181,8 +189,124 @@ fn overlay_leaves(a: &[Leaf2D<'_>], b: &[Leaf2D<'_>], op: OverlayOp) -> Result<V
     let Some(frame) = common_frame(a, b) else {
         return Ok(Vec::new());
     };
-    let result = subject.overlay(&clip, op.into(), FillRule::NonZero);
-    Ok(shapes::shapes_to_polygons(result, frame))
+    let dissolve = |shapes: &Vec<shapes::Shape>| {
+        let empty: Vec<shapes::Shape> = Vec::new();
+        shapes::shapes_to_polygons(
+            shapes.overlay(&empty, OverlayRule::Union, FillRule::NonZero),
+            frame,
+        )
+    };
+    match exact_plan(a, b, op) {
+        Plan::Empty => Ok(Vec::new()),
+        Plan::DissolveA => Ok(dissolve(&subject)),
+        Plan::DissolveB => Ok(dissolve(&clip)),
+        Plan::DissolveBoth => {
+            let mut out = dissolve(&subject);
+            out.extend(dissolve(&clip));
+            Ok(out)
+        }
+        Plan::Run(op) => {
+            let result = subject.overlay(&clip, op.into(), FillRule::NonZero);
+            Ok(shapes::shapes_to_polygons(result, frame))
+        }
+    }
+}
+
+// --- exactness gate --------------------------------------------------------
+
+/// How an overlay call is executed once the operands' exact relationship is
+/// known.
+enum Plan {
+    /// The result is empty.
+    Empty,
+    /// The result is `a` alone, dissolved.
+    DissolveA,
+    /// The result is `b` alone, dissolved.
+    DissolveB,
+    /// The result is `a` and `b` dissolved separately, side by side.
+    DissolveBoth,
+    /// The backend computes the operation.
+    Run(OverlayOp),
+}
+
+/// Decide how to execute `a <op> b` from the operands' exact relationship.
+///
+/// When the relationship can be established with the exact
+/// [`relate`](crate::predicates::relate()) kernel and it alone determines the
+/// result (disjoint, boundary-only touch, containment, equality), the backend
+/// and its coordinate snapping are bypassed, so zero-area configurations
+/// cannot produce snap slivers or gaps. Every other pair, and every pair whose
+/// relationship cannot be established exactly, runs the backend unchanged.
+fn exact_plan(a: &[Leaf2D<'_>], b: &[Leaf2D<'_>], op: OverlayOp) -> Plan {
+    if a.is_empty() || b.is_empty() {
+        return Plan::Run(op);
+    }
+    let a_boxes: Vec<Aabb> = a.iter().filter_map(Leaf2D::bbox).collect();
+    let b_boxes: Vec<Aabb> = b.iter().filter_map(Leaf2D::bbox).collect();
+    let (Some(a_union), Some(b_union)) = (
+        a_boxes.iter().copied().reduce(Aabb::union),
+        b_boxes.iter().copied().reduce(Aabb::union),
+    ) else {
+        return Plan::Run(op);
+    };
+    // Operand-level box reject: disjoint without touching the kernel.
+    if !a_union.intersects(&b_union) {
+        return disjoint_plan(op);
+    }
+    // relate is exact only on operands whose own members cannot interact;
+    // pairwise disjoint leaf boxes guarantee that.
+    if !pairwise_disjoint(&a_boxes) || !pairwise_disjoint(&b_boxes) {
+        return Plan::Run(op);
+    }
+    let m = relate_leaves(a.to_vec(), b.to_vec());
+    if m.is_disjoint() {
+        disjoint_plan(op)
+    } else if m.is_touches() {
+        // Boundary-only contact: the intersection has zero area, so union and
+        // xor coincide and the difference leaves `a` whole.
+        match op {
+            OverlayOp::Intersection => Plan::Empty,
+            OverlayOp::Difference => Plan::DissolveA,
+            OverlayOp::Union | OverlayOp::Xor => Plan::Run(OverlayOp::Union),
+        }
+    } else if m.is_equal_topo() {
+        match op {
+            OverlayOp::Union | OverlayOp::Intersection => Plan::DissolveA,
+            OverlayOp::Difference | OverlayOp::Xor => Plan::Empty,
+        }
+    } else if m.is_within() {
+        match op {
+            OverlayOp::Intersection => Plan::DissolveA,
+            OverlayOp::Union => Plan::DissolveB,
+            OverlayOp::Difference => Plan::Empty,
+            OverlayOp::Xor => Plan::Run(OverlayOp::Xor),
+        }
+    } else if m.is_contains() {
+        match op {
+            OverlayOp::Intersection => Plan::DissolveB,
+            OverlayOp::Union => Plan::DissolveA,
+            OverlayOp::Difference | OverlayOp::Xor => Plan::Run(op),
+        }
+    } else {
+        Plan::Run(op)
+    }
+}
+
+/// The plan for two disjoint operands.
+fn disjoint_plan(op: OverlayOp) -> Plan {
+    match op {
+        OverlayOp::Intersection => Plan::Empty,
+        OverlayOp::Difference => Plan::DissolveA,
+        OverlayOp::Union | OverlayOp::Xor => Plan::DissolveBoth,
+    }
+}
+
+/// Whether the boxes are pairwise non-overlapping.
+fn pairwise_disjoint(boxes: &[Aabb]) -> bool {
+    boxes
+        .iter()
+        .enumerate()
+        .all(|(i, x)| boxes[i + 1..].iter().all(|y| !x.intersects(y)))
 }
 
 fn clip_leaves(

--- a/engine/runtime/geometry/src/overlay/mod.rs
+++ b/engine/runtime/geometry/src/overlay/mod.rs
@@ -1,0 +1,282 @@
+//! 2D boolean overlay and linear clipping for the new geometry model.
+//!
+//! Phase 4 of the predicates plan: the *constructed* binary operations. They
+//! share the [`predicates`](crate::predicates) substrate — flattened
+//! [`Leaf2D`] views, the frame and dimension policy, [`PredicateError`] — but
+//! return geometry instead of answering a question:
+//!
+//! - [`overlay()`] and its [`union()`] / [`intersection()`] / [`difference()`]
+//!   / [`xor()`] shorthands — areal boolean overlay, backed by `i_overlay`
+//!   (the same pure-Rust backend as the legacy `BooleanOps`).
+//! - [`clip()`] — the portion of a set of polylines inside (or, inverted,
+//!   outside) an areal geometry.
+//! - [`segment_intersections()`] — the pairwise segment × segment
+//!   intersections between two polyline sets.
+//!
+//! The operand policy is the predicates': both operands in one coordinate
+//! frame ([`MixedFrames`](PredicateError::MixedFrames) otherwise, reprojection
+//! is the caller's step), a 2D × 3D pair is
+//! [`CrossDimension`](PredicateError::CrossDimension), a purely 3D pair
+//! [`UnsupportedPair`](PredicateError::UnsupportedPair) until the 3D phases
+//! land. Collections flatten to their leaves; `Geometry::None` and empty
+//! collections are the empty geometry. Beyond that, each operation constrains
+//! the leaf kinds it accepts — an areal operand takes `Polygon`,
+//! `PolygonMesh`, and `TriangularMesh` leaves, a polyline operand takes
+//! `LineString` leaves, and any other leaf is an
+//! [`UnsupportedPair`](PredicateError::UnsupportedPair) naming it.
+//!
+//! Semantics and caveats:
+//!
+//! - An operand is the point-set **union** of its leaves: the non-zero fill
+//!   rule dissolves overlapping or edge-adjacent members exactly, and mesh
+//!   leaves are pre-dissolved to their union-boundary rings (the
+//!   [`relate`](crate::predicates::relate()) boundary pre-pass) so shared face
+//!   edges cancel before the backend ever snaps a coordinate. Unlike
+//!   [`relate`](crate::predicates::relate()), such operands are *not* a
+//!   limitation here.
+//! - Valid ring winding is assumed (exteriors CCW, holes CW — Flow's
+//!   convention, checked by `Validate`): under the non-zero rule a mis-wound
+//!   hole reads as filled area. Results follow the same convention.
+//! - Constructed output is **not exact**: `i_overlay` snaps input to an
+//!   adaptive integer grid, so vertices can move by a relative epsilon,
+//!   degenerate slivers are dropped, collinear vertices are removed, and
+//!   chained overlays can drift. Segment intersection points are f64-rounded
+//!   robust-kernel constructions (no grid snap). Same trade-offs as the
+//!   legacy backends.
+//! - Output is pure 2D: any per-vertex elevation on the inputs is ignored and
+//!   dropped, and appearance does not propagate.
+
+mod segments;
+mod shapes;
+#[cfg(test)]
+mod tests;
+
+use i_overlay::core::fill_rule::FillRule;
+use i_overlay::core::overlay_rule::OverlayRule;
+use i_overlay::float::clip::FloatClip;
+use i_overlay::float::single::SingleFloatOverlay;
+use i_overlay::string::clip::ClipRule;
+
+use crate::coordinate::CoordinateFrame;
+use crate::line_string::LineString2D;
+use crate::polygon::Polygon2D;
+use crate::predicates::view::{flatten_2d, require_common_frame_leaves, Leaf2D};
+use crate::predicates::{flatten_2d_pair, PredicateError, Result};
+use crate::{Euclidean2DGeometry, Geometry};
+
+pub use crate::predicates::kernel::SegmentIntersection;
+
+/// The boolean overlay operation to apply.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OverlayOp {
+    /// Points in `a`, `b`, or both.
+    Union,
+    /// Points in both `a` and `b`.
+    Intersection,
+    /// Points in `a` but not in `b`.
+    Difference,
+    /// Points in exactly one of `a` and `b`.
+    Xor,
+}
+
+impl From<OverlayOp> for OverlayRule {
+    fn from(op: OverlayOp) -> Self {
+        match op {
+            OverlayOp::Union => OverlayRule::Union,
+            OverlayOp::Intersection => OverlayRule::Intersect,
+            OverlayOp::Difference => OverlayRule::Difference,
+            OverlayOp::Xor => OverlayRule::Xor,
+        }
+    }
+}
+
+/// The boolean overlay `a <op> b` of two areal geometries, as disjoint
+/// polygons in the operands' common frame (empty when the result is empty).
+pub fn overlay(a: &Geometry, b: &Geometry, op: OverlayOp) -> Result<Vec<Polygon2D>> {
+    let (a_leaves, b_leaves) = flatten_2d_pair(a, b)?;
+    overlay_leaves(&a_leaves, &b_leaves, op)
+}
+
+/// [`overlay`] with [`OverlayOp::Union`]: points in `a`, `b`, or both.
+pub fn union(a: &Geometry, b: &Geometry) -> Result<Vec<Polygon2D>> {
+    overlay(a, b, OverlayOp::Union)
+}
+
+/// [`overlay`] with [`OverlayOp::Intersection`]: points in both `a` and `b`.
+pub fn intersection(a: &Geometry, b: &Geometry) -> Result<Vec<Polygon2D>> {
+    overlay(a, b, OverlayOp::Intersection)
+}
+
+/// [`overlay`] with [`OverlayOp::Difference`]: points in `a` but not in `b`.
+pub fn difference(a: &Geometry, b: &Geometry) -> Result<Vec<Polygon2D>> {
+    overlay(a, b, OverlayOp::Difference)
+}
+
+/// [`overlay`] with [`OverlayOp::Xor`]: points in exactly one of `a` and `b`.
+pub fn xor(a: &Geometry, b: &Geometry) -> Result<Vec<Polygon2D>> {
+    overlay(a, b, OverlayOp::Xor)
+}
+
+/// [`overlay`] over two 2D geometries.
+pub fn overlay_2d(
+    a: &Euclidean2DGeometry,
+    b: &Euclidean2DGeometry,
+    op: OverlayOp,
+) -> Result<Vec<Polygon2D>> {
+    let mut a_leaves = Vec::new();
+    flatten_2d(a, &mut a_leaves);
+    let mut b_leaves = Vec::new();
+    flatten_2d(b, &mut b_leaves);
+    overlay_leaves(&a_leaves, &b_leaves, op)
+}
+
+/// The portion of the polylines of `lines` inside the areal geometry `area` —
+/// or, with `invert`, the portion outside it. Points exactly on `area`'s
+/// boundary count as inside either way.
+pub fn clip(lines: &Geometry, area: &Geometry, invert: bool) -> Result<Vec<LineString2D>> {
+    let (line_leaves, area_leaves) = flatten_2d_pair(lines, area)?;
+    clip_leaves(&line_leaves, &area_leaves, invert)
+}
+
+/// [`clip`] over two 2D geometries.
+pub fn clip_2d(
+    lines: &Euclidean2DGeometry,
+    area: &Euclidean2DGeometry,
+    invert: bool,
+) -> Result<Vec<LineString2D>> {
+    let mut line_leaves = Vec::new();
+    flatten_2d(lines, &mut line_leaves);
+    let mut area_leaves = Vec::new();
+    flatten_2d(area, &mut area_leaves);
+    clip_leaves(&line_leaves, &area_leaves, invert)
+}
+
+/// Every segment × segment intersection between the polylines of `a` and the
+/// polylines of `b`: proper crossings, endpoint touches, and collinear
+/// overlaps, deduplicated and in a deterministic order. Segments *within* one
+/// operand are never paired with each other, so consecutive segments of one
+/// polyline do not report their shared vertex.
+pub fn segment_intersections(a: &Geometry, b: &Geometry) -> Result<Vec<SegmentIntersection>> {
+    let (a_leaves, b_leaves) = flatten_2d_pair(a, b)?;
+    segment_intersections_leaves(&a_leaves, &b_leaves)
+}
+
+/// [`segment_intersections`] over two 2D geometries.
+pub fn segment_intersections_2d(
+    a: &Euclidean2DGeometry,
+    b: &Euclidean2DGeometry,
+) -> Result<Vec<SegmentIntersection>> {
+    let mut a_leaves = Vec::new();
+    flatten_2d(a, &mut a_leaves);
+    let mut b_leaves = Vec::new();
+    flatten_2d(b, &mut b_leaves);
+    segment_intersections_leaves(&a_leaves, &b_leaves)
+}
+
+// --- leaf-level implementations ------------------------------------------------
+
+fn overlay_leaves(a: &[Leaf2D<'_>], b: &[Leaf2D<'_>], op: OverlayOp) -> Result<Vec<Polygon2D>> {
+    require_common_frame_leaves(a, b)?;
+    let unsupported = || unsupported_pair(a, b, is_areal);
+    let subject = shapes::areal_shapes(a).map_err(|_| unsupported())?;
+    let clip = shapes::areal_shapes(b).map_err(|_| unsupported())?;
+    let Some(frame) = common_frame(a, b) else {
+        return Ok(Vec::new());
+    };
+    let result = subject.overlay(&clip, op.into(), FillRule::NonZero);
+    Ok(shapes::shapes_to_polygons(result, frame))
+}
+
+fn clip_leaves(
+    lines: &[Leaf2D<'_>],
+    area: &[Leaf2D<'_>],
+    invert: bool,
+) -> Result<Vec<LineString2D>> {
+    require_common_frame_leaves(lines, area)?;
+    let unsupported = || PredicateError::UnsupportedPair {
+        left: operand_name(lines, is_line),
+        right: operand_name(area, is_areal),
+    };
+    let subject = shapes::line_paths(lines).map_err(|_| unsupported())?;
+    let clip = shapes::areal_shapes(area).map_err(|_| unsupported())?;
+    let Some(frame) = common_frame(lines, area) else {
+        return Ok(Vec::new());
+    };
+    // An empty clip area contains nothing: the inside portion is empty and the
+    // outside portion is the polylines verbatim.
+    if clip.is_empty() {
+        let outside = if invert { subject } else { Vec::new() };
+        return Ok(shapes::paths_to_line_strings(outside, frame));
+    }
+    let clip_rule = ClipRule {
+        invert,
+        boundary_included: true,
+    };
+    let result = subject.clip_by(&clip, FillRule::NonZero, clip_rule);
+    Ok(shapes::paths_to_line_strings(result, frame))
+}
+
+fn segment_intersections_leaves(
+    a: &[Leaf2D<'_>],
+    b: &[Leaf2D<'_>],
+) -> Result<Vec<SegmentIntersection>> {
+    require_common_frame_leaves(a, b)?;
+    let unsupported = || unsupported_pair(a, b, is_line);
+    let a_segments = segments::leaf_segments(a).map_err(|_| unsupported())?;
+    let b_segments = segments::leaf_segments(b).map_err(|_| unsupported())?;
+    Ok(segments::intersections(a_segments, b_segments))
+}
+
+// --- operand policy helpers ----------------------------------------------------
+
+fn is_areal(leaf: &Leaf2D<'_>) -> bool {
+    matches!(
+        leaf,
+        Leaf2D::Polygon(_) | Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_)
+    )
+}
+
+fn is_line(leaf: &Leaf2D<'_>) -> bool {
+    matches!(leaf, Leaf2D::Line(_))
+}
+
+/// The concrete 2D leaf name, for `UnsupportedPair` diagnostics.
+fn leaf_type_name(leaf: &Leaf2D<'_>) -> &'static str {
+    match leaf {
+        Leaf2D::Point(_) => "Point2D",
+        Leaf2D::Line(_) => "LineString2D",
+        Leaf2D::Polygon(_) => "Polygon2D",
+        Leaf2D::PolygonMesh(_) => "PolygonMesh2D",
+        Leaf2D::TriangularMesh(_) => "TriangularMesh2D",
+    }
+}
+
+/// Describe an operand for an `UnsupportedPair` diagnostic: its first leaf
+/// that fails `ok` if any, else its first leaf, else "empty geometry".
+fn operand_name(leaves: &[Leaf2D<'_>], ok: fn(&Leaf2D<'_>) -> bool) -> &'static str {
+    leaves
+        .iter()
+        .find(|leaf| !ok(leaf))
+        .or_else(|| leaves.first())
+        .map(leaf_type_name)
+        .unwrap_or("empty geometry")
+}
+
+/// The `UnsupportedPair` for an operation whose two operands both require
+/// `ok` leaves.
+fn unsupported_pair(
+    a: &[Leaf2D<'_>],
+    b: &[Leaf2D<'_>],
+    ok: fn(&Leaf2D<'_>) -> bool,
+) -> PredicateError {
+    PredicateError::UnsupportedPair {
+        left: operand_name(a, ok),
+        right: operand_name(b, ok),
+    }
+}
+
+/// The operands' shared frame — the first leaf's, all being equal after
+/// [`require_common_frame_leaves`] — or `None` when both are empty.
+fn common_frame<'l>(a: &[Leaf2D<'l>], b: &[Leaf2D<'l>]) -> Option<&'l CoordinateFrame> {
+    a.first().or_else(|| b.first()).map(Leaf2D::frame)
+}

--- a/engine/runtime/geometry/src/overlay/mod.rs
+++ b/engine/runtime/geometry/src/overlay/mod.rs
@@ -1,28 +1,27 @@
-//! 2D boolean overlay and linear clipping for the new geometry model.
+//! 2D boolean overlay and linear clipping for the geometry model.
 //!
-//! Phase 4 of the predicates plan: the *constructed* binary operations. They
-//! share the [`predicates`](crate::predicates) substrate — flattened
-//! [`Leaf2D`] views, the frame and dimension policy, [`PredicateError`] — but
-//! return geometry instead of answering a question:
+//! The *constructed* binary operations. They share the
+//! [`predicates`](crate::predicates) substrate (flattened [`Leaf2D`] views, the
+//! frame and dimension policy, [`PredicateError`]) but return geometry instead
+//! of answering a question:
 //!
 //! - [`overlay()`] and its [`union()`] / [`intersection()`] / [`difference()`]
-//!   / [`xor()`] shorthands — areal boolean overlay, backed by `i_overlay`
-//!   (the same pure-Rust backend as the legacy `BooleanOps`).
-//! - [`clip()`] — the portion of a set of polylines inside (or, inverted,
+//!   / [`xor()`] shorthands: areal boolean overlay, backed by the `i_overlay`
+//!   pure-Rust backend.
+//! - [`clip()`]: the portion of a set of polylines inside (or, inverted,
 //!   outside) an areal geometry.
-//! - [`segment_intersections()`] — the pairwise segment × segment
+//! - [`segment_intersections()`]: the pairwise segment × segment
 //!   intersections between two polyline sets.
 //!
 //! The operand policy is the predicates': both operands in one coordinate
 //! frame ([`MixedFrames`](PredicateError::MixedFrames) otherwise, reprojection
 //! is the caller's step), a 2D × 3D pair is
 //! [`CrossDimension`](PredicateError::CrossDimension), a purely 3D pair
-//! [`UnsupportedPair`](PredicateError::UnsupportedPair) until the 3D phases
-//! land. Collections flatten to their leaves; `Geometry::None` and empty
-//! collections are the empty geometry. Beyond that, each operation constrains
-//! the leaf kinds it accepts — an areal operand takes `Polygon`,
-//! `PolygonMesh`, and `TriangularMesh` leaves, a polyline operand takes
-//! `LineString` leaves, and any other leaf is an
+//! [`UnsupportedPair`](PredicateError::UnsupportedPair). Collections flatten to
+//! their leaves; `Geometry::None` and empty collections are the empty geometry.
+//! Beyond that, each operation constrains the leaf kinds it accepts: an areal
+//! operand takes `Polygon`, `PolygonMesh`, and `TriangularMesh` leaves, a
+//! polyline operand takes `LineString` leaves, and any other leaf is an
 //! [`UnsupportedPair`](PredicateError::UnsupportedPair) naming it.
 //!
 //! Semantics and caveats:
@@ -34,15 +33,14 @@
 //!   edges cancel before the backend ever snaps a coordinate. Unlike
 //!   [`relate`](crate::predicates::relate()), such operands are *not* a
 //!   limitation here.
-//! - Valid ring winding is assumed (exteriors CCW, holes CW — Flow's
+//! - Valid ring winding is assumed (exteriors CCW, holes CW, Flow's
 //!   convention, checked by `Validate`): under the non-zero rule a mis-wound
 //!   hole reads as filled area. Results follow the same convention.
 //! - Constructed output is **not exact**: `i_overlay` snaps input to an
 //!   adaptive integer grid, so vertices can move by a relative epsilon,
 //!   degenerate slivers are dropped, collinear vertices are removed, and
 //!   chained overlays can drift. Segment intersection points are f64-rounded
-//!   robust-kernel constructions (no grid snap). Same trade-offs as the
-//!   legacy backends.
+//!   robust-kernel constructions (no grid snap).
 //! - Output is pure 2D: any per-vertex elevation on the inputs is ignored and
 //!   dropped, and appearance does not propagate.
 
@@ -130,7 +128,7 @@ pub fn overlay_2d(
     overlay_leaves(&a_leaves, &b_leaves, op)
 }
 
-/// The portion of the polylines of `lines` inside the areal geometry `area` —
+/// The portion of the polylines of `lines` inside the areal geometry `area`,
 /// or, with `invert`, the portion outside it. Points exactly on `area`'s
 /// boundary count as inside either way.
 pub fn clip(lines: &Geometry, area: &Geometry, invert: bool) -> Result<Vec<LineString2D>> {
@@ -275,8 +273,8 @@ fn unsupported_pair(
     }
 }
 
-/// The operands' shared frame — the first leaf's, all being equal after
-/// [`require_common_frame_leaves`] — or `None` when both are empty.
+/// The operands' shared frame (the first leaf's, all being equal after
+/// [`require_common_frame_leaves`]), or `None` when both are empty.
 fn common_frame<'l>(a: &[Leaf2D<'l>], b: &[Leaf2D<'l>]) -> Option<&'l CoordinateFrame> {
     a.first().or_else(|| b.first()).map(Leaf2D::frame)
 }

--- a/engine/runtime/geometry/src/overlay/segments.rs
+++ b/engine/runtime/geometry/src/overlay/segments.rs
@@ -1,9 +1,9 @@
 //! Pairwise segment × segment intersections between two polyline sets.
 //!
-//! The substrate for `LineOnLineOverlayer`: every segment of one operand is
-//! tested against every bbox-overlapping segment of the other via an
-//! rstar-indexed candidate sweep, and each hit goes through the robust
-//! phase-1 [`kernel::segment_intersection`](segment_intersection).
+//! Every segment of one operand is tested against every bbox-overlapping
+//! segment of the other via an rstar-indexed candidate sweep, and each hit
+//! goes through the robust
+//! [`kernel::segment_intersection`](segment_intersection).
 
 use std::cmp::Ordering;
 
@@ -30,7 +30,7 @@ impl rstar::RTreeObject for Segment {
 }
 
 /// The segments of the line leaves. Zero-length segments (repeated vertices)
-/// are dropped — they carry no direction and no crossing. Errs with the leaf's
+/// are dropped: they carry no direction and no crossing. Errs with the leaf's
 /// type name on the first non-line leaf.
 pub(super) fn leaf_segments(leaves: &[Leaf2D<'_>]) -> Result<Vec<Segment>, &'static str> {
     let mut segments = Vec::new();

--- a/engine/runtime/geometry/src/overlay/segments.rs
+++ b/engine/runtime/geometry/src/overlay/segments.rs
@@ -1,0 +1,108 @@
+//! Pairwise segment × segment intersections between two polyline sets.
+//!
+//! The substrate for `LineOnLineOverlayer`: every segment of one operand is
+//! tested against every bbox-overlapping segment of the other via an
+//! rstar-indexed candidate sweep, and each hit goes through the robust
+//! phase-1 [`kernel::segment_intersection`](segment_intersection).
+
+use std::cmp::Ordering;
+
+use rstar::RTree;
+
+use crate::predicates::kernel::{segment_intersection, SegmentIntersection};
+use crate::predicates::view::Leaf2D;
+
+use super::leaf_type_name;
+
+/// One directed segment of a polyline, with its precomputed rstar envelope.
+pub(super) struct Segment {
+    start: [f64; 2],
+    end: [f64; 2],
+    envelope: rstar::AABB<[f64; 2]>,
+}
+
+impl rstar::RTreeObject for Segment {
+    type Envelope = rstar::AABB<[f64; 2]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.envelope
+    }
+}
+
+/// The segments of the line leaves. Zero-length segments (repeated vertices)
+/// are dropped — they carry no direction and no crossing. Errs with the leaf's
+/// type name on the first non-line leaf.
+pub(super) fn leaf_segments(leaves: &[Leaf2D<'_>]) -> Result<Vec<Segment>, &'static str> {
+    let mut segments = Vec::new();
+    for leaf in leaves {
+        match leaf {
+            Leaf2D::Line(l) => segments.extend(l.coords().windows(2).filter(|w| w[0] != w[1]).map(
+                |w| Segment {
+                    start: w[0],
+                    end: w[1],
+                    envelope: rstar::AABB::from_corners(w[0], w[1]),
+                },
+            )),
+            _ => return Err(leaf_type_name(leaf)),
+        }
+    }
+    Ok(segments)
+}
+
+/// All intersections between the two segment sets, deduplicated and in a
+/// deterministic (lexicographic) order. Collinear overlaps are canonicalized
+/// to lexicographically ordered endpoints so the same span found from
+/// different segment pairs deduplicates.
+pub(super) fn intersections(a: Vec<Segment>, b: Vec<Segment>) -> Vec<SegmentIntersection> {
+    let tree_a = RTree::bulk_load(a);
+    let tree_b = RTree::bulk_load(b);
+
+    let mut hits: Vec<SegmentIntersection> = tree_a
+        .intersection_candidates_with_other_tree(&tree_b)
+        .filter_map(|(sa, sb)| segment_intersection(sa.start, sa.end, sb.start, sb.end))
+        .map(canonicalize)
+        .collect();
+    hits.sort_by(cmp_hits);
+    hits.dedup();
+    hits
+}
+
+/// Order a collinear overlap's endpoints lexicographically.
+fn canonicalize(hit: SegmentIntersection) -> SegmentIntersection {
+    match hit {
+        SegmentIntersection::Collinear { start, end } if cmp_coords(&end, &start).is_lt() => {
+            SegmentIntersection::Collinear {
+                start: end,
+                end: start,
+            }
+        }
+        other => other,
+    }
+}
+
+fn cmp_coords(a: &[f64; 2], b: &[f64; 2]) -> Ordering {
+    a[0].total_cmp(&b[0]).then(a[1].total_cmp(&b[1]))
+}
+
+/// Total order over hits: points before overlaps, then by coordinates, with
+/// proper crossings before improper ones at the same point.
+fn cmp_hits(a: &SegmentIntersection, b: &SegmentIntersection) -> Ordering {
+    use SegmentIntersection::*;
+    match (a, b) {
+        (SinglePoint { .. }, Collinear { .. }) => Ordering::Less,
+        (Collinear { .. }, SinglePoint { .. }) => Ordering::Greater,
+        (
+            SinglePoint {
+                intersection: pa,
+                is_proper: qa,
+            },
+            SinglePoint {
+                intersection: pb,
+                is_proper: qb,
+            },
+        ) => cmp_coords(pa, pb).then(qb.cmp(qa)),
+        (Collinear { start: sa, end: ea }, Collinear { start: sb, end: eb }) => {
+            cmp_coords(sa, sb).then(cmp_coords(ea, eb))
+        }
+    }
+}

--- a/engine/runtime/geometry/src/overlay/shapes.rs
+++ b/engine/runtime/geometry/src/overlay/shapes.rs
@@ -1,17 +1,15 @@
 //! Conversions between the flattened leaf views and `i_overlay`'s shape model.
 //!
-//! `i_overlay` works over `Shapes` — a list of shapes, each a list of contours
-//! (paths), each an *implicitly closed* list of `[f64; 2]` — and `Paths` for
-//! open polylines. The direct template is the legacy
-//! `algorithm/bool_ops/ioverlap_bridge.rs`, minus its `FlowCoord` newtype:
-//! the new leaves' `[f64; 2]` layout is `FloatPointCompatible` as-is, so both
-//! directions are plain buffer reshuffles.
+//! `i_overlay` works over `Shapes`, a list of shapes, each a list of contours
+//! (paths), each an *implicitly closed* list of `[f64; 2]`, and `Paths` for
+//! open polylines. The leaves' `[f64; 2]` layout is `FloatPointCompatible`
+//! as-is, so both directions are plain buffer reshuffles.
 //!
 //! Mesh leaves do not enter face by face: their faces dissolve to
 //! union-boundary rings first (see
 //! [`boundary`](crate::predicates::relate::boundary)), which cancels shared
-//! internal edges exactly — before `i_overlay`'s snap to its integer grid —
-//! and preserves the interior-left direction of every surviving ring.
+//! internal edges exactly (before `i_overlay`'s snap to its integer grid) and
+//! preserves the interior-left direction of every surviving ring.
 
 use crate::coordinate::CoordinateFrame;
 use crate::line_string::LineString2D;
@@ -80,7 +78,7 @@ pub(super) fn line_paths(leaves: &[Leaf2D<'_>]) -> Result<Vec<Path>, &'static st
 
 /// Convert `i_overlay` result shapes back into polygons in `frame`, closing
 /// each ring. The backend emits the outer contour first (CCW) and holes after
-/// (CW) — Flow's winding convention — so rings pass through verbatim.
+/// (CW), Flow's winding convention, so rings pass through verbatim.
 pub(super) fn shapes_to_polygons(shapes: Vec<Shape>, frame: &CoordinateFrame) -> Vec<Polygon2D> {
     shapes
         .into_iter()

--- a/engine/runtime/geometry/src/overlay/shapes.rs
+++ b/engine/runtime/geometry/src/overlay/shapes.rs
@@ -1,0 +1,112 @@
+//! Conversions between the flattened leaf views and `i_overlay`'s shape model.
+//!
+//! `i_overlay` works over `Shapes` — a list of shapes, each a list of contours
+//! (paths), each an *implicitly closed* list of `[f64; 2]` — and `Paths` for
+//! open polylines. The direct template is the legacy
+//! `algorithm/bool_ops/ioverlap_bridge.rs`, minus its `FlowCoord` newtype:
+//! the new leaves' `[f64; 2]` layout is `FloatPointCompatible` as-is, so both
+//! directions are plain buffer reshuffles.
+//!
+//! Mesh leaves do not enter face by face: their faces dissolve to
+//! union-boundary rings first (see
+//! [`boundary`](crate::predicates::relate::boundary)), which cancels shared
+//! internal edges exactly — before `i_overlay`'s snap to its integer grid —
+//! and preserves the interior-left direction of every surviving ring.
+
+use crate::coordinate::CoordinateFrame;
+use crate::line_string::LineString2D;
+use crate::polygon::Polygon2D;
+use crate::predicates::relate::boundary::union_boundary_rings;
+use crate::predicates::view::{polygon2d_rings, Leaf2D, RingView};
+
+use super::leaf_type_name;
+
+/// One implicitly closed contour (ring) or open polyline.
+pub(super) type Path = Vec<[f64; 2]>;
+/// One areal shape: its outer contour and hole contours.
+pub(super) type Shape = Vec<Path>;
+
+/// Convert areal leaves into `i_overlay` shapes: a polygon contributes its
+/// rings verbatim, a mesh its union-boundary rings. Empty leaves contribute
+/// nothing. Errs with the leaf's type name on the first non-areal leaf.
+pub(super) fn areal_shapes(leaves: &[Leaf2D<'_>]) -> Result<Vec<Shape>, &'static str> {
+    let mut shapes = Vec::new();
+    for leaf in leaves {
+        let shape: Shape = match leaf {
+            Leaf2D::Polygon(p) => polygon2d_rings(p)
+                .map(|ring| ring_to_path(RingView::Slice(ring)))
+                .filter(|path| !path.is_empty())
+                .collect(),
+            Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_) => {
+                let area = leaf.area_view().expect("mesh leaves are areal");
+                union_boundary_rings(&area)
+                    .into_iter()
+                    .map(|ring| ring_to_path(RingView::Slice(&ring)))
+                    .filter(|path| !path.is_empty())
+                    .collect()
+            }
+            Leaf2D::Point(_) | Leaf2D::Line(_) => return Err(leaf_type_name(leaf)),
+        };
+        if !shape.is_empty() {
+            shapes.push(shape);
+        }
+    }
+    Ok(shapes)
+}
+
+/// A ring as an implicitly closed `i_overlay` path: the stored vertices with
+/// the closing duplicate (if stored) dropped.
+fn ring_to_path(ring: RingView<'_>) -> Path {
+    (0..ring.open_len()).map(|i| ring.coord(i)).collect()
+}
+
+/// Convert line leaves into open `i_overlay` paths, one per polyline. Empty
+/// polylines contribute nothing. Errs with the leaf's type name on the first
+/// non-line leaf.
+pub(super) fn line_paths(leaves: &[Leaf2D<'_>]) -> Result<Vec<Path>, &'static str> {
+    let mut paths = Vec::new();
+    for leaf in leaves {
+        match leaf {
+            Leaf2D::Line(l) => {
+                if !l.coords().is_empty() {
+                    paths.push(l.coords().to_vec());
+                }
+            }
+            _ => return Err(leaf_type_name(leaf)),
+        }
+    }
+    Ok(paths)
+}
+
+/// Convert `i_overlay` result shapes back into polygons in `frame`, closing
+/// each ring. The backend emits the outer contour first (CCW) and holes after
+/// (CW) — Flow's winding convention — so rings pass through verbatim.
+pub(super) fn shapes_to_polygons(shapes: Vec<Shape>, frame: &CoordinateFrame) -> Vec<Polygon2D> {
+    shapes
+        .into_iter()
+        .filter_map(|shape| {
+            let mut rings = shape.into_iter().map(close_path);
+            let exterior = rings.next()?;
+            Some(Polygon2D::from_rings(frame.clone(), exterior, rings))
+        })
+        .collect()
+}
+
+/// Convert `i_overlay` result paths back into polylines in `frame`.
+pub(super) fn paths_to_line_strings(
+    paths: Vec<Path>,
+    frame: &CoordinateFrame,
+) -> Vec<LineString2D> {
+    paths
+        .into_iter()
+        .map(|path| LineString2D::from_coords(frame.clone(), path))
+        .collect()
+}
+
+/// Close an implicitly closed path by appending its first vertex.
+fn close_path(mut path: Path) -> Path {
+    if let Some(&first) = path.first() {
+        path.push(first);
+    }
+    path
+}

--- a/engine/runtime/geometry/src/overlay/tests.rs
+++ b/engine/runtime/geometry/src/overlay/tests.rs
@@ -1,0 +1,704 @@
+//! Overlay tests: canonical cases, differential sweeps against the legacy
+//! `BooleanOps` (same `i_overlay` backend, so results must be bit-identical),
+//! and cross-phase consistency with the phase-2/3 predicates.
+
+use pretty_assertions::assert_eq;
+
+use super::*;
+use crate::collection::Collection2D;
+use crate::coordinate::{CoordinateFrame, EpsgCode};
+use crate::point::Point2D;
+use crate::polygon_mesh::PolygonMesh2D;
+use crate::predicates::kernel::CoordPos;
+use crate::predicates::relate::Dimensions;
+use crate::predicates::view::polygon2d_rings;
+use crate::predicates::{covers, relate};
+use crate::triangular_mesh::TriangularMesh2D;
+
+use crate::algorithm::bool_ops::{BooleanOps, OpType};
+use crate::types::coordinate::Coordinate2D;
+use crate::types::line_string::LineString2D as LegacyLineString2D;
+use crate::types::multi_line_string::MultiLineString2D as LegacyMultiLineString2D;
+use crate::types::multi_polygon::MultiPolygon2D as LegacyMultiPolygon2D;
+use crate::types::polygon::Polygon2D as LegacyPolygon2D;
+
+fn e() -> CoordinateFrame {
+    CoordinateFrame::Euclidean
+}
+
+// --- builders ------------------------------------------------------------------
+
+fn point(p: [f64; 2]) -> Geometry {
+    Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(e(), p)))
+}
+
+fn line(coords: &[[f64; 2]]) -> Geometry {
+    Geometry::Euclidean2D(Euclidean2DGeometry::LineString(LineString2D::from_coords(
+        e(),
+        coords.to_vec(),
+    )))
+}
+
+fn polygon(exterior: &[[f64; 2]], holes: &[Vec<[f64; 2]>]) -> Geometry {
+    Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
+        Polygon2D::from_rings(e(), exterior.to_vec(), holes.to_vec()),
+    )))
+}
+
+fn rect(x0: f64, y0: f64, x1: f64, y1: f64) -> Vec<[f64; 2]> {
+    vec![[x0, y0], [x1, y0], [x1, y1], [x0, y1], [x0, y0]]
+}
+
+/// A clockwise rect ring (hole orientation).
+fn rect_cw(x0: f64, y0: f64, x1: f64, y1: f64) -> Vec<[f64; 2]> {
+    vec![[x0, y0], [x0, y1], [x1, y1], [x1, y0], [x0, y0]]
+}
+
+/// Wrap an overlay result as a geometry, for feeding back into the predicates.
+fn to_geometry(polygons: Vec<Polygon2D>) -> Geometry {
+    Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new(
+        polygons
+            .into_iter()
+            .map(|p| Euclidean2DGeometry::Polygon(Box::new(p))),
+    )))
+}
+
+/// Twice the signed area of a closed ring (positive = CCW).
+fn doubled_signed_area(ring: &[[f64; 2]]) -> f64 {
+    ring.windows(2)
+        .map(|w| w[0][0] * w[1][1] - w[1][0] * w[0][1])
+        .sum()
+}
+
+/// The area of an overlay result (holes wound CW subtract themselves).
+fn area(polygons: &[Polygon2D]) -> f64 {
+    polygons
+        .iter()
+        .flat_map(polygon2d_rings)
+        .map(|ring| doubled_signed_area(ring) / 2.0)
+        .sum()
+}
+
+// --- canonical overlay cases ---------------------------------------------------
+
+#[test]
+fn two_overlapping_squares() {
+    let a = polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]);
+    let b = polygon(&rect(1.0, 1.0, 3.0, 3.0), &[]);
+
+    let union = union(&a, &b).unwrap();
+    assert_eq!(union.len(), 1);
+    assert_eq!(area(&union), 7.0);
+    assert_eq!(union[0].exterior().len(), 9); // 8-corner staircase, closed
+    assert!(doubled_signed_area(union[0].exterior()) > 0.0); // CCW
+
+    let intersection = intersection(&a, &b).unwrap();
+    assert_eq!(intersection.len(), 1);
+    assert_eq!(area(&intersection), 1.0);
+
+    let difference = difference(&a, &b).unwrap();
+    assert_eq!(difference.len(), 1);
+    assert_eq!(area(&difference), 3.0);
+
+    let xor = xor(&a, &b).unwrap();
+    assert_eq!(xor.len(), 2);
+    assert_eq!(area(&xor), 6.0);
+}
+
+#[test]
+fn difference_can_create_a_hole() {
+    let outer = polygon(&rect(0.0, 0.0, 4.0, 4.0), &[]);
+    let inner = polygon(&rect(1.0, 1.0, 3.0, 3.0), &[]);
+
+    let result = difference(&outer, &inner).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(area(&result), 12.0);
+    let rings: Vec<&[[f64; 2]]> = polygon2d_rings(&result[0]).collect();
+    assert_eq!(rings.len(), 2);
+    assert!(doubled_signed_area(rings[0]) > 0.0); // exterior CCW
+    assert!(doubled_signed_area(rings[1]) < 0.0); // hole CW
+
+    // ... and a hole in the input participates: the donut minus nothing.
+    let donut = polygon(&rect(0.0, 0.0, 4.0, 4.0), &[rect_cw(1.0, 1.0, 3.0, 3.0)]);
+    let kept = union(&donut, &Geometry::None).unwrap();
+    assert_eq!(area(&kept), 12.0);
+}
+
+#[test]
+fn disjoint_squares() {
+    let a = polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]);
+    let b = polygon(&rect(5.0, 5.0, 7.0, 7.0), &[]);
+
+    assert_eq!(union(&a, &b).unwrap().len(), 2);
+    assert!(intersection(&a, &b).unwrap().is_empty());
+    assert_eq!(area(&difference(&a, &b).unwrap()), 4.0);
+    assert_eq!(area(&xor(&a, &b).unwrap()), 8.0);
+}
+
+#[test]
+fn empty_and_none_operands() {
+    let a = polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]);
+    let empty = Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([])));
+
+    assert_eq!(area(&union(&a, &Geometry::None).unwrap()), 4.0);
+    assert_eq!(area(&union(&Geometry::None, &a).unwrap()), 4.0);
+    assert_eq!(area(&difference(&a, &empty).unwrap()), 4.0);
+    assert!(intersection(&a, &Geometry::None).unwrap().is_empty());
+    assert!(difference(&Geometry::None, &a).unwrap().is_empty());
+    assert!(union(&Geometry::None, &empty).unwrap().is_empty());
+}
+
+#[test]
+fn collection_operand_is_a_point_set_union() {
+    // Edge-adjacent members — the pair `relate` cannot label — dissolve
+    // exactly under the non-zero fill rule.
+    let adjacent = Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([
+        Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            e(),
+            rect(0.0, 0.0, 2.0, 2.0),
+            Vec::<Vec<[f64; 2]>>::new(),
+        ))),
+        Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            e(),
+            rect(2.0, 0.0, 4.0, 2.0),
+            Vec::<Vec<[f64; 2]>>::new(),
+        ))),
+    ])));
+    let dissolved = union(&adjacent, &Geometry::None).unwrap();
+    assert_eq!(dissolved.len(), 1);
+    assert_eq!(area(&dissolved), 8.0);
+
+    // Overlapping members dissolve too (counts add, not cancel).
+    let overlapping = Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new([
+        Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            e(),
+            rect(0.0, 0.0, 3.0, 2.0),
+            Vec::<Vec<[f64; 2]>>::new(),
+        ))),
+        Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            e(),
+            rect(1.0, 0.0, 4.0, 2.0),
+            Vec::<Vec<[f64; 2]>>::new(),
+        ))),
+    ])));
+    let dissolved = union(&overlapping, &Geometry::None).unwrap();
+    assert_eq!(dissolved.len(), 1);
+    assert_eq!(area(&dissolved), 8.0);
+}
+
+#[test]
+fn mesh_operands_dissolve_to_their_union() {
+    // Two quads sharing the edge x = 2 form the rect [0,4] x [0,2].
+    let mesh = PolygonMesh2D::from_parts(
+        e(),
+        vec![
+            [0.0, 0.0],
+            [2.0, 0.0],
+            [2.0, 2.0],
+            [0.0, 2.0],
+            [4.0, 0.0],
+            [4.0, 2.0],
+        ],
+        vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+    )
+    .unwrap();
+    let mesh = Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(Box::new(mesh)));
+    let dissolved = polygon(&rect(0.0, 0.0, 4.0, 2.0), &[]);
+    let other = polygon(&rect(1.0, 1.0, 3.0, 3.0), &[]);
+
+    for op in [
+        OverlayOp::Union,
+        OverlayOp::Intersection,
+        OverlayOp::Difference,
+        OverlayOp::Xor,
+    ] {
+        let from_mesh = to_geometry(overlay(&mesh, &other, op).unwrap());
+        let from_polygon = to_geometry(overlay(&dissolved, &other, op).unwrap());
+        assert!(
+            relate(&from_mesh, &from_polygon).unwrap().is_equal_topo(),
+            "{op:?} over the mesh diverges from its dissolved polygon"
+        );
+    }
+
+    // A triangulated square unions like the square.
+    let tri = TriangularMesh2D::from_parts(
+        e(),
+        vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0], [0.0, 2.0]],
+        [0u32, 1, 2, 0, 2, 3],
+    )
+    .unwrap();
+    let tri = Geometry::Euclidean2D(Euclidean2DGeometry::TriangularMesh(Box::new(tri)));
+    let out = union(&tri, &Geometry::None).unwrap();
+    assert_eq!(out.len(), 1);
+    assert_eq!(area(&out), 4.0);
+}
+
+#[test]
+fn error_operands() {
+    let a = polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]);
+
+    // A non-areal leaf in an overlay operand.
+    assert_eq!(
+        union(&a, &line(&[[0.0, 0.0], [1.0, 1.0]])),
+        Err(PredicateError::UnsupportedPair {
+            left: "Polygon2D",
+            right: "LineString2D",
+        })
+    );
+    assert_eq!(
+        union(&point([0.0, 0.0]), &a),
+        Err(PredicateError::UnsupportedPair {
+            left: "Point2D",
+            right: "Polygon2D",
+        })
+    );
+
+    // Mixed frames.
+    let other_frame = Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
+        Polygon2D::from_rings(
+            CoordinateFrame::Crs(EpsgCode::new(4326)),
+            rect(0.0, 0.0, 2.0, 2.0),
+            Vec::<Vec<[f64; 2]>>::new(),
+        ),
+    )));
+    assert_eq!(union(&a, &other_frame), Err(PredicateError::MixedFrames));
+
+    // Dimension policy.
+    let p3 = Geometry::Euclidean3D(crate::Euclidean3DGeometry::Point(
+        crate::point::Point3D::new(e(), [0.0, 0.0, 0.0]),
+    ));
+    assert_eq!(union(&a, &p3), Err(PredicateError::CrossDimension));
+    assert!(matches!(
+        union(&p3, &p3),
+        Err(PredicateError::UnsupportedPair { .. })
+    ));
+}
+
+// --- clip ------------------------------------------------------------------------
+
+fn clip_coords(result: &[LineString2D]) -> Vec<Vec<[f64; 2]>> {
+    result.iter().map(|l| l.coords().to_vec()).collect()
+}
+
+#[test]
+fn clip_line_against_square() {
+    let square = polygon(&rect(0.0, 0.0, 4.0, 4.0), &[]);
+    let crossing = line(&[[-1.0, 1.0], [5.0, 1.0]]);
+
+    let inside = clip(&crossing, &square, false).unwrap();
+    assert_eq!(clip_coords(&inside), vec![vec![[0.0, 1.0], [4.0, 1.0]]]);
+
+    let mut outside = clip_coords(&clip(&crossing, &square, true).unwrap());
+    outside.sort_by(|a, b| a[0][0].total_cmp(&b[0][0]));
+    assert_eq!(
+        outside,
+        vec![vec![[-1.0, 1.0], [0.0, 1.0]], vec![[4.0, 1.0], [5.0, 1.0]],]
+    );
+
+    // Fully inside comes back verbatim; on the boundary counts as inside.
+    let inner = line(&[[1.0, 1.0], [3.0, 3.0]]);
+    assert_eq!(
+        clip_coords(&clip(&inner, &square, false).unwrap()),
+        vec![vec![[1.0, 1.0], [3.0, 3.0]]]
+    );
+    assert!(clip(&inner, &square, true).unwrap().is_empty());
+    let boundary = line(&[[1.0, 0.0], [3.0, 0.0]]);
+    assert_eq!(
+        clip_coords(&clip(&boundary, &square, false).unwrap()),
+        vec![vec![[1.0, 0.0], [3.0, 0.0]]]
+    );
+}
+
+#[test]
+fn clip_against_mesh_crosses_internal_edges_unbroken() {
+    let mesh = PolygonMesh2D::from_parts(
+        e(),
+        vec![
+            [0.0, 0.0],
+            [2.0, 0.0],
+            [2.0, 2.0],
+            [0.0, 2.0],
+            [4.0, 0.0],
+            [4.0, 2.0],
+        ],
+        vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+    )
+    .unwrap();
+    let mesh = Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(Box::new(mesh)));
+    // Crosses the dissolved internal edge x = 2: must survive as one piece.
+    let inner = line(&[[1.0, 1.0], [3.0, 1.0]]);
+    assert_eq!(
+        clip_coords(&clip(&inner, &mesh, false).unwrap()),
+        vec![vec![[1.0, 1.0], [3.0, 1.0]]]
+    );
+}
+
+#[test]
+fn clip_empty_and_error_operands() {
+    let square = polygon(&rect(0.0, 0.0, 4.0, 4.0), &[]);
+    let l = line(&[[1.0, 1.0], [3.0, 1.0]]);
+
+    // No lines -> nothing; no area -> nothing inside, everything outside.
+    assert!(clip(&Geometry::None, &square, false).unwrap().is_empty());
+    assert!(clip(&l, &Geometry::None, false).unwrap().is_empty());
+    assert_eq!(
+        clip_coords(&clip(&l, &Geometry::None, true).unwrap()),
+        vec![vec![[1.0, 1.0], [3.0, 1.0]]]
+    );
+
+    // Wrong leaf kinds on either side.
+    assert_eq!(
+        clip(&square, &square, false),
+        Err(PredicateError::UnsupportedPair {
+            left: "Polygon2D",
+            right: "Polygon2D",
+        })
+    );
+    assert_eq!(
+        clip(&l, &l, false),
+        Err(PredicateError::UnsupportedPair {
+            left: "LineString2D",
+            right: "LineString2D",
+        })
+    );
+}
+
+#[test]
+fn clip_differential_against_legacy() {
+    let mut rng = Rng(20260716);
+    for case in 0..100 {
+        let (ext, holes) = random_polygon_rings(&mut rng);
+        let area_new = polygon(&ext, &holes);
+        let area_legacy = LegacyPolygon2D::new(
+            LegacyLineString2D::new(legacy_coords(&ext)),
+            holes
+                .iter()
+                .map(|h| LegacyLineString2D::new(legacy_coords(h)))
+                .collect(),
+        );
+
+        let coords: Vec<[f64; 2]> = (0..2 + rng.range(3)).map(|_| rng.coord()).collect();
+        let line_new = line(&coords);
+        let line_legacy =
+            LegacyMultiLineString2D::new(vec![LegacyLineString2D::new(legacy_coords(&coords))]);
+
+        for invert in [false, true] {
+            let ours = clip_coords(&clip(&line_new, &area_new, invert).unwrap());
+            let oracle: Vec<Vec<[f64; 2]>> =
+                <LegacyPolygon2D<f64> as BooleanOps>::clip(&area_legacy, &line_legacy, invert)
+                    .0
+                    .into_iter()
+                    .map(|l| l.0.into_iter().map(|c| [c.x, c.y]).collect())
+                    .collect();
+            assert_eq!(
+                ours, oracle,
+                "case {case} invert={invert}: clip diverges from legacy"
+            );
+        }
+    }
+}
+
+// --- segment intersections -------------------------------------------------------
+
+#[test]
+fn segment_intersections_cases() {
+    let horizontal = line(&[[0.0, 0.0], [4.0, 0.0]]);
+
+    // Proper crossing.
+    assert_eq!(
+        segment_intersections(&horizontal, &line(&[[2.0, -2.0], [2.0, 2.0]])).unwrap(),
+        vec![SegmentIntersection::SinglePoint {
+            intersection: [2.0, 0.0],
+            is_proper: true,
+        }]
+    );
+
+    // T-junction: an endpoint on the other's interior is improper.
+    assert_eq!(
+        segment_intersections(&horizontal, &line(&[[2.0, 0.0], [2.0, 2.0]])).unwrap(),
+        vec![SegmentIntersection::SinglePoint {
+            intersection: [2.0, 0.0],
+            is_proper: false,
+        }]
+    );
+
+    // Collinear overlap, canonicalized endpoints.
+    assert_eq!(
+        segment_intersections(&horizontal, &line(&[[6.0, 0.0], [2.0, 0.0]])).unwrap(),
+        vec![SegmentIntersection::Collinear {
+            start: [2.0, 0.0],
+            end: [4.0, 0.0],
+        }]
+    );
+
+    // A crossing at a shared vertex of consecutive segments deduplicates.
+    let bent = line(&[[0.0, 0.0], [2.0, 2.0], [4.0, 0.0]]);
+    assert_eq!(
+        segment_intersections(&bent, &line(&[[2.0, 0.0], [2.0, 4.0]])).unwrap(),
+        vec![SegmentIntersection::SinglePoint {
+            intersection: [2.0, 2.0],
+            is_proper: false,
+        }]
+    );
+
+    // Disjoint and empty.
+    assert!(
+        segment_intersections(&horizontal, &line(&[[0.0, 1.0], [4.0, 1.0]]))
+            .unwrap()
+            .is_empty()
+    );
+    assert!(segment_intersections(&horizontal, &Geometry::None)
+        .unwrap()
+        .is_empty());
+
+    // Non-line leaves error.
+    assert_eq!(
+        segment_intersections(&horizontal, &polygon(&rect(0.0, 0.0, 2.0, 2.0), &[])),
+        Err(PredicateError::UnsupportedPair {
+            left: "LineString2D",
+            right: "Polygon2D",
+        })
+    );
+}
+
+// --- differential + consistency sweeps --------------------------------------------
+
+/// Deterministic splitmix-style generator.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    }
+
+    fn range(&mut self, n: u64) -> u64 {
+        self.next() % n
+    }
+
+    fn coord(&mut self) -> [f64; 2] {
+        [self.range(9) as f64, self.range(9) as f64]
+    }
+}
+
+fn legacy_coords(coords: &[[f64; 2]]) -> Vec<Coordinate2D<f64>> {
+    coords
+        .iter()
+        .map(|c| Coordinate2D::new_(c[0], c[1]))
+        .collect()
+}
+
+/// One random valid polygon as `(exterior, holes)` rings on the integer grid:
+/// a rect, a rect with a hole, or a CCW triangle.
+fn random_polygon_rings(rng: &mut Rng) -> PolygonRings {
+    match rng.range(3) {
+        0 => {
+            let (x0, y0) = (rng.range(6) as f64, rng.range(6) as f64);
+            let (w, h) = (1 + rng.range(3), 1 + rng.range(3));
+            (rect(x0, y0, x0 + w as f64, y0 + h as f64), vec![])
+        }
+        1 => {
+            let (x0, y0) = (rng.range(4) as f64, rng.range(4) as f64);
+            let (x1, y1) = (
+                x0 + 3.0 + rng.range(2) as f64,
+                y0 + 3.0 + rng.range(2) as f64,
+            );
+            (
+                rect(x0, y0, x1, y1),
+                vec![rect_cw(x0 + 1.0, y0 + 1.0, x1 - 1.0, y1 - 1.0)],
+            )
+        }
+        _ => loop {
+            // Triangle, wound CCW: overlay assumes Flow's validated winding
+            // (a CW exterior reads as negative space when members overlap).
+            let (a, b, c) = (rng.coord(), rng.coord(), rng.coord());
+            let doubled_area = (b[0] - a[0]) * (c[1] - a[1]) - (c[0] - a[0]) * (b[1] - a[1]);
+            if doubled_area > 0.0 {
+                return (vec![a, b, c, a], vec![]);
+            }
+            if doubled_area < 0.0 {
+                return (vec![a, c, b, a], vec![]);
+            }
+        },
+    }
+}
+
+/// The `(exterior, holes)` rings of one polygon.
+type PolygonRings = (Vec<[f64; 2]>, Vec<Vec<[f64; 2]>>);
+
+/// One random areal operand (one or two polygons) in both representations.
+fn random_areal(rng: &mut Rng) -> (Geometry, LegacyMultiPolygon2D<f64>) {
+    let polygons: Vec<PolygonRings> = (0..1 + rng.range(2))
+        .map(|_| random_polygon_rings(rng))
+        .collect();
+    let new = Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new(
+        polygons.iter().map(|(ext, holes)| {
+            Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+                e(),
+                ext.clone(),
+                holes.clone(),
+            )))
+        }),
+    )));
+    let legacy = LegacyMultiPolygon2D::new(
+        polygons
+            .iter()
+            .map(|(ext, holes)| {
+                LegacyPolygon2D::new(
+                    LegacyLineString2D::new(legacy_coords(ext)),
+                    holes
+                        .iter()
+                        .map(|h| LegacyLineString2D::new(legacy_coords(h)))
+                        .collect(),
+                )
+            })
+            .collect(),
+    );
+    (new, legacy)
+}
+
+/// An overlay result's rings, for exact comparison with the legacy output.
+fn result_rings(polygons: &[Polygon2D]) -> Vec<Vec<Vec<[f64; 2]>>> {
+    polygons
+        .iter()
+        .map(|p| polygon2d_rings(p).map(<[[f64; 2]]>::to_vec).collect())
+        .collect()
+}
+
+#[test]
+fn differential_against_legacy_boolean_ops() {
+    let mut rng = Rng(20260715);
+    for case in 0..200 {
+        let (a, legacy_a) = random_areal(&mut rng);
+        let (b, legacy_b) = random_areal(&mut rng);
+        for (op, legacy_op) in [
+            (OverlayOp::Union, OpType::Union),
+            (OverlayOp::Intersection, OpType::Intersection),
+            (OverlayOp::Difference, OpType::Difference),
+            (OverlayOp::Xor, OpType::Xor),
+        ] {
+            let ours = result_rings(&overlay(&a, &b, op).unwrap());
+            let oracle: Vec<Vec<Vec<[f64; 2]>>> = legacy_a
+                .boolean_op(&legacy_b, legacy_op)
+                .0
+                .iter()
+                .map(|p| {
+                    core::iter::once(p.exterior())
+                        .chain(p.interiors().iter())
+                        .map(|ring| ring.0.iter().map(|c| [c.x, c.y]).collect())
+                        .collect()
+                })
+                .collect();
+            assert_eq!(
+                ours, oracle,
+                "case {case}: {op:?} diverges from legacy BooleanOps"
+            );
+        }
+    }
+}
+
+#[test]
+fn overlay_satisfies_area_identities() {
+    let mut rng = Rng(42);
+    for case in 0..200 {
+        let (a, _) = random_areal(&mut rng);
+        let (b, _) = random_areal(&mut rng);
+
+        let area_a = area(&union(&a, &Geometry::None).unwrap());
+        let area_b = area(&union(&b, &Geometry::None).unwrap());
+        let union_ab = area(&union(&a, &b).unwrap());
+        let intersection_ab = area(&intersection(&a, &b).unwrap());
+        let difference_ab = area(&difference(&a, &b).unwrap());
+        let xor_ab = area(&xor(&a, &b).unwrap());
+
+        // Not exact: `i_overlay` snaps constructed intersection points (the
+        // triangle kinds produce off-grid ones) to its adaptive grid, moving
+        // them by a relative ~1e-9 — areas inherit an absolute ~1e-7.
+        let close = |x: f64, y: f64| (x - y).abs() < 1e-6;
+        assert!(
+            close(union_ab + intersection_ab, area_a + area_b),
+            "case {case}: |A∪B| + |A∩B| = |A| + |B| violated"
+        );
+        assert!(
+            close(difference_ab, area_a - intersection_ab),
+            "case {case}: |A\\B| = |A| - |A∩B| violated"
+        );
+        assert!(
+            close(xor_ab, union_ab - intersection_ab),
+            "case {case}: |A⊕B| = |A∪B| - |A∩B| violated"
+        );
+    }
+}
+
+#[test]
+fn overlay_agrees_with_predicates() {
+    let mut rng = Rng(7);
+    for case in 0..150 {
+        // Single-polygon operands: `relate` does not support operands whose
+        // own members overlap (see its module docs), which `random_areal`
+        // produces — overlay itself handles those, tested elsewhere.
+        let (ext, holes) = random_polygon_rings(&mut rng);
+        let a = polygon(&ext, &holes);
+        let (ext, holes) = random_polygon_rings(&mut rng);
+        let b = polygon(&ext, &holes);
+
+        // The interiors share area exactly when the intersection is non-empty.
+        // (Robust on this generator: two integer-grid polygons either share no
+        // area or share far more of it than the backend's snap can erase.)
+        let im = relate(&a, &b).unwrap();
+        let interiors_share_area =
+            im.get(CoordPos::Inside, CoordPos::Inside) == Dimensions::TwoDimensional;
+        let intersection = intersection(&a, &b).unwrap();
+        assert_eq!(
+            interiors_share_area,
+            !intersection.is_empty(),
+            "case {case}: relate II dimension vs intersection emptiness"
+        );
+    }
+}
+
+#[test]
+fn overlay_output_covers_exactly_on_the_grid() {
+    // Axis-aligned operands only: every constructed intersection point then
+    // lies on the integer grid, the backend snap is the identity, and the
+    // set relations hold *exactly* under the phase-2 `covers`. (With oblique
+    // edges the snapped union boundary may cut ~1e-9 inside the true union.)
+    let mut rng = Rng(11);
+    for case in 0..150 {
+        let rectal = |rng: &mut Rng| loop {
+            let (a, _) = random_areal(rng);
+            let oblique = match &a {
+                Geometry::Euclidean2D(Euclidean2DGeometry::Collection(c)) => {
+                    c.members().iter().any(|m| match m {
+                        Euclidean2DGeometry::Polygon(p) => p.exterior().len() == 4, // triangle
+                        _ => true,
+                    })
+                }
+                _ => true,
+            };
+            if !oblique {
+                return a;
+            }
+        };
+        let a = rectal(&mut rng);
+        let b = rectal(&mut rng);
+
+        // The union covers both operands; both operands cover the intersection.
+        let union = to_geometry(union(&a, &b).unwrap());
+        assert!(
+            covers(&union, &a).unwrap() && covers(&union, &b).unwrap(),
+            "case {case}: union does not cover its operands"
+        );
+        let intersection = intersection(&a, &b).unwrap();
+        if !intersection.is_empty() {
+            let intersection = to_geometry(intersection);
+            assert!(
+                covers(&a, &intersection).unwrap() && covers(&b, &intersection).unwrap(),
+                "case {case}: operands do not cover their intersection"
+            );
+        }
+    }
+}

--- a/engine/runtime/geometry/src/overlay/tests.rs
+++ b/engine/runtime/geometry/src/overlay/tests.rs
@@ -597,3 +597,82 @@ fn overlay_output_covers_exactly_on_the_grid() {
         }
     }
 }
+
+// --- exactness gate ---------------------------------------------------------
+
+#[test]
+fn gate_touching_operands_have_exact_zero_area_results() {
+    // Squares sharing the edge x = 2: boundary-only contact.
+    let a = polygon(&rect(0.0, 0.0, 2.0, 2.0), &[]);
+    let b = polygon(&rect(2.0, 0.0, 4.0, 2.0), &[]);
+
+    // Zero-area intersection is exactly empty, never a sliver.
+    assert!(intersection(&a, &b).unwrap().is_empty());
+    // The difference leaves `a` whole.
+    let diff = difference(&a, &b).unwrap();
+    assert_eq!(diff.len(), 1);
+    assert_eq!(area(&diff), 4.0);
+    // Xor coincides with union: one merged polygon, no sliver carved out.
+    let xor = xor(&a, &b).unwrap();
+    assert_eq!(xor.len(), 1);
+    assert_eq!(area(&xor), 8.0);
+    let union = union(&a, &b).unwrap();
+    assert_eq!(union.len(), 1);
+    assert_eq!(area(&union), 8.0);
+}
+
+#[test]
+fn gate_containment_bypasses_the_backend() {
+    let outer = polygon(&rect(0.0, 0.0, 8.0, 8.0), &[]);
+    let inner = polygon(&rect(2.0, 2.0, 5.0, 5.0), &[]);
+
+    // a contains b: the intersection is b, the union is a.
+    let i = intersection(&outer, &inner).unwrap();
+    assert_eq!(i.len(), 1);
+    assert_eq!(area(&i), 9.0);
+    let u = union(&outer, &inner).unwrap();
+    assert_eq!(u.len(), 1);
+    assert_eq!(area(&u), 64.0);
+    // a within b: the difference is exactly empty.
+    assert!(difference(&inner, &outer).unwrap().is_empty());
+    // Genuine construction still runs: carving the hole.
+    assert_eq!(area(&difference(&outer, &inner).unwrap()), 55.0);
+    assert_eq!(area(&xor(&inner, &outer).unwrap()), 55.0);
+}
+
+#[test]
+fn gate_equal_operands() {
+    let a = polygon(&rect(0.0, 0.0, 4.0, 4.0), &[]);
+    let b = polygon(&rect(0.0, 0.0, 4.0, 4.0), &[]);
+    assert_eq!(area(&union(&a, &b).unwrap()), 16.0);
+    assert_eq!(area(&intersection(&a, &b).unwrap()), 16.0);
+    assert!(difference(&a, &b).unwrap().is_empty());
+    assert!(xor(&a, &b).unwrap().is_empty());
+}
+
+#[test]
+fn gate_disjoint_inside_a_hole() {
+    // Overlapping bounding boxes, disjoint geometries: decided by relate.
+    let donut = polygon(&rect(0.0, 0.0, 8.0, 8.0), &[rect_cw(2.0, 2.0, 6.0, 6.0)]);
+    let inner = polygon(&rect(3.0, 3.0, 5.0, 5.0), &[]);
+
+    assert!(intersection(&donut, &inner).unwrap().is_empty());
+    let u = union(&donut, &inner).unwrap();
+    assert_eq!(u.len(), 2);
+    assert_eq!(area(&u), 52.0);
+    assert_eq!(area(&difference(&donut, &inner).unwrap()), 48.0);
+}
+
+#[test]
+fn gate_keeps_nearly_touching_operands_separate() {
+    // Two triangles separated across the diagonal by a gap far below the
+    // backend's snap grid; their boxes overlap, so relate decides. The exact
+    // answer is two disjoint polygons, and the gate keeps them that way.
+    let eps = 1e-9;
+    let a = polygon(&[[0.0, 0.0], [8.0, 0.0], [0.0, 8.0], [0.0, 0.0]], &[]);
+    let b = polygon(&[[8.0, 8.0], [eps, 8.0], [8.0, eps], [8.0, 8.0]], &[]);
+
+    let u = union(&a, &b).unwrap();
+    assert_eq!(u.len(), 2);
+    assert!(intersection(&a, &b).unwrap().is_empty());
+}

--- a/engine/runtime/geometry/src/overlay/tests.rs
+++ b/engine/runtime/geometry/src/overlay/tests.rs
@@ -1,6 +1,5 @@
-//! Overlay tests: canonical cases, differential sweeps against the legacy
-//! `BooleanOps` (same `i_overlay` backend, so results must be bit-identical),
-//! and cross-phase consistency with the phase-2/3 predicates.
+//! Overlay tests: canonical cases, area and set-relation identities, and
+//! consistency with the predicates.
 
 use pretty_assertions::assert_eq;
 
@@ -14,13 +13,6 @@ use crate::predicates::relate::Dimensions;
 use crate::predicates::view::polygon2d_rings;
 use crate::predicates::{covers, relate};
 use crate::triangular_mesh::TriangularMesh2D;
-
-use crate::algorithm::bool_ops::{BooleanOps, OpType};
-use crate::types::coordinate::Coordinate2D;
-use crate::types::line_string::LineString2D as LegacyLineString2D;
-use crate::types::multi_line_string::MultiLineString2D as LegacyMultiLineString2D;
-use crate::types::multi_polygon::MultiPolygon2D as LegacyMultiPolygon2D;
-use crate::types::polygon::Polygon2D as LegacyPolygon2D;
 
 fn e() -> CoordinateFrame {
     CoordinateFrame::Euclidean
@@ -363,41 +355,6 @@ fn clip_empty_and_error_operands() {
     );
 }
 
-#[test]
-fn clip_differential_against_legacy() {
-    let mut rng = Rng(20260716);
-    for case in 0..100 {
-        let (ext, holes) = random_polygon_rings(&mut rng);
-        let area_new = polygon(&ext, &holes);
-        let area_legacy = LegacyPolygon2D::new(
-            LegacyLineString2D::new(legacy_coords(&ext)),
-            holes
-                .iter()
-                .map(|h| LegacyLineString2D::new(legacy_coords(h)))
-                .collect(),
-        );
-
-        let coords: Vec<[f64; 2]> = (0..2 + rng.range(3)).map(|_| rng.coord()).collect();
-        let line_new = line(&coords);
-        let line_legacy =
-            LegacyMultiLineString2D::new(vec![LegacyLineString2D::new(legacy_coords(&coords))]);
-
-        for invert in [false, true] {
-            let ours = clip_coords(&clip(&line_new, &area_new, invert).unwrap());
-            let oracle: Vec<Vec<[f64; 2]>> =
-                <LegacyPolygon2D<f64> as BooleanOps>::clip(&area_legacy, &line_legacy, invert)
-                    .0
-                    .into_iter()
-                    .map(|l| l.0.into_iter().map(|c| [c.x, c.y]).collect())
-                    .collect();
-            assert_eq!(
-                ours, oracle,
-                "case {case} invert={invert}: clip diverges from legacy"
-            );
-        }
-    }
-}
-
 // --- segment intersections -------------------------------------------------------
 
 #[test]
@@ -461,7 +418,7 @@ fn segment_intersections_cases() {
     );
 }
 
-// --- differential + consistency sweeps --------------------------------------------
+// --- consistency sweeps ----------------------------------------------------------
 
 /// Deterministic splitmix-style generator.
 struct Rng(u64);
@@ -482,13 +439,6 @@ impl Rng {
     fn coord(&mut self) -> [f64; 2] {
         [self.range(9) as f64, self.range(9) as f64]
     }
-}
-
-fn legacy_coords(coords: &[[f64; 2]]) -> Vec<Coordinate2D<f64>> {
-    coords
-        .iter()
-        .map(|c| Coordinate2D::new_(c[0], c[1]))
-        .collect()
 }
 
 /// One random valid polygon as `(exterior, holes)` rings on the integer grid:
@@ -529,12 +479,12 @@ fn random_polygon_rings(rng: &mut Rng) -> PolygonRings {
 /// The `(exterior, holes)` rings of one polygon.
 type PolygonRings = (Vec<[f64; 2]>, Vec<Vec<[f64; 2]>>);
 
-/// One random areal operand (one or two polygons) in both representations.
-fn random_areal(rng: &mut Rng) -> (Geometry, LegacyMultiPolygon2D<f64>) {
+/// One random areal operand (one or two polygons).
+fn random_areal(rng: &mut Rng) -> Geometry {
     let polygons: Vec<PolygonRings> = (0..1 + rng.range(2))
         .map(|_| random_polygon_rings(rng))
         .collect();
-    let new = Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new(
+    Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new(
         polygons.iter().map(|(ext, holes)| {
             Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
                 e(),
@@ -542,70 +492,15 @@ fn random_areal(rng: &mut Rng) -> (Geometry, LegacyMultiPolygon2D<f64>) {
                 holes.clone(),
             )))
         }),
-    )));
-    let legacy = LegacyMultiPolygon2D::new(
-        polygons
-            .iter()
-            .map(|(ext, holes)| {
-                LegacyPolygon2D::new(
-                    LegacyLineString2D::new(legacy_coords(ext)),
-                    holes
-                        .iter()
-                        .map(|h| LegacyLineString2D::new(legacy_coords(h)))
-                        .collect(),
-                )
-            })
-            .collect(),
-    );
-    (new, legacy)
-}
-
-/// An overlay result's rings, for exact comparison with the legacy output.
-fn result_rings(polygons: &[Polygon2D]) -> Vec<Vec<Vec<[f64; 2]>>> {
-    polygons
-        .iter()
-        .map(|p| polygon2d_rings(p).map(<[[f64; 2]]>::to_vec).collect())
-        .collect()
-}
-
-#[test]
-fn differential_against_legacy_boolean_ops() {
-    let mut rng = Rng(20260715);
-    for case in 0..200 {
-        let (a, legacy_a) = random_areal(&mut rng);
-        let (b, legacy_b) = random_areal(&mut rng);
-        for (op, legacy_op) in [
-            (OverlayOp::Union, OpType::Union),
-            (OverlayOp::Intersection, OpType::Intersection),
-            (OverlayOp::Difference, OpType::Difference),
-            (OverlayOp::Xor, OpType::Xor),
-        ] {
-            let ours = result_rings(&overlay(&a, &b, op).unwrap());
-            let oracle: Vec<Vec<Vec<[f64; 2]>>> = legacy_a
-                .boolean_op(&legacy_b, legacy_op)
-                .0
-                .iter()
-                .map(|p| {
-                    core::iter::once(p.exterior())
-                        .chain(p.interiors().iter())
-                        .map(|ring| ring.0.iter().map(|c| [c.x, c.y]).collect())
-                        .collect()
-                })
-                .collect();
-            assert_eq!(
-                ours, oracle,
-                "case {case}: {op:?} diverges from legacy BooleanOps"
-            );
-        }
-    }
+    )))
 }
 
 #[test]
 fn overlay_satisfies_area_identities() {
     let mut rng = Rng(42);
     for case in 0..200 {
-        let (a, _) = random_areal(&mut rng);
-        let (b, _) = random_areal(&mut rng);
+        let a = random_areal(&mut rng);
+        let b = random_areal(&mut rng);
 
         let area_a = area(&union(&a, &Geometry::None).unwrap());
         let area_b = area(&union(&b, &Geometry::None).unwrap());
@@ -664,12 +559,12 @@ fn overlay_agrees_with_predicates() {
 fn overlay_output_covers_exactly_on_the_grid() {
     // Axis-aligned operands only: every constructed intersection point then
     // lies on the integer grid, the backend snap is the identity, and the
-    // set relations hold *exactly* under the phase-2 `covers`. (With oblique
-    // edges the snapped union boundary may cut ~1e-9 inside the true union.)
+    // set relations hold *exactly* under `covers`. (With oblique edges the
+    // snapped union boundary may cut ~1e-9 inside the true union.)
     let mut rng = Rng(11);
     for case in 0..150 {
         let rectal = |rng: &mut Rng| loop {
-            let (a, _) = random_areal(rng);
+            let a = random_areal(rng);
             let oblique = match &a {
                 Geometry::Euclidean2D(Euclidean2DGeometry::Collection(c)) => {
                     c.members().iter().any(|m| match m {

--- a/engine/runtime/geometry/src/point/mod.rs
+++ b/engine/runtime/geometry/src/point/mod.rs
@@ -27,6 +27,20 @@ pub struct Point3D {
     position: [f64; 3],
 }
 
+impl Point2D {
+    /// The coordinate frame this position is expressed in.
+    #[inline]
+    pub fn frame(&self) -> &CoordinateFrame {
+        &self.frame
+    }
+
+    /// The `[x, y]` position.
+    #[inline]
+    pub fn position(&self) -> [f64; 2] {
+        self.position
+    }
+}
+
 impl Point3D {
     /// The `[x, y, z]` position.
     #[inline]

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -104,6 +104,39 @@ impl PolygonMesh3DData {
 }
 
 impl PolygonMesh2D {
+    /// The coordinate frame these vertices are expressed in.
+    #[inline]
+    pub fn frame(&self) -> &CoordinateFrame {
+        &self.frame
+    }
+
+    /// The shared vertex pool.
+    #[inline]
+    pub fn vertices(&self) -> &[[f64; 2]] {
+        &self.vertices
+    }
+
+    /// The number of faces.
+    #[inline]
+    pub fn num_faces(&self) -> usize {
+        if self.face_indices.len() == 0 {
+            0
+        } else {
+            self.face_offsets.len() + 1
+        }
+    }
+
+    /// The CSR ring buffers `(face_indices, face_offsets, interior_offsets)`,
+    /// for the predicate views to decode.
+    #[inline]
+    pub(crate) fn csr_buffers(&self) -> (&IndexBuffer<1>, &IndexBuffer<1>, &IndexBuffer<1>) {
+        (
+            &self.face_indices,
+            &self.face_offsets,
+            &self.interior_offsets,
+        )
+    }
+
     /// Borrow the appearance, if any.
     #[inline]
     pub fn appearance(&self) -> &Option<Appearance> {

--- a/engine/runtime/geometry/src/predicates/contains.rs
+++ b/engine/runtime/geometry/src/predicates/contains.rs
@@ -65,7 +65,7 @@ fn containment(a: &Geometry, b: &Geometry, need_witness: bool) -> Result<bool> {
 
 /// Flatten a `Geometry` into its 2D leaves; the second value names the first
 /// 3D leaf encountered, if any.
-fn flatten_geometry(geometry: &Geometry) -> (Vec<Leaf2D<'_>>, Option<&'static str>) {
+pub(crate) fn flatten_geometry(geometry: &Geometry) -> (Vec<Leaf2D<'_>>, Option<&'static str>) {
     fn walk<'a>(
         geometry: &'a Geometry,
         leaves: &mut Vec<Leaf2D<'a>>,

--- a/engine/runtime/geometry/src/predicates/contains.rs
+++ b/engine/runtime/geometry/src/predicates/contains.rs
@@ -1,7 +1,7 @@
 //! The `contains` and `covers` predicates, with OGC point-set semantics.
 //!
 //! `covers(a, b)`: every point of `b` lies in the closure of `a`.
-//! `contains(a, b)`: `covers(a, b)` **and** the interiors intersect — so a
+//! `contains(a, b)`: `covers(a, b)` **and** the interiors intersect, so a
 //! geometry lying entirely on `a`'s boundary is covered but not contained.
 //!
 //! The evaluation is split-based rather than heuristic: every boundary segment
@@ -9,13 +9,13 @@
 //! entirely in one region of `a` and its midpoint classifies the whole piece.
 //! Three checks compose the answer:
 //!
-//! 1. **Boundary coverage** — every piece midpoint of `b`'s segments and ring
+//! 1. **Boundary coverage**: every piece midpoint of `b`'s segments and ring
 //!    edges must not be outside `a`.
-//! 2. **Face interiors** — every face of an areal `b` contributes one interior
+//! 2. **Face interiors**: every face of an areal `b` contributes one interior
 //!    sample point, which must be strictly inside `a`'s areal union. Since a
 //!    face interior that never meets `a`'s boundary lies in a single region,
 //!    one sample decides it (check 3 guarantees the premise).
-//! 3. **Reverse leak** — no piece of `a`'s areal boundary may run strictly
+//! 3. **Reverse leak**: no piece of `a`'s areal boundary may run strictly
 //!    inside `b`'s areal interior while being true union boundary of `a` (a
 //!    hole or gap of `a` swallowed by `b`'s interior). Internal shared mesh
 //!    edges of `a` classify as interior and pass.

--- a/engine/runtime/geometry/src/predicates/contains.rs
+++ b/engine/runtime/geometry/src/predicates/contains.rs
@@ -30,7 +30,7 @@ use super::intersects::type_name_3d;
 use super::kernel::{segment_intersection, CoordPos, SegmentIntersection};
 use super::position::{areal_union_position, face_position, union_position};
 use super::view::{flatten_2d, require_common_frame, FaceView, Leaf2D, Operand2D};
-use super::{PredicateError, Result};
+use super::Result;
 use crate::ops::Aabb;
 use crate::Geometry;
 
@@ -48,15 +48,7 @@ pub fn covers(a: &Geometry, b: &Geometry) -> Result<bool> {
 }
 
 fn containment(a: &Geometry, b: &Geometry, need_witness: bool) -> Result<bool> {
-    let (a_leaves, a_3d) = flatten_geometry(a);
-    let (b_leaves, b_3d) = flatten_geometry(b);
-    match (a_3d, b_3d) {
-        (None, None) => {}
-        (Some(left), Some(right)) if a_leaves.is_empty() && b_leaves.is_empty() => {
-            return Err(PredicateError::UnsupportedPair { left, right })
-        }
-        _ => return Err(PredicateError::CrossDimension),
-    }
+    let (a_leaves, b_leaves) = super::flatten_2d_pair(a, b)?;
     let a = Operand2D::from_leaves(a_leaves);
     let b = Operand2D::from_leaves(b_leaves);
     require_common_frame(&a, &b)?;
@@ -307,6 +299,7 @@ mod tests {
     use crate::point::Point2D;
     use crate::polygon::Polygon2D;
     use crate::polygon_mesh::PolygonMesh2D;
+    use crate::predicates::PredicateError;
     use crate::{Euclidean2DGeometry, Geometry};
     use pretty_assertions::assert_eq;
 

--- a/engine/runtime/geometry/src/predicates/contains.rs
+++ b/engine/runtime/geometry/src/predicates/contains.rs
@@ -26,6 +26,7 @@
 //! constructed (f64-rounded) coordinates; classification at them inherits that
 //! rounding. Collections mixing 2D and 3D members error, as elsewhere.
 
+use super::edge_set::{operand_edges, operand_segment_count, Edge2, EdgeSet};
 use super::intersects::type_name_3d;
 use super::kernel::{segment_intersection, CoordPos, SegmentIntersection};
 use super::position::{areal_union_position, face_position, union_position};
@@ -83,6 +84,32 @@ pub(crate) fn flatten_geometry(geometry: &Geometry) -> (Vec<Leaf2D<'_>>, Option<
 }
 
 fn containment_2d(a: &Operand2D<'_>, b: &Operand2D<'_>, need_witness: bool) -> bool {
+    containment_2d_impl(a, b, need_witness, None)
+}
+
+/// [`containment_2d`] with the [`EdgeSet`] strategy forced, for strategy
+/// parity tests.
+#[cfg(test)]
+fn containment_2d_forced(
+    a: &Operand2D<'_>,
+    b: &Operand2D<'_>,
+    need_witness: bool,
+    indexed: bool,
+) -> bool {
+    containment_2d_impl(a, b, need_witness, Some(indexed))
+}
+
+fn containment_2d_impl(
+    a: &Operand2D<'_>,
+    b: &Operand2D<'_>,
+    need_witness: bool,
+    force_indexed: Option<bool>,
+) -> bool {
+    let build = |edges: Vec<Edge2>, probes: usize| match force_indexed {
+        Some(indexed) => EdgeSet::with_strategy(edges, indexed),
+        None => EdgeSet::new(edges, probes),
+    };
+
     // Coverage requires b's extent within a's.
     let Some(bbox_b) = union_bbox(b) else {
         return false;
@@ -94,8 +121,9 @@ fn containment_2d(a: &Operand2D<'_>, b: &Operand2D<'_>, need_witness: bool) -> b
         return false;
     }
 
-    // The splitting edge set of `a`: areal ring edges and line segments.
-    let a_edges: Vec<([f64; 2], [f64; 2])> = collect_edges(a);
+    // The splitting edge set of `a`: areal ring edges and line segments,
+    // probed once per segment of `b`.
+    let a_edges = build(operand_edges(a), operand_segment_count(b));
     let mut witness = false;
 
     for prepared in &b.leaves {
@@ -161,9 +189,12 @@ fn containment_2d(a: &Operand2D<'_>, b: &Operand2D<'_>, need_witness: bool) -> b
     // interior must be interior to a as well (a shared mesh edge), or b's
     // interior extends past a across it.
     if b.areas().next().is_some() {
-        let b_area_edges: Vec<([f64; 2], [f64; 2])> =
-            b.areas().flat_map(|view| view.edges()).collect();
-        for (u, v) in a.areas().flat_map(|view| view.edges()) {
+        let a_areal: Vec<Edge2> = a.areas().flat_map(|view| view.edges()).collect();
+        let b_area_edges = build(
+            b.areas().flat_map(|view| view.edges()).collect(),
+            a_areal.len(),
+        );
+        for &(u, v) in &a_areal {
             for m in piece_midpoints(u, v, &b_area_edges) {
                 if areal_union_position(m, b.areas()) == CoordPos::Inside
                     && areal_union_position(m, a.areas()) != CoordPos::Inside
@@ -177,30 +208,12 @@ fn containment_2d(a: &Operand2D<'_>, b: &Operand2D<'_>, need_witness: bool) -> b
     !need_witness || witness
 }
 
-/// The areal ring edges and line segments of an operand (points contribute
-/// nothing to splitting).
-fn collect_edges(operand: &Operand2D<'_>) -> Vec<([f64; 2], [f64; 2])> {
-    let mut edges = Vec::new();
-    for prepared in &operand.leaves {
-        match prepared.leaf {
-            Leaf2D::Point(_) => {}
-            Leaf2D::Line(l) => {
-                edges.extend(l.coords().windows(2).map(|s| (s[0], s[1])));
-            }
-            _ => {
-                edges.extend(prepared.area.as_ref().expect("leaf is areal").edges());
-            }
-        }
-    }
-    edges
-}
-
 /// Split the segment `u -> v` at every intersection with `edges` and yield the
 /// midpoint of each resulting piece. Each piece lies entirely in one region of
 /// the geometry the edges came from, so its midpoint classifies it.
-fn piece_midpoints(u: [f64; 2], v: [f64; 2], edges: &[([f64; 2], [f64; 2])]) -> Vec<[f64; 2]> {
+fn piece_midpoints(u: [f64; 2], v: [f64; 2], edges: &EdgeSet) -> Vec<[f64; 2]> {
     let mut cuts: Vec<[f64; 2]> = vec![u, v];
-    for &(s, t) in edges {
+    edges.probe(u, v, |s, t| {
         match segment_intersection(u, v, s, t) {
             Some(SegmentIntersection::SinglePoint { intersection, .. }) => cuts.push(intersection),
             Some(SegmentIntersection::Collinear { start, end }) => {
@@ -209,7 +222,8 @@ fn piece_midpoints(u: [f64; 2], v: [f64; 2], edges: &[([f64; 2], [f64; 2])]) -> 
             }
             None => {}
         }
-    }
+        false
+    });
     // Order along the segment by projection onto its direction.
     let d = [v[0] - u[0], v[1] - u[1]];
     let param = |p: &[f64; 2]| (p[0] - u[0]) * d[0] + (p[1] - u[1]) * d[1];
@@ -561,5 +575,127 @@ mod tests {
         let view = super::super::view::AreaView::from_polygon(&p);
         let sample = face_interior_point(view.face(0)).unwrap();
         assert_eq!(face_position(sample, view.face(0)), CoordPos::Inside);
+    }
+
+    // --- linear / indexed strategy parity -------------------------------------
+
+    /// Deterministic splitmix-style generator.
+    struct Rng(u64);
+
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            z ^ (z >> 31)
+        }
+
+        fn range(&mut self, n: u64) -> u64 {
+            self.next() % n
+        }
+
+        fn coord(&mut self) -> [f64; 2] {
+            [self.range(9) as f64, self.range(9) as f64]
+        }
+    }
+
+    /// One random geometry on a small integer grid.
+    fn rng_geometry(rng: &mut Rng) -> Geometry {
+        match rng.range(6) {
+            0 => {
+                let p = rng.coord();
+                point(p[0], p[1])
+            }
+            1 => line(vec![rng.coord(), rng.coord()]),
+            2 => line(vec![rng.coord(), rng.coord(), rng.coord(), rng.coord()]),
+            3 => {
+                let (x, y) = (rng.range(6) as f64, rng.range(6) as f64);
+                square(x, y, (1 + rng.range(3)) as f64)
+            }
+            4 => holey(
+                (1 + rng.range(3)) as f64,
+                (1 + rng.range(3)) as f64,
+                (1 + rng.range(3)) as f64,
+            ),
+            _ => {
+                // Two quads sharing an edge, as a mesh.
+                let (x, y) = (rng.range(5) as f64, rng.range(5) as f64);
+                let mesh = PolygonMesh2D::from_parts(
+                    e(),
+                    vec![
+                        [x, y],
+                        [x + 2.0, y],
+                        [x + 2.0, y + 2.0],
+                        [x, y + 2.0],
+                        [x + 4.0, y],
+                        [x + 4.0, y + 2.0],
+                    ],
+                    vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+                )
+                .unwrap();
+                g2(Euclidean2DGeometry::PolygonMesh(Box::new(mesh)))
+            }
+        }
+    }
+
+    fn operands<'g>(a: &'g Geometry, b: &'g Geometry) -> (Operand2D<'g>, Operand2D<'g>) {
+        let (a_leaves, _) = flatten_geometry(a);
+        let (b_leaves, _) = flatten_geometry(b);
+        (
+            Operand2D::from_leaves(a_leaves),
+            Operand2D::from_leaves(b_leaves),
+        )
+    }
+
+    #[test]
+    fn linear_and_indexed_strategies_agree() {
+        let mut rng = Rng(20260716);
+        for case in 0..300 {
+            let ga = rng_geometry(&mut rng);
+            let gb = rng_geometry(&mut rng);
+            let (a, b) = operands(&ga, &gb);
+            for need_witness in [false, true] {
+                assert_eq!(
+                    containment_2d_forced(&a, &b, need_witness, false),
+                    containment_2d_forced(&a, &b, need_witness, true),
+                    "case {case} witness={need_witness}: strategies diverge for {ga:?} / {gb:?}"
+                );
+            }
+            assert_eq!(
+                Ok(containment_2d(&a, &b, true)),
+                contains(&ga, &gb),
+                "case {case}: public path diverges for {ga:?} / {gb:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn auto_indexed_large_inputs_answer_correctly() {
+        // 100-gon pairs: the probe-count product crosses the index gate.
+        let ngon = |cx: f64, cy: f64, r: f64| {
+            let ring: Vec<[f64; 2]> = (0..=100)
+                .map(|i| {
+                    let t = core::f64::consts::TAU * (i % 100) as f64 / 100.0;
+                    [cx + r * t.cos(), cy + r * t.sin()]
+                })
+                .collect();
+            g2(Euclidean2DGeometry::Polygon(Box::new(
+                Polygon2D::from_rings(e(), ring, Vec::<Vec<[f64; 2]>>::new()),
+            )))
+        };
+        assert_eq!(
+            contains(&ngon(0.0, 0.0, 10.0), &ngon(0.0, 0.0, 5.0)),
+            Ok(true)
+        );
+        assert_eq!(
+            contains(&ngon(0.0, 0.0, 5.0), &ngon(0.0, 0.0, 10.0)),
+            Ok(false)
+        );
+        // Partial overlap: covered fails on the poking-out part.
+        assert_eq!(
+            covers(&ngon(0.0, 0.0, 10.0), &ngon(8.0, 0.0, 5.0)),
+            Ok(false)
+        );
     }
 }

--- a/engine/runtime/geometry/src/predicates/contains.rs
+++ b/engine/runtime/geometry/src/predicates/contains.rs
@@ -1,0 +1,572 @@
+//! The `contains` and `covers` predicates, with OGC point-set semantics.
+//!
+//! `covers(a, b)`: every point of `b` lies in the closure of `a`.
+//! `contains(a, b)`: `covers(a, b)` **and** the interiors intersect — so a
+//! geometry lying entirely on `a`'s boundary is covered but not contained.
+//!
+//! The evaluation is split-based rather than heuristic: every boundary segment
+//! of `b` is split at each intersection with `a`'s boundary, so each piece lies
+//! entirely in one region of `a` and its midpoint classifies the whole piece.
+//! Three checks compose the answer:
+//!
+//! 1. **Boundary coverage** — every piece midpoint of `b`'s segments and ring
+//!    edges must not be outside `a`.
+//! 2. **Face interiors** — every face of an areal `b` contributes one interior
+//!    sample point, which must be strictly inside `a`'s areal union. Since a
+//!    face interior that never meets `a`'s boundary lies in a single region,
+//!    one sample decides it (check 3 guarantees the premise).
+//! 3. **Reverse leak** — no piece of `a`'s areal boundary may run strictly
+//!    inside `b`'s areal interior while being true union boundary of `a` (a
+//!    hole or gap of `a` swallowed by `b`'s interior). Internal shared mesh
+//!    edges of `a` classify as interior and pass.
+//!
+//! Both operands are treated as point-set unions of their flattened leaves, so
+//! collection containers are exact: a `b` spanning several touching members of
+//! a collection `a` is contained. Split points and piece midpoints are
+//! constructed (f64-rounded) coordinates; classification at them inherits that
+//! rounding. Collections mixing 2D and 3D members error, as elsewhere.
+
+use super::intersects::type_name_3d;
+use super::kernel::{segment_intersection, CoordPos, SegmentIntersection};
+use super::position::{areal_union_position, face_position, union_position};
+use super::view::{flatten_2d, require_common_frame, FaceView, Leaf2D, Operand2D};
+use super::{PredicateError, Result};
+use crate::ops::Aabb;
+use crate::Geometry;
+
+/// Whether `a` contains `b`: `b` lies in `a`'s closure and their interiors
+/// intersect. Nothing contains an absent or empty geometry.
+pub fn contains(a: &Geometry, b: &Geometry) -> Result<bool> {
+    containment(a, b, true)
+}
+
+/// Whether `a` covers `b`: every point of `b` lies in `a`'s closure. Unlike
+/// [`contains`], pure boundary contact suffices. Nothing covers an absent or
+/// empty geometry.
+pub fn covers(a: &Geometry, b: &Geometry) -> Result<bool> {
+    containment(a, b, false)
+}
+
+fn containment(a: &Geometry, b: &Geometry, need_witness: bool) -> Result<bool> {
+    let (a_leaves, a_3d) = flatten_geometry(a);
+    let (b_leaves, b_3d) = flatten_geometry(b);
+    match (a_3d, b_3d) {
+        (None, None) => {}
+        (Some(left), Some(right)) if a_leaves.is_empty() && b_leaves.is_empty() => {
+            return Err(PredicateError::UnsupportedPair { left, right })
+        }
+        _ => return Err(PredicateError::CrossDimension),
+    }
+    let a = Operand2D::from_leaves(a_leaves);
+    let b = Operand2D::from_leaves(b_leaves);
+    require_common_frame(&a, &b)?;
+    Ok(containment_2d(&a, &b, need_witness))
+}
+
+/// Flatten a `Geometry` into its 2D leaves; the second value names the first
+/// 3D leaf encountered, if any.
+fn flatten_geometry(geometry: &Geometry) -> (Vec<Leaf2D<'_>>, Option<&'static str>) {
+    fn walk<'a>(
+        geometry: &'a Geometry,
+        leaves: &mut Vec<Leaf2D<'a>>,
+        first_3d: &mut Option<&'static str>,
+    ) {
+        match geometry {
+            Geometry::None => {}
+            Geometry::Euclidean2D(g) => flatten_2d(g, leaves),
+            Geometry::Euclidean3D(g) => {
+                first_3d.get_or_insert(type_name_3d(g));
+            }
+            Geometry::GeometryCollection(c) => {
+                for member in c.members() {
+                    walk(member, leaves, first_3d);
+                }
+            }
+        }
+    }
+    let mut leaves = Vec::new();
+    let mut first_3d = None;
+    walk(geometry, &mut leaves, &mut first_3d);
+    (leaves, first_3d)
+}
+
+fn containment_2d(a: &Operand2D<'_>, b: &Operand2D<'_>, need_witness: bool) -> bool {
+    // Coverage requires b's extent within a's.
+    let Some(bbox_b) = union_bbox(b) else {
+        return false;
+    };
+    let Some(bbox_a) = union_bbox(a) else {
+        return false;
+    };
+    if !bbox_within(&bbox_b, &bbox_a) {
+        return false;
+    }
+
+    // The splitting edge set of `a`: areal ring edges and line segments.
+    let a_edges: Vec<([f64; 2], [f64; 2])> = collect_edges(a);
+    let mut witness = false;
+
+    for prepared in &b.leaves {
+        match prepared.leaf {
+            Leaf2D::Point(p) => match union_position(p.position(), a) {
+                CoordPos::Outside => return false,
+                CoordPos::Inside => witness = true,
+                CoordPos::OnBoundary => {}
+            },
+            Leaf2D::Line(l) => {
+                let coords = l.coords();
+                let closed = coords.len() >= 2 && coords.first() == coords.last();
+                // Chain vertices: coverage, and interior vertices as witnesses.
+                for (i, &v) in coords.iter().enumerate() {
+                    match union_position(v, a) {
+                        CoordPos::Outside => return false,
+                        CoordPos::Inside => {
+                            let endpoint = !closed && (i == 0 || i + 1 == coords.len());
+                            // A single-vertex chain is point-like: all interior.
+                            if !endpoint || coords.len() == 1 {
+                                witness = true;
+                            }
+                        }
+                        CoordPos::OnBoundary => {}
+                    }
+                }
+                // Piece midpoints: coverage and witnesses (chain interior).
+                for seg in coords.windows(2) {
+                    for m in piece_midpoints(seg[0], seg[1], &a_edges) {
+                        match union_position(m, a) {
+                            CoordPos::Outside => return false,
+                            CoordPos::Inside => witness = true,
+                            CoordPos::OnBoundary => {}
+                        }
+                    }
+                }
+            }
+            _ => {
+                let view = prepared.area.as_ref().expect("leaf is areal");
+                // Boundary coverage: every ring edge piece within a's closure.
+                for (u, v) in view.edges() {
+                    for m in piece_midpoints(u, v, &a_edges) {
+                        if union_position(m, a) == CoordPos::Outside {
+                            return false;
+                        }
+                    }
+                }
+                // Face interiors: one sample per face, strictly inside a's
+                // areal union. A degenerate face has no interior and no sample.
+                for face in view.faces() {
+                    if let Some(sample) = face_interior_point(face) {
+                        if areal_union_position(sample, a.areas()) != CoordPos::Inside {
+                            return false;
+                        }
+                        witness = true;
+                    }
+                }
+            }
+        }
+    }
+
+    // Reverse leak: a piece of a's areal boundary strictly inside b's areal
+    // interior must be interior to a as well (a shared mesh edge), or b's
+    // interior extends past a across it.
+    if b.areas().next().is_some() {
+        let b_area_edges: Vec<([f64; 2], [f64; 2])> =
+            b.areas().flat_map(|view| view.edges()).collect();
+        for (u, v) in a.areas().flat_map(|view| view.edges()) {
+            for m in piece_midpoints(u, v, &b_area_edges) {
+                if areal_union_position(m, b.areas()) == CoordPos::Inside
+                    && areal_union_position(m, a.areas()) != CoordPos::Inside
+                {
+                    return false;
+                }
+            }
+        }
+    }
+
+    !need_witness || witness
+}
+
+/// The areal ring edges and line segments of an operand (points contribute
+/// nothing to splitting).
+fn collect_edges(operand: &Operand2D<'_>) -> Vec<([f64; 2], [f64; 2])> {
+    let mut edges = Vec::new();
+    for prepared in &operand.leaves {
+        match prepared.leaf {
+            Leaf2D::Point(_) => {}
+            Leaf2D::Line(l) => {
+                edges.extend(l.coords().windows(2).map(|s| (s[0], s[1])));
+            }
+            _ => {
+                edges.extend(prepared.area.as_ref().expect("leaf is areal").edges());
+            }
+        }
+    }
+    edges
+}
+
+/// Split the segment `u -> v` at every intersection with `edges` and yield the
+/// midpoint of each resulting piece. Each piece lies entirely in one region of
+/// the geometry the edges came from, so its midpoint classifies it.
+fn piece_midpoints(u: [f64; 2], v: [f64; 2], edges: &[([f64; 2], [f64; 2])]) -> Vec<[f64; 2]> {
+    let mut cuts: Vec<[f64; 2]> = vec![u, v];
+    for &(s, t) in edges {
+        match segment_intersection(u, v, s, t) {
+            Some(SegmentIntersection::SinglePoint { intersection, .. }) => cuts.push(intersection),
+            Some(SegmentIntersection::Collinear { start, end }) => {
+                cuts.push(start);
+                cuts.push(end);
+            }
+            None => {}
+        }
+    }
+    // Order along the segment by projection onto its direction.
+    let d = [v[0] - u[0], v[1] - u[1]];
+    let param = |p: &[f64; 2]| (p[0] - u[0]) * d[0] + (p[1] - u[1]) * d[1];
+    cuts.sort_by(|p, q| param(p).total_cmp(&param(q)));
+    cuts.dedup();
+    cuts.windows(2)
+        .map(|w| [(w[0][0] + w[1][0]) / 2.0, (w[0][1] + w[1][1]) / 2.0])
+        .collect()
+}
+
+/// A point strictly inside the face, or `None` when the face has no interior.
+///
+/// Horizontal scanline construction: pick a scan height strictly between two
+/// adjacent vertex levels (so no edge endpoint lies on the line), collect the
+/// edge crossings of all rings, and take the midpoint of an even-odd interior
+/// interval. Every candidate is verified with [`face_position`] before being
+/// returned, so an exotic face can only fail to a `None`, never to a wrong
+/// point.
+fn face_interior_point(face: FaceView<'_>) -> Option<[f64; 2]> {
+    let mut levels: Vec<f64> = face
+        .rings()
+        .flat_map(|r| r.coords().map(|c| c[1]))
+        .collect();
+    levels.sort_by(f64::total_cmp);
+    levels.dedup();
+    if levels.len() < 2 {
+        return None;
+    }
+
+    for pair in levels.windows(2) {
+        let y = (pair[0] + pair[1]) / 2.0;
+        if !(y > pair[0] && y < pair[1]) {
+            continue; // adjacent levels too close for a strict midpoint
+        }
+        // Crossings of the scanline with every ring edge; no endpoint lies on
+        // it, so each edge either straddles cleanly or is skipped.
+        let mut xs: Vec<f64> = Vec::new();
+        for (s, t) in face.edges() {
+            if (s[1] < y && t[1] > y) || (t[1] < y && s[1] > y) {
+                xs.push(s[0] + (y - s[1]) * (t[0] - s[0]) / (t[1] - s[1]));
+            }
+        }
+        xs.sort_by(f64::total_cmp);
+        // Even-odd: [xs[0], xs[1]], [xs[2], xs[3]], … are interior intervals.
+        for span in xs.chunks_exact(2) {
+            let candidate = [(span[0] + span[1]) / 2.0, y];
+            if face_position(candidate, face) == CoordPos::Inside {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// The union of the operand's leaf boxes, `None` when every leaf is empty.
+fn union_bbox(operand: &Operand2D<'_>) -> Option<Aabb> {
+    operand
+        .leaves
+        .iter()
+        .filter_map(|l| l.bbox)
+        .reduce(Aabb::union)
+}
+
+/// Whether `inner` lies within `outer` (inclusive). 2D leaf boxes only.
+fn bbox_within(inner: &Aabb, outer: &Aabb) -> bool {
+    match (inner, outer) {
+        (
+            Aabb::D2 {
+                min: imin,
+                max: imax,
+            },
+            Aabb::D2 {
+                min: omin,
+                max: omax,
+            },
+        ) => (0..2).all(|i| omin[i] <= imin[i] && imax[i] <= omax[i]),
+        _ => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collection::Collection2D;
+    use crate::coordinate::{CoordinateFrame, EpsgCode};
+    use crate::line_string::LineString2D;
+    use crate::point::Point2D;
+    use crate::polygon::Polygon2D;
+    use crate::polygon_mesh::PolygonMesh2D;
+    use crate::{Euclidean2DGeometry, Geometry};
+    use pretty_assertions::assert_eq;
+
+    fn e() -> CoordinateFrame {
+        CoordinateFrame::Euclidean
+    }
+
+    fn g2(g: Euclidean2DGeometry) -> Geometry {
+        Geometry::Euclidean2D(g)
+    }
+
+    fn point(x: f64, y: f64) -> Geometry {
+        g2(Euclidean2DGeometry::Point(Point2D::new(e(), [x, y])))
+    }
+
+    fn line(coords: Vec<[f64; 2]>) -> Geometry {
+        g2(Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            e(),
+            coords,
+        )))
+    }
+
+    fn square(x: f64, y: f64, s: f64) -> Geometry {
+        g2(square_2d(x, y, s))
+    }
+
+    fn square_2d(x: f64, y: f64, s: f64) -> Euclidean2DGeometry {
+        Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            e(),
+            [[x, y], [x + s, y], [x + s, y + s], [x, y + s], [x, y]],
+            Vec::<Vec<[f64; 2]>>::new(),
+        )))
+    }
+
+    /// `[0, 8]²` with the hole `[hx, hx+hs] × [hy, hy+hs]`.
+    fn holey(hx: f64, hy: f64, hs: f64) -> Geometry {
+        let outer = [[0.0, 0.0], [8.0, 0.0], [8.0, 8.0], [0.0, 8.0], [0.0, 0.0]];
+        let hole = vec![
+            [hx, hy],
+            [hx, hy + hs],
+            [hx + hs, hy + hs],
+            [hx + hs, hy],
+            [hx, hy],
+        ];
+        g2(Euclidean2DGeometry::Polygon(Box::new(
+            Polygon2D::from_rings(e(), outer, vec![hole]),
+        )))
+    }
+
+    #[test]
+    fn point_containment() {
+        let sq = square(0.0, 0.0, 4.0);
+        assert_eq!(contains(&sq, &point(2.0, 2.0)), Ok(true));
+        // A boundary point is covered but not contained.
+        assert_eq!(contains(&sq, &point(0.0, 2.0)), Ok(false));
+        assert_eq!(covers(&sq, &point(0.0, 2.0)), Ok(true));
+        assert_eq!(contains(&sq, &point(9.0, 2.0)), Ok(false));
+        // In the hole is outside.
+        let a = holey(2.0, 2.0, 4.0);
+        assert_eq!(covers(&a, &point(4.0, 4.0)), Ok(false));
+        assert_eq!(covers(&a, &point(2.0, 4.0)), Ok(true)); // on hole ring
+        assert_eq!(contains(&a, &point(2.0, 4.0)), Ok(false));
+    }
+
+    #[test]
+    fn point_contains_point() {
+        assert_eq!(contains(&point(1.0, 1.0), &point(1.0, 1.0)), Ok(true));
+        assert_eq!(contains(&point(1.0, 1.0), &point(1.0, 2.0)), Ok(false));
+    }
+
+    #[test]
+    fn polygon_contains_line() {
+        let sq = square(0.0, 0.0, 4.0);
+        assert_eq!(contains(&sq, &line(vec![[1.0, 1.0], [3.0, 3.0]])), Ok(true));
+        // Touching the boundary from inside still contains.
+        assert_eq!(contains(&sq, &line(vec![[0.0, 0.0], [3.0, 3.0]])), Ok(true));
+        // Along the boundary: covered, not contained.
+        let rim = line(vec![[0.0, 0.0], [4.0, 0.0]]);
+        assert_eq!(contains(&sq, &rim), Ok(false));
+        assert_eq!(covers(&sq, &rim), Ok(true));
+        // Poking out is neither.
+        let out = line(vec![[2.0, 2.0], [6.0, 2.0]]);
+        assert_eq!(covers(&sq, &out), Ok(false));
+        // Crossing the hole of a holey polygon is not covered, even though
+        // both endpoints are in the solid part.
+        let a = holey(2.0, 2.0, 4.0);
+        assert_eq!(covers(&a, &line(vec![[1.0, 4.0], [7.0, 4.0]])), Ok(false));
+    }
+
+    #[test]
+    fn line_contains_line_and_point() {
+        let long = line(vec![[0.0, 0.0], [8.0, 0.0]]);
+        let sub = line(vec![[2.0, 0.0], [5.0, 0.0]]);
+        assert_eq!(contains(&long, &sub), Ok(true));
+        assert_eq!(contains(&sub, &long), Ok(false));
+        // Sharing only a crossing point is not containment.
+        let cross = line(vec![[4.0, -1.0], [4.0, 1.0]]);
+        assert_eq!(contains(&long, &cross), Ok(false));
+        // Chain interior point is contained; an endpoint is only covered.
+        assert_eq!(contains(&long, &point(3.0, 0.0)), Ok(true));
+        assert_eq!(contains(&long, &point(0.0, 0.0)), Ok(false));
+        assert_eq!(covers(&long, &point(0.0, 0.0)), Ok(true));
+    }
+
+    #[test]
+    fn polygon_contains_polygon() {
+        let big = square(0.0, 0.0, 8.0);
+        assert_eq!(contains(&big, &square(1.0, 1.0, 2.0)), Ok(true));
+        // Touching the boundary from inside still contains (interiors meet).
+        assert_eq!(contains(&big, &square(0.0, 0.0, 2.0)), Ok(true));
+        assert_eq!(contains(&big, &square(7.0, 7.0, 2.0)), Ok(false));
+        assert_eq!(contains(&big, &big.clone()), Ok(true));
+        assert_eq!(contains(&square(1.0, 1.0, 2.0), &big), Ok(false));
+    }
+
+    #[test]
+    fn hole_defeats_containment() {
+        // b covers a's (off-center) hole entirely: the reverse-leak check must
+        // reject it even though b's boundary and interior samples all pass.
+        let a = holey(1.0, 1.0, 1.0);
+        let b = square(0.0, 0.0, 8.0);
+        assert_eq!(covers(&a, &b), Ok(false));
+        // And a genuinely-inside b (avoiding the hole) is contained.
+        assert_eq!(contains(&a, &square(4.0, 4.0, 3.0)), Ok(true));
+        // b sitting exactly in the hole touches only closure: covered by the
+        // outer square minus hole? No: the hole interior is outside a.
+        assert_eq!(covers(&a, &square(1.0, 1.0, 1.0)), Ok(false));
+    }
+
+    #[test]
+    fn hole_filler_mesh_is_not_covered() {
+        // b = mesh { the hole-filling square, a small square in a's solid }.
+        // Every ring of b lies in a's closure, but b1's interior is a's hole.
+        let a = holey(2.0, 2.0, 4.0);
+        let mesh = PolygonMesh2D::from_parts(
+            e(),
+            vec![
+                // b1: the hole filler [2,6]².
+                [2.0, 2.0],
+                [6.0, 2.0],
+                [6.0, 6.0],
+                [2.0, 6.0],
+                // b2: solid part [0.5,1.5]².
+                [0.5, 0.5],
+                [1.5, 0.5],
+                [1.5, 1.5],
+                [0.5, 1.5],
+            ],
+            vec![vec![0u32, 1, 2, 3], vec![4, 5, 6, 7]],
+        )
+        .unwrap();
+        let b = g2(Euclidean2DGeometry::PolygonMesh(Box::new(mesh)));
+        assert_eq!(covers(&a, &b), Ok(false));
+    }
+
+    #[test]
+    fn mesh_shared_edge_interior_supports_containment() {
+        // a = two quads sharing the edge x = 2; a line along that edge lies in
+        // the union's interior.
+        let mesh = PolygonMesh2D::from_parts(
+            e(),
+            vec![
+                [0.0, 0.0],
+                [2.0, 0.0],
+                [2.0, 2.0],
+                [0.0, 2.0],
+                [4.0, 0.0],
+                [4.0, 2.0],
+            ],
+            vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+        )
+        .unwrap();
+        let a = g2(Euclidean2DGeometry::PolygonMesh(Box::new(mesh)));
+        let along = line(vec![[2.0, 0.5], [2.0, 1.5]]);
+        assert_eq!(contains(&a, &along), Ok(true));
+        // The outer rim is only covered.
+        let rim = line(vec![[0.0, 0.5], [0.0, 1.5]]);
+        assert_eq!(contains(&a, &rim), Ok(false));
+        assert_eq!(covers(&a, &rim), Ok(true));
+    }
+
+    #[test]
+    fn collection_union_contains_spanning_line() {
+        // Two squares sharing the edge x = 2: their union contains a line
+        // crossing from one into the other.
+        let a = g2(Euclidean2DGeometry::Collection(Collection2D::new([
+            square_2d(0.0, 0.0, 2.0),
+            square_2d(2.0, 0.0, 2.0),
+        ])));
+        let spanning = line(vec![[1.0, 1.0], [3.0, 1.0]]);
+        assert_eq!(contains(&a, &spanning), Ok(true));
+        // A line escaping both is not covered.
+        assert_eq!(covers(&a, &line(vec![[1.0, 1.0], [5.0, 1.0]])), Ok(false));
+    }
+
+    #[test]
+    fn collection_containee_needs_every_member_covered() {
+        let a = square(0.0, 0.0, 8.0);
+        let b_ok = g2(Euclidean2DGeometry::Collection(Collection2D::new([
+            Euclidean2DGeometry::Point(Point2D::new(e(), [1.0, 1.0])),
+            Euclidean2DGeometry::Point(Point2D::new(e(), [2.0, 2.0])),
+        ])));
+        let b_escapes = g2(Euclidean2DGeometry::Collection(Collection2D::new([
+            Euclidean2DGeometry::Point(Point2D::new(e(), [1.0, 1.0])),
+            Euclidean2DGeometry::Point(Point2D::new(e(), [9.0, 9.0])),
+        ])));
+        assert_eq!(contains(&a, &b_ok), Ok(true));
+        assert_eq!(contains(&a, &b_escapes), Ok(false));
+        // All members on the boundary: covered, not contained; one interior
+        // member is witness enough.
+        let b_boundary = g2(Euclidean2DGeometry::Collection(Collection2D::new([
+            Euclidean2DGeometry::Point(Point2D::new(e(), [0.0, 1.0])),
+            Euclidean2DGeometry::Point(Point2D::new(e(), [0.0, 2.0])),
+        ])));
+        assert_eq!(covers(&a, &b_boundary), Ok(true));
+        assert_eq!(contains(&a, &b_boundary), Ok(false));
+        let b_mixed = g2(Euclidean2DGeometry::Collection(Collection2D::new([
+            Euclidean2DGeometry::Point(Point2D::new(e(), [0.0, 1.0])),
+            Euclidean2DGeometry::Point(Point2D::new(e(), [3.0, 3.0])),
+        ])));
+        assert_eq!(contains(&a, &b_mixed), Ok(true));
+    }
+
+    #[test]
+    fn nothing_contains_empty_or_none() {
+        let sq = square(0.0, 0.0, 4.0);
+        assert_eq!(contains(&sq, &Geometry::None), Ok(false));
+        assert_eq!(covers(&sq, &Geometry::None), Ok(false));
+        let empty = g2(Euclidean2DGeometry::Collection(Collection2D::new([])));
+        assert_eq!(covers(&sq, &empty), Ok(false));
+        assert_eq!(contains(&Geometry::None, &sq), Ok(false));
+    }
+
+    #[test]
+    fn frame_and_dimension_errors() {
+        let a = square(0.0, 0.0, 4.0);
+        let b = g2(Euclidean2DGeometry::Point(Point2D::new(
+            CoordinateFrame::Crs(EpsgCode::new(4326)),
+            [1.0, 1.0],
+        )));
+        assert_eq!(contains(&a, &b), Err(PredicateError::MixedFrames));
+
+        let p3 = Geometry::Euclidean3D(crate::Euclidean3DGeometry::Point(
+            crate::point::Point3D::new(e(), [0.0, 0.0, 0.0]),
+        ));
+        assert_eq!(contains(&a, &p3), Err(PredicateError::CrossDimension));
+        assert!(matches!(
+            contains(&p3, &p3),
+            Err(PredicateError::UnsupportedPair { .. })
+        ));
+    }
+
+    #[test]
+    fn face_interior_point_lands_inside() {
+        // Sample a holey face: the point must avoid the hole.
+        let outer = [[0.0, 0.0], [8.0, 0.0], [8.0, 8.0], [0.0, 8.0], [0.0, 0.0]];
+        let hole = vec![[2.0, 2.0], [2.0, 6.0], [6.0, 6.0], [6.0, 2.0], [2.0, 2.0]];
+        let p = Polygon2D::from_rings(e(), outer, vec![hole]);
+        let view = super::super::view::AreaView::from_polygon(&p);
+        let sample = face_interior_point(view.face(0)).unwrap();
+        assert_eq!(face_position(sample, view.face(0)), CoordPos::Inside);
+    }
+}

--- a/engine/runtime/geometry/src/predicates/edge_set.rs
+++ b/engine/runtime/geometry/src/predicates/edge_set.rs
@@ -1,0 +1,210 @@
+//! A queryable set of 2D segments with a size-gated search strategy.
+//!
+//! [`EdgeSet`] answers "visit every stored segment that may touch this probe
+//! segment" either by a linear scan or through an rstar index. The strategy is
+//! chosen at construction from the expected total number of kernel calls, so
+//! small inputs skip the index build and large inputs avoid the quadratic
+//! scan. Both strategies visit a superset of the truly intersecting segments;
+//! callers decide each candidate with the exact kernel, so the strategy never
+//! changes an answer.
+
+use rstar::RTree;
+
+use super::view::{Leaf2D, Operand2D};
+
+/// One directed 2D segment as an endpoint pair.
+pub(crate) type Edge2 = ([f64; 2], [f64; 2]);
+
+/// Kernel-call budget above which a probe sweep builds an rstar index instead
+/// of scanning linearly.
+// TODO: tune with a benchmark on representative datasets.
+pub(crate) const DIRECT_WORK_LIMIT: usize = 4096;
+
+/// Whether probing `edges` stored segments `probes` times warrants an index.
+pub(crate) fn should_index(edges: usize, probes: usize) -> bool {
+    edges.saturating_mul(probes) > DIRECT_WORK_LIMIT
+}
+
+/// One stored segment with its precomputed rstar envelope.
+pub(crate) struct IndexedEdge {
+    start: [f64; 2],
+    end: [f64; 2],
+    envelope: rstar::AABB<[f64; 2]>,
+}
+
+impl rstar::RTreeObject for IndexedEdge {
+    type Envelope = rstar::AABB<[f64; 2]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.envelope
+    }
+}
+
+/// A set of 2D segments queryable by probe segment, behind one of two
+/// strategies: a plain vector scanned linearly, or an rstar tree queried by
+/// the probe's bounding box.
+pub(crate) enum EdgeSet {
+    /// Scan every stored segment per probe.
+    Linear(Vec<Edge2>),
+    /// Query segments whose box overlaps the probe's box.
+    Indexed(RTree<IndexedEdge>),
+}
+
+impl EdgeSet {
+    /// Build the set, picking the strategy from the stored segment count and
+    /// the expected number of probes.
+    pub(crate) fn new(edges: Vec<Edge2>, probe_hint: usize) -> Self {
+        let indexed = should_index(edges.len(), probe_hint);
+        Self::with_strategy(edges, indexed)
+    }
+
+    /// Build the set with an explicit strategy.
+    pub(crate) fn with_strategy(edges: Vec<Edge2>, indexed: bool) -> Self {
+        if indexed {
+            EdgeSet::Indexed(RTree::bulk_load(
+                edges
+                    .into_iter()
+                    .map(|(start, end)| IndexedEdge {
+                        start,
+                        end,
+                        envelope: rstar::AABB::from_corners(start, end),
+                    })
+                    .collect(),
+            ))
+        } else {
+            EdgeSet::Linear(edges)
+        }
+    }
+
+    /// Visit stored segments that may touch the probe `u -> v`, stopping early
+    /// when `visit` returns `true` and reporting whether it did. The linear
+    /// strategy visits every segment; the indexed one only those whose box
+    /// overlaps the probe's box, which never skips an intersecting segment.
+    pub(crate) fn probe(
+        &self,
+        u: [f64; 2],
+        v: [f64; 2],
+        mut visit: impl FnMut([f64; 2], [f64; 2]) -> bool,
+    ) -> bool {
+        match self {
+            EdgeSet::Linear(edges) => {
+                for &(s, t) in edges {
+                    if visit(s, t) {
+                        return true;
+                    }
+                }
+                false
+            }
+            EdgeSet::Indexed(tree) => {
+                let envelope = rstar::AABB::from_corners(u, v);
+                for edge in tree.locate_in_envelope_intersecting(&envelope) {
+                    if visit(edge.start, edge.end) {
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
+}
+
+/// Every segment of the operand: line chain segments and areal ring edges
+/// (points contribute nothing). Zero-length segments are kept verbatim.
+pub(crate) fn operand_edges(operand: &Operand2D<'_>) -> Vec<Edge2> {
+    let mut edges = Vec::new();
+    for prepared in &operand.leaves {
+        match prepared.leaf {
+            Leaf2D::Point(_) => {}
+            Leaf2D::Line(l) => {
+                edges.extend(l.coords().windows(2).map(|s| (s[0], s[1])));
+            }
+            _ => {
+                edges.extend(prepared.area.as_ref().expect("leaf is areal").edges());
+            }
+        }
+    }
+    edges
+}
+
+/// The operand's segment count (the length [`operand_edges`] would have),
+/// computed structurally without touching coordinates.
+pub(crate) fn operand_segment_count(operand: &Operand2D<'_>) -> usize {
+    operand
+        .leaves
+        .iter()
+        .map(|prepared| match prepared.leaf {
+            Leaf2D::Point(_) => 0,
+            Leaf2D::Line(l) => l.coords().len().saturating_sub(1),
+            _ => {
+                let view = prepared.area.as_ref().expect("leaf is areal");
+                view.faces()
+                    .flat_map(|f| f.rings())
+                    .map(|r| r.open_len())
+                    .sum()
+            }
+        })
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grid_edges(n: usize) -> Vec<Edge2> {
+        (0..n)
+            .map(|i| {
+                let x = i as f64;
+                ([x, 0.0], [x, 1.0])
+            })
+            .collect()
+    }
+
+    #[test]
+    fn strategies_visit_the_same_intersecting_segments() {
+        let edges = grid_edges(20);
+        let linear = EdgeSet::with_strategy(edges.clone(), false);
+        let indexed = EdgeSet::with_strategy(edges, true);
+
+        let collect = |set: &EdgeSet, u: [f64; 2], v: [f64; 2]| {
+            let mut hits: Vec<Edge2> = Vec::new();
+            set.probe(u, v, |s, t| {
+                if crate::predicates::kernel::segment_intersection(u, v, s, t).is_some() {
+                    hits.push((s, t));
+                }
+                false
+            });
+            hits.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            hits
+        };
+
+        let probes = [
+            ([2.5, 0.5], [7.5, 0.5]),
+            ([0.0, 0.0], [19.0, 1.0]),
+            ([-5.0, 0.5], [-1.0, 0.5]),
+            ([3.0, 0.0], [3.0, 1.0]),
+        ];
+        for (u, v) in probes {
+            assert_eq!(collect(&linear, u, v), collect(&indexed, u, v));
+        }
+    }
+
+    #[test]
+    fn probe_early_exit_reports_a_hit() {
+        for indexed in [false, true] {
+            let set = EdgeSet::with_strategy(grid_edges(10), indexed);
+            assert!(set.probe([4.5, 0.5], [5.5, 0.5], |_, _| true));
+            assert!(!set.probe([100.0, 0.5], [101.0, 0.5], |s, t| {
+                crate::predicates::kernel::segment_intersection([100.0, 0.5], [101.0, 0.5], s, t)
+                    .is_some()
+            }));
+        }
+    }
+
+    #[test]
+    fn should_index_gates_on_the_work_product() {
+        assert!(!should_index(10, 10));
+        assert!(!should_index(0, usize::MAX));
+        assert!(should_index(100, 100));
+        assert!(should_index(usize::MAX, 2));
+    }
+}

--- a/engine/runtime/geometry/src/predicates/intersects.rs
+++ b/engine/runtime/geometry/src/predicates/intersects.rs
@@ -15,41 +15,16 @@ use super::kernel::segment_intersection;
 use super::kernel::CoordPos;
 use super::position::{face_position, line_position};
 use super::view::{require_common_frame, AreaView, Leaf2D, Operand2D, PreparedLeaf};
-use super::{PredicateError, Result};
+use super::Result;
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 
 /// Whether `a` and `b` share at least one point.
 pub fn intersects(a: &Geometry, b: &Geometry) -> Result<bool> {
-    match (a, b) {
-        (Geometry::None, _) | (_, Geometry::None) => Ok(false),
-        (Geometry::GeometryCollection(c), other) => {
-            for member in c.members() {
-                if intersects(member, other)? {
-                    return Ok(true);
-                }
-            }
-            Ok(false)
-        }
-        (other, Geometry::GeometryCollection(c)) => {
-            for member in c.members() {
-                if intersects(other, member)? {
-                    return Ok(true);
-                }
-            }
-            Ok(false)
-        }
-        (Geometry::Euclidean2D(a), Geometry::Euclidean2D(b)) => intersects_2d(a, b),
-        (Geometry::Euclidean2D(_), Geometry::Euclidean3D(_))
-        | (Geometry::Euclidean3D(_), Geometry::Euclidean2D(_)) => {
-            Err(PredicateError::CrossDimension)
-        }
-        (Geometry::Euclidean3D(a), Geometry::Euclidean3D(b)) => {
-            Err(PredicateError::UnsupportedPair {
-                left: type_name_3d(a),
-                right: type_name_3d(b),
-            })
-        }
-    }
+    let (a_leaves, b_leaves) = super::flatten_2d_pair(a, b)?;
+    let a = Operand2D::from_leaves(a_leaves);
+    let b = Operand2D::from_leaves(b_leaves);
+    require_common_frame(&a, &b)?;
+    Ok(intersects_operands(&a, &b))
 }
 
 /// `intersects` over two 2D geometries.
@@ -278,6 +253,7 @@ mod tests {
     use crate::line_string::{LineString2D, LineString3D};
     use crate::point::Point2D;
     use crate::polygon::Polygon2D;
+    use crate::predicates::PredicateError;
     use crate::{Euclidean2DGeometry, Euclidean3DGeometry, GeometryCollection};
     use pretty_assertions::assert_eq;
 
@@ -392,6 +368,42 @@ mod tests {
 
         let gc = Geometry::GeometryCollection(GeometryCollection::new([square.clone()]));
         assert_eq!(intersects(&gc, &c), Ok(true));
+    }
+
+    #[test]
+    fn collection_errors_do_not_depend_on_member_order() {
+        let square = unit_square_at(0.0, 0.0, 4.0);
+        let hit = unit_square_at(1.0, 1.0, 1.0);
+
+        // A 3D member errors even when an earlier member already intersects.
+        let line3d = Geometry::Euclidean3D(Euclidean3DGeometry::LineString(
+            LineString3D::from_coords(e(), [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]),
+        ));
+        for members in [[hit.clone(), line3d.clone()], [line3d.clone(), hit.clone()]] {
+            let gc = Geometry::GeometryCollection(GeometryCollection::new(members));
+            assert_eq!(
+                intersects(&gc, &square),
+                Err(PredicateError::CrossDimension)
+            );
+            assert_eq!(
+                intersects(&square, &gc),
+                Err(PredicateError::CrossDimension)
+            );
+        }
+
+        // Same for a member in a different frame.
+        let other_frame = g2(Euclidean2DGeometry::Point(Point2D::new(
+            CoordinateFrame::Crs(EpsgCode::new(4326)),
+            [1.5, 1.5],
+        )));
+        for members in [
+            [hit.clone(), other_frame.clone()],
+            [other_frame.clone(), hit.clone()],
+        ] {
+            let gc = Geometry::GeometryCollection(GeometryCollection::new(members));
+            assert_eq!(intersects(&gc, &square), Err(PredicateError::MixedFrames));
+            assert_eq!(intersects(&square, &gc), Err(PredicateError::MixedFrames));
+        }
     }
 
     #[test]

--- a/engine/runtime/geometry/src/predicates/intersects.rs
+++ b/engine/runtime/geometry/src/predicates/intersects.rs
@@ -1,0 +1,333 @@
+//! The `intersects` predicate: whether two geometries share at least one point.
+//!
+//! Boundary contact counts — a shared vertex, a T-junction, or a segment lying
+//! along a ring all intersect. Collections are point-set unions (any member
+//! pair intersecting suffices). Every leaf pair goes through a bounding-box
+//! quick reject first.
+//!
+//! Phase-2 scope: 2D × 2D pairs. A 2D × 3D pair is a
+//! [`CrossDimension`](PredicateError::CrossDimension) error, a 3D × 3D pair an
+//! [`UnsupportedPair`](PredicateError::UnsupportedPair) until the 3D phases
+//! land. `Geometry::None` intersects nothing.
+
+use super::kernel::segment_intersection;
+use super::kernel::CoordPos;
+use super::position::{face_position, line_position};
+use super::view::{require_common_frame, AreaView, Leaf2D, Operand2D, PreparedLeaf};
+use super::{PredicateError, Result};
+use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
+
+/// Whether `a` and `b` share at least one point.
+pub fn intersects(a: &Geometry, b: &Geometry) -> Result<bool> {
+    match (a, b) {
+        (Geometry::None, _) | (_, Geometry::None) => Ok(false),
+        (Geometry::GeometryCollection(c), other) => {
+            for member in c.members() {
+                if intersects(member, other)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        (other, Geometry::GeometryCollection(c)) => {
+            for member in c.members() {
+                if intersects(other, member)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        (Geometry::Euclidean2D(a), Geometry::Euclidean2D(b)) => intersects_2d(a, b),
+        (Geometry::Euclidean2D(_), Geometry::Euclidean3D(_))
+        | (Geometry::Euclidean3D(_), Geometry::Euclidean2D(_)) => {
+            Err(PredicateError::CrossDimension)
+        }
+        (Geometry::Euclidean3D(a), Geometry::Euclidean3D(b)) => {
+            Err(PredicateError::UnsupportedPair {
+                left: type_name_3d(a),
+                right: type_name_3d(b),
+            })
+        }
+    }
+}
+
+/// `intersects` over two 2D geometries.
+pub fn intersects_2d(a: &Euclidean2DGeometry, b: &Euclidean2DGeometry) -> Result<bool> {
+    let a = Operand2D::new(a);
+    let b = Operand2D::new(b);
+    require_common_frame(&a, &b)?;
+    for la in &a.leaves {
+        for lb in &b.leaves {
+            if leaf_intersects(la, lb) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+/// The concrete 3D leaf name, for `UnsupportedPair` diagnostics.
+pub(crate) fn type_name_3d(g: &Euclidean3DGeometry) -> &'static str {
+    match g {
+        Euclidean3DGeometry::Point(_) => "Point3D",
+        Euclidean3DGeometry::PointCloud(_) => "PointCloud",
+        Euclidean3DGeometry::LineString(_) => "LineString3D",
+        Euclidean3DGeometry::Polygon(_) => "Polygon3D",
+        Euclidean3DGeometry::PolygonMesh(_) => "PolygonMesh3D",
+        Euclidean3DGeometry::TriangularMesh(_) => "TriangularMesh3D",
+        Euclidean3DGeometry::Solid(_) => "Solid",
+        Euclidean3DGeometry::Csg(_) => "Csg",
+        Euclidean3DGeometry::Collection(_) => "Collection3D",
+    }
+}
+
+/// Whether two prepared leaves intersect, after a bounding-box quick reject.
+/// An empty leaf (no bounding box) intersects nothing.
+pub(crate) fn leaf_intersects(a: &PreparedLeaf<'_>, b: &PreparedLeaf<'_>) -> bool {
+    let (Some(box_a), Some(box_b)) = (&a.bbox, &b.bbox) else {
+        return false;
+    };
+    if !box_a.intersects(box_b) {
+        return false;
+    }
+    match (&a.leaf, &b.leaf) {
+        (Leaf2D::Point(pa), Leaf2D::Point(pb)) => pa.position() == pb.position(),
+        (Leaf2D::Point(p), Leaf2D::Line(l)) | (Leaf2D::Line(l), Leaf2D::Point(p)) => {
+            line_position(p.position(), l.coords()) != CoordPos::Outside
+        }
+        (Leaf2D::Point(p), _) => point_vs_area(p.position(), area(b)),
+        (_, Leaf2D::Point(p)) => point_vs_area(p.position(), area(a)),
+        (Leaf2D::Line(la), Leaf2D::Line(lb)) => line_vs_line(la.coords(), lb.coords()),
+        (Leaf2D::Line(l), _) => line_vs_area(l.coords(), area(b)),
+        (_, Leaf2D::Line(l)) => line_vs_area(l.coords(), area(a)),
+        (_, _) => area_vs_area(area(a), area(b)),
+    }
+}
+
+/// The areal view of a leaf known to be areal.
+fn area<'a, 'b>(leaf: &'b PreparedLeaf<'a>) -> &'b AreaView<'a> {
+    leaf.area.as_ref().expect("leaf is areal")
+}
+
+fn point_vs_area(coord: [f64; 2], area: &AreaView<'_>) -> bool {
+    area.faces()
+        .any(|f| face_position(coord, f) != CoordPos::Outside)
+}
+
+fn line_vs_line(a: &[[f64; 2]], b: &[[f64; 2]]) -> bool {
+    // A single-vertex chain is point-like.
+    if a.len() == 1 {
+        return line_position(a[0], b) != CoordPos::Outside;
+    }
+    if b.len() == 1 {
+        return line_position(b[0], a) != CoordPos::Outside;
+    }
+    a.windows(2).any(|sa| {
+        b.windows(2)
+            .any(|sb| segment_intersection(sa[0], sa[1], sb[0], sb[1]).is_some())
+    })
+}
+
+fn line_vs_area(coords: &[[f64; 2]], area: &AreaView<'_>) -> bool {
+    if coords.len() == 1 {
+        return point_vs_area(coords[0], area);
+    }
+    // Any chain segment meeting the boundary intersects. Otherwise the chain
+    // never touches the boundary, so it lies entirely in one region: one
+    // vertex decides.
+    if coords.windows(2).any(|s| {
+        area.edges()
+            .any(|(u, v)| segment_intersection(s[0], s[1], u, v).is_some())
+    }) {
+        return true;
+    }
+    coords.first().is_some_and(|&c| point_vs_area(c, area))
+}
+
+fn area_vs_area(a: &AreaView<'_>, b: &AreaView<'_>) -> bool {
+    // Any boundary contact intersects.
+    if a.edges().any(|(u, v)| {
+        b.edges()
+            .any(|(s, t)| segment_intersection(u, v, s, t).is_some())
+    }) {
+        return true;
+    }
+    // No contact: every ring lies entirely in one region of the other operand,
+    // so one vertex per ring decides full containment either way (a ring
+    // inside the other's hole classifies as outside).
+    let ring_inside = |x: &AreaView<'_>, y: &AreaView<'_>| {
+        x.faces().any(|f| {
+            f.rings().any(|r| {
+                !r.is_empty()
+                    && y.faces()
+                        .any(|g| face_position(r.coord(0), g) != CoordPos::Outside)
+            })
+        })
+    };
+    ring_inside(a, b) || ring_inside(b, a)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collection::Collection2D;
+    use crate::coordinate::{CoordinateFrame, EpsgCode};
+    use crate::line_string::{LineString2D, LineString3D};
+    use crate::point::Point2D;
+    use crate::polygon::Polygon2D;
+    use crate::{Euclidean2DGeometry, Euclidean3DGeometry, GeometryCollection};
+    use pretty_assertions::assert_eq;
+
+    fn e() -> CoordinateFrame {
+        CoordinateFrame::Euclidean
+    }
+
+    fn poly(ring: [[f64; 2]; 5]) -> Euclidean2DGeometry {
+        Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            e(),
+            ring,
+            Vec::<Vec<[f64; 2]>>::new(),
+        )))
+    }
+
+    fn unit_square_at(x: f64, y: f64, s: f64) -> Geometry {
+        g2(poly([
+            [x, y],
+            [x + s, y],
+            [x + s, y + s],
+            [x, y + s],
+            [x, y],
+        ]))
+    }
+
+    fn g2(g: Euclidean2DGeometry) -> Geometry {
+        Geometry::Euclidean2D(g)
+    }
+
+    #[test]
+    fn point_pairs() {
+        let p = |x, y| g2(Euclidean2DGeometry::Point(Point2D::new(e(), [x, y])));
+        assert_eq!(intersects(&p(1.0, 1.0), &p(1.0, 1.0)), Ok(true));
+        assert_eq!(intersects(&p(1.0, 1.0), &p(1.0, 2.0)), Ok(false));
+    }
+
+    #[test]
+    fn line_line_crossing_touching_disjoint() {
+        let l = |coords: Vec<[f64; 2]>| {
+            g2(Euclidean2DGeometry::LineString(LineString2D::from_coords(
+                e(),
+                coords,
+            )))
+        };
+        let cross_a = l(vec![[0.0, 0.0], [2.0, 2.0]]);
+        let cross_b = l(vec![[0.0, 2.0], [2.0, 0.0]]);
+        assert_eq!(intersects(&cross_a, &cross_b), Ok(true));
+        // T-junction (improper) also intersects.
+        let touch = l(vec![[1.0, 1.0], [1.0, 5.0]]);
+        assert_eq!(intersects(&cross_a, &touch), Ok(true));
+        let disjoint = l(vec![[5.0, 5.0], [6.0, 5.0]]);
+        assert_eq!(intersects(&cross_a, &disjoint), Ok(false));
+    }
+
+    #[test]
+    fn polygon_pairs_cover_touch_contain_hole() {
+        let big = unit_square_at(0.0, 0.0, 8.0);
+        let inside = unit_square_at(1.0, 1.0, 2.0);
+        let overlapping = unit_square_at(6.0, 6.0, 4.0);
+        let touching = unit_square_at(8.0, 0.0, 2.0);
+        let disjoint = unit_square_at(20.0, 0.0, 1.0);
+        assert_eq!(intersects(&big, &inside), Ok(true)); // containment, no crossing
+        assert_eq!(intersects(&inside, &big), Ok(true));
+        assert_eq!(intersects(&big, &overlapping), Ok(true));
+        assert_eq!(intersects(&big, &touching), Ok(true)); // shared edge only
+        assert_eq!(intersects(&big, &disjoint), Ok(false));
+
+        // A polygon sitting entirely in the other's hole does not intersect.
+        let outer = [[0.0, 0.0], [8.0, 0.0], [8.0, 8.0], [0.0, 8.0], [0.0, 0.0]];
+        let hole = vec![[2.0, 2.0], [2.0, 6.0], [6.0, 6.0], [6.0, 2.0], [2.0, 2.0]];
+        let with_hole = g2(Euclidean2DGeometry::Polygon(Box::new(
+            Polygon2D::from_rings(e(), outer, vec![hole]),
+        )));
+        let in_hole = unit_square_at(3.0, 3.0, 2.0);
+        assert_eq!(intersects(&with_hole, &in_hole), Ok(false));
+        // But one crossing the hole ring does.
+        let across = unit_square_at(1.0, 3.0, 2.0);
+        assert_eq!(intersects(&with_hole, &across), Ok(true));
+    }
+
+    #[test]
+    fn line_polygon_inside_crossing_disjoint() {
+        let square = unit_square_at(0.0, 0.0, 4.0);
+        let l = |coords: Vec<[f64; 2]>| {
+            g2(Euclidean2DGeometry::LineString(LineString2D::from_coords(
+                e(),
+                coords,
+            )))
+        };
+        assert_eq!(
+            intersects(&square, &l(vec![[1.0, 1.0], [2.0, 2.0]])),
+            Ok(true)
+        );
+        assert_eq!(
+            intersects(&square, &l(vec![[-1.0, 2.0], [5.0, 2.0]])),
+            Ok(true)
+        );
+        assert_eq!(
+            intersects(&square, &l(vec![[5.0, 5.0], [6.0, 6.0]])),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn collections_intersect_through_any_member() {
+        let c = g2(Euclidean2DGeometry::Collection(Collection2D::new([
+            Euclidean2DGeometry::Point(Point2D::new(e(), [10.0, 10.0])),
+            Euclidean2DGeometry::Point(Point2D::new(e(), [1.0, 1.0])),
+        ])));
+        let square = unit_square_at(0.0, 0.0, 2.0);
+        assert_eq!(intersects(&c, &square), Ok(true));
+
+        let gc = Geometry::GeometryCollection(GeometryCollection::new([square.clone()]));
+        assert_eq!(intersects(&gc, &c), Ok(true));
+    }
+
+    #[test]
+    fn none_intersects_nothing() {
+        let square = unit_square_at(0.0, 0.0, 2.0);
+        assert_eq!(intersects(&Geometry::None, &square), Ok(false));
+        assert_eq!(intersects(&Geometry::None, &Geometry::None), Ok(false));
+    }
+
+    #[test]
+    fn mixed_frames_error() {
+        let a = g2(Euclidean2DGeometry::Point(Point2D::new(
+            CoordinateFrame::Crs(EpsgCode::new(4326)),
+            [0.0, 0.0],
+        )));
+        let b = g2(Euclidean2DGeometry::Point(Point2D::new(e(), [0.0, 0.0])));
+        assert_eq!(intersects(&a, &b), Err(PredicateError::MixedFrames));
+    }
+
+    #[test]
+    fn cross_dimension_and_3d_errors() {
+        let a = unit_square_at(0.0, 0.0, 1.0);
+        let b3 = Geometry::Euclidean3D(Euclidean3DGeometry::LineString(LineString3D::from_coords(
+            e(),
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+        )));
+        assert_eq!(intersects(&a, &b3), Err(PredicateError::CrossDimension));
+        assert!(matches!(
+            intersects(&b3, &b3),
+            Err(PredicateError::UnsupportedPair { .. })
+        ));
+    }
+
+    #[test]
+    fn bbox_reject_short_circuits() {
+        // Far-apart geometries with expensive shapes still answer quickly and
+        // correctly through the box reject.
+        let a = unit_square_at(0.0, 0.0, 1.0);
+        let b = unit_square_at(1000.0, 1000.0, 1.0);
+        assert_eq!(intersects(&a, &b), Ok(false));
+    }
+}

--- a/engine/runtime/geometry/src/predicates/intersects.rs
+++ b/engine/runtime/geometry/src/predicates/intersects.rs
@@ -1,14 +1,14 @@
 //! The `intersects` predicate: whether two geometries share at least one point.
 //!
-//! Boundary contact counts — a shared vertex, a T-junction, or a segment lying
+//! Boundary contact counts: a shared vertex, a T-junction, or a segment lying
 //! along a ring all intersect. Collections are point-set unions (any member
 //! pair intersecting suffices). Every leaf pair goes through a bounding-box
 //! quick reject first.
 //!
-//! Phase-2 scope: 2D × 2D pairs. A 2D × 3D pair is a
+//! Scope: 2D × 2D pairs. A 2D × 3D pair is a
 //! [`CrossDimension`](PredicateError::CrossDimension) error, a 3D × 3D pair an
-//! [`UnsupportedPair`](PredicateError::UnsupportedPair) until the 3D phases
-//! land. `Geometry::None` intersects nothing.
+//! [`UnsupportedPair`](PredicateError::UnsupportedPair). `Geometry::None`
+//! intersects nothing.
 
 use super::kernel::segment_intersection;
 use super::kernel::CoordPos;

--- a/engine/runtime/geometry/src/predicates/intersects.rs
+++ b/engine/runtime/geometry/src/predicates/intersects.rs
@@ -10,6 +10,7 @@
 //! [`UnsupportedPair`](PredicateError::UnsupportedPair). `Geometry::None`
 //! intersects nothing.
 
+use super::edge_set::{operand_edges, operand_segment_count, should_index, EdgeSet};
 use super::kernel::segment_intersection;
 use super::kernel::CoordPos;
 use super::position::{face_position, line_position};
@@ -56,14 +57,68 @@ pub fn intersects_2d(a: &Euclidean2DGeometry, b: &Euclidean2DGeometry) -> Result
     let a = Operand2D::new(a);
     let b = Operand2D::new(b);
     require_common_frame(&a, &b)?;
+    Ok(intersects_operands(&a, &b))
+}
+
+/// `intersects` over prepared operands, dispatching on input size: a direct
+/// leaf-pair scan for small inputs, an rstar-indexed crossing sweep above
+/// [`DIRECT_WORK_LIMIT`](super::edge_set::DIRECT_WORK_LIMIT) kernel calls.
+fn intersects_operands(a: &Operand2D<'_>, b: &Operand2D<'_>) -> bool {
+    let (na, nb) = (operand_segment_count(a), operand_segment_count(b));
+    if should_index(na, nb) {
+        intersects_indexed(a, b, na <= nb)
+    } else {
+        intersects_direct(a, b)
+    }
+}
+
+/// The direct strategy: every leaf pair through [`leaf_intersects`].
+fn intersects_direct(a: &Operand2D<'_>, b: &Operand2D<'_>) -> bool {
     for la in &a.leaves {
         for lb in &b.leaves {
             if leaf_intersects(la, lb) {
-                return Ok(true);
+                return true;
             }
         }
     }
-    Ok(false)
+    false
+}
+
+/// The indexed strategy: one global early-exit crossing sweep of one operand's
+/// segments against an rstar index over the other's, then the point and
+/// containment cases no segment crossing can witness. `index_b` picks which
+/// operand is indexed (the one with more segments).
+fn intersects_indexed(a: &Operand2D<'_>, b: &Operand2D<'_>, index_b: bool) -> bool {
+    let (probe, indexed) = if index_b { (a, b) } else { (b, a) };
+    let set = EdgeSet::with_strategy(operand_edges(indexed), true);
+    for prepared in &probe.leaves {
+        let crossing = |u: [f64; 2], v: [f64; 2]| {
+            set.probe(u, v, |s, t| segment_intersection(u, v, s, t).is_some())
+        };
+        let hit = match prepared.leaf {
+            Leaf2D::Point(_) => false,
+            Leaf2D::Line(l) => l.coords().windows(2).any(|s| crossing(s[0], s[1])),
+            _ => prepared
+                .area
+                .as_ref()
+                .expect("leaf is areal")
+                .edges()
+                .any(|(u, v)| crossing(u, v)),
+        };
+        if hit {
+            return true;
+        }
+    }
+    // No segment of one operand touches any segment of the other: only
+    // point contact and strict containment remain, decided per leaf pair.
+    for la in &a.leaves {
+        for lb in &b.leaves {
+            if residual_leaf_intersects(la, lb) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// The concrete 3D leaf name, for `UnsupportedPair` diagnostics.
@@ -101,6 +156,49 @@ pub(crate) fn leaf_intersects(a: &PreparedLeaf<'_>, b: &PreparedLeaf<'_>) -> boo
         (Leaf2D::Line(l), _) => line_vs_area(l.coords(), area(b)),
         (_, Leaf2D::Line(l)) => line_vs_area(l.coords(), area(a)),
         (_, _) => area_vs_area(area(a), area(b)),
+    }
+}
+
+/// Whether two prepared leaves intersect, given that no segment of one crosses
+/// any segment of the other (established by the indexed sweep): only point
+/// contact and strict containment can still hold.
+fn residual_leaf_intersects(a: &PreparedLeaf<'_>, b: &PreparedLeaf<'_>) -> bool {
+    let (Some(box_a), Some(box_b)) = (&a.bbox, &b.bbox) else {
+        return false;
+    };
+    if !box_a.intersects(box_b) {
+        return false;
+    }
+    match (&a.leaf, &b.leaf) {
+        (Leaf2D::Point(pa), Leaf2D::Point(pb)) => pa.position() == pb.position(),
+        (Leaf2D::Point(p), Leaf2D::Line(l)) | (Leaf2D::Line(l), Leaf2D::Point(p)) => {
+            line_position(p.position(), l.coords()) != CoordPos::Outside
+        }
+        (Leaf2D::Point(p), _) => point_vs_area(p.position(), area(b)),
+        (_, Leaf2D::Point(p)) => point_vs_area(p.position(), area(a)),
+        (Leaf2D::Line(la), Leaf2D::Line(lb)) => {
+            // Chains with segments were fully swept; only a point-like
+            // single-vertex chain can still touch.
+            if la.coords().len() == 1 {
+                line_position(la.coords()[0], lb.coords()) != CoordPos::Outside
+            } else if lb.coords().len() == 1 {
+                line_position(lb.coords()[0], la.coords()) != CoordPos::Outside
+            } else {
+                false
+            }
+        }
+        (Leaf2D::Line(l), _) => {
+            // No boundary contact: the chain lies in one region; one vertex
+            // decides.
+            l.coords()
+                .first()
+                .is_some_and(|&c| point_vs_area(c, area(b)))
+        }
+        (_, Leaf2D::Line(l)) => l
+            .coords()
+            .first()
+            .is_some_and(|&c| point_vs_area(c, area(a))),
+        (_, _) => areas_nested(area(a), area(b)),
     }
 }
 
@@ -152,9 +250,14 @@ fn area_vs_area(a: &AreaView<'_>, b: &AreaView<'_>) -> bool {
     }) {
         return true;
     }
-    // No contact: every ring lies entirely in one region of the other operand,
-    // so one vertex per ring decides full containment either way (a ring
-    // inside the other's hole classifies as outside).
+    areas_nested(a, b)
+}
+
+/// Whether one boundary-disjoint areal view lies inside the other. With no
+/// boundary contact every ring lies entirely in one region of the other
+/// operand, so one vertex per ring decides full containment either way (a
+/// ring inside the other's hole classifies as outside).
+fn areas_nested(a: &AreaView<'_>, b: &AreaView<'_>) -> bool {
     let ring_inside = |x: &AreaView<'_>, y: &AreaView<'_>| {
         x.faces().any(|f| {
             f.rings().any(|r| {
@@ -329,5 +432,180 @@ mod tests {
         let a = unit_square_at(0.0, 0.0, 1.0);
         let b = unit_square_at(1000.0, 1000.0, 1.0);
         assert_eq!(intersects(&a, &b), Ok(false));
+    }
+
+    // --- direct / indexed strategy parity ------------------------------------
+
+    /// Deterministic splitmix-style generator.
+    struct Rng(u64);
+
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+            z ^ (z >> 31)
+        }
+
+        fn range(&mut self, n: u64) -> u64 {
+            self.next() % n
+        }
+
+        fn coord(&mut self) -> [f64; 2] {
+            [self.range(9) as f64, self.range(9) as f64]
+        }
+    }
+
+    /// One random 2D geometry on a small integer grid, so touching, collinear,
+    /// and degenerate configurations occur often.
+    fn rng_geometry(rng: &mut Rng) -> Euclidean2DGeometry {
+        let rect = |x0: f64, y0: f64, w: f64, h: f64| {
+            [
+                [x0, y0],
+                [x0 + w, y0],
+                [x0 + w, y0 + h],
+                [x0, y0 + h],
+                [x0, y0],
+            ]
+        };
+        match rng.range(9) {
+            0 => Euclidean2DGeometry::Point(Point2D::new(e(), rng.coord())),
+            // Single-vertex chain: point-like, no segments.
+            1 => Euclidean2DGeometry::LineString(LineString2D::from_coords(e(), [rng.coord()])),
+            2 => Euclidean2DGeometry::LineString(LineString2D::from_coords(
+                e(),
+                [rng.coord(), rng.coord()],
+            )),
+            3 => Euclidean2DGeometry::LineString(LineString2D::from_coords(
+                e(),
+                [rng.coord(), rng.coord(), rng.coord(), rng.coord()],
+            )),
+            4 => {
+                // Closed chain.
+                let (a, b, c) = (rng.coord(), rng.coord(), rng.coord());
+                Euclidean2DGeometry::LineString(LineString2D::from_coords(e(), [a, b, c, a]))
+            }
+            5 => {
+                let (x0, y0) = (rng.range(6) as f64, rng.range(6) as f64);
+                let (w, h) = (1 + rng.range(3), 1 + rng.range(3));
+                poly(rect(x0, y0, w as f64, h as f64))
+            }
+            6 => {
+                // Rect with a hole strictly inside.
+                let (x0, y0) = (rng.range(4) as f64, rng.range(4) as f64);
+                let (w, h) = (3 + rng.range(2), 3 + rng.range(2));
+                let outer = rect(x0, y0, w as f64, h as f64);
+                let hole = vec![
+                    [x0 + 1.0, y0 + 1.0],
+                    [x0 + 1.0, y0 + h as f64 - 1.0],
+                    [x0 + w as f64 - 1.0, y0 + h as f64 - 1.0],
+                    [x0 + w as f64 - 1.0, y0 + 1.0],
+                    [x0 + 1.0, y0 + 1.0],
+                ];
+                Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+                    e(),
+                    outer,
+                    vec![hole],
+                )))
+            }
+            7 => {
+                // Two quads sharing an edge, as a mesh.
+                let (x0, y0) = (rng.range(5) as f64, rng.range(5) as f64);
+                let mesh = crate::polygon_mesh::PolygonMesh2D::from_parts(
+                    e(),
+                    vec![
+                        [x0, y0],
+                        [x0 + 2.0, y0],
+                        [x0 + 2.0, y0 + 2.0],
+                        [x0, y0 + 2.0],
+                        [x0 + 4.0, y0],
+                        [x0 + 4.0, y0 + 2.0],
+                    ],
+                    vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+                )
+                .unwrap();
+                Euclidean2DGeometry::PolygonMesh(Box::new(mesh))
+            }
+            _ => {
+                // Collection of two rects (possibly overlapping or touching).
+                let member = |rng: &mut Rng| {
+                    let (x0, y0) = (rng.range(6) as f64, rng.range(6) as f64);
+                    poly(rect(
+                        x0,
+                        y0,
+                        (1 + rng.range(3)) as f64,
+                        (1 + rng.range(3)) as f64,
+                    ))
+                };
+                Euclidean2DGeometry::Collection(Collection2D::new([member(rng), member(rng)]))
+            }
+        }
+    }
+
+    #[test]
+    fn direct_and_indexed_strategies_agree() {
+        let mut rng = Rng(20260716);
+        for case in 0..400 {
+            let ga = rng_geometry(&mut rng);
+            let gb = rng_geometry(&mut rng);
+            let a = Operand2D::new(&ga);
+            let b = Operand2D::new(&gb);
+            let direct = intersects_direct(&a, &b);
+            assert_eq!(
+                direct,
+                intersects_indexed(&a, &b, true),
+                "case {case}: indexed(b) diverges for {ga:?} / {gb:?}"
+            );
+            assert_eq!(
+                direct,
+                intersects_indexed(&a, &b, false),
+                "case {case}: indexed(a) diverges for {ga:?} / {gb:?}"
+            );
+            assert_eq!(
+                Ok(direct),
+                intersects_2d(&ga, &gb),
+                "case {case}: public path diverges for {ga:?} / {gb:?}"
+            );
+        }
+    }
+
+    /// A closed regular `n`-gon ring around `(cx, cy)`.
+    fn ngon_ring(cx: f64, cy: f64, r: f64, n: usize) -> Vec<[f64; 2]> {
+        (0..=n)
+            .map(|i| {
+                let t = core::f64::consts::TAU * (i % n) as f64 / n as f64;
+                [cx + r * t.cos(), cy + r * t.sin()]
+            })
+            .collect()
+    }
+
+    #[test]
+    fn auto_indexed_large_inputs_answer_correctly() {
+        // 100-gon pairs: the segment-count product crosses the index gate.
+        let ngon = |cx: f64, cy: f64, r: f64| {
+            g2(Euclidean2DGeometry::Polygon(Box::new(
+                Polygon2D::from_rings(e(), ngon_ring(cx, cy, r, 100), Vec::<Vec<[f64; 2]>>::new()),
+            )))
+        };
+        // Strict containment: no boundary crossing, decided by the residual.
+        assert_eq!(
+            intersects(&ngon(0.0, 0.0, 10.0), &ngon(0.0, 0.0, 5.0)),
+            Ok(true)
+        );
+        assert_eq!(
+            intersects(&ngon(0.0, 0.0, 5.0), &ngon(0.0, 0.0, 10.0)),
+            Ok(true)
+        );
+        // Overlapping boundaries: found by the indexed sweep.
+        assert_eq!(
+            intersects(&ngon(0.0, 0.0, 10.0), &ngon(12.0, 0.0, 5.0)),
+            Ok(true)
+        );
+        // Disjoint.
+        assert_eq!(
+            intersects(&ngon(0.0, 0.0, 10.0), &ngon(40.0, 0.0, 5.0)),
+            Ok(false)
+        );
     }
 }

--- a/engine/runtime/geometry/src/predicates/kernel.rs
+++ b/engine/runtime/geometry/src/predicates/kernel.rs
@@ -106,6 +106,21 @@ pub enum SegmentIntersection {
     },
 }
 
+impl SegmentIntersection {
+    /// Whether this is a proper crossing: a single point interior to both
+    /// segments. Collinear overlaps are never proper.
+    #[inline]
+    pub fn is_proper(&self) -> bool {
+        matches!(
+            self,
+            SegmentIntersection::SinglePoint {
+                is_proper: true,
+                ..
+            }
+        )
+    }
+}
+
 /// Robust 2D segment × segment intersection.
 ///
 /// A direct port of the legacy `line_intersection` (a JTS `RobustLineIntersector`
@@ -387,7 +402,7 @@ pub enum CoordPos {
 /// the legacy `coord_pos_relative_to_ring`.
 ///
 /// `ring` is a closed ring (first vertex == last), the storage convention of the
-/// new [`Polygon`](crate::polygon) leaves. The `z` of any 2.5D ring is ignored:
+/// new [`Polygon`](mod@crate::polygon) leaves. The `z` of any 2.5D ring is ignored:
 /// the test is the XY-projection algorithm, matching legacy 2D semantics.
 pub fn coord_pos_relative_to_ring(coord: [f64; 2], ring: &[[f64; 2]]) -> CoordPos {
     if ring.is_empty() {

--- a/engine/runtime/geometry/src/predicates/kernel.rs
+++ b/engine/runtime/geometry/src/predicates/kernel.rs
@@ -400,16 +400,25 @@ pub fn coord_pos_relative_to_ring(coord: [f64; 2], ring: &[[f64; 2]]) -> CoordPo
             CoordPos::Outside
         };
     }
+    coord_pos_relative_to_edges(coord, ring.windows(2).map(|e| (e[0], e[1])))
+}
 
+/// Point-in-ring by winding number over a directed edge iterator — the same
+/// algorithm as [`coord_pos_relative_to_ring`] but over any edge source, so
+/// indexed mesh rings feed it without a contiguous copy. The edges must form
+/// one or more closed loops; a zero-length edge contributes nothing (unless the
+/// coordinate sits on it, which is on-boundary).
+pub fn coord_pos_relative_to_edges(
+    coord: [f64; 2],
+    edges: impl Iterator<Item = ([f64; 2], [f64; 2])>,
+) -> CoordPos {
     // Winding number with the standard edge-crossing rules:
     //   1. an upward edge includes its start, excludes its end;
     //   2. a downward edge excludes its start, includes its end;
     //   3. horizontal edges are ignored;
     //   4. the crossing must be strictly right of `coord`.
     let mut winding_number: i32 = 0;
-    for edge in ring.windows(2) {
-        let start = edge[0];
-        let end = edge[1];
+    for (start, end) in edges {
         if start[1] <= coord[1] {
             if end[1] >= coord[1] {
                 let o = orient2d(start, end, coord);
@@ -436,6 +445,32 @@ pub fn coord_pos_relative_to_ring(coord: [f64; 2], ring: &[[f64; 2]]) -> CoordPo
     } else {
         CoordPos::Inside
     }
+}
+
+/// Whether `p` lies on the closed segment `[a, b]`: robustly collinear and
+/// within the segment's bounding box.
+#[inline]
+pub fn point_on_segment(p: [f64; 2], a: [f64; 2], b: [f64; 2]) -> bool {
+    orient2d(a, b, p) == Orientation::Collinear && point_in_bbox(p, a, b)
+}
+
+/// Whether the rays `origin -> u` and `origin -> w` point in the same direction:
+/// robustly collinear with matching per-axis difference signs. The sign of an
+/// IEEE subtraction is exact, so this is exact for distinct endpoints.
+#[inline]
+pub fn same_direction(origin: [f64; 2], u: [f64; 2], w: [f64; 2]) -> bool {
+    fn sign(v: f64) -> i8 {
+        if v > 0.0 {
+            1
+        } else if v < 0.0 {
+            -1
+        } else {
+            0
+        }
+    }
+    orient2d(origin, u, w) == Orientation::Collinear
+        && sign(u[0] - origin[0]) == sign(w[0] - origin[0])
+        && sign(u[1] - origin[1]) == sign(w[1] - origin[1])
 }
 
 // --- small numeric helpers (ports of legacy `intersects`/`utils`) -----------

--- a/engine/runtime/geometry/src/predicates/kernel.rs
+++ b/engine/runtime/geometry/src/predicates/kernel.rs
@@ -1,20 +1,18 @@
-//! Robust geometric kernel for the new geometry predicates.
+//! Robust geometric kernel for the geometry predicates.
 //!
-//! Pure-Rust ports of the load-bearing legacy primitives, re-hosted over the new
-//! flat `[f64; 2]` / `[f64; 3]` coordinate layout instead of the generic
-//! `Coordinate<T, Z>`:
+//! The load-bearing primitives over the flat `[f64; 2]` / `[f64; 3]` coordinate
+//! layout:
 //!
-//! - [`orient2d`] / [`orient3d`] — robust orientation signs (wrapping the
+//! - [`orient2d`] / [`orient3d`]: robust orientation signs (wrapping the
 //!   `robust` crate's adaptive-precision predicates).
-//! - [`segment_intersection`] — robust 2D segment × segment intersection,
-//!   preserving the JTS central-endpoint conditioning of the legacy
-//!   `line_intersection`.
-//! - [`segment_intersection_3d`] — 3D segment × segment (coplanar) intersection.
-//! - [`coord_pos_relative_to_ring`] — winding-number point-in-ring with an
+//! - [`segment_intersection`]: robust 2D segment × segment intersection, using
+//!   the JTS central-endpoint conditioning.
+//! - [`segment_intersection_3d`]: 3D segment × segment (coplanar) intersection.
+//! - [`coord_pos_relative_to_ring`]: winding-number point-in-ring with an
 //!   on-boundary short-circuit.
 //!
 //! All sign decisions go through the robust predicates; only *constructed* points
-//! (the intersection coordinates) are f64-rounded, matching legacy behavior.
+//! (the intersection coordinates) are f64-rounded.
 
 use robust::{orient2d as robust_orient2d, orient3d as robust_orient3d, Coord, Coord3D};
 
@@ -31,8 +29,8 @@ pub enum Orientation {
 }
 
 impl Orientation {
-    /// Map the robust predicate's signed value to an [`Orientation`], using the
-    /// same sign convention as the legacy kernel: positive is counter-clockwise.
+    /// Map the robust predicate's signed value to an [`Orientation`]: positive
+    /// is counter-clockwise.
     #[inline]
     fn from_sign(value: f64) -> Orientation {
         if value < 0.0 {
@@ -121,11 +119,11 @@ impl SegmentIntersection {
     }
 }
 
-/// Robust 2D segment × segment intersection.
+/// Robust 2D segment × segment intersection (the JTS `RobustLineIntersector`
+/// algorithm).
 ///
-/// A direct port of the legacy `line_intersection` (a JTS `RobustLineIntersector`
-/// port): robust orientation short-circuits, exact endpoint copying when the
-/// crossing is at an endpoint (for coordinate exactness), and central-endpoint
+/// Robust orientation short-circuits, exact endpoint copying when the crossing
+/// is at an endpoint (for coordinate exactness), and central-endpoint
 /// conditioning for the proper-crossing coordinate. Returns `None` when the
 /// segments are disjoint.
 pub fn segment_intersection(
@@ -208,7 +206,7 @@ pub fn segment_intersection(
     }
 }
 
-/// Overlap of two collinear segments; a port of the legacy `collinear_intersection`.
+/// Overlap of two collinear segments.
 fn collinear_intersection(
     p_start: [f64; 2],
     p_end: [f64; 2],
@@ -243,7 +241,7 @@ fn collinear_intersection(
 }
 
 /// The homogeneous-coordinate segment crossing with central-endpoint
-/// conditioning; a port of the legacy `raw_line_intersection` (2D projection).
+/// conditioning (2D projection).
 fn raw_line_intersection(
     p_start: [f64; 2],
     p_end: [f64; 2],
@@ -301,8 +299,8 @@ fn raw_line_intersection(
     }
 }
 
-/// The endpoint of either segment nearest to the other segment; the legacy
-/// `nearest_endpoint` fallback for the central-endpoint heuristic.
+/// The endpoint of either segment nearest to the other segment; the fallback
+/// for the central-endpoint heuristic.
 fn nearest_endpoint(
     p_start: [f64; 2],
     p_end: [f64; 2],
@@ -330,8 +328,7 @@ fn nearest_endpoint(
 }
 
 /// The proper (interior) crossing point, falling back to the nearest endpoint
-/// when the raw computation lands outside both segments' boxes; a port of the
-/// legacy `proper_intersection`.
+/// when the raw computation lands outside both segments' boxes.
 fn proper_intersection(
     p_start: [f64; 2],
     p_end: [f64; 2],
@@ -346,10 +343,9 @@ fn proper_intersection(
     pt
 }
 
-/// 3D segment × segment intersection, for coplanar, non-parallel segments; a
-/// port of the legacy `line_intersection3d`. Returns the crossing point when it
-/// lies within both segments, `None` for skew, parallel, or non-overlapping
-/// segments.
+/// 3D segment × segment intersection, for coplanar, non-parallel segments.
+/// Returns the crossing point when it lies within both segments, `None` for
+/// skew, parallel, or non-overlapping segments.
 pub fn segment_intersection_3d(
     p_start: [f64; 3],
     p_end: [f64; 3],
@@ -398,12 +394,11 @@ pub enum CoordPos {
     Outside,
 }
 
-/// Point-in-ring by winding number, with an on-boundary short-circuit; a port of
-/// the legacy `coord_pos_relative_to_ring`.
+/// Point-in-ring by winding number, with an on-boundary short-circuit.
 ///
 /// `ring` is a closed ring (first vertex == last), the storage convention of the
-/// new [`Polygon`](mod@crate::polygon) leaves. The `z` of any 2.5D ring is ignored:
-/// the test is the XY-projection algorithm, matching legacy 2D semantics.
+/// [`Polygon`](mod@crate::polygon) leaves. The `z` of any 2.5D ring is ignored:
+/// the test is the XY-projection algorithm.
 pub fn coord_pos_relative_to_ring(coord: [f64; 2], ring: &[[f64; 2]]) -> CoordPos {
     if ring.is_empty() {
         return CoordPos::Outside;
@@ -418,7 +413,7 @@ pub fn coord_pos_relative_to_ring(coord: [f64; 2], ring: &[[f64; 2]]) -> CoordPo
     coord_pos_relative_to_edges(coord, ring.windows(2).map(|e| (e[0], e[1])))
 }
 
-/// Point-in-ring by winding number over a directed edge iterator — the same
+/// Point-in-ring by winding number over a directed edge iterator: the same
 /// algorithm as [`coord_pos_relative_to_ring`] but over any edge source, so
 /// indexed mesh rings feed it without a contiguous copy. The edges must form
 /// one or more closed loops; a zero-length edge contributes nothing (unless the
@@ -488,7 +483,7 @@ pub fn same_direction(origin: [f64; 2], u: [f64; 2], w: [f64; 2]) -> bool {
         && sign(u[1] - origin[1]) == sign(w[1] - origin[1])
 }
 
-// --- small numeric helpers (ports of legacy `intersects`/`utils`) -----------
+// --- small numeric helpers ---------------------------------------------------
 
 /// Whether `value` lies within `[min(a, b), max(a, b)]` (inclusive).
 #[inline]
@@ -524,8 +519,7 @@ fn segments_bbox_overlap(
     p_min_x <= q_max_x && q_min_x <= p_max_x && p_min_y <= q_max_y && q_min_y <= p_max_y
 }
 
-/// Euclidean distance from a 2D point to a segment; a port of the legacy
-/// `line_segment_distance`.
+/// Euclidean distance from a 2D point to a segment.
 fn point_segment_distance(point: [f64; 2], start: [f64; 2], end: [f64; 2]) -> f64 {
     if start == end {
         return (point[0] - start[0]).hypot(point[1] - start[1]);
@@ -648,9 +642,8 @@ mod tests {
         }
     }
 
-    // JTS/GEOS central-endpoint heuristic cases carried over from the legacy
-    // `line_intersection` test suite (the intersection coordinate must match
-    // exactly to preserve robustness parity).
+    // JTS/GEOS central-endpoint heuristic cases (the intersection coordinate
+    // must match exactly to preserve robustness).
     #[test]
     fn jts_central_endpoint_heuristic_failure_1() {
         let x = segment_intersection(

--- a/engine/runtime/geometry/src/predicates/kernel.rs
+++ b/engine/runtime/geometry/src/predicates/kernel.rs
@@ -1,0 +1,728 @@
+//! Robust geometric kernel for the new geometry predicates.
+//!
+//! Pure-Rust ports of the load-bearing legacy primitives, re-hosted over the new
+//! flat `[f64; 2]` / `[f64; 3]` coordinate layout instead of the generic
+//! `Coordinate<T, Z>`:
+//!
+//! - [`orient2d`] / [`orient3d`] — robust orientation signs (wrapping the
+//!   `robust` crate's adaptive-precision predicates).
+//! - [`segment_intersection`] — robust 2D segment × segment intersection,
+//!   preserving the JTS central-endpoint conditioning of the legacy
+//!   `line_intersection`.
+//! - [`segment_intersection_3d`] — 3D segment × segment (coplanar) intersection.
+//! - [`coord_pos_relative_to_ring`] — winding-number point-in-ring with an
+//!   on-boundary short-circuit.
+//!
+//! All sign decisions go through the robust predicates; only *constructed* points
+//! (the intersection coordinates) are f64-rounded, matching legacy behavior.
+
+use robust::{orient2d as robust_orient2d, orient3d as robust_orient3d, Coord, Coord3D};
+
+/// The orientation of an ordered point triple, from the robust sign of the
+/// signed area (2D) or signed volume (3D).
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum Orientation {
+    /// Positive orientation (left turn / above the plane).
+    CounterClockwise,
+    /// Negative orientation (right turn / below the plane).
+    Clockwise,
+    /// Zero orientation: collinear (2D) or coplanar (3D).
+    Collinear,
+}
+
+impl Orientation {
+    /// Map the robust predicate's signed value to an [`Orientation`], using the
+    /// same sign convention as the legacy kernel: positive is counter-clockwise.
+    #[inline]
+    fn from_sign(value: f64) -> Orientation {
+        if value < 0.0 {
+            Orientation::Clockwise
+        } else if value > 0.0 {
+            Orientation::CounterClockwise
+        } else {
+            Orientation::Collinear
+        }
+    }
+}
+
+/// Robust orientation of the 2D triple `(p, q, r)`: counter-clockwise if `r` is
+/// left of the directed line `p -> q`, clockwise if right, collinear if on it.
+#[inline]
+pub fn orient2d(p: [f64; 2], q: [f64; 2], r: [f64; 2]) -> Orientation {
+    Orientation::from_sign(robust_orient2d(
+        Coord { x: p[0], y: p[1] },
+        Coord { x: q[0], y: q[1] },
+        Coord { x: r[0], y: r[1] },
+    ))
+}
+
+/// Robust orientation of the 3D quadruple `(p, q, r, s)`: the sign of the signed
+/// volume of the tetrahedron, i.e. which side of the plane through `p, q, r` the
+/// point `s` lies on. Collinear here means `s` is coplanar with `p, q, r`.
+#[inline]
+pub fn orient3d(p: [f64; 3], q: [f64; 3], r: [f64; 3], s: [f64; 3]) -> Orientation {
+    Orientation::from_sign(robust_orient3d(
+        Coord3D {
+            x: p[0],
+            y: p[1],
+            z: p[2],
+        },
+        Coord3D {
+            x: q[0],
+            y: q[1],
+            z: q[2],
+        },
+        Coord3D {
+            x: r[0],
+            y: r[1],
+            z: r[2],
+        },
+        Coord3D {
+            x: s[0],
+            y: s[1],
+            z: s[2],
+        },
+    ))
+}
+
+/// The intersection of two 2D segments.
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub enum SegmentIntersection {
+    /// The segments meet at a single point. `is_proper` is true when the
+    /// crossing is in the interior of both segments (not at a shared endpoint or
+    /// a T-junction).
+    SinglePoint {
+        /// The intersection point.
+        intersection: [f64; 2],
+        /// Whether the crossing is proper (interior to both segments).
+        is_proper: bool,
+    },
+    /// The segments overlap along a collinear sub-segment `[start, end]`.
+    Collinear {
+        /// One end of the overlap.
+        start: [f64; 2],
+        /// The other end of the overlap.
+        end: [f64; 2],
+    },
+}
+
+/// Robust 2D segment × segment intersection.
+///
+/// A direct port of the legacy `line_intersection` (a JTS `RobustLineIntersector`
+/// port): robust orientation short-circuits, exact endpoint copying when the
+/// crossing is at an endpoint (for coordinate exactness), and central-endpoint
+/// conditioning for the proper-crossing coordinate. Returns `None` when the
+/// segments are disjoint.
+pub fn segment_intersection(
+    p_start: [f64; 2],
+    p_end: [f64; 2],
+    q_start: [f64; 2],
+    q_end: [f64; 2],
+) -> Option<SegmentIntersection> {
+    // Bounding-box quick reject.
+    if !segments_bbox_overlap(p_start, p_end, q_start, q_end) {
+        return None;
+    }
+
+    let p_q1 = orient2d(p_start, p_end, q_start);
+    let p_q2 = orient2d(p_start, p_end, q_end);
+    if matches!(
+        (p_q1, p_q2),
+        (Orientation::Clockwise, Orientation::Clockwise)
+            | (Orientation::CounterClockwise, Orientation::CounterClockwise)
+    ) {
+        return None;
+    }
+
+    let q_p1 = orient2d(q_start, q_end, p_start);
+    let q_p2 = orient2d(q_start, q_end, p_end);
+    if matches!(
+        (q_p1, q_p2),
+        (Orientation::Clockwise, Orientation::Clockwise)
+            | (Orientation::CounterClockwise, Orientation::CounterClockwise)
+    ) {
+        return None;
+    }
+
+    if matches!(
+        (p_q1, p_q2, q_p1, q_p2),
+        (
+            Orientation::Collinear,
+            Orientation::Collinear,
+            Orientation::Collinear,
+            Orientation::Collinear
+        )
+    ) {
+        return collinear_intersection(p_start, p_end, q_start, q_end);
+    }
+
+    // A single, non-collinear intersection. When it lands on an endpoint, copy
+    // that endpoint verbatim so the returned coordinate is exact; otherwise
+    // compute the crossing.
+    if p_q1 == Orientation::Collinear
+        || p_q2 == Orientation::Collinear
+        || q_p1 == Orientation::Collinear
+        || q_p2 == Orientation::Collinear
+    {
+        let intersection: [f64; 2];
+        #[allow(clippy::suspicious_operation_groupings)]
+        if p_start == q_start || p_start == q_end {
+            intersection = p_start;
+        } else if p_end == q_start || p_end == q_end {
+            intersection = p_end;
+        } else if p_q1 == Orientation::Collinear {
+            intersection = q_start;
+        } else if p_q2 == Orientation::Collinear {
+            intersection = q_end;
+        } else if q_p1 == Orientation::Collinear {
+            intersection = p_start;
+        } else {
+            debug_assert_eq!(q_p2, Orientation::Collinear);
+            intersection = p_end;
+        }
+        Some(SegmentIntersection::SinglePoint {
+            intersection,
+            is_proper: false,
+        })
+    } else {
+        let intersection = proper_intersection(p_start, p_end, q_start, q_end);
+        Some(SegmentIntersection::SinglePoint {
+            intersection,
+            is_proper: true,
+        })
+    }
+}
+
+/// Overlap of two collinear segments; a port of the legacy `collinear_intersection`.
+fn collinear_intersection(
+    p_start: [f64; 2],
+    p_end: [f64; 2],
+    q_start: [f64; 2],
+    q_end: [f64; 2],
+) -> Option<SegmentIntersection> {
+    let collinear = |start: [f64; 2], end: [f64; 2]| SegmentIntersection::Collinear { start, end };
+    let improper = |intersection: [f64; 2]| SegmentIntersection::SinglePoint {
+        intersection,
+        is_proper: false,
+    };
+
+    // `p_contains_qx`: does p's bounding box contain q's endpoint (inclusive)?
+    let p_has_qs = point_in_bbox(q_start, p_start, p_end);
+    let p_has_qe = point_in_bbox(q_end, p_start, p_end);
+    let q_has_ps = point_in_bbox(p_start, q_start, q_end);
+    let q_has_pe = point_in_bbox(p_end, q_start, q_end);
+
+    Some(match (p_has_qs, p_has_qe, q_has_ps, q_has_pe) {
+        (true, true, _, _) => collinear(q_start, q_end),
+        (_, _, true, true) => collinear(p_start, p_end),
+        (true, false, true, false) if q_start == p_start => improper(q_start),
+        (true, _, true, _) => collinear(q_start, p_start),
+        (true, false, false, true) if q_start == p_end => improper(q_start),
+        (true, _, _, true) => collinear(q_start, p_end),
+        (false, true, true, false) if q_end == p_start => improper(q_end),
+        (_, true, true, _) => collinear(q_end, p_start),
+        (false, true, false, true) if q_end == p_end => improper(q_end),
+        (_, true, _, true) => collinear(q_end, p_end),
+        _ => return None,
+    })
+}
+
+/// The homogeneous-coordinate segment crossing with central-endpoint
+/// conditioning; a port of the legacy `raw_line_intersection` (2D projection).
+fn raw_line_intersection(
+    p_start: [f64; 2],
+    p_end: [f64; 2],
+    q_start: [f64; 2],
+    q_end: [f64; 2],
+) -> Option<[f64; 2]> {
+    let p_min_x = p_start[0].min(p_end[0]);
+    let p_min_y = p_start[1].min(p_end[1]);
+    let p_max_x = p_start[0].max(p_end[0]);
+    let p_max_y = p_start[1].max(p_end[1]);
+
+    let q_min_x = q_start[0].min(q_end[0]);
+    let q_min_y = q_start[1].min(q_end[1]);
+    let q_max_x = q_start[0].max(q_end[0]);
+    let q_max_y = q_start[1].max(q_end[1]);
+
+    let int_min_x = p_min_x.max(q_min_x);
+    let int_max_x = p_max_x.min(q_max_x);
+    let int_min_y = p_min_y.max(q_min_y);
+    let int_max_y = p_max_y.min(q_max_y);
+
+    let mid_x = (int_min_x + int_max_x) / 2.0;
+    let mid_y = (int_min_y + int_max_y) / 2.0;
+
+    // Condition ordinates by subtracting the midpoint of the overlap box.
+    let p1x = p_start[0] - mid_x;
+    let p1y = p_start[1] - mid_y;
+    let p2x = p_end[0] - mid_x;
+    let p2y = p_end[1] - mid_y;
+    let q1x = q_start[0] - mid_x;
+    let q1y = q_start[1] - mid_y;
+    let q2x = q_end[0] - mid_x;
+    let q2y = q_end[1] - mid_y;
+
+    // Unrolled homogeneous-coordinate line intersection.
+    let px = p1y - p2y;
+    let py = p2x - p1x;
+    let pw = p1x * p2y - p2x * p1y;
+
+    let qx = q1y - q2y;
+    let qy = q2x - q1x;
+    let qw = q1x * q2y - q2x * q1y;
+
+    let xw = py * qw - qy * pw;
+    let yw = qx * pw - px * qw;
+    let w = px * qy - qx * py;
+
+    let x_int = xw / w;
+    let y_int = yw / w;
+
+    if x_int.is_nan() || x_int.is_infinite() || y_int.is_nan() || y_int.is_infinite() {
+        None
+    } else {
+        Some([x_int + mid_x, y_int + mid_y])
+    }
+}
+
+/// The endpoint of either segment nearest to the other segment; the legacy
+/// `nearest_endpoint` fallback for the central-endpoint heuristic.
+fn nearest_endpoint(
+    p_start: [f64; 2],
+    p_end: [f64; 2],
+    q_start: [f64; 2],
+    q_end: [f64; 2],
+) -> [f64; 2] {
+    let mut nearest = p_start;
+    let mut min_dist = point_segment_distance(p_start, q_start, q_end);
+
+    let dist = point_segment_distance(p_end, q_start, q_end);
+    if dist < min_dist {
+        min_dist = dist;
+        nearest = p_end;
+    }
+    let dist = point_segment_distance(q_start, p_start, p_end);
+    if dist < min_dist {
+        min_dist = dist;
+        nearest = q_start;
+    }
+    let dist = point_segment_distance(q_end, p_start, p_end);
+    if dist < min_dist {
+        nearest = q_end;
+    }
+    nearest
+}
+
+/// The proper (interior) crossing point, falling back to the nearest endpoint
+/// when the raw computation lands outside both segments' boxes; a port of the
+/// legacy `proper_intersection`.
+fn proper_intersection(
+    p_start: [f64; 2],
+    p_end: [f64; 2],
+    q_start: [f64; 2],
+    q_end: [f64; 2],
+) -> [f64; 2] {
+    let mut pt = raw_line_intersection(p_start, p_end, q_start, q_end)
+        .unwrap_or_else(|| nearest_endpoint(p_start, p_end, q_start, q_end));
+    if !(point_in_bbox(pt, p_start, p_end) && point_in_bbox(pt, q_start, q_end)) {
+        pt = nearest_endpoint(p_start, p_end, q_start, q_end);
+    }
+    pt
+}
+
+/// 3D segment × segment intersection, for coplanar, non-parallel segments; a
+/// port of the legacy `line_intersection3d`. Returns the crossing point when it
+/// lies within both segments, `None` for skew, parallel, or non-overlapping
+/// segments.
+pub fn segment_intersection_3d(
+    p_start: [f64; 3],
+    p_end: [f64; 3],
+    q_start: [f64; 3],
+    q_end: [f64; 3],
+) -> Option<[f64; 3]> {
+    let d1 = sub3(p_end, p_start);
+    let d2 = sub3(q_end, q_start);
+
+    let cross_d1_d2 = cross3(d1, d2);
+    // Parallel or collinear.
+    if norm_sq3(cross_d1_d2) == 0.0 {
+        return None;
+    }
+
+    // Reject skew (non-coplanar) segments.
+    let v1 = sub3(q_start, p_start);
+    let plane_normal = cross3(d1, v1);
+    if dot3(plane_normal, d2) != 0.0 {
+        return None;
+    }
+
+    let denom = norm_sq3(cross_d1_d2);
+    let t = dot3(cross3(v1, d2), cross_d1_d2) / denom;
+    let u = dot3(cross3(v1, d1), cross_d1_d2) / denom;
+
+    if (0.0..=1.0).contains(&t) && (0.0..=1.0).contains(&u) {
+        Some([
+            p_start[0] + t * d1[0],
+            p_start[1] + t * d1[1],
+            p_start[2] + t * d1[2],
+        ])
+    } else {
+        None
+    }
+}
+
+/// Where a coordinate lies relative to a single closed ring.
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum CoordPos {
+    /// On the ring boundary.
+    OnBoundary,
+    /// Strictly inside the ring.
+    Inside,
+    /// Strictly outside the ring.
+    Outside,
+}
+
+/// Point-in-ring by winding number, with an on-boundary short-circuit; a port of
+/// the legacy `coord_pos_relative_to_ring`.
+///
+/// `ring` is a closed ring (first vertex == last), the storage convention of the
+/// new [`Polygon`](crate::polygon) leaves. The `z` of any 2.5D ring is ignored:
+/// the test is the XY-projection algorithm, matching legacy 2D semantics.
+pub fn coord_pos_relative_to_ring(coord: [f64; 2], ring: &[[f64; 2]]) -> CoordPos {
+    if ring.is_empty() {
+        return CoordPos::Outside;
+    }
+    if ring.len() == 1 {
+        return if coord == ring[0] {
+            CoordPos::OnBoundary
+        } else {
+            CoordPos::Outside
+        };
+    }
+
+    // Winding number with the standard edge-crossing rules:
+    //   1. an upward edge includes its start, excludes its end;
+    //   2. a downward edge excludes its start, includes its end;
+    //   3. horizontal edges are ignored;
+    //   4. the crossing must be strictly right of `coord`.
+    let mut winding_number: i32 = 0;
+    for edge in ring.windows(2) {
+        let start = edge[0];
+        let end = edge[1];
+        if start[1] <= coord[1] {
+            if end[1] >= coord[1] {
+                let o = orient2d(start, end, coord);
+                if o == Orientation::CounterClockwise && end[1] != coord[1] {
+                    winding_number += 1;
+                } else if o == Orientation::Collinear
+                    && value_in_between(coord[0], start[0], end[0])
+                {
+                    return CoordPos::OnBoundary;
+                }
+            }
+        } else if end[1] <= coord[1] {
+            let o = orient2d(start, end, coord);
+            if o == Orientation::Clockwise {
+                winding_number -= 1;
+            } else if o == Orientation::Collinear && value_in_between(coord[0], start[0], end[0]) {
+                return CoordPos::OnBoundary;
+            }
+        }
+    }
+
+    if winding_number == 0 {
+        CoordPos::Outside
+    } else {
+        CoordPos::Inside
+    }
+}
+
+// --- small numeric helpers (ports of legacy `intersects`/`utils`) -----------
+
+/// Whether `value` lies within `[min(a, b), max(a, b)]` (inclusive).
+#[inline]
+fn value_in_between(value: f64, a: f64, b: f64) -> bool {
+    let (lo, hi) = if a < b { (a, b) } else { (b, a) };
+    value >= lo && value <= hi
+}
+
+/// Whether `p` lies inside the axis-aligned box spanned by `a` and `b`
+/// (inclusive on every axis).
+#[inline]
+fn point_in_bbox(p: [f64; 2], a: [f64; 2], b: [f64; 2]) -> bool {
+    value_in_between(p[0], a[0], b[0]) && value_in_between(p[1], a[1], b[1])
+}
+
+/// Whether the bounding boxes of two 2D segments overlap (inclusive).
+#[inline]
+fn segments_bbox_overlap(
+    p_start: [f64; 2],
+    p_end: [f64; 2],
+    q_start: [f64; 2],
+    q_end: [f64; 2],
+) -> bool {
+    let p_min_x = p_start[0].min(p_end[0]);
+    let p_max_x = p_start[0].max(p_end[0]);
+    let p_min_y = p_start[1].min(p_end[1]);
+    let p_max_y = p_start[1].max(p_end[1]);
+    let q_min_x = q_start[0].min(q_end[0]);
+    let q_max_x = q_start[0].max(q_end[0]);
+    let q_min_y = q_start[1].min(q_end[1]);
+    let q_max_y = q_start[1].max(q_end[1]);
+
+    p_min_x <= q_max_x && q_min_x <= p_max_x && p_min_y <= q_max_y && q_min_y <= p_max_y
+}
+
+/// Euclidean distance from a 2D point to a segment; a port of the legacy
+/// `line_segment_distance`.
+fn point_segment_distance(point: [f64; 2], start: [f64; 2], end: [f64; 2]) -> f64 {
+    if start == end {
+        return (point[0] - start[0]).hypot(point[1] - start[1]);
+    }
+    let dx = end[0] - start[0];
+    let dy = end[1] - start[1];
+    let r = ((point[0] - start[0]) * dx + (point[1] - start[1]) * dy) / (dx * dx + dy * dy);
+    if r <= 0.0 {
+        return (point[0] - start[0]).hypot(point[1] - start[1]);
+    }
+    if r >= 1.0 {
+        return (point[0] - end[0]).hypot(point[1] - end[1]);
+    }
+    let s = ((start[1] - point[1]) * dx - (start[0] - point[0]) * dy) / (dx * dx + dy * dy);
+    s.abs() * dx.hypot(dy)
+}
+
+// --- 3D vector helpers ------------------------------------------------------
+
+#[inline]
+fn sub3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+#[inline]
+fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+#[inline]
+fn dot3(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+#[inline]
+fn norm_sq3(a: [f64; 3]) -> f64 {
+    dot3(a, a)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orient2d_basic_signs() {
+        assert_eq!(
+            orient2d([0.0, 0.0], [1.0, 0.0], [0.0, 1.0]),
+            Orientation::CounterClockwise
+        );
+        assert_eq!(
+            orient2d([0.0, 0.0], [1.0, 0.0], [0.0, -1.0]),
+            Orientation::Clockwise
+        );
+        assert_eq!(
+            orient2d([0.0, 0.0], [1.0, 0.0], [2.0, 0.0]),
+            Orientation::Collinear
+        );
+    }
+
+    #[test]
+    fn orient3d_basic_signs() {
+        // z above / below the z=0 plane spanned by the first three points.
+        let a = [0.0, 0.0, 0.0];
+        let b = [1.0, 0.0, 0.0];
+        let c = [0.0, 1.0, 0.0];
+        assert_ne!(
+            orient3d(a, b, c, [0.0, 0.0, 1.0]),
+            orient3d(a, b, c, [0.0, 0.0, -1.0])
+        );
+        assert_eq!(orient3d(a, b, c, [5.0, 5.0, 0.0]), Orientation::Collinear);
+    }
+
+    #[test]
+    fn proper_crossing() {
+        let x = segment_intersection([0.0, 0.0], [2.0, 2.0], [0.0, 2.0], [2.0, 0.0]);
+        assert_eq!(
+            x,
+            Some(SegmentIntersection::SinglePoint {
+                intersection: [1.0, 1.0],
+                is_proper: true,
+            })
+        );
+    }
+
+    #[test]
+    fn endpoint_touch_is_improper_and_exact() {
+        // q starts exactly on p's interior: a T-junction, improper, exact copy.
+        let x = segment_intersection([0.0, 0.0], [4.0, 0.0], [2.0, 0.0], [2.0, 3.0]);
+        assert_eq!(
+            x,
+            Some(SegmentIntersection::SinglePoint {
+                intersection: [2.0, 0.0],
+                is_proper: false,
+            })
+        );
+    }
+
+    #[test]
+    fn disjoint_segments_do_not_intersect() {
+        assert_eq!(
+            segment_intersection([0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [1.0, 1.0]),
+            None
+        );
+    }
+
+    #[test]
+    fn collinear_overlap() {
+        let x = segment_intersection([0.0, 0.0], [4.0, 0.0], [2.0, 0.0], [6.0, 0.0]);
+        match x {
+            Some(SegmentIntersection::Collinear { start, end }) => {
+                let mut pts = [start, end];
+                pts.sort_by(|a, b| a[0].partial_cmp(&b[0]).unwrap());
+                assert_eq!(pts, [[2.0, 0.0], [4.0, 0.0]]);
+            }
+            other => panic!("expected collinear overlap, got {other:?}"),
+        }
+    }
+
+    // JTS/GEOS central-endpoint heuristic cases carried over from the legacy
+    // `line_intersection` test suite (the intersection coordinate must match
+    // exactly to preserve robustness parity).
+    #[test]
+    fn jts_central_endpoint_heuristic_failure_1() {
+        let x = segment_intersection(
+            [163.81867067, -211.31840378],
+            [165.9174252, -214.1665075],
+            [2.84139601, -57.95412726],
+            [469.59990601, -502.63851732],
+        );
+        assert_eq!(
+            x,
+            Some(SegmentIntersection::SinglePoint {
+                intersection: [163.81867067, -211.31840378],
+                is_proper: true,
+            })
+        );
+    }
+
+    #[test]
+    fn jts_leduc_1() {
+        let x = segment_intersection(
+            [305690.0434123494, 254176.46578338774],
+            [305601.9999843455, 254243.19999846347],
+            [305689.6153764265, 254177.33102743194],
+            [305692.4999844298, 254171.4999983967],
+        );
+        assert_eq!(
+            x,
+            Some(SegmentIntersection::SinglePoint {
+                intersection: [305690.0434123494, 254176.46578338774],
+                is_proper: true,
+            })
+        );
+    }
+
+    #[test]
+    fn geos_1() {
+        let x = segment_intersection(
+            [588750.7429703881, 4518950.493668233],
+            [588748.2060409798, 4518933.9452804085],
+            [588745.824857241, 4518940.742239175],
+            [588748.2060437313, 4518933.9452791475],
+        );
+        assert_eq!(
+            x,
+            Some(SegmentIntersection::SinglePoint {
+                intersection: [588748.2060416829, 4518933.945284994],
+                is_proper: true,
+            })
+        );
+    }
+
+    #[test]
+    fn segment_intersection_3d_coplanar_crossing() {
+        let x = segment_intersection_3d(
+            [0.0, 0.0, 0.0],
+            [2.0, 2.0, 2.0],
+            [2.0, 0.0, 0.0],
+            [0.0, 2.0, 2.0],
+        );
+        assert_eq!(x, Some([1.0, 1.0, 1.0]));
+    }
+
+    #[test]
+    fn segment_intersection_3d_skew_is_none() {
+        // Skew lines (different planes) do not meet.
+        assert_eq!(
+            segment_intersection_3d(
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 1.0],
+                [0.0, -1.0, 1.0],
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn point_in_ring_winding() {
+        // CCW unit square, stored closed.
+        let sq: [[f64; 2]; 5] = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
+        assert_eq!(
+            coord_pos_relative_to_ring([2.0, 2.0], &sq),
+            CoordPos::Inside
+        );
+        assert_eq!(
+            coord_pos_relative_to_ring([5.0, 2.0], &sq),
+            CoordPos::Outside
+        );
+        assert_eq!(
+            coord_pos_relative_to_ring([0.0, 2.0], &sq),
+            CoordPos::OnBoundary
+        );
+        // A vertex is on the boundary.
+        assert_eq!(
+            coord_pos_relative_to_ring([4.0, 4.0], &sq),
+            CoordPos::OnBoundary
+        );
+    }
+
+    #[test]
+    fn point_in_ring_orientation_independent() {
+        // CW winding gives the same inside/outside answer.
+        let cw: [[f64; 2]; 5] = [[0.0, 0.0], [0.0, 4.0], [4.0, 4.0], [4.0, 0.0], [0.0, 0.0]];
+        assert_eq!(
+            coord_pos_relative_to_ring([2.0, 2.0], &cw),
+            CoordPos::Inside
+        );
+        assert_eq!(
+            coord_pos_relative_to_ring([9.0, 9.0], &cw),
+            CoordPos::Outside
+        );
+    }
+
+    #[test]
+    fn degenerate_rings() {
+        assert_eq!(
+            coord_pos_relative_to_ring([0.0, 0.0], &[]),
+            CoordPos::Outside
+        );
+        assert_eq!(
+            coord_pos_relative_to_ring([1.0, 1.0], &[[1.0, 1.0]]),
+            CoordPos::OnBoundary
+        );
+    }
+}

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -1,8 +1,6 @@
 //! Binary geometric predicates and their supporting robust kernels.
 //!
-//! Unlike the unary [`ops`](crate::ops) traits, binary operations do not fit the
-//! `enum_dispatch` single-dispatch pattern: `predicate(a, b)` is a double
-//! dispatch over two geometry enums. They therefore live here as free functions
+//! The predicates are available as free functions
 //! with internal pair-matching, over lightweight coordinate **views** (see
 //! [`view`]) so a `Polygon`, a `PolygonMesh` face, and a `TriangularMesh`
 //! triangle all feed the same [`kernel`] with zero copying.
@@ -10,21 +8,20 @@
 //! Available predicates, all 2D (collections are point-set unions of their
 //! members; every leaf pair takes a bounding-box quick reject first):
 //!
-//! - [`intersects()`] — whether two geometries share at least one point.
-//! - [`contains()`] / [`covers`] — split-based containment with OGC semantics;
+//! - [`intersects()`]: whether two geometries share at least one point.
+//! - [`contains()`] / [`covers`]: split-based containment with OGC semantics;
 //!   see [`contains`](contains()) for the algorithm.
-//! - [`point_position_2d`] — coordinate vs. geometry classification
+//! - [`point_position_2d`]: coordinate vs. geometry classification
 //!   (`Inside` / `OnBoundary` / `Outside`), with exact shared-edge and
 //!   surrounded-vertex refinement on meshes.
-//! - [`relate()`] — the full DE-9IM [`IntersectionMatrix`], from which every
+//! - [`relate()`]: the full DE-9IM [`IntersectionMatrix`], from which every
 //!   named predicate (touches, crosses, overlaps, ...) and arbitrary DE-9IM
 //!   patterns can be read; meshes relate as their dissolved face union.
 //!
 //! The 2D leaves' optional per-vertex elevation is ignored throughout. The
-//! constructed counterparts — boolean overlay, line clipping, segment
-//! intersection points — live in [`overlay`](crate::overlay) over the same
-//! views and kernel; the remaining families (ray casting, 3D pairs) come in
-//! later phases.
+//! constructed counterparts, boolean overlay, line clipping, segment
+//! intersection points, live in [`overlay`](crate::overlay) over the same
+//! views and kernel. Ray casting and 3D pairs are not yet supported.
 
 pub mod contains;
 pub mod intersects;
@@ -106,9 +103,9 @@ pub fn require_same_frame(a: &CoordinateFrame, b: &CoordinateFrame) -> Result<()
 
 /// Flatten both operands of a binary 2D operation into their 2D leaves under
 /// the shared dimension policy: a 2D × 3D pair is
-/// [`CrossDimension`](PredicateError::CrossDimension), a purely 3D pair
-/// [`UnsupportedPair`](PredicateError::UnsupportedPair) until the 3D phases
-/// land. `Geometry::None` and empty collections flatten to no leaves.
+/// [`CrossDimension`](PredicateError::CrossDimension), a purely 3D pair is
+/// [`UnsupportedPair`](PredicateError::UnsupportedPair). `Geometry::None` and
+/// empty collections flatten to no leaves.
 pub(crate) fn flatten_2d_pair<'a>(
     a: &'a Geometry,
     b: &'a Geometry,

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -7,13 +7,30 @@
 //! [`view`]) so a `Polygon`, a `PolygonMesh` face, and a `TriangularMesh`
 //! triangle all feed the same [`kernel`] with zero copying.
 //!
-//! This module is the phase-1 foundation: the robust kernel, the views, and the
-//! error and frame-policy plumbing. The predicates themselves (`intersects`,
-//! `contains`, `relate`, boolean overlay, ray casting) build on top in later
-//! phases.
+//! Available predicates, all 2D (collections are point-set unions of their
+//! members; every leaf pair takes a bounding-box quick reject first):
+//!
+//! - [`intersects`] — whether two geometries share at least one point.
+//! - [`contains`] / [`covers`] — split-based containment with OGC semantics;
+//!   see [`contains`](contains()) for the algorithm.
+//! - [`point_position_2d`] — coordinate vs. geometry classification
+//!   (`Inside` / `OnBoundary` / `Outside`), with exact shared-edge and
+//!   surrounded-vertex refinement on meshes.
+//!
+//! The 2D leaves' optional per-vertex elevation is ignored throughout. The
+//! remaining families (`relate`, boolean overlay, ray casting, 3D pairs) build
+//! on the same kernel and views in later phases.
 
+pub mod contains;
+pub mod intersects;
 pub mod kernel;
+pub mod position;
 pub mod view;
+
+pub use contains::{contains, covers};
+pub use intersects::intersects;
+pub use kernel::CoordPos;
+pub use position::point_position_2d;
 
 use crate::coordinate::CoordinateFrame;
 

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -10,27 +10,32 @@
 //! Available predicates, all 2D (collections are point-set unions of their
 //! members; every leaf pair takes a bounding-box quick reject first):
 //!
-//! - [`intersects`] — whether two geometries share at least one point.
-//! - [`contains`] / [`covers`] — split-based containment with OGC semantics;
+//! - [`intersects()`] — whether two geometries share at least one point.
+//! - [`contains()`] / [`covers`] — split-based containment with OGC semantics;
 //!   see [`contains`](contains()) for the algorithm.
 //! - [`point_position_2d`] — coordinate vs. geometry classification
 //!   (`Inside` / `OnBoundary` / `Outside`), with exact shared-edge and
 //!   surrounded-vertex refinement on meshes.
+//! - [`relate()`] — the full DE-9IM [`IntersectionMatrix`], from which every
+//!   named predicate (touches, crosses, overlaps, ...) and arbitrary DE-9IM
+//!   patterns can be read; meshes relate as their dissolved face union.
 //!
 //! The 2D leaves' optional per-vertex elevation is ignored throughout. The
-//! remaining families (`relate`, boolean overlay, ray casting, 3D pairs) build
-//! on the same kernel and views in later phases.
+//! remaining families (boolean overlay, ray casting, 3D pairs) build on the
+//! same kernel and views in later phases.
 
 pub mod contains;
 pub mod intersects;
 pub mod kernel;
 pub mod position;
+pub mod relate;
 pub mod view;
 
 pub use contains::{contains, covers};
 pub use intersects::intersects;
 pub use kernel::CoordPos;
 pub use position::point_position_2d;
+pub use relate::{relate, Dimensions, IntersectionMatrix};
 
 use crate::coordinate::CoordinateFrame;
 

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -1,0 +1,110 @@
+//! Binary geometric predicates and their supporting robust kernels.
+//!
+//! Unlike the unary [`ops`](crate::ops) traits, binary operations do not fit the
+//! `enum_dispatch` single-dispatch pattern: `predicate(a, b)` is a double
+//! dispatch over two geometry enums. They therefore live here as free functions
+//! with internal pair-matching, over lightweight coordinate **views** (see
+//! [`view`]) so a `Polygon`, a `PolygonMesh` face, and a `TriangularMesh`
+//! triangle all feed the same [`kernel`] with zero copying.
+//!
+//! This module is the phase-1 foundation: the robust kernel, the views, and the
+//! error and frame-policy plumbing. The predicates themselves (`intersects`,
+//! `contains`, `relate`, boolean overlay, ray casting) build on top in later
+//! phases.
+
+pub mod kernel;
+pub mod view;
+
+use crate::coordinate::CoordinateFrame;
+
+/// Why a binary predicate or overlay could not be evaluated.
+///
+/// Richer than [`UnsupportedOperation`](crate::ops::UnsupportedOperation): a
+/// binary op fails not only on an unsupported type but on operands the policy
+/// refuses to mix. Frame reprojection and dimension promotion are the caller's
+/// explicit steps, so the kernel reports the mismatch rather than guessing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PredicateError {
+    /// The two operands are in different coordinate frames. Reproject one to the
+    /// other's frame first (via [`Reproject`](crate::ops::Reproject)); the
+    /// predicates never reproject implicitly.
+    MixedFrames,
+    /// A 2D-embedded operand was paired with a 3D-embedded one. There is no
+    /// implicit promotion; the only cross-dimension path is an explicit
+    /// XY-projection opt-in exposed by the individual predicates.
+    CrossDimension,
+    /// The operation is not defined for this ordered pair of concrete geometry
+    /// types.
+    UnsupportedPair {
+        /// The left operand's concrete type name.
+        left: &'static str,
+        /// The right operand's concrete type name.
+        right: &'static str,
+    },
+}
+
+impl core::fmt::Display for PredicateError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            PredicateError::MixedFrames => {
+                write!(f, "operands are in different coordinate frames")
+            }
+            PredicateError::CrossDimension => {
+                write!(
+                    f,
+                    "cannot pair a 2D-embedded operand with a 3D-embedded one"
+                )
+            }
+            PredicateError::UnsupportedPair { left, right } => {
+                write!(f, "operation is not defined for `{left}` and `{right}`")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PredicateError {}
+
+/// The result of a binary predicate.
+pub type Result<T> = core::result::Result<T, PredicateError>;
+
+/// Require both operands to be in the **same** coordinate frame, returning
+/// [`PredicateError::MixedFrames`] otherwise. Every binary op runs this before
+/// touching coordinates; reprojection stays the caller's explicit step.
+pub fn require_same_frame(a: &CoordinateFrame, b: &CoordinateFrame) -> Result<()> {
+    if a == b {
+        Ok(())
+    } else {
+        Err(PredicateError::MixedFrames)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinate::EpsgCode;
+
+    #[test]
+    fn same_frame_passes() {
+        let a = CoordinateFrame::Crs(EpsgCode::new(4326));
+        let b = CoordinateFrame::Crs(EpsgCode::new(4326));
+        assert!(require_same_frame(&a, &b).is_ok());
+    }
+
+    #[test]
+    fn different_frame_is_mixed_frames() {
+        let a = CoordinateFrame::Crs(EpsgCode::new(4326));
+        let b = CoordinateFrame::Euclidean;
+        assert_eq!(require_same_frame(&a, &b), Err(PredicateError::MixedFrames));
+    }
+
+    #[test]
+    fn error_display_is_descriptive() {
+        assert!(PredicateError::MixedFrames.to_string().contains("frame"));
+        assert!(PredicateError::CrossDimension.to_string().contains("2D"));
+        let up = PredicateError::UnsupportedPair {
+            left: "Point2D",
+            right: "Solid",
+        };
+        assert!(up.to_string().contains("Point2D") && up.to_string().contains("Solid"));
+    }
+}

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -21,8 +21,10 @@
 //!   patterns can be read; meshes relate as their dissolved face union.
 //!
 //! The 2D leaves' optional per-vertex elevation is ignored throughout. The
-//! remaining families (boolean overlay, ray casting, 3D pairs) build on the
-//! same kernel and views in later phases.
+//! constructed counterparts — boolean overlay, line clipping, segment
+//! intersection points — live in [`overlay`](crate::overlay) over the same
+//! views and kernel; the remaining families (ray casting, 3D pairs) come in
+//! later phases.
 
 pub mod contains;
 pub mod intersects;
@@ -38,6 +40,8 @@ pub use position::point_position_2d;
 pub use relate::{relate, Dimensions, IntersectionMatrix};
 
 use crate::coordinate::CoordinateFrame;
+use crate::Geometry;
+use view::Leaf2D;
 
 /// Why a binary predicate or overlay could not be evaluated.
 ///
@@ -97,6 +101,26 @@ pub fn require_same_frame(a: &CoordinateFrame, b: &CoordinateFrame) -> Result<()
         Ok(())
     } else {
         Err(PredicateError::MixedFrames)
+    }
+}
+
+/// Flatten both operands of a binary 2D operation into their 2D leaves under
+/// the shared dimension policy: a 2D × 3D pair is
+/// [`CrossDimension`](PredicateError::CrossDimension), a purely 3D pair
+/// [`UnsupportedPair`](PredicateError::UnsupportedPair) until the 3D phases
+/// land. `Geometry::None` and empty collections flatten to no leaves.
+pub(crate) fn flatten_2d_pair<'a>(
+    a: &'a Geometry,
+    b: &'a Geometry,
+) -> Result<(Vec<Leaf2D<'a>>, Vec<Leaf2D<'a>>)> {
+    let (a_leaves, a_3d) = contains::flatten_geometry(a);
+    let (b_leaves, b_3d) = contains::flatten_geometry(b);
+    match (a_3d, b_3d) {
+        (None, None) => Ok((a_leaves, b_leaves)),
+        (Some(left), Some(right)) if a_leaves.is_empty() && b_leaves.is_empty() => {
+            Err(PredicateError::UnsupportedPair { left, right })
+        }
+        _ => Err(PredicateError::CrossDimension),
     }
 }
 

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -6,7 +6,9 @@
 //! triangle all feed the same [`kernel`] with zero copying.
 //!
 //! Available predicates, all 2D (collections are point-set unions of their
-//! members; every leaf pair takes a bounding-box quick reject first):
+//! members; every leaf pair takes a bounding-box quick reject first, and the
+//! segment-crossing searches switch from a direct scan to an rstar-indexed
+//! sweep above a size threshold, with identical answers):
 //!
 //! - [`intersects()`]: whether two geometries share at least one point.
 //! - [`contains()`] / [`covers`]: split-based containment with OGC semantics;
@@ -24,6 +26,7 @@
 //! views and kernel. Ray casting and 3D pairs are not yet supported.
 
 pub mod contains;
+mod edge_set;
 pub mod intersects;
 pub mod kernel;
 pub mod position;

--- a/engine/runtime/geometry/src/predicates/position.rs
+++ b/engine/runtime/geometry/src/predicates/position.rs
@@ -1,0 +1,431 @@
+//! Point position relative to 2D geometry.
+//!
+//! [`point_position_2d`] classifies a coordinate against any 2D geometry as
+//! [`Inside`](CoordPos::Inside) (the geometry's interior),
+//! [`OnBoundary`](CoordPos::OnBoundary), or [`Outside`](CoordPos::Outside),
+//! with OGC point-set semantics per leaf:
+//!
+//! - **Point** — the interior is the point itself; the boundary is empty.
+//! - **LineString** — the interior is the chain minus its endpoints; the
+//!   endpoints are the boundary, unless the chain is closed (then everything
+//!   is interior).
+//! - **Polygon / meshes** — faces are treated as a point-set union. A
+//!   coordinate on a ring edge shared by two faces (or on a mesh vertex whose
+//!   incident faces cover a full disk) is *interior* to the union, not on its
+//!   boundary; the refinement is an exact angular-coverage test around the
+//!   coordinate. It assumes valid winding (exteriors CCW, holes CW) and
+//!   non-overlapping face interiors; on invalid input and on degenerate
+//!   (all-equal) rings it degrades to `OnBoundary`, never to a false `Inside`.
+//! - **Collections** — the union of the members: the highest member
+//!   classification wins (`Inside` > `OnBoundary` > `Outside`), with the
+//!   line-endpoint boundary counted mod 2 across all line members.
+//!
+//! The optional per-vertex elevation of 2D leaves is ignored throughout.
+
+use super::kernel::{coord_pos_relative_to_edges, point_on_segment, same_direction, CoordPos};
+use super::view::{AreaView, FaceView, Leaf2D, Operand2D, RingView};
+use crate::Euclidean2DGeometry;
+
+/// Position of a coordinate relative to a 2D geometry, treating collections as
+/// point-set unions of their members.
+pub fn point_position_2d(coord: [f64; 2], geometry: &Euclidean2DGeometry) -> CoordPos {
+    union_position(coord, &Operand2D::new(geometry))
+}
+
+/// Position of a coordinate relative to an operand's union of leaves.
+pub(crate) fn union_position(coord: [f64; 2], operand: &Operand2D<'_>) -> CoordPos {
+    // Areal members: exact union with shared-boundary refinement.
+    let area_pos = areal_union_position(coord, operand.areas());
+    if area_pos == CoordPos::Inside {
+        return CoordPos::Inside;
+    }
+
+    // Line members: interior on any chain, boundary endpoints counted mod 2
+    // across members (two chains meeting at an endpoint join into interior).
+    let mut on_any_line = false;
+    let mut boundary_endpoints = 0usize;
+    // Point members.
+    let mut on_point = false;
+
+    for prepared in &operand.leaves {
+        match prepared.leaf {
+            Leaf2D::Point(p) => on_point |= coord == p.position(),
+            Leaf2D::Line(l) => {
+                let coords = l.coords();
+                if on_chain(coord, coords) {
+                    on_any_line = true;
+                }
+                let closed = coords.len() >= 2 && coords.first() == coords.last();
+                if !closed && coords.len() >= 2 {
+                    if coord == coords[0] {
+                        boundary_endpoints += 1;
+                    }
+                    if coord == coords[coords.len() - 1] {
+                        boundary_endpoints += 1;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let line_pos = if !on_any_line {
+        CoordPos::Outside
+    } else if boundary_endpoints % 2 == 1 {
+        CoordPos::OnBoundary
+    } else {
+        CoordPos::Inside
+    };
+    let point_pos = if on_point {
+        CoordPos::Inside
+    } else {
+        CoordPos::Outside
+    };
+
+    max_pos(max_pos(area_pos, line_pos), point_pos)
+}
+
+/// The higher of two classifications (`Inside` > `OnBoundary` > `Outside`).
+fn max_pos(a: CoordPos, b: CoordPos) -> CoordPos {
+    fn rank(p: CoordPos) -> u8 {
+        match p {
+            CoordPos::Outside => 0,
+            CoordPos::OnBoundary => 1,
+            CoordPos::Inside => 2,
+        }
+    }
+    if rank(a) >= rank(b) {
+        a
+    } else {
+        b
+    }
+}
+
+/// Whether the coordinate lies anywhere on the chain (interior or endpoint).
+fn on_chain(coord: [f64; 2], coords: &[[f64; 2]]) -> bool {
+    match coords {
+        [] => false,
+        [single] => coord == *single,
+        _ => coords
+            .windows(2)
+            .any(|e| point_on_segment(coord, e[0], e[1])),
+    }
+}
+
+/// Position of a coordinate on a polyline: `Inside` on the chain (including a
+/// closed chain's join), `OnBoundary` at an open chain's endpoints, `Outside`
+/// off the chain. A single-vertex chain is point-like: its vertex is interior.
+pub(crate) fn line_position(coord: [f64; 2], coords: &[[f64; 2]]) -> CoordPos {
+    if !on_chain(coord, coords) {
+        return CoordPos::Outside;
+    }
+    let closed = coords.len() >= 2 && coords.first() == coords.last();
+    if !closed && coords.len() >= 2 && (coord == coords[0] || coord == coords[coords.len() - 1]) {
+        CoordPos::OnBoundary
+    } else {
+        CoordPos::Inside
+    }
+}
+
+/// Position of a coordinate relative to a single ring's closed loop.
+pub(crate) fn ring_position(coord: [f64; 2], ring: RingView<'_>) -> CoordPos {
+    coord_pos_relative_to_edges(coord, ring.edges())
+}
+
+/// Position of a coordinate relative to one face (exterior minus holes).
+pub(crate) fn face_position(coord: [f64; 2], face: FaceView<'_>) -> CoordPos {
+    match ring_position(coord, face.exterior()) {
+        CoordPos::Outside => CoordPos::Outside,
+        CoordPos::OnBoundary => CoordPos::OnBoundary,
+        CoordPos::Inside => {
+            for hole in face.interiors() {
+                match ring_position(coord, hole) {
+                    CoordPos::Inside => return CoordPos::Outside,
+                    CoordPos::OnBoundary => return CoordPos::OnBoundary,
+                    CoordPos::Outside => {}
+                }
+            }
+            CoordPos::Inside
+        }
+    }
+}
+
+/// Position of a coordinate relative to the union of areal views.
+///
+/// Strictly inside any face is inside the union. On a face boundary, the
+/// classification is refined by angular coverage: the coordinate is interior
+/// to the union exactly when the incident faces cover a full disk around it
+/// (a shared mesh edge, or a fully surrounded vertex).
+pub(crate) fn areal_union_position<'a, 'b>(
+    coord: [f64; 2],
+    areas: impl Iterator<Item = &'b AreaView<'a>>,
+) -> CoordPos
+where
+    'a: 'b,
+{
+    let mut wedges: Vec<([f64; 2], [f64; 2])> = Vec::new();
+    let mut on_boundary = false;
+    let mut degenerate = false;
+    for area in areas {
+        for face in area.faces() {
+            match face_position(coord, face) {
+                CoordPos::Inside => return CoordPos::Inside,
+                CoordPos::OnBoundary => {
+                    on_boundary = true;
+                    gather_wedges(coord, face, &mut wedges, &mut degenerate);
+                }
+                CoordPos::Outside => {}
+            }
+        }
+    }
+    if !on_boundary {
+        CoordPos::Outside
+    } else if !degenerate && wedges_cover(coord, &wedges) {
+        CoordPos::Inside
+    } else {
+        CoordPos::OnBoundary
+    }
+}
+
+/// Collect the angular wedges of face interior incident to `coord`, one per
+/// occurrence of `coord` on the face's rings.
+///
+/// With valid winding the face interior lies locally left of every directed
+/// ring edge (exterior CCW, holes CW), so an edge through `coord` contributes
+/// the left half-plane `(toward end, toward start)` and a ring vertex at
+/// `coord` contributes `(toward next, toward prev)`. Wedge ends are the actual
+/// neighbor coordinates, keeping the later direction comparisons exact. A ring
+/// collapsed entirely onto `coord` sets `degenerate` instead.
+fn gather_wedges(
+    coord: [f64; 2],
+    face: FaceView<'_>,
+    wedges: &mut Vec<([f64; 2], [f64; 2])>,
+    degenerate: &mut bool,
+) {
+    for ring in face.rings() {
+        let n = ring.open_len();
+        for i in 0..n {
+            let v = ring.coord(i);
+            let next = ring.coord(if i + 1 == n { 0 } else { i + 1 });
+            if v == coord {
+                // Vertex occurrence: walk to the nearest distinct neighbors.
+                let mut prev = None;
+                for step in 1..n {
+                    let c = ring.coord((i + n - step) % n);
+                    if c != coord {
+                        prev = Some(c);
+                        break;
+                    }
+                }
+                let mut nxt = None;
+                for step in 1..n {
+                    let c = ring.coord((i + step) % n);
+                    if c != coord {
+                        nxt = Some(c);
+                        break;
+                    }
+                }
+                match (nxt, prev) {
+                    (Some(nxt), Some(prev)) => wedges.push((nxt, prev)),
+                    _ => *degenerate = true,
+                }
+            } else if next != v && next != coord && point_on_segment(coord, v, next) {
+                // Interior of the edge `v -> next`: the left half-plane.
+                wedges.push((next, v));
+            }
+        }
+    }
+}
+
+/// Whether disjoint wedges around `coord` cover the full disk: every wedge end
+/// must continue into another wedge's start (same exact direction), leaving no
+/// angular gap. Assumes non-overlapping face interiors.
+fn wedges_cover(coord: [f64; 2], wedges: &[([f64; 2], [f64; 2])]) -> bool {
+    if wedges.is_empty() {
+        return false;
+    }
+    let mut starts: Vec<[f64; 2]> = wedges.iter().map(|w| w.0).collect();
+    for &(_, end) in wedges {
+        let Some(pos) = starts
+            .iter()
+            .position(|&start| same_direction(coord, end, start))
+        else {
+            return false;
+        };
+        starts.swap_remove(pos);
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collection::Collection2D;
+    use crate::coordinate::CoordinateFrame;
+    use crate::line_string::LineString2D;
+    use crate::point::Point2D;
+    use crate::polygon::Polygon2D;
+    use crate::polygon_mesh::PolygonMesh2D;
+    use crate::triangular_mesh::TriangularMesh2D;
+    use pretty_assertions::assert_eq;
+
+    fn e() -> CoordinateFrame {
+        CoordinateFrame::Euclidean
+    }
+
+    fn polygon_with_hole() -> Euclidean2DGeometry {
+        let square = [[0.0, 0.0], [8.0, 0.0], [8.0, 8.0], [0.0, 8.0], [0.0, 0.0]];
+        let hole = vec![[2.0, 2.0], [2.0, 6.0], [6.0, 6.0], [6.0, 2.0], [2.0, 2.0]];
+        Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(e(), square, vec![hole])))
+    }
+
+    /// Two quads sharing the edge x = 2 (both wound CCW).
+    fn two_quads() -> Euclidean2DGeometry {
+        let mesh = PolygonMesh2D::from_parts(
+            e(),
+            vec![
+                [0.0, 0.0],
+                [2.0, 0.0],
+                [2.0, 2.0],
+                [0.0, 2.0],
+                [4.0, 0.0],
+                [4.0, 2.0],
+            ],
+            vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+        )
+        .unwrap();
+        Euclidean2DGeometry::PolygonMesh(Box::new(mesh))
+    }
+
+    #[test]
+    fn point_leaf_interior_is_itself() {
+        let p = Euclidean2DGeometry::Point(Point2D::new(e(), [1.0, 2.0]));
+        assert_eq!(point_position_2d([1.0, 2.0], &p), CoordPos::Inside);
+        assert_eq!(point_position_2d([1.0, 2.1], &p), CoordPos::Outside);
+    }
+
+    #[test]
+    fn line_endpoints_are_boundary_interior_is_inside() {
+        let l = Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            e(),
+            [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0]],
+        ));
+        assert_eq!(point_position_2d([2.0, 0.0], &l), CoordPos::Inside);
+        assert_eq!(point_position_2d([4.0, 0.0], &l), CoordPos::Inside); // mid vertex
+        assert_eq!(point_position_2d([0.0, 0.0], &l), CoordPos::OnBoundary);
+        assert_eq!(point_position_2d([4.0, 4.0], &l), CoordPos::OnBoundary);
+        assert_eq!(point_position_2d([1.0, 1.0], &l), CoordPos::Outside);
+    }
+
+    #[test]
+    fn closed_line_has_no_boundary() {
+        let l = Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            e(),
+            [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 0.0]],
+        ));
+        assert_eq!(point_position_2d([0.0, 0.0], &l), CoordPos::Inside);
+    }
+
+    #[test]
+    fn polygon_hole_positions() {
+        let p = polygon_with_hole();
+        assert_eq!(point_position_2d([1.0, 1.0], &p), CoordPos::Inside);
+        assert_eq!(point_position_2d([4.0, 4.0], &p), CoordPos::Outside); // in the hole
+        assert_eq!(point_position_2d([2.0, 4.0], &p), CoordPos::OnBoundary); // hole ring
+        assert_eq!(point_position_2d([0.0, 4.0], &p), CoordPos::OnBoundary); // outer ring
+        assert_eq!(point_position_2d([9.0, 4.0], &p), CoordPos::Outside);
+    }
+
+    #[test]
+    fn shared_mesh_edge_is_interior() {
+        let m = two_quads();
+        // Interior of the shared edge x = 2.
+        assert_eq!(point_position_2d([2.0, 1.0], &m), CoordPos::Inside);
+        // The outer rim stays boundary.
+        assert_eq!(point_position_2d([0.0, 1.0], &m), CoordPos::OnBoundary);
+        assert_eq!(point_position_2d([3.0, 0.0], &m), CoordPos::OnBoundary);
+        // A fully surrounded shared vertex is interior; a rim vertex is not.
+        assert_eq!(point_position_2d([2.0, 0.0], &m), CoordPos::OnBoundary);
+    }
+
+    #[test]
+    fn surrounded_vertex_is_interior() {
+        // Four quads around the central vertex (1, 1).
+        let mesh = PolygonMesh2D::from_parts(
+            e(),
+            vec![
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [2.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [2.0, 1.0],
+                [0.0, 2.0],
+                [1.0, 2.0],
+                [2.0, 2.0],
+            ],
+            vec![
+                vec![0u32, 1, 4, 3],
+                vec![1, 2, 5, 4],
+                vec![4, 5, 8, 7],
+                vec![3, 4, 7, 6],
+            ],
+        )
+        .unwrap();
+        let m = Euclidean2DGeometry::PolygonMesh(Box::new(mesh));
+        assert_eq!(point_position_2d([1.0, 1.0], &m), CoordPos::Inside);
+        // An edge midpoint between two quads is interior too.
+        assert_eq!(point_position_2d([1.0, 0.5], &m), CoordPos::Inside);
+        // A rim vertex is boundary.
+        assert_eq!(point_position_2d([1.0, 0.0], &m), CoordPos::OnBoundary);
+    }
+
+    #[test]
+    fn pinched_vertex_is_boundary() {
+        // Two triangles touching only at (1, 1): opposite quadrants.
+        let mesh = TriangularMesh2D::from_parts(
+            e(),
+            vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [2.0, 2.0], [1.0, 2.0]],
+            [0u32, 1, 2, 2, 3, 4],
+        )
+        .unwrap();
+        let m = Euclidean2DGeometry::TriangularMesh(Box::new(mesh));
+        assert_eq!(point_position_2d([1.0, 1.0], &m), CoordPos::OnBoundary);
+    }
+
+    #[test]
+    fn triangular_mesh_shared_edge_is_interior() {
+        let mesh = TriangularMesh2D::from_parts(
+            e(),
+            vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0], [0.0, 2.0]],
+            [0u32, 1, 2, 0, 2, 3],
+        )
+        .unwrap();
+        let m = Euclidean2DGeometry::TriangularMesh(Box::new(mesh));
+        // Midpoint of the shared diagonal.
+        assert_eq!(point_position_2d([1.0, 1.0], &m), CoordPos::Inside);
+        assert_eq!(point_position_2d([1.0, 0.0], &m), CoordPos::OnBoundary);
+        assert_eq!(point_position_2d([1.5, 0.5], &m), CoordPos::Inside);
+    }
+
+    #[test]
+    fn two_chains_joined_at_endpoint_make_it_interior() {
+        let a = Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            e(),
+            [[0.0, 0.0], [1.0, 0.0]],
+        ));
+        let b = Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            e(),
+            [[1.0, 0.0], [2.0, 0.0]],
+        ));
+        let c = Euclidean2DGeometry::Collection(Collection2D::new([a, b]));
+        assert_eq!(point_position_2d([1.0, 0.0], &c), CoordPos::Inside);
+        assert_eq!(point_position_2d([0.0, 0.0], &c), CoordPos::OnBoundary);
+    }
+
+    #[test]
+    fn empty_geometry_is_outside() {
+        let c = Euclidean2DGeometry::Collection(Collection2D::new([]));
+        assert_eq!(point_position_2d([0.0, 0.0], &c), CoordPos::Outside);
+    }
+}

--- a/engine/runtime/geometry/src/predicates/position.rs
+++ b/engine/runtime/geometry/src/predicates/position.rs
@@ -5,18 +5,18 @@
 //! [`OnBoundary`](CoordPos::OnBoundary), or [`Outside`](CoordPos::Outside),
 //! with OGC point-set semantics per leaf:
 //!
-//! - **Point** — the interior is the point itself; the boundary is empty.
-//! - **LineString** — the interior is the chain minus its endpoints; the
+//! - **Point**: the interior is the point itself; the boundary is empty.
+//! - **LineString**: the interior is the chain minus its endpoints; the
 //!   endpoints are the boundary, unless the chain is closed (then everything
 //!   is interior).
-//! - **Polygon / meshes** — faces are treated as a point-set union. A
+//! - **Polygon / meshes**: faces are treated as a point-set union. A
 //!   coordinate on a ring edge shared by two faces (or on a mesh vertex whose
 //!   incident faces cover a full disk) is *interior* to the union, not on its
 //!   boundary; the refinement is an exact angular-coverage test around the
 //!   coordinate. It assumes valid winding (exteriors CCW, holes CW) and
 //!   non-overlapping face interiors; on invalid input and on degenerate
 //!   (all-equal) rings it degrades to `OnBoundary`, never to a false `Inside`.
-//! - **Collections** — the union of the members: the highest member
+//! - **Collections**: the union of the members, the highest member
 //!   classification wins (`Inside` > `OnBoundary` > `Outside`), with the
 //!   line-endpoint boundary counted mod 2 across all line members.
 //!

--- a/engine/runtime/geometry/src/predicates/relate/boundary.rs
+++ b/engine/runtime/geometry/src/predicates/relate/boundary.rs
@@ -1,0 +1,277 @@
+//! Union-boundary extraction for mesh leaves.
+//!
+//! A mesh cannot feed the geometry graph face by face: adjacent faces share
+//! whole edges, which the JTS graph would label as boundary even though they
+//! are interior to the union (the same fact the shared-edge refinement in
+//! [`position`](crate::predicates::position) encodes). This pre-pass reduces a
+//! mesh to the directed boundary rings of its face union:
+//!
+//! 1. collect every directed ring edge of every face (holes included);
+//! 2. cancel pairs that occur in both directions — internal shared edges;
+//! 3. stitch the survivors into closed loops.
+//!
+//! Directions are preserved throughout, so with Flow's validated winding
+//! (exteriors CCW, holes CW — face interior locally *left* of every directed
+//! edge) each output ring has the union interior on its left, and can be fed
+//! to the graph with fixed `On = Boundary, Left = Inside, Right = Outside`
+//! labels — no winding recomputation.
+//!
+//! Assumes a valid mesh (non-overlapping face interiors, consistent winding),
+//! like the rest of the predicates; on invalid input where a walk cannot
+//! close, the chain is force-closed with a synthetic edge back to its start
+//! rather than panicking.
+
+use std::collections::BTreeMap;
+
+use crate::predicates::view::AreaView;
+
+/// A coordinate as its bit pattern, usable as an exact, `Ord` map key.
+type BitCoord = [u64; 2];
+
+fn bits(c: [f64; 2]) -> BitCoord {
+    // Fold -0.0 into 0.0 so the two bit patterns of numeric zero cancel.
+    let f = |v: f64| {
+        if v == 0.0 {
+            0.0f64.to_bits()
+        } else {
+            v.to_bits()
+        }
+    };
+    [f(c[0]), f(c[1])]
+}
+
+/// The union boundary of an areal leaf, as closed directed rings
+/// (first == last) with the union interior locally left of every edge.
+pub(crate) fn union_boundary_rings(area: &AreaView<'_>) -> Vec<Vec<[f64; 2]>> {
+    // Multiset of surviving directed edges, opposite pairs cancelled.
+    let mut counts: BTreeMap<(BitCoord, BitCoord), usize> = BTreeMap::new();
+    let mut coord_of: BTreeMap<BitCoord, [f64; 2]> = BTreeMap::new();
+    for (start, end) in area.edges() {
+        if start == end {
+            continue;
+        }
+        let key = (bits(start), bits(end));
+        let reverse = (key.1, key.0);
+        match counts.get_mut(&reverse) {
+            Some(count) => {
+                *count -= 1;
+                if *count == 0 {
+                    counts.remove(&reverse);
+                }
+            }
+            None => {
+                *counts.entry(key).or_insert(0) += 1;
+                coord_of.insert(key.0, start);
+                coord_of.insert(key.1, end);
+            }
+        }
+    }
+
+    // Outgoing-edge multimap over the survivors.
+    let mut outgoing: BTreeMap<BitCoord, Vec<BitCoord>> = BTreeMap::new();
+    for ((start, end), count) in counts {
+        outgoing
+            .entry(start)
+            .or_default()
+            .extend(std::iter::repeat_n(end, count));
+    }
+
+    // Stitch loops by walking outgoing edges. Whenever the walk revisits a
+    // vertex already on the current path, the piece since that visit is a
+    // closed loop: split it off as its own ring. This keeps every output ring
+    // simple — a walk through a pinch vertex yields one ring per wedge, never
+    // a figure eight.
+    let mut rings = Vec::new();
+    while let Some((&start, _)) = outgoing.iter().next() {
+        let mut path: Vec<BitCoord> = vec![start];
+        let mut position_in_path: BTreeMap<BitCoord, usize> = BTreeMap::from([(start, 0)]);
+        loop {
+            let current = *path.last().expect("path starts non-empty");
+            let Some(nexts) = outgoing.get_mut(&current) else {
+                // No outgoing edge. A leftover chain means invalid input
+                // (unmatched edges): force-close it rather than panic.
+                if path.len() > 1 {
+                    let mut ring: Vec<[f64; 2]> = path.iter().map(|k| coord_of[k]).collect();
+                    ring.push(ring[0]);
+                    rings.push(ring);
+                }
+                break;
+            };
+            let next = nexts.pop().expect("empty entries are removed eagerly");
+            if nexts.is_empty() {
+                outgoing.remove(&current);
+            }
+            match position_in_path.get(&next) {
+                Some(&p) => {
+                    // Closed a loop back to path[p]: emit path[p..] + closer.
+                    let mut ring: Vec<[f64; 2]> = path[p..].iter().map(|k| coord_of[k]).collect();
+                    ring.push(coord_of[&next]);
+                    rings.push(ring);
+                    for popped in path.drain(p + 1..) {
+                        position_in_path.remove(&popped);
+                    }
+                }
+                None => {
+                    position_in_path.insert(next, path.len());
+                    path.push(next);
+                }
+            }
+        }
+    }
+    rings
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinate::CoordinateFrame;
+    use crate::polygon_mesh::PolygonMesh2D;
+    use crate::triangular_mesh::TriangularMesh2D;
+    use pretty_assertions::assert_eq;
+
+    fn e() -> CoordinateFrame {
+        CoordinateFrame::Euclidean
+    }
+
+    /// Twice the signed area of a closed ring (positive = CCW).
+    fn doubled_signed_area(ring: &[[f64; 2]]) -> f64 {
+        ring.windows(2)
+            .map(|e| e[0][0] * e[1][1] - e[1][0] * e[0][1])
+            .sum()
+    }
+
+    fn ring_edges(ring: &[[f64; 2]]) -> Vec<([f64; 2], [f64; 2])> {
+        ring.windows(2).map(|e| (e[0], e[1])).collect()
+    }
+
+    #[test]
+    fn two_quads_dissolve_to_one_ring() {
+        // Two quads sharing the edge x = 2.
+        let mesh = PolygonMesh2D::from_parts(
+            e(),
+            vec![
+                [0.0, 0.0],
+                [2.0, 0.0],
+                [2.0, 2.0],
+                [0.0, 2.0],
+                [4.0, 0.0],
+                [4.0, 2.0],
+            ],
+            vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+        )
+        .unwrap();
+        let rings = union_boundary_rings(&AreaView::from_polygon_mesh(&mesh));
+
+        assert_eq!(rings.len(), 1);
+        let ring = &rings[0];
+        assert_eq!(ring.first(), ring.last());
+        assert_eq!(ring.len(), 7); // 6 boundary vertices, stored closed
+        assert!(doubled_signed_area(ring) > 0.0); // interior on the left
+        let edges = ring_edges(ring);
+        // The shared edge is gone in both directions.
+        assert!(!edges.contains(&([2.0, 0.0], [2.0, 2.0])));
+        assert!(!edges.contains(&([2.0, 2.0], [2.0, 0.0])));
+        // Rim edges keep their face direction.
+        assert!(edges.contains(&([0.0, 0.0], [2.0, 0.0])));
+        assert!(edges.contains(&([2.0, 0.0], [4.0, 0.0])));
+    }
+
+    #[test]
+    fn triangulated_square_dissolves_to_square() {
+        let mesh = TriangularMesh2D::from_parts(
+            e(),
+            vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0], [0.0, 2.0]],
+            [0u32, 1, 2, 0, 2, 3],
+        )
+        .unwrap();
+        let rings = union_boundary_rings(&AreaView::from_triangular_mesh(&mesh));
+
+        assert_eq!(rings.len(), 1);
+        assert_eq!(rings[0].len(), 5);
+        assert_eq!(doubled_signed_area(&rings[0]), 8.0);
+    }
+
+    #[test]
+    fn quad_ring_yields_outer_and_hole_rings() {
+        // A 3x3 grid of unit quads with the center quad missing: the union is
+        // a square annulus whose boundary is an outer CCW and an inner CW ring.
+        let mut vertices = Vec::new();
+        for y in 0..4 {
+            for x in 0..4 {
+                vertices.push([x as f64, y as f64]);
+            }
+        }
+        let index = |x: u32, y: u32| y * 4 + x;
+        let mut faces = Vec::new();
+        for y in 0..3u32 {
+            for x in 0..3u32 {
+                if x == 1 && y == 1 {
+                    continue;
+                }
+                faces.push(vec![
+                    index(x, y),
+                    index(x + 1, y),
+                    index(x + 1, y + 1),
+                    index(x, y + 1),
+                ]);
+            }
+        }
+        let mesh = PolygonMesh2D::from_parts(e(), vertices, faces).unwrap();
+        let mut rings = union_boundary_rings(&AreaView::from_polygon_mesh(&mesh));
+        rings.sort_by_key(|r| r.len());
+
+        assert_eq!(rings.len(), 2);
+        // Inner ring: the hole, wound CW (union interior still on the left).
+        assert_eq!(rings[0].len(), 5);
+        assert_eq!(doubled_signed_area(&rings[0]), -2.0);
+        // Outer ring: CCW around the full 3x3 square.
+        assert_eq!(rings[1].len(), 13);
+        assert_eq!(doubled_signed_area(&rings[1]), 18.0);
+    }
+
+    #[test]
+    fn pinch_vertex_yields_two_rings() {
+        // Two triangles touching only at (1, 1).
+        let mesh = TriangularMesh2D::from_parts(
+            e(),
+            vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [2.0, 2.0], [1.0, 2.0]],
+            [0u32, 1, 2, 2, 3, 4],
+        )
+        .unwrap();
+        let rings = union_boundary_rings(&AreaView::from_triangular_mesh(&mesh));
+
+        assert_eq!(rings.len(), 2);
+        for ring in &rings {
+            assert_eq!(ring.len(), 4);
+            assert!(doubled_signed_area(ring) > 0.0);
+        }
+    }
+
+    #[test]
+    fn face_hole_ring_passes_through() {
+        // One quad with an unshared hole: both rings survive verbatim.
+        let mesh = PolygonMesh2D::from_raw_parts(
+            e(),
+            vec![
+                [0.0, 0.0],
+                [6.0, 0.0],
+                [6.0, 6.0],
+                [0.0, 6.0],
+                [2.0, 2.0],
+                [2.0, 4.0],
+                [4.0, 4.0],
+                [4.0, 2.0],
+            ],
+            vec![0, 1, 2, 3, 0, 4, 5, 6, 7, 4],
+            vec![],
+            vec![5],
+        )
+        .unwrap();
+        let mut rings = union_boundary_rings(&AreaView::from_polygon_mesh(&mesh));
+        rings.sort_by_key(|r| doubled_signed_area(r) as i64);
+
+        assert_eq!(rings.len(), 2);
+        assert_eq!(doubled_signed_area(&rings[0]), -8.0); // hole, CW
+        assert_eq!(doubled_signed_area(&rings[1]), 72.0); // exterior, CCW
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/boundary.rs
+++ b/engine/runtime/geometry/src/predicates/relate/boundary.rs
@@ -7,14 +7,14 @@
 //! mesh to the directed boundary rings of its face union:
 //!
 //! 1. collect every directed ring edge of every face (holes included);
-//! 2. cancel pairs that occur in both directions — internal shared edges;
+//! 2. cancel pairs that occur in both directions (internal shared edges);
 //! 3. stitch the survivors into closed loops.
 //!
 //! Directions are preserved throughout, so with Flow's validated winding
-//! (exteriors CCW, holes CW — face interior locally *left* of every directed
-//! edge) each output ring has the union interior on its left, and can be fed
-//! to the graph with fixed `On = Boundary, Left = Inside, Right = Outside`
-//! labels — no winding recomputation.
+//! (exteriors CCW, holes CW, with face interior locally *left* of every
+//! directed edge) each output ring has the union interior on its left, and can
+//! be fed to the graph with fixed `On = Boundary, Left = Inside, Right =
+//! Outside` labels, with no winding recomputation.
 //!
 //! Assumes a valid mesh (non-overlapping face interiors, consistent winding),
 //! like the rest of the predicates; on invalid input where a walk cannot
@@ -79,7 +79,7 @@ pub(crate) fn union_boundary_rings(area: &AreaView<'_>) -> Vec<Vec<[f64; 2]>> {
     // Stitch loops by walking outgoing edges. Whenever the walk revisits a
     // vertex already on the current path, the piece since that visit is a
     // closed loop: split it off as its own ring. This keeps every output ring
-    // simple — a walk through a pinch vertex yields one ring per wedge, never
+    // simple: a walk through a pinch vertex yields one ring per wedge, never
     // a figure eight.
     let mut rings = Vec::new();
     while let Some((&start, _)) = outgoing.iter().next() {

--- a/engine/runtime/geometry/src/predicates/relate/edge_end_builder.rs
+++ b/engine/runtime/geometry/src/predicates/relate/edge_end_builder.rs
@@ -1,0 +1,116 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use super::graph::{Edge, EdgeEnd, EdgeIntersection};
+
+/// Computes the [`EdgeEnd`]s which arise from a noded [`Edge`]: one stub per
+/// direction at every intersection point along the edge.
+pub(crate) struct EdgeEndBuilder;
+
+impl EdgeEndBuilder {
+    pub fn new() -> Self {
+        EdgeEndBuilder
+    }
+
+    pub fn compute_ends_for_edges(&self, edges: &[Rc<RefCell<Edge>>]) -> Vec<EdgeEnd> {
+        let mut list = vec![];
+        for edge in edges {
+            self.compute_ends_for_edge(&mut edge.borrow_mut(), &mut list);
+        }
+        list
+    }
+
+    fn compute_ends_for_edge(&self, edge: &mut Edge, list: &mut Vec<EdgeEnd>) {
+        edge.add_edge_intersection_list_endpoints();
+
+        let mut ei_iter = edge.edge_intersections().iter();
+        let mut ei_prev;
+        let mut ei_curr = None;
+        let mut ei_next = ei_iter.next();
+        if ei_next.is_none() {
+            return;
+        }
+
+        loop {
+            ei_prev = ei_curr;
+            ei_curr = ei_next;
+            ei_next = ei_iter.next();
+            if let Some(ei_curr) = ei_curr {
+                self.create_edge_end_for_prev(edge, list, ei_curr, ei_prev);
+                self.create_edge_end_for_next(edge, list, ei_curr, ei_next);
+            }
+
+            if ei_curr.is_none() {
+                break;
+            }
+        }
+    }
+
+    /// Adds a `EdgeEnd`, if any, to `list` for the edge before the intersection ei_curr.
+    ///
+    /// The previous intersection is provided in case it is the endpoint for the stub edge.
+    /// Otherwise, the previous point from the parent edge will be the endpoint.
+    fn create_edge_end_for_prev(
+        &self,
+        edge: &Edge,
+        list: &mut Vec<EdgeEnd>,
+        ei_curr: &EdgeIntersection,
+        ei_prev: Option<&EdgeIntersection>,
+    ) {
+        let mut i_prev = ei_curr.segment_index();
+        if ei_curr.distance() == 0.0 {
+            // if at the start of the edge there is no previous edge
+            if i_prev == 0 {
+                return;
+            }
+            i_prev -= 1;
+        }
+
+        let mut coord_prev = edge.coords()[i_prev];
+        // if prev intersection is past the previous vertex, use it instead
+        if let Some(ei_prev) = ei_prev {
+            if ei_prev.segment_index() >= i_prev {
+                coord_prev = ei_prev.coordinate();
+            }
+        }
+
+        let mut label = edge.label().clone();
+        // since edgeStub is oriented opposite to its parent edge, have to flip sides for edge label
+        label.flip();
+
+        let edge_end = EdgeEnd::new(ei_curr.coordinate(), coord_prev, label);
+        list.push(edge_end);
+    }
+
+    /// Adds a `EdgeEnd`, if any, to `list` for the edge after the intersection ei_curr.
+    ///
+    /// The next intersection is provided in case it is the endpoint for the stub edge.
+    /// Otherwise, the next point from the parent edge will be the endpoint.
+    fn create_edge_end_for_next(
+        &self,
+        edge: &Edge,
+        list: &mut Vec<EdgeEnd>,
+        ei_curr: &EdgeIntersection,
+        ei_next: Option<&EdgeIntersection>,
+    ) {
+        let i_next = ei_curr.segment_index() + 1;
+
+        // if there is no next edge there is nothing to do
+        if i_next >= edge.coords().len() && ei_next.is_none() {
+            return;
+        }
+
+        let mut coord_next = edge.coords()[i_next];
+
+        // if the next intersection is in the same segment as the current, use it as the endpoint
+        if let Some(ei_next) = ei_next {
+            if ei_next.segment_index() == ei_curr.segment_index() {
+                coord_next = ei_next.coordinate();
+            }
+        }
+
+        let label = edge.label().clone();
+        let edge_end = EdgeEnd::new(ei_curr.coordinate(), coord_next, label);
+        list.push(edge_end);
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/edge.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/edge.rs
@@ -155,10 +155,8 @@ impl Edge {
 }
 
 /// The relative position of `intersection` along the segment `start -> end`,
-/// measured on the segment's dominant axis; a port of the legacy
-/// `RobustLineIntersector::compute_edge_distance`. Not a true distance —
-/// only its ordering along the segment matters (it keys
-/// [`EdgeIntersection`]'s sort).
+/// measured on the segment's dominant axis. Not a true distance: only its
+/// ordering along the segment matters (it keys [`EdgeIntersection`]'s sort).
 fn compute_edge_distance(intersection: [f64; 2], start: [f64; 2], end: [f64; 2]) -> f64 {
     let dx = (end[0] - start[0]).abs();
     let dy = (end[1] - start[1]).abs();

--- a/engine/runtime/geometry/src/predicates/relate/graph/edge.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/edge.rs
@@ -1,0 +1,189 @@
+use std::collections::BTreeSet;
+
+use crate::predicates::kernel::SegmentIntersection;
+use crate::predicates::relate::intersection_matrix::Dimensions;
+
+use super::{Direction, EdgeIntersection, IntersectionMatrix, Label};
+
+#[derive(Debug)]
+pub(crate) struct Edge {
+    /// `coordinates` of the line geometry
+    coords: Vec<[f64; 2]>,
+
+    /// an edge is "isolated" if no other edge touches it
+    is_isolated: bool,
+
+    /// other edges that this edge intersects with
+    edge_intersections: BTreeSet<EdgeIntersection>,
+
+    /// where the line's topological classification to the two geometries is recorded
+    label: Label,
+}
+
+impl Edge {
+    /// Create a new Edge.
+    ///
+    /// - `coords` a *non-empty* Vec of Coords
+    /// - `label` an appropriately dimensioned topology label for the Edge. See
+    ///   [`TopologyPosition`](super::TopologyPosition) for details
+    pub(crate) fn new(mut coords: Vec<[f64; 2]>, label: Label) -> Edge {
+        assert!(!coords.is_empty(), "Can't add empty edge");
+        coords.shrink_to_fit();
+        Edge {
+            coords,
+            label,
+            is_isolated: true,
+            edge_intersections: BTreeSet::new(),
+        }
+    }
+
+    pub(crate) fn label(&self) -> &Label {
+        &self.label
+    }
+
+    pub(crate) fn label_mut(&mut self) -> &mut Label {
+        &mut self.label
+    }
+
+    pub fn coords(&self) -> &[[f64; 2]] {
+        &self.coords
+    }
+
+    pub fn is_isolated(&self) -> bool {
+        self.is_isolated
+    }
+    pub fn mark_as_unisolated(&mut self) {
+        self.is_isolated = false;
+    }
+
+    pub fn edge_intersections(&self) -> &BTreeSet<EdgeIntersection> {
+        &self.edge_intersections
+    }
+
+    pub fn edge_intersections_mut(&mut self) -> &mut BTreeSet<EdgeIntersection> {
+        &mut self.edge_intersections
+    }
+
+    pub fn add_edge_intersection_list_endpoints(&mut self) {
+        let max_segment_index = self.coords().len() - 1;
+        let first_coord = self.coords()[0];
+        let max_coord = self.coords()[max_segment_index];
+        self.edge_intersections_mut()
+            .insert(EdgeIntersection::new(first_coord, 0, 0.0));
+        self.edge_intersections_mut().insert(EdgeIntersection::new(
+            max_coord,
+            max_segment_index,
+            0.0,
+        ));
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.coords().first() == self.coords().last()
+    }
+
+    /// Adds EdgeIntersections for one or both intersections found for a segment of an edge to the
+    /// edge intersection list.
+    pub fn add_intersections(
+        &mut self,
+        intersection: SegmentIntersection,
+        line: ([f64; 2], [f64; 2]),
+        segment_index: usize,
+    ) {
+        match intersection {
+            SegmentIntersection::SinglePoint { intersection, .. } => {
+                self.add_intersection(intersection, line, segment_index);
+            }
+            SegmentIntersection::Collinear { start, end } => {
+                self.add_intersection(start, line, segment_index);
+                self.add_intersection(end, line, segment_index);
+            }
+        }
+    }
+
+    /// Add an EdgeIntersection for `intersection`.
+    ///
+    /// An intersection that falls exactly on a vertex of the edge is normalized to use the higher
+    /// of the two possible `segment_index`
+    pub fn add_intersection(
+        &mut self,
+        intersection_coord: [f64; 2],
+        line: ([f64; 2], [f64; 2]),
+        segment_index: usize,
+    ) {
+        let mut normalized_segment_index = segment_index;
+        let mut distance = compute_edge_distance(intersection_coord, line.0, line.1);
+
+        let next_segment_index = normalized_segment_index + 1;
+
+        if next_segment_index < self.coords.len() {
+            let next_coord = self.coords[next_segment_index];
+            if intersection_coord == next_coord {
+                normalized_segment_index = next_segment_index;
+                distance = 0.0;
+            }
+        }
+        self.edge_intersections.insert(EdgeIntersection::new(
+            intersection_coord,
+            normalized_segment_index,
+            distance,
+        ));
+    }
+
+    /// Update the IM with the contribution for this component.
+    ///
+    /// A component only contributes if it has a labelling for both parent geometries
+    pub fn update_intersection_matrix(label: &Label, intersection_matrix: &mut IntersectionMatrix) {
+        intersection_matrix.set_at_least_if_in_both(
+            label.position(0, Direction::On),
+            label.position(1, Direction::On),
+            Dimensions::OneDimensional,
+        );
+
+        if label.is_area() {
+            intersection_matrix.set_at_least_if_in_both(
+                label.position(0, Direction::Left),
+                label.position(1, Direction::Left),
+                Dimensions::TwoDimensional,
+            );
+            intersection_matrix.set_at_least_if_in_both(
+                label.position(0, Direction::Right),
+                label.position(1, Direction::Right),
+                Dimensions::TwoDimensional,
+            );
+        }
+    }
+}
+
+/// The relative position of `intersection` along the segment `start -> end`,
+/// measured on the segment's dominant axis; a port of the legacy
+/// `RobustLineIntersector::compute_edge_distance`. Not a true distance —
+/// only its ordering along the segment matters (it keys
+/// [`EdgeIntersection`]'s sort).
+fn compute_edge_distance(intersection: [f64; 2], start: [f64; 2], end: [f64; 2]) -> f64 {
+    let dx = (end[0] - start[0]).abs();
+    let dy = (end[1] - start[1]).abs();
+
+    let mut dist: f64;
+    if intersection == start {
+        dist = 0.0;
+    } else if intersection == end {
+        if dx > dy {
+            dist = dx;
+        } else {
+            dist = dy;
+        }
+    } else {
+        let intersection_dx = (intersection[0] - start[0]).abs();
+        let intersection_dy = (intersection[1] - start[1]).abs();
+        if dx > dy {
+            dist = intersection_dx;
+        } else {
+            dist = intersection_dy;
+        }
+        // hack to ensure that non-endpoints always have a non-zero distance
+        if dist == 0.0 && intersection != start {
+            dist = intersection_dx.max(intersection_dy);
+        }
+    }
+    dist
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/edge_end.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/edge_end.rs
@@ -94,13 +94,9 @@ impl std::cmp::Ord for EdgeEndKey {
 }
 
 impl EdgeEndKey {
-    /// JTS `EdgeEnd::compareDirection`: same quadrant ties break on the robust
-    /// orientation of this end's direction point against the other end's ray.
-    ///
-    /// Note: the legacy in-tree copy routes this through a four-point
-    /// `orient3d` with `z` defaulted to `0`, which degenerates to `Collinear`
-    /// for all-2D input and over-bundles same-quadrant edge ends; this port
-    /// restores the JTS/georust three-point `orient2d`.
+    /// Compares the directions of two edge ends (JTS `EdgeEnd::compareDirection`):
+    /// same-quadrant ties break on the robust orientation of this end's
+    /// direction point against the other end's ray.
     pub(crate) fn compare_direction(&self, other: &EdgeEndKey) -> std::cmp::Ordering {
         use std::cmp::Ordering;
         if self.delta == other.delta {

--- a/engine/runtime/geometry/src/predicates/relate/graph/edge_end.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/edge_end.rs
@@ -76,8 +76,10 @@ impl EdgeEnd {
 impl std::cmp::Eq for EdgeEndKey {}
 
 impl std::cmp::PartialEq for EdgeEndKey {
+    /// Consistent with [`Ord`]: two keys are equal exactly when they point in
+    /// the same direction, so the `Ord`/`Eq` contract holds.
     fn eq(&self, other: &EdgeEndKey) -> bool {
-        self.delta == other.delta
+        self.compare_direction(other) == std::cmp::Ordering::Equal
     }
 }
 

--- a/engine/runtime/geometry/src/predicates/relate/graph/edge_end.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/edge_end.rs
@@ -1,0 +1,120 @@
+use crate::predicates::kernel::{orient2d, Orientation};
+
+use super::{Label, Quadrant};
+
+use std::fmt;
+
+/// Models the end of an edge incident on a node.
+///
+/// EdgeEnds have a direction determined by the direction of the ray from the initial
+/// point to the next point.
+///
+/// EdgeEnds are comparable by their EdgeEndKey, under the ordering
+/// "a has a greater angle with the x-axis than b".
+///
+/// This ordering is used to sort EdgeEnds around a node.
+///
+/// This is based on [JTS's EdgeEnd as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/geomgraph/EdgeEnd.java)
+#[derive(Clone, Debug)]
+pub(crate) struct EdgeEnd {
+    label: Label,
+    key: EdgeEndKey,
+}
+
+#[derive(Clone)]
+pub(crate) struct EdgeEndKey {
+    coord_0: [f64; 2],
+    coord_1: [f64; 2],
+    delta: [f64; 2],
+    quadrant: Option<Quadrant>,
+}
+
+impl fmt::Debug for EdgeEndKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EdgeEndKey")
+            .field(
+                "coords",
+                &format!("{:?} -> {:?}", &self.coord_0, &self.coord_1),
+            )
+            .field("quadrant", &self.quadrant)
+            .finish()
+    }
+}
+
+impl EdgeEnd {
+    pub fn new(coord_0: [f64; 2], coord_1: [f64; 2], label: Label) -> EdgeEnd {
+        let delta = [coord_1[0] - coord_0[0], coord_1[1] - coord_0[1]];
+        let quadrant = Quadrant::new(delta[0], delta[1]);
+        EdgeEnd {
+            label,
+            key: EdgeEndKey {
+                coord_0,
+                coord_1,
+                delta,
+                quadrant,
+            },
+        }
+    }
+
+    pub fn label(&self) -> &Label {
+        &self.label
+    }
+
+    pub fn label_mut(&mut self) -> &mut Label {
+        &mut self.label
+    }
+
+    pub fn coordinate(&self) -> &[f64; 2] {
+        &self.key.coord_0
+    }
+
+    pub fn key(&self) -> &EdgeEndKey {
+        &self.key
+    }
+}
+
+impl std::cmp::Eq for EdgeEndKey {}
+
+impl std::cmp::PartialEq for EdgeEndKey {
+    fn eq(&self, other: &EdgeEndKey) -> bool {
+        self.delta == other.delta
+    }
+}
+
+impl std::cmp::PartialOrd for EdgeEndKey {
+    fn partial_cmp(&self, other: &EdgeEndKey) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for EdgeEndKey {
+    fn cmp(&self, other: &EdgeEndKey) -> std::cmp::Ordering {
+        self.compare_direction(other)
+    }
+}
+
+impl EdgeEndKey {
+    /// JTS `EdgeEnd::compareDirection`: same quadrant ties break on the robust
+    /// orientation of this end's direction point against the other end's ray.
+    ///
+    /// Note: the legacy in-tree copy routes this through a four-point
+    /// `orient3d` with `z` defaulted to `0`, which degenerates to `Collinear`
+    /// for all-2D input and over-bundles same-quadrant edge ends; this port
+    /// restores the JTS/georust three-point `orient2d`.
+    pub(crate) fn compare_direction(&self, other: &EdgeEndKey) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        if self.delta == other.delta {
+            return Ordering::Equal;
+        }
+
+        match (self.quadrant, other.quadrant) {
+            (Some(q1), Some(q2)) if q1 > q2 => Ordering::Greater,
+            (Some(q1), Some(q2)) if q1 < q2 => Ordering::Less,
+            _ => match orient2d(other.coord_0, other.coord_1, self.coord_1) {
+                Orientation::Clockwise => Ordering::Less,
+                Orientation::CounterClockwise => Ordering::Greater,
+                Orientation::Collinear => Ordering::Equal,
+            },
+        }
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/edge_end_bundle.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/edge_end_bundle.rs
@@ -1,0 +1,160 @@
+use crate::predicates::kernel::CoordPos;
+
+use super::{determine_boundary, Direction, Edge, EdgeEnd, IntersectionMatrix, Label};
+
+/// A collection of [`EdgeEnds`](EdgeEnd) which obey the following invariant:
+/// They originate at the same node and have the same direction.
+///
+/// This is based on [JTS's `EdgeEndBundle` as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/operation/relate/EdgeEndBundle.java)
+#[derive(Clone, Debug)]
+pub(crate) struct EdgeEndBundle {
+    coordinate: [f64; 2],
+    edge_ends: Vec<EdgeEnd>,
+}
+
+impl EdgeEndBundle {
+    pub(crate) fn new(coordinate: [f64; 2]) -> Self {
+        Self {
+            coordinate,
+            edge_ends: vec![],
+        }
+    }
+
+    fn edge_ends_iter(&self) -> impl Iterator<Item = &EdgeEnd> {
+        self.edge_ends.iter()
+    }
+
+    fn edge_ends_iter_mut(&mut self) -> impl Iterator<Item = &mut EdgeEnd> {
+        self.edge_ends.iter_mut()
+    }
+
+    pub(crate) fn insert(&mut self, edge_end: EdgeEnd) {
+        self.edge_ends.push(edge_end);
+    }
+
+    pub(crate) fn into_labeled(mut self) -> LabeledEdgeEndBundle {
+        let is_area = self
+            .edge_ends_iter()
+            .any(|edge_end| edge_end.label().is_area());
+
+        let mut label = if is_area {
+            Label::empty_area()
+        } else {
+            Label::empty_line_or_point()
+        };
+
+        for i in 0..2 {
+            self.compute_label_on(&mut label, i);
+            if is_area {
+                self.compute_label_side(&mut label, i, Direction::Left);
+                self.compute_label_side(&mut label, i, Direction::Right);
+            }
+        }
+
+        LabeledEdgeEndBundle {
+            label,
+            edge_end_bundle: self,
+        }
+    }
+
+    fn compute_label_on(&mut self, label: &mut Label, geom_index: usize) {
+        let mut boundary_count = 0;
+        let mut found_interior = false;
+
+        for edge_end in self.edge_ends_iter() {
+            match edge_end.label().on_position(geom_index) {
+                Some(CoordPos::OnBoundary) => {
+                    boundary_count += 1;
+                }
+                Some(CoordPos::Inside) => {
+                    found_interior = true;
+                }
+                None | Some(CoordPos::Outside) => {}
+            }
+        }
+
+        let mut position = None;
+        if found_interior {
+            position = Some(CoordPos::Inside);
+        }
+
+        if boundary_count > 0 {
+            position = Some(determine_boundary(boundary_count));
+        }
+
+        if let Some(location) = position {
+            label.set_on_position(geom_index, location);
+        } else {
+            // This is technically a diversion from JTS, but I don't think we'd ever
+            // get here, unless `l.on_location` was *already* None, in which cases this is a
+            // no-op, so assert that assumption.
+            // If this assert is rightfully triggered, we may need to add a method like
+            // `l.clear_on_location(geom_index)`
+            debug_assert!(
+                label.on_position(geom_index).is_none(),
+                "diverging from JTS, which would have replaced the existing Location with None"
+            );
+        }
+    }
+
+    /// To compute the summary label for a side, the algorithm is:
+    ///     FOR all edges
+    ///       IF any edge's location is INTERIOR for the side, side location = INTERIOR
+    ///       ELSE IF there is at least one EXTERIOR attribute, side location = EXTERIOR
+    ///       ELSE  side location = NULL
+    /// Note that it is possible for two sides to have apparently contradictory information
+    /// i.e. one edge side may indicate that it is in the interior of a geometry, while
+    /// another edge side may indicate the exterior of the same geometry.  This is
+    /// not an incompatibility - GeometryCollections may contain two Polygons that touch
+    /// along an edge.  This is the reason for Interior-primacy rule above - it
+    /// results in the summary label having the Geometry interior on _both_ sides.
+    fn compute_label_side(&mut self, label: &mut Label, geom_index: usize, side: Direction) {
+        let mut position = None;
+        for edge_end in self.edge_ends_iter_mut() {
+            if edge_end.label().is_area() {
+                match edge_end.label_mut().position(geom_index, side) {
+                    Some(CoordPos::Inside) => {
+                        position = Some(CoordPos::Inside);
+                        break;
+                    }
+                    Some(CoordPos::Outside) => {
+                        position = Some(CoordPos::Outside);
+                    }
+                    None | Some(CoordPos::OnBoundary) => {}
+                }
+            }
+        }
+
+        if let Some(position) = position {
+            label.set_position(geom_index, side, position);
+        }
+    }
+}
+
+/// An [`EdgeEndBundle`] whose topological relationships have been aggregated into a single
+/// [`Label`].
+///
+/// `update_intersection_matrix` applies this aggregated topology to an `IntersectionMatrix`.
+#[derive(Clone, Debug)]
+pub(crate) struct LabeledEdgeEndBundle {
+    label: Label,
+    edge_end_bundle: EdgeEndBundle,
+}
+
+impl LabeledEdgeEndBundle {
+    pub fn label(&self) -> &Label {
+        &self.label
+    }
+
+    pub fn label_mut(&mut self) -> &mut Label {
+        &mut self.label
+    }
+
+    pub fn update_intersection_matrix(&self, intersection_matrix: &mut IntersectionMatrix) {
+        Edge::update_intersection_matrix(self.label(), intersection_matrix);
+    }
+
+    pub fn coordinate(&self) -> &[f64; 2] {
+        &self.edge_end_bundle.coordinate
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/edge_end_bundle_star.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/edge_end_bundle_star.rs
@@ -30,9 +30,8 @@ impl LabeledEdgeEndBundleStar {
     fn compute_labeling(&mut self, graph_a: &GeometryGraph<'_>, graph_b: &GeometryGraph<'_>) {
         self.propagate_side_labels(0);
         self.propagate_side_labels(1);
-        // Note: JTS ORs this flag across the bundles; the georust port (and the
-        // legacy in-tree copy) overwrite it, so the last bundle wins. Kept
-        // as-is for differential parity with the in-tree legacy relate.
+        // Note: JTS ORs this flag across the bundles; here it is overwritten, so
+        // the last bundle wins.
         let mut has_dimensional_collapse_edge = [false, false];
         for edge_end in self.edges.iter() {
             let label = edge_end.label();

--- a/engine/runtime/geometry/src/predicates/relate/graph/edge_end_bundle_star.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/edge_end_bundle_star.rs
@@ -1,0 +1,171 @@
+use crate::predicates::kernel::CoordPos;
+use crate::predicates::relate::intersection_matrix::Dimensions;
+
+use super::{
+    Direction, EdgeEnd, EdgeEndBundle, EdgeEndKey, GeometryGraph, IntersectionMatrix,
+    LabeledEdgeEndBundle,
+};
+
+pub(crate) struct EdgeEndBundleStar {
+    edge_map: std::collections::BTreeMap<EdgeEndKey, EdgeEndBundle>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LabeledEdgeEndBundleStar {
+    edges: Vec<LabeledEdgeEndBundle>,
+}
+
+impl LabeledEdgeEndBundleStar {
+    pub(crate) fn new(
+        edges: Vec<LabeledEdgeEndBundle>,
+        graph_a: &GeometryGraph<'_>,
+        graph_b: &GeometryGraph<'_>,
+    ) -> Self {
+        let mut labeled_bundle_star = Self { edges };
+        labeled_bundle_star.compute_labeling(graph_a, graph_b);
+        labeled_bundle_star
+    }
+
+    /// Compute a label for the star based on the labels of its EdgeEndBundles.
+    fn compute_labeling(&mut self, graph_a: &GeometryGraph<'_>, graph_b: &GeometryGraph<'_>) {
+        self.propagate_side_labels(0);
+        self.propagate_side_labels(1);
+        // Note: JTS ORs this flag across the bundles; the georust port (and the
+        // legacy in-tree copy) overwrite it, so the last bundle wins. Kept
+        // as-is for differential parity with the in-tree legacy relate.
+        let mut has_dimensional_collapse_edge = [false, false];
+        for edge_end in self.edges.iter() {
+            let label = edge_end.label();
+            for (geom_index, is_collapsed) in has_dimensional_collapse_edge.iter_mut().enumerate() {
+                *is_collapsed = label.is_line(geom_index)
+                    && label.on_position(geom_index) == Some(CoordPos::OnBoundary);
+            }
+        }
+        for edge_end_bundle in &mut self.edges {
+            let coord = *edge_end_bundle.coordinate();
+            let label = edge_end_bundle.label_mut();
+            for (geom_index, is_dimensionally_collapsed) in
+                has_dimensional_collapse_edge.iter().enumerate()
+            {
+                if label.is_any_empty(geom_index) {
+                    let position: CoordPos = if *is_dimensionally_collapsed {
+                        CoordPos::Outside
+                    } else {
+                        // PERF: In JTS this is memoized, but that gets a little tricky with rust's
+                        // borrow checker. Let's wait to see if it's a hotspot.
+                        let geometry = match geom_index {
+                            0 => graph_a.geometry(),
+                            1 => graph_b.geometry(),
+                            _ => unreachable!("invalid geom_index"),
+                        };
+                        if geometry.dimensions() == Dimensions::TwoDimensional {
+                            geometry.coordinate_position(coord)
+                        } else {
+                            // if geometry is *not* an area, Coord is always Outside
+                            CoordPos::Outside
+                        }
+                    };
+                    label.set_all_positions_if_empty(geom_index, position);
+                }
+            }
+        }
+    }
+
+    fn propagate_side_labels(&mut self, geom_index: usize) {
+        let mut start_position = None;
+
+        for edge_ends in self.edge_end_bundles_iter() {
+            let label = edge_ends.label();
+            if label.is_geom_area(geom_index) {
+                if let Some(position) = label.position(geom_index, Direction::Left) {
+                    start_position = Some(position);
+                }
+            }
+        }
+        if start_position.is_none() {
+            return;
+        }
+        let mut current_position = start_position.unwrap();
+
+        for edge_ends in self.edge_end_bundles_iter_mut() {
+            let label = edge_ends.label_mut();
+            if label.position(geom_index, Direction::On).is_none() {
+                label.set_position(geom_index, Direction::On, current_position);
+            }
+            if label.is_geom_area(geom_index) {
+                let left_position = label.position(geom_index, Direction::Left);
+                let right_position = label.position(geom_index, Direction::Right);
+
+                if let Some(right_position) = right_position {
+                    debug_assert!(right_position == current_position, "side_location conflict with coordinate: {:?}, right_location: {:?}, current_location: {:?}", edge_ends.coordinate(), right_position, current_position);
+                    assert!(left_position.is_some(), "found single null side");
+                    current_position = left_position.unwrap();
+                } else {
+                    debug_assert!(label.position(geom_index, Direction::Left).is_none());
+                    label.set_position(geom_index, Direction::Right, current_position);
+                    label.set_position(geom_index, Direction::Left, current_position);
+                }
+            }
+        }
+    }
+
+    fn edge_end_bundles_iter(&self) -> impl Iterator<Item = &LabeledEdgeEndBundle> {
+        self.edges.iter()
+    }
+
+    fn edge_end_bundles_iter_mut(&mut self) -> impl Iterator<Item = &mut LabeledEdgeEndBundle> {
+        self.edges.iter_mut()
+    }
+
+    pub fn update_intersection_matrix(&self, intersection_matrix: &mut IntersectionMatrix) {
+        for edge_end_bundle in self.edge_end_bundles_iter() {
+            edge_end_bundle.update_intersection_matrix(intersection_matrix);
+        }
+    }
+}
+
+impl EdgeEndBundleStar {
+    pub(crate) fn new() -> Self {
+        EdgeEndBundleStar {
+            edge_map: std::collections::BTreeMap::new(),
+        }
+    }
+
+    pub(crate) fn insert(&mut self, edge_end: EdgeEnd) {
+        let bundle = self
+            .edge_map
+            .entry(edge_end.key().clone())
+            .or_insert_with(|| EdgeEndBundle::new(*edge_end.coordinate()));
+        bundle.insert(edge_end);
+    }
+
+    /// Compute labeling for the star's EdgeEndBundles, and use them to compute an overall label
+    /// for the star.
+    ///
+    /// Implementation Note: This is a bit of a divergence from JTS in two ways.
+    ///
+    /// Firstly, JTS doesn't leverage optionals, and sets nullable `Label`s, whereas here we convert
+    /// to an explicitly labeled type to avoid unwrapping optionals later.
+    ///
+    /// Secondly, in JTS this functionality does not live directly on EdgeEndBundleStar, but rather
+    /// on it's parent class [EdgeEndStar](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/geomgraph/EdgeEndStar.java#L117)
+    ///
+    /// Since we're only using this one subclass (EdgeEndBundleStar), we skip the
+    /// complexity of mapping Java inheritance to Rust and implement this functionality
+    /// on EdgeEndBundleStar directly.
+    ///
+    /// If/When we implement overlay operations we might consider extracting the superclass
+    /// behavior.
+    pub(crate) fn into_labeled(
+        self,
+        graph_a: &GeometryGraph<'_>,
+        graph_b: &GeometryGraph<'_>,
+    ) -> LabeledEdgeEndBundleStar {
+        let labeled_edges = self
+            .edge_map
+            .into_values()
+            .map(|edge_end_bundle| edge_end_bundle.into_labeled())
+            .collect();
+        LabeledEdgeEndBundleStar::new(labeled_edges, graph_a, graph_b)
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/edge_end_bundle_star.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/edge_end_bundle_star.rs
@@ -30,13 +30,11 @@ impl LabeledEdgeEndBundleStar {
     fn compute_labeling(&mut self, graph_a: &GeometryGraph<'_>, graph_b: &GeometryGraph<'_>) {
         self.propagate_side_labels(0);
         self.propagate_side_labels(1);
-        // Note: JTS ORs this flag across the bundles; here it is overwritten, so
-        // the last bundle wins.
         let mut has_dimensional_collapse_edge = [false, false];
         for edge_end in self.edges.iter() {
             let label = edge_end.label();
             for (geom_index, is_collapsed) in has_dimensional_collapse_edge.iter_mut().enumerate() {
-                *is_collapsed = label.is_line(geom_index)
+                *is_collapsed |= label.is_line(geom_index)
                     && label.on_position(geom_index) == Some(CoordPos::OnBoundary);
             }
         }

--- a/engine/runtime/geometry/src/predicates/relate/graph/edge_intersection.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/edge_intersection.rs
@@ -1,0 +1,68 @@
+/// A point on an [`Edge`](super::Edge) where another edge crosses it, keyed by
+/// its position along the edge (segment index, then distance within the
+/// segment) so the edge's intersections sort in traversal order.
+#[derive(Debug)]
+pub(crate) struct EdgeIntersection {
+    coord: [f64; 2],
+    segment_index: usize,
+    dist: f64,
+}
+
+impl EdgeIntersection {
+    pub fn new(coord: [f64; 2], segment_index: usize, dist: f64) -> EdgeIntersection {
+        EdgeIntersection {
+            coord,
+            segment_index,
+            dist,
+        }
+    }
+
+    pub fn coordinate(&self) -> [f64; 2] {
+        self.coord
+    }
+
+    pub fn segment_index(&self) -> usize {
+        self.segment_index
+    }
+
+    pub fn distance(&self) -> f64 {
+        self.dist
+    }
+}
+
+impl std::cmp::PartialEq for EdgeIntersection {
+    fn eq(&self, other: &EdgeIntersection) -> bool {
+        self.segment_index == other.segment_index && self.dist == other.dist
+    }
+}
+
+impl std::cmp::Eq for EdgeIntersection {}
+
+impl std::cmp::PartialOrd for EdgeIntersection {
+    fn partial_cmp(&self, other: &EdgeIntersection) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for EdgeIntersection {
+    fn cmp(&self, other: &EdgeIntersection) -> std::cmp::Ordering {
+        if self.segment_index < other.segment_index {
+            return std::cmp::Ordering::Less;
+        }
+        if self.segment_index > other.segment_index {
+            return std::cmp::Ordering::Greater;
+        }
+        if self.dist < other.dist {
+            return std::cmp::Ordering::Less;
+        }
+        if self.dist > other.dist {
+            return std::cmp::Ordering::Greater;
+        }
+
+        // BTreeSet requires nodes to be fully `Ord`, but we're comparing floats, so we require
+        // non-NaN for valid results.
+        debug_assert!(!self.dist.is_nan() && !other.dist.is_nan());
+
+        std::cmp::Ordering::Equal
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/geometry_graph.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/geometry_graph.rs
@@ -12,9 +12,8 @@ use std::rc::Rc;
 
 /// One operand's topology graph: its components as labeled nodes and edges.
 ///
-/// The legacy version consumed a `GeometryCow`; this one is built from a
-/// [`RelateOperand`] — flattened leaves, with mesh leaves contributing their
-/// union-boundary rings rather than raw faces.
+/// Built from a [`RelateOperand`]: flattened leaves, with mesh leaves
+/// contributing their union-boundary rings rather than raw faces.
 pub(crate) struct GeometryGraph<'a> {
     arg_index: usize,
     parent_geometry: &'a RelateOperand<'a>,
@@ -305,8 +304,7 @@ enum WindingOrder {
 }
 
 /// The winding order of a closed ring, by robust orientation at its
-/// lexicographically least vertex; a port of the legacy `Winding` for
-/// `LineString`. `None` for open or degenerate rings.
+/// lexicographically least vertex. `None` for open or degenerate rings.
 fn ring_winding_order(ring: &[[f64; 2]]) -> Option<WindingOrder> {
     // If the ring has at most 3 coords, it is either not closed, or is at
     // most two distinct points. Either way, the winding is unspecified.

--- a/engine/runtime/geometry/src/predicates/relate/graph/geometry_graph.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/geometry_graph.rs
@@ -1,0 +1,388 @@
+use crate::predicates::kernel::{orient2d, CoordPos, Orientation};
+use crate::predicates::relate::operand::RelateOperand;
+use crate::predicates::view::Leaf2D;
+
+use super::index::{
+    compute_intersections_between_sets, compute_intersections_within_set, SegmentIntersector,
+};
+use super::{determine_boundary, CoordNode, Direction, Edge, Label, PlanarGraph, TopologyPosition};
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// One operand's topology graph: its components as labeled nodes and edges.
+///
+/// The legacy version consumed a `GeometryCow`; this one is built from a
+/// [`RelateOperand`] — flattened leaves, with mesh leaves contributing their
+/// union-boundary rings rather than raw faces.
+pub(crate) struct GeometryGraph<'a> {
+    arg_index: usize,
+    parent_geometry: &'a RelateOperand<'a>,
+    use_boundary_determination_rule: bool,
+    planar_graph: PlanarGraph,
+}
+
+///  PlanarGraph delegations
+///
+/// In JTS, which is written in Java, GeometryGraph inherits from PlanarGraph. Here in Rust land we
+/// use composition and delegation to the same effect.
+impl GeometryGraph<'_> {
+    pub fn edges(&self) -> &[Rc<RefCell<Edge>>] {
+        self.planar_graph.edges()
+    }
+
+    pub fn insert_edge(&mut self, edge: Edge) {
+        self.planar_graph.insert_edge(edge)
+    }
+
+    pub fn is_boundary_node(&self, coord: [f64; 2]) -> bool {
+        self.planar_graph.is_boundary_node(self.arg_index, coord)
+    }
+
+    pub fn add_node_with_coordinate(&mut self, coord: [f64; 2]) -> &mut CoordNode {
+        self.planar_graph.add_node_with_coordinate(coord)
+    }
+
+    pub fn nodes_iter(&self) -> impl Iterator<Item = &CoordNode> {
+        self.planar_graph.nodes.iter()
+    }
+}
+
+impl<'a> GeometryGraph<'a> {
+    pub fn new(arg_index: usize, parent_geometry: &'a RelateOperand<'a>) -> Self {
+        let mut graph = GeometryGraph {
+            arg_index,
+            parent_geometry,
+            // Meshes are the MultiPolygon analog: in JTS every collection
+            // except MultiPolygon obeys the mod-2 boundary rule.
+            use_boundary_determination_rule: !parent_geometry.has_mesh(),
+            planar_graph: PlanarGraph::new(),
+        };
+        graph.add_geometry();
+        graph
+    }
+
+    pub fn geometry(&self) -> &RelateOperand<'a> {
+        self.parent_geometry
+    }
+
+    fn boundary_nodes(&self) -> impl Iterator<Item = &CoordNode> {
+        self.planar_graph.boundary_nodes(self.arg_index)
+    }
+
+    fn add_geometry(&mut self) {
+        for (i, prepared) in self.parent_geometry.leaves().iter().enumerate() {
+            match prepared.leaf {
+                Leaf2D::Point(point) => self.add_point(point.position()),
+                Leaf2D::Line(line) => self.add_line_string(line.coords()),
+                Leaf2D::Polygon(polygon) => {
+                    self.add_polygon_ring(polygon.exterior(), CoordPos::Outside, CoordPos::Inside);
+                    // Holes are topologically labeled opposite to the shell, since
+                    // the interior of the polygon lies on their opposite side
+                    // (on the left, if the hole is oriented CW)
+                    for hole in polygon.interiors() {
+                        self.add_polygon_ring(hole, CoordPos::Inside, CoordPos::Outside)
+                    }
+                }
+                Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_) => {
+                    let rings = self
+                        .parent_geometry
+                        .boundary_rings(i)
+                        .expect("mesh leaves carry boundary rings")
+                        .to_vec();
+                    for ring in rings {
+                        // Union-boundary rings preserve face-edge direction, so
+                        // the union interior is on the left by construction.
+                        self.insert_ring_edge(
+                            dedup_consecutive(&ring),
+                            CoordPos::Inside,
+                            CoordPos::Outside,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn add_polygon_ring(
+        &mut self,
+        linear_ring: &[[f64; 2]],
+        cw_left: CoordPos,
+        cw_right: CoordPos,
+    ) {
+        debug_assert!(
+            linear_ring.len() < 2 || linear_ring.first() == linear_ring.last(),
+            "polygon rings are stored closed"
+        );
+        if linear_ring.is_empty() {
+            return;
+        }
+
+        let coords = dedup_consecutive(linear_ring);
+
+        let (left, right) = match ring_winding_order(&coords) {
+            Some(WindingOrder::Clockwise) => (cw_left, cw_right),
+            Some(WindingOrder::CounterClockwise) => (cw_right, cw_left),
+            None => (cw_left, cw_right),
+        };
+
+        self.insert_ring_edge(coords, left, right);
+    }
+
+    /// Insert a closed area-boundary edge whose interior side is already
+    /// resolved, and mark its start as a boundary node.
+    fn insert_ring_edge(&mut self, coords: Vec<[f64; 2]>, left: CoordPos, right: CoordPos) {
+        if coords.is_empty() {
+            return;
+        }
+        let first_point = coords[0];
+
+        let edge = Edge::new(
+            coords,
+            Label::new(
+                self.arg_index,
+                TopologyPosition::area(CoordPos::OnBoundary, left, right),
+            ),
+        );
+        self.insert_edge(edge);
+
+        // insert the endpoint as a node, to mark that it is on the boundary
+        self.insert_point(self.arg_index, first_point, CoordPos::OnBoundary);
+    }
+
+    fn add_line_string(&mut self, line_string: &[[f64; 2]]) {
+        if line_string.is_empty() {
+            return;
+        }
+
+        let coords = dedup_consecutive(line_string);
+
+        if coords.len() < 2 {
+            self.add_point(coords[0]);
+            return;
+        }
+
+        self.insert_boundary_point(*coords.first().unwrap());
+        self.insert_boundary_point(*coords.last().unwrap());
+
+        let edge = Edge::new(
+            coords,
+            Label::new(
+                self.arg_index,
+                TopologyPosition::line_or_point(CoordPos::Inside),
+            ),
+        );
+        self.insert_edge(edge);
+    }
+
+    /// Add a point computed externally.  The point is assumed to be a
+    /// Point Geometry part, which has a location of INTERIOR.
+    fn add_point(&mut self, point: [f64; 2]) {
+        self.insert_point(self.arg_index, point, CoordPos::Inside);
+    }
+
+    /// Compute self-nodes, taking advantage of the Geometry type to minimize the number of
+    /// intersection tests.  (E.g. rings are not tested for self-intersection, since they are
+    /// assumed to be valid).
+    pub fn compute_self_nodes(&mut self) -> SegmentIntersector {
+        let mut segment_intersector = SegmentIntersector::new(true);
+
+        // optimize intersection search for valid Polygons and LinearRings
+        let is_rings = self.geometry().is_rings();
+        let check_for_self_intersecting_edges = !is_rings;
+
+        compute_intersections_within_set(
+            self.edges(),
+            check_for_self_intersecting_edges,
+            &mut segment_intersector,
+        );
+
+        self.add_self_intersection_nodes();
+
+        segment_intersector
+    }
+
+    pub fn compute_edge_intersections(&self, other: &GeometryGraph<'_>) -> SegmentIntersector {
+        let mut segment_intersector = SegmentIntersector::new(false);
+        segment_intersector.set_boundary_nodes(
+            self.boundary_nodes().cloned().collect(),
+            other.boundary_nodes().cloned().collect(),
+        );
+
+        compute_intersections_between_sets(self.edges(), other.edges(), &mut segment_intersector);
+
+        segment_intersector
+    }
+
+    fn insert_point(&mut self, arg_index: usize, coord: [f64; 2], position: CoordPos) {
+        let node: &mut CoordNode = self.add_node_with_coordinate(coord);
+        node.label_mut().set_on_position(arg_index, position);
+    }
+
+    /// Add the boundary points of 1-dim (line) geometries.
+    fn insert_boundary_point(&mut self, coord: [f64; 2]) {
+        let arg_index = self.arg_index;
+        let node: &mut CoordNode = self.add_node_with_coordinate(coord);
+
+        let label: &mut Label = node.label_mut();
+
+        // determine the current location for the point (if any)
+        let boundary_count = {
+            #[allow(clippy::bool_to_int_with_if)]
+            let prev_boundary_count =
+                if Some(CoordPos::OnBoundary) == label.position(arg_index, Direction::On) {
+                    1
+                } else {
+                    0
+                };
+            prev_boundary_count + 1
+        };
+
+        let new_position = determine_boundary(boundary_count);
+        label.set_on_position(arg_index, new_position);
+    }
+
+    fn add_self_intersection_nodes(&mut self) {
+        let positions_and_intersections: Vec<(CoordPos, Vec<[f64; 2]>)> = self
+            .edges()
+            .iter()
+            .map(|cell| cell.borrow())
+            .map(|edge| {
+                let position = edge
+                    .label()
+                    .on_position(self.arg_index)
+                    .expect("all edge labels should have an `on` position by now");
+                let coordinates = edge
+                    .edge_intersections()
+                    .iter()
+                    .map(|edge_intersection| edge_intersection.coordinate());
+
+                (position, coordinates.collect())
+            })
+            .collect();
+
+        for (position, edge_intersection_coordinates) in positions_and_intersections {
+            for coordinate in edge_intersection_coordinates {
+                self.add_self_intersection_node(coordinate, position)
+            }
+        }
+    }
+
+    /// Add a node for a self-intersection.
+    ///
+    /// If the node is a potential boundary node (e.g. came from an edge which is a boundary), then
+    /// insert it as a potential boundary node.  Otherwise, just add it as a regular node.
+    fn add_self_intersection_node(&mut self, coord: [f64; 2], position: CoordPos) {
+        // if this node is already a boundary node, don't change it
+        if self.is_boundary_node(coord) {
+            return;
+        }
+
+        if position == CoordPos::OnBoundary && self.use_boundary_determination_rule {
+            self.insert_boundary_point(coord)
+        } else {
+            self.insert_point(self.arg_index, coord, position)
+        }
+    }
+}
+
+/// Copy `coords` with consecutive duplicates removed (a closed ring keeps its
+/// closing duplicate, which is not consecutive with itself).
+fn dedup_consecutive(coords: &[[f64; 2]]) -> Vec<[f64; 2]> {
+    let mut out: Vec<[f64; 2]> = Vec::with_capacity(coords.len());
+    for coord in coords {
+        if out.last() != Some(coord) {
+            out.push(*coord);
+        }
+    }
+    out
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WindingOrder {
+    Clockwise,
+    CounterClockwise,
+}
+
+/// The winding order of a closed ring, by robust orientation at its
+/// lexicographically least vertex; a port of the legacy `Winding` for
+/// `LineString`. `None` for open or degenerate rings.
+fn ring_winding_order(ring: &[[f64; 2]]) -> Option<WindingOrder> {
+    // If the ring has at most 3 coords, it is either not closed, or is at
+    // most two distinct points. Either way, the winding is unspecified.
+    if ring.len() < 4 || ring.first() != ring.last() {
+        return None;
+    }
+    let least = ring
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| a.partial_cmp(b).expect("ring coordinates must not be NaN"))
+        .map(|(i, _)| i)
+        .expect("ring is non-empty");
+
+    let n = ring.len();
+    let increment = |x: usize| if x + 1 >= n { 0 } else { x + 1 };
+    let decrement = |x: usize| if x == 0 { n - 1 } else { x - 1 };
+
+    let mut next = increment(least);
+    while ring[next] == ring[least] {
+        if next == least {
+            // We've looped too much. There aren't enough unique coords to
+            // compute orientation.
+            return None;
+        }
+        next = increment(next);
+    }
+
+    let mut prev = decrement(least);
+    while ring[prev] == ring[least] {
+        // We don't need to check if prev == least as the previous loop
+        // succeeded, so there are at least two distinct elements.
+        prev = decrement(prev);
+    }
+
+    match orient2d(ring[prev], ring[least], ring[next]) {
+        Orientation::CounterClockwise => Some(WindingOrder::CounterClockwise),
+        Orientation::Clockwise => Some(WindingOrder::Clockwise),
+        Orientation::Collinear => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn winding_of_simple_rings() {
+        let ccw = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
+        assert_eq!(
+            ring_winding_order(&ccw),
+            Some(WindingOrder::CounterClockwise)
+        );
+        let cw: Vec<[f64; 2]> = ccw.iter().rev().copied().collect();
+        assert_eq!(ring_winding_order(&cw), Some(WindingOrder::Clockwise));
+        // Open chains and degenerate rings have no winding.
+        assert_eq!(ring_winding_order(&ccw[..4]), None);
+        assert_eq!(
+            ring_winding_order(&[[1.0, 1.0], [1.0, 1.0], [1.0, 1.0], [1.0, 1.0]]),
+            None
+        );
+    }
+
+    #[test]
+    fn dedup_keeps_closing_duplicate() {
+        let ring = [
+            [0.0, 0.0],
+            [0.0, 0.0],
+            [4.0, 0.0],
+            [4.0, 4.0],
+            [4.0, 4.0],
+            [0.0, 0.0],
+        ];
+        assert_eq!(
+            dedup_consecutive(&ring),
+            vec![[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 0.0]]
+        );
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/index/mod.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/index/mod.rs
@@ -1,10 +1,8 @@
 //! Noding support: finding the intersections among the graph's edges.
 //!
-//! The legacy `EdgeSetIntersector` trait and its `Simple` implementation are
-//! gone — the rstar-backed edge-set sweep is the only implementation, exposed
-//! as free functions — and [`SegmentIntersector`] calls the phase-1
-//! [`kernel`](crate::predicates::kernel) directly instead of going through a
-//! boxed `LineIntersector`.
+//! The rstar-backed edge-set sweep is exposed as free functions, and
+//! [`SegmentIntersector`] calls the
+//! [`kernel`](crate::predicates::kernel) directly.
 
 mod rstar_edge_set_intersector;
 mod segment_intersector;

--- a/engine/runtime/geometry/src/predicates/relate/graph/index/mod.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/index/mod.rs
@@ -1,0 +1,15 @@
+//! Noding support: finding the intersections among the graph's edges.
+//!
+//! The legacy `EdgeSetIntersector` trait and its `Simple` implementation are
+//! gone — the rstar-backed edge-set sweep is the only implementation, exposed
+//! as free functions — and [`SegmentIntersector`] calls the phase-1
+//! [`kernel`](crate::predicates::kernel) directly instead of going through a
+//! boxed `LineIntersector`.
+
+mod rstar_edge_set_intersector;
+mod segment_intersector;
+
+pub(crate) use rstar_edge_set_intersector::{
+    compute_intersections_between_sets, compute_intersections_within_set,
+};
+pub(crate) use segment_intersector::SegmentIntersector;

--- a/engine/runtime/geometry/src/predicates/relate/graph/index/rstar_edge_set_intersector.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/index/rstar_edge_set_intersector.rs
@@ -1,0 +1,79 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use rstar::RTree;
+
+use super::super::Edge;
+use super::SegmentIntersector;
+
+struct Segment<'a> {
+    i: usize,
+    edge: &'a Rc<RefCell<Edge>>,
+    envelope: rstar::AABB<[f64; 2]>,
+}
+
+impl<'a> Segment<'a> {
+    fn new(i: usize, edge: &'a Rc<RefCell<Edge>>) -> Self {
+        let p1 = edge.borrow().coords()[i];
+        let p2 = edge.borrow().coords()[i + 1];
+        Self {
+            i,
+            edge,
+            envelope: rstar::AABB::from_corners(p1, p2),
+        }
+    }
+}
+
+impl rstar::RTreeObject for Segment<'_> {
+    type Envelope = rstar::AABB<[f64; 2]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.envelope
+    }
+}
+
+fn to_segments(edges: &[Rc<RefCell<Edge>>]) -> Vec<Segment<'_>> {
+    edges
+        .iter()
+        .flat_map(|edge| {
+            let start_of_final_segment: usize = edge.borrow().coords().len() - 1;
+            (0..start_of_final_segment).map(move |segment_i| Segment::new(segment_i, edge))
+        })
+        .collect()
+}
+
+/// Compute all intersections between the edges within a set, recording those intersections on
+/// the intersecting edges.
+///
+/// `edges`: the set of edges to check. Mutated to record any intersections.
+/// `check_for_self_intersecting_edges`: if false, an edge is not checked for intersections with
+/// itself.
+/// `segment_intersector`: the SegmentIntersector to use
+pub(crate) fn compute_intersections_within_set(
+    edges: &[Rc<RefCell<Edge>>],
+    check_for_self_intersecting_edges: bool,
+    segment_intersector: &mut SegmentIntersector,
+) {
+    let tree = RTree::bulk_load(to_segments(edges));
+
+    for (edge0, edge1) in tree.intersection_candidates_with_other_tree(&tree) {
+        if check_for_self_intersecting_edges || !Rc::ptr_eq(edge0.edge, edge1.edge) {
+            segment_intersector.add_intersections(edge0.edge, edge0.i, edge1.edge, edge1.i);
+        }
+    }
+}
+
+/// Compute all intersections between two sets of edges, recording those intersections on
+/// the intersecting edges.
+pub(crate) fn compute_intersections_between_sets(
+    edges0: &[Rc<RefCell<Edge>>],
+    edges1: &[Rc<RefCell<Edge>>],
+    segment_intersector: &mut SegmentIntersector,
+) {
+    let tree_0 = RTree::bulk_load(to_segments(edges0));
+    let tree_1 = RTree::bulk_load(to_segments(edges1));
+
+    for (edge0, edge1) in tree_0.intersection_candidates_with_other_tree(&tree_1) {
+        segment_intersector.add_intersections(edge0.edge, edge0.i, edge1.edge, edge1.i);
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/index/segment_intersector.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/index/segment_intersector.rs
@@ -1,0 +1,170 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use super::super::{CoordNode, Edge};
+use crate::predicates::kernel::{segment_intersection, SegmentIntersection};
+
+/// Computes the intersection of line segments and adds the intersection to the [`Edge`]s
+/// containing the segments.
+pub(crate) struct SegmentIntersector {
+    edges_are_from_same_geometry: bool,
+    proper_intersection_point: Option<[f64; 2]>,
+    has_proper_interior_intersection: bool,
+    boundary_nodes: Option<[Vec<CoordNode>; 2]>,
+}
+
+impl SegmentIntersector {
+    fn is_adjacent_segments(i1: usize, i2: usize) -> bool {
+        let difference = i1.abs_diff(i2);
+        difference == 1
+    }
+
+    pub fn new(edges_are_from_same_geometry: bool) -> SegmentIntersector {
+        SegmentIntersector {
+            edges_are_from_same_geometry,
+            has_proper_interior_intersection: false,
+            proper_intersection_point: None,
+            boundary_nodes: None,
+        }
+    }
+    pub fn set_boundary_nodes(
+        &mut self,
+        boundary_nodes_0: Vec<CoordNode>,
+        boundary_nodes_1: Vec<CoordNode>,
+    ) {
+        debug_assert!(
+            self.boundary_nodes.is_none(),
+            "Should only set boundaries between geometries once"
+        );
+        self.boundary_nodes = Some([boundary_nodes_0, boundary_nodes_1]);
+    }
+
+    pub fn has_proper_intersection(&self) -> bool {
+        self.proper_intersection_point.is_some()
+    }
+
+    pub fn has_proper_interior_intersection(&self) -> bool {
+        self.has_proper_interior_intersection
+    }
+
+    /// A trivial intersection is an apparent self-intersection which in fact is simply the point
+    /// shared by adjacent line segments.  Note that closed edges require a special check for the
+    /// point shared by the beginning and end segments.
+    fn is_trivial_intersection(
+        &self,
+        intersection: SegmentIntersection,
+        edge0: &Rc<RefCell<Edge>>,
+        segment_index_0: usize,
+        edge1: &Rc<RefCell<Edge>>,
+        segment_index_1: usize,
+    ) -> bool {
+        if !Rc::ptr_eq(edge0, edge1) {
+            return false;
+        }
+
+        if matches!(intersection, SegmentIntersection::Collinear { .. }) {
+            return false;
+        }
+
+        if Self::is_adjacent_segments(segment_index_0, segment_index_1) {
+            return true;
+        }
+
+        let edge0 = edge0.borrow();
+        if edge0.is_closed() {
+            // first and last coords in a ring are adjacent
+            let max_segment_index = edge0.coords().len() - 1;
+            if (segment_index_0 == 0 && segment_index_1 == max_segment_index)
+                || (segment_index_1 == 0 && segment_index_0 == max_segment_index)
+            {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    pub fn add_intersections(
+        &mut self,
+        edge0: &Rc<RefCell<Edge>>,
+        segment_index_0: usize,
+        edge1: &Rc<RefCell<Edge>>,
+        segment_index_1: usize,
+    ) {
+        // avoid a segment spuriously "intersecting" with itself
+        if Rc::ptr_eq(edge0, edge1) && segment_index_0 == segment_index_1 {
+            return;
+        }
+
+        let line_0 = {
+            let edge0 = edge0.borrow();
+            (
+                edge0.coords()[segment_index_0],
+                edge0.coords()[segment_index_0 + 1],
+            )
+        };
+        let line_1 = {
+            let edge1 = edge1.borrow();
+            (
+                edge1.coords()[segment_index_1],
+                edge1.coords()[segment_index_1 + 1],
+            )
+        };
+
+        let intersection = segment_intersection(line_0.0, line_0.1, line_1.0, line_1.1);
+
+        if intersection.is_none() {
+            return;
+        }
+        let intersection = intersection.unwrap();
+
+        if !self.edges_are_from_same_geometry {
+            edge0.borrow_mut().mark_as_unisolated();
+            edge1.borrow_mut().mark_as_unisolated();
+        }
+        if !self.is_trivial_intersection(
+            intersection,
+            edge0,
+            segment_index_0,
+            edge1,
+            segment_index_1,
+        ) {
+            if self.edges_are_from_same_geometry || !intersection.is_proper() {
+                // In the case of self-noding, `edge0` might alias `edge1`, so it's imperative that
+                // the mutable borrows are short lived and do not overlap.
+                edge0
+                    .borrow_mut()
+                    .add_intersections(intersection, line_0, segment_index_0);
+
+                edge1
+                    .borrow_mut()
+                    .add_intersections(intersection, line_1, segment_index_1);
+            }
+            if let SegmentIntersection::SinglePoint {
+                is_proper: true,
+                intersection: intersection_coord,
+            } = intersection
+            {
+                self.proper_intersection_point = Some(intersection_coord);
+
+                if !self.is_boundary_point(&intersection_coord, &self.boundary_nodes) {
+                    self.has_proper_interior_intersection = true
+                }
+            }
+        }
+    }
+
+    fn is_boundary_point(
+        &self,
+        intersection: &[f64; 2],
+        boundary_nodes: &Option<[Vec<CoordNode>; 2]>,
+    ) -> bool {
+        match &boundary_nodes {
+            Some(boundary_nodes) => boundary_nodes
+                .iter()
+                .flatten()
+                .any(|node| intersection == node.coordinate()),
+            None => false,
+        }
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/label.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/label.rs
@@ -1,0 +1,122 @@
+use crate::predicates::kernel::CoordPos;
+
+use super::{Direction, TopologyPosition};
+
+use std::fmt;
+
+/// A GeometryGraph has components (nodes and edges) which are labeled with their topological
+/// relations to the geometries.
+///
+/// More precisely, each `Label` holds a `TopologyPosition` for each geometry that states whether
+/// the node or edge being labeled occurs `Inside`, `Outside`, or `OnBoundary` of the geometry.
+///
+/// For lines and points, a `TopologyPosition` tracks only an `On` position,
+/// while areas have positions for `On`, `Left`, and `Right`.
+///
+/// If the component has *no* incidence with one of the geometries, than the `Label`'s
+/// `TopologyPosition` for that geometry is called `empty`.
+#[derive(Clone)]
+pub(crate) struct Label {
+    geometry_topologies: [TopologyPosition; 2],
+}
+
+impl fmt::Debug for Label {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Label {{ A: {:?}, B: {:?} }}",
+            &self.geometry_topologies[0], &self.geometry_topologies[1]
+        )
+    }
+}
+
+impl Label {
+    /// Construct an empty `Label` for relating a 1-D line or 0-D point to both geometries.
+    pub fn empty_line_or_point() -> Label {
+        Label {
+            geometry_topologies: [
+                TopologyPosition::empty_line_or_point(),
+                TopologyPosition::empty_line_or_point(),
+            ],
+        }
+    }
+
+    /// Construct an empty `Label` for relating a 2-D area to both geometries.
+    pub fn empty_area() -> Self {
+        Self {
+            geometry_topologies: [
+                TopologyPosition::empty_area(),
+                TopologyPosition::empty_area(),
+            ],
+        }
+    }
+
+    /// Construct a `Label` initialized with `position` for the geometry specified by
+    /// `geom_index`.
+    ///
+    /// The label's position for the other geometry will be initialized as empty.
+    pub fn new(geom_index: usize, position: TopologyPosition) -> Self {
+        let mut label = match position {
+            TopologyPosition::LineOrPoint { .. } => Self::empty_line_or_point(),
+            TopologyPosition::Area { .. } => Self::empty_area(),
+        };
+        label.geometry_topologies[geom_index] = position;
+        label
+    }
+
+    pub fn flip(&mut self) {
+        self.geometry_topologies[0].flip();
+        self.geometry_topologies[1].flip();
+    }
+
+    pub fn position(&self, geom_index: usize, direction: Direction) -> Option<CoordPos> {
+        self.geometry_topologies[geom_index].get(direction)
+    }
+
+    pub fn on_position(&self, geom_index: usize) -> Option<CoordPos> {
+        self.geometry_topologies[geom_index].get(Direction::On)
+    }
+
+    pub fn set_position(&mut self, geom_index: usize, direction: Direction, position: CoordPos) {
+        self.geometry_topologies[geom_index].set_position(direction, position);
+    }
+
+    pub fn set_on_position(&mut self, geom_index: usize, position: CoordPos) {
+        self.geometry_topologies[geom_index].set_position(Direction::On, position);
+    }
+
+    pub fn set_all_positions(&mut self, geom_index: usize, position: CoordPos) {
+        self.geometry_topologies[geom_index].set_all_positions(position)
+    }
+
+    pub fn set_all_positions_if_empty(&mut self, geom_index: usize, position: CoordPos) {
+        self.geometry_topologies[geom_index].set_all_positions_if_empty(position)
+    }
+
+    pub fn geometry_count(&self) -> usize {
+        self.geometry_topologies
+            .iter()
+            .filter(|location| !location.is_empty())
+            .count()
+    }
+
+    pub fn is_empty(&self, geom_index: usize) -> bool {
+        self.geometry_topologies[geom_index].is_empty()
+    }
+
+    pub fn is_any_empty(&self, geom_index: usize) -> bool {
+        self.geometry_topologies[geom_index].is_any_empty()
+    }
+
+    pub fn is_area(&self) -> bool {
+        self.geometry_topologies[0].is_area() || self.geometry_topologies[1].is_area()
+    }
+
+    pub fn is_geom_area(&self, geom_index: usize) -> bool {
+        self.geometry_topologies[geom_index].is_area()
+    }
+
+    pub fn is_line(&self, geom_index: usize) -> bool {
+        self.geometry_topologies[geom_index].is_line()
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/mod.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/mod.rs
@@ -1,11 +1,8 @@
 //! The geometry graph underlying [`relate`](super): nodes and edges labeled
 //! with their topological positions relative to both operands.
 //!
-//! A port of the legacy `algorithm/relate/geomgraph/` (a georust/geo port of
-//! JTS 1.18) with the `<T, Z>` generics dropped in favor of concrete
-//! `[f64; 2]` coordinates, `Rc<RefCell<Edge>>` instead of `Arc<RwLock<Edge>>`
-//! (a relate call owns its graphs; nothing crosses threads), and the phase-1
-//! [`kernel`](crate::predicates::kernel) as the one robust line intersector.
+//! Follows the structure of JTS 1.18 `relate/geomgraph/`, using the
+//! [`kernel`](crate::predicates::kernel) as the robust line intersector.
 
 pub(crate) use super::intersection_matrix::IntersectionMatrix;
 pub(crate) use edge::Edge;

--- a/engine/runtime/geometry/src/predicates/relate/graph/mod.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/mod.rs
@@ -1,0 +1,53 @@
+//! The geometry graph underlying [`relate`](super): nodes and edges labeled
+//! with their topological positions relative to both operands.
+//!
+//! A port of the legacy `algorithm/relate/geomgraph/` (a georust/geo port of
+//! JTS 1.18) with the `<T, Z>` generics dropped in favor of concrete
+//! `[f64; 2]` coordinates, `Rc<RefCell<Edge>>` instead of `Arc<RwLock<Edge>>`
+//! (a relate call owns its graphs; nothing crosses threads), and the phase-1
+//! [`kernel`](crate::predicates::kernel) as the one robust line intersector.
+
+pub(crate) use super::intersection_matrix::IntersectionMatrix;
+pub(crate) use edge::Edge;
+pub(crate) use edge_end::{EdgeEnd, EdgeEndKey};
+pub(crate) use edge_end_bundle::{EdgeEndBundle, LabeledEdgeEndBundle};
+pub(crate) use edge_end_bundle_star::{EdgeEndBundleStar, LabeledEdgeEndBundleStar};
+pub(crate) use edge_intersection::EdgeIntersection;
+pub(crate) use geometry_graph::GeometryGraph;
+pub(crate) use label::Label;
+pub(crate) use node::CoordNode;
+use planar_graph::PlanarGraph;
+pub(crate) use quadrant::Quadrant;
+use topology_position::TopologyPosition;
+
+mod edge;
+mod edge_end;
+mod edge_end_bundle;
+mod edge_end_bundle_star;
+mod edge_intersection;
+mod geometry_graph;
+pub(crate) mod index;
+mod label;
+mod node;
+pub(crate) mod node_map;
+mod planar_graph;
+mod quadrant;
+mod topology_position;
+
+/// Position relative to a point
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Direction {
+    On,
+    Left,
+    Right,
+}
+
+/// The SFS "Mod-2 Rule": a point shared by an odd number of line endpoints is
+/// on the boundary, an even number interior.
+pub(crate) fn determine_boundary(boundary_count: usize) -> crate::predicates::kernel::CoordPos {
+    if boundary_count % 2 == 1 {
+        crate::predicates::kernel::CoordPos::OnBoundary
+    } else {
+        crate::predicates::kernel::CoordPos::Inside
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/node.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/node.rs
@@ -1,0 +1,59 @@
+use crate::predicates::kernel::CoordPos;
+use crate::predicates::relate::intersection_matrix::Dimensions;
+
+use super::{IntersectionMatrix, Label};
+
+#[derive(Debug, Clone)]
+pub(crate) struct CoordNode {
+    coordinate: [f64; 2],
+    label: Label,
+}
+
+impl CoordNode {
+    pub(crate) fn label(&self) -> &Label {
+        &self.label
+    }
+
+    pub(crate) fn label_mut(&mut self) -> &mut Label {
+        &mut self.label
+    }
+
+    pub(crate) fn is_isolated(&self) -> bool {
+        self.label.geometry_count() == 1
+    }
+}
+
+impl CoordNode {
+    pub fn new(coordinate: [f64; 2]) -> CoordNode {
+        CoordNode {
+            coordinate,
+            label: Label::empty_line_or_point(),
+        }
+    }
+
+    pub fn coordinate(&self) -> &[f64; 2] {
+        &self.coordinate
+    }
+
+    pub fn set_label_on_position(&mut self, geom_index: usize, position: CoordPos) {
+        self.label.set_on_position(geom_index, position)
+    }
+
+    /// Updates the label of a node to BOUNDARY, obeying the mod-2 rule.
+    pub fn set_label_boundary(&mut self, geom_index: usize) {
+        let new_position = match self.label.on_position(geom_index) {
+            Some(CoordPos::OnBoundary) => CoordPos::Inside,
+            Some(CoordPos::Inside) => CoordPos::OnBoundary,
+            None | Some(CoordPos::Outside) => CoordPos::OnBoundary,
+        };
+        self.label.set_on_position(geom_index, new_position);
+    }
+
+    pub fn update_intersection_matrix(&self, intersection_matrix: &mut IntersectionMatrix) {
+        intersection_matrix.set_at_least_if_in_both(
+            self.label.on_position(0),
+            self.label.on_position(1),
+            Dimensions::ZeroDimensional,
+        );
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/node_map.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/node_map.rs
@@ -1,0 +1,111 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::marker::PhantomData;
+
+/// Lexicographic comparison of two coordinates (x first, then y). The
+/// coordinates must be non-NaN, the invariant of every graph coordinate.
+pub(crate) fn lex_cmp(a: &[f64; 2], b: &[f64; 2]) -> std::cmp::Ordering {
+    a.partial_cmp(b).expect("graph coordinates must not be NaN")
+}
+
+/// A map of nodes, indexed by the coordinate of the node
+pub(crate) struct NodeMap<NF>
+where
+    NF: NodeFactory,
+{
+    map: BTreeMap<NodeKey, NF::Node>,
+    _node_factory: PhantomData<NF>,
+}
+
+/// Creates the node stored in `NodeMap`
+pub(crate) trait NodeFactory {
+    type Node;
+    fn create_node(coordinate: [f64; 2]) -> Self::Node;
+}
+
+impl<NF> fmt::Debug for NodeMap<NF>
+where
+    NF: NodeFactory,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NodeMap")
+            .field("map.len()", &self.map.len())
+            .finish()
+    }
+}
+
+#[derive(Clone)]
+struct NodeKey([f64; 2]);
+
+impl std::cmp::Ord for NodeKey {
+    fn cmp(&self, other: &NodeKey) -> std::cmp::Ordering {
+        debug_assert!(!self.0[0].is_nan());
+        debug_assert!(!self.0[1].is_nan());
+        debug_assert!(!other.0[0].is_nan());
+        debug_assert!(!other.0[1].is_nan());
+        lex_cmp(&self.0, &other.0)
+    }
+}
+
+impl std::cmp::PartialOrd for NodeKey {
+    fn partial_cmp(&self, other: &NodeKey) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::PartialEq for NodeKey {
+    fn eq(&self, other: &NodeKey) -> bool {
+        debug_assert!(!self.0[0].is_nan());
+        debug_assert!(!self.0[1].is_nan());
+        debug_assert!(!other.0[0].is_nan());
+        debug_assert!(!other.0[1].is_nan());
+        self.0 == other.0
+    }
+}
+
+impl std::cmp::Eq for NodeKey {}
+
+impl<NF> NodeMap<NF>
+where
+    NF: NodeFactory,
+{
+    pub fn new() -> Self {
+        NodeMap {
+            map: BTreeMap::new(),
+            _node_factory: PhantomData,
+        }
+    }
+    /// Adds a `NF::Node` with the given `Coord`.
+    ///
+    /// Note: Coords must be non-NaN.
+    pub fn insert_node_with_coordinate(&mut self, coord: [f64; 2]) -> &mut NF::Node {
+        debug_assert!(
+            !coord[0].is_nan() && !coord[1].is_nan(),
+            "NaN coordinates are not supported"
+        );
+        let key = NodeKey(coord);
+        self.map
+            .entry(key)
+            .or_insert_with(|| NF::create_node(coord))
+    }
+
+    /// returns the `NF::Node`, if any, matching `coord`
+    pub fn find(&self, coord: [f64; 2]) -> Option<&NF::Node> {
+        self.map.get(&NodeKey(coord))
+    }
+
+    /// Iterates across `NF::Node`s in lexical order of their `Coord`
+    pub fn iter(&self) -> impl Iterator<Item = &NF::Node> {
+        self.map.values()
+    }
+
+    /// Iterates across `NF::Node`s in lexical order of their `Coord`
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut NF::Node> {
+        self.map.values_mut()
+    }
+
+    /// Iterates across `NF::Node`s in lexical order of their `Coord`
+    pub fn into_iter(self) -> impl Iterator<Item = NF::Node> {
+        self.map.into_values()
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/planar_graph.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/planar_graph.rs
@@ -1,0 +1,61 @@
+use super::{
+    node_map::{NodeFactory, NodeMap},
+    CoordNode, Edge,
+};
+use crate::predicates::kernel::CoordPos;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub(crate) struct PlanarGraphNode;
+
+/// The basic node constructor does not allow for incident edges
+impl NodeFactory for PlanarGraphNode {
+    type Node = CoordNode;
+    fn create_node(coordinate: [f64; 2]) -> Self::Node {
+        CoordNode::new(coordinate)
+    }
+}
+
+pub(crate) struct PlanarGraph {
+    pub(crate) nodes: NodeMap<PlanarGraphNode>,
+    edges: Vec<Rc<RefCell<Edge>>>,
+}
+
+impl PlanarGraph {
+    pub fn edges(&self) -> &[Rc<RefCell<Edge>>] {
+        &self.edges
+    }
+
+    pub fn new() -> Self {
+        PlanarGraph {
+            nodes: NodeMap::new(),
+            edges: vec![],
+        }
+    }
+
+    pub fn is_boundary_node(&self, geom_index: usize, coord: [f64; 2]) -> bool {
+        self.nodes
+            .find(coord)
+            .and_then(|node| node.label().on_position(geom_index))
+            .map(|position| position == CoordPos::OnBoundary)
+            .unwrap_or(false)
+    }
+
+    pub fn insert_edge(&mut self, edge: Edge) {
+        self.edges.push(Rc::new(RefCell::new(edge)));
+    }
+
+    pub fn add_node_with_coordinate(&mut self, coord: [f64; 2]) -> &mut CoordNode {
+        self.nodes.insert_node_with_coordinate(coord)
+    }
+
+    pub fn boundary_nodes(&self, geom_index: usize) -> impl Iterator<Item = &CoordNode> {
+        self.nodes.iter().filter(move |node| {
+            matches!(
+                node.label().on_position(geom_index),
+                Some(CoordPos::OnBoundary)
+            )
+        })
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/quadrant.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/quadrant.rs
@@ -1,0 +1,24 @@
+/// The quadrant of a direction vector, for sorting edge ends around a node.
+#[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq)]
+pub enum Quadrant {
+    NE,
+    NW,
+    SW,
+    SE,
+}
+
+impl Quadrant {
+    pub fn new(dx: f64, dy: f64) -> Option<Quadrant> {
+        if dx == 0.0 && dy == 0.0 {
+            return None;
+        }
+
+        match (dy >= 0.0, dx >= 0.0) {
+            (true, true) => Quadrant::NE,
+            (true, false) => Quadrant::NW,
+            (false, false) => Quadrant::SW,
+            (false, true) => Quadrant::SE,
+        }
+        .into()
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/graph/topology_position.rs
+++ b/engine/runtime/geometry/src/predicates/relate/graph/topology_position.rs
@@ -1,0 +1,165 @@
+use std::fmt;
+
+use crate::predicates::kernel::CoordPos;
+
+use super::Direction;
+
+#[derive(Copy, Clone)]
+pub(crate) enum TopologyPosition {
+    Area {
+        on: Option<CoordPos>,
+        left: Option<CoordPos>,
+        right: Option<CoordPos>,
+    },
+    LineOrPoint {
+        on: Option<CoordPos>,
+    },
+}
+
+impl fmt::Debug for TopologyPosition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn fmt_position(position: &Option<CoordPos>, f: &mut fmt::Formatter) -> fmt::Result {
+            match position {
+                Some(CoordPos::Inside) => write!(f, "i"),
+                Some(CoordPos::OnBoundary) => write!(f, "b"),
+                Some(CoordPos::Outside) => write!(f, "e"),
+                None => write!(f, "_"),
+            }
+        }
+        match self {
+            Self::LineOrPoint { on } => fmt_position(on, f)?,
+            Self::Area { on, left, right } => {
+                fmt_position(left, f)?;
+                fmt_position(on, f)?;
+                fmt_position(right, f)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl TopologyPosition {
+    pub fn area(on: CoordPos, left: CoordPos, right: CoordPos) -> Self {
+        Self::Area {
+            on: Some(on),
+            left: Some(left),
+            right: Some(right),
+        }
+    }
+
+    pub fn empty_area() -> Self {
+        Self::Area {
+            on: None,
+            left: None,
+            right: None,
+        }
+    }
+
+    pub fn line_or_point(on: CoordPos) -> Self {
+        Self::LineOrPoint { on: Some(on) }
+    }
+
+    pub fn empty_line_or_point() -> Self {
+        Self::LineOrPoint { on: None }
+    }
+
+    pub fn get(&self, direction: Direction) -> Option<CoordPos> {
+        match (direction, self) {
+            (Direction::Left, Self::Area { left, .. }) => *left,
+            (Direction::Right, Self::Area { right, .. }) => *right,
+            (Direction::On, Self::LineOrPoint { on }) | (Direction::On, Self::Area { on, .. }) => {
+                *on
+            }
+            (_, Self::LineOrPoint { .. }) => {
+                panic!("LineOrPoint only has a position for `Direction::On`")
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        matches!(
+            self,
+            Self::LineOrPoint { on: None }
+                | Self::Area {
+                    on: None,
+                    left: None,
+                    right: None,
+                }
+        )
+    }
+
+    pub fn is_any_empty(&self) -> bool {
+        !matches!(
+            self,
+            Self::LineOrPoint { on: Some(_) }
+                | Self::Area {
+                    on: Some(_),
+                    left: Some(_),
+                    right: Some(_),
+                }
+        )
+    }
+
+    pub fn is_area(&self) -> bool {
+        matches!(self, Self::Area { .. })
+    }
+
+    pub fn is_line(&self) -> bool {
+        matches!(self, Self::LineOrPoint { .. })
+    }
+
+    pub fn flip(&mut self) {
+        match self {
+            Self::LineOrPoint { .. } => {}
+            Self::Area { left, right, .. } => {
+                std::mem::swap(left, right);
+            }
+        }
+    }
+
+    pub fn set_all_positions(&mut self, position: CoordPos) {
+        match self {
+            Self::LineOrPoint { on } => {
+                *on = Some(position);
+            }
+            Self::Area { on, left, right } => {
+                *on = Some(position);
+                *left = Some(position);
+                *right = Some(position);
+            }
+        }
+    }
+
+    pub fn set_all_positions_if_empty(&mut self, position: CoordPos) {
+        match self {
+            Self::LineOrPoint { on } => {
+                if on.is_none() {
+                    *on = Some(position);
+                }
+            }
+            Self::Area { on, left, right } => {
+                if on.is_none() {
+                    *on = Some(position);
+                }
+                if left.is_none() {
+                    *left = Some(position);
+                }
+                if right.is_none() {
+                    *right = Some(position);
+                }
+            }
+        }
+    }
+
+    pub fn set_position(&mut self, direction: Direction, position: CoordPos) {
+        match (direction, self) {
+            (Direction::On, Self::LineOrPoint { on }) => *on = Some(position),
+            (_, Self::LineOrPoint { .. }) => {
+                panic!("invalid assignment dimensions for Self::Line")
+            }
+            (Direction::On, Self::Area { on, .. }) => *on = Some(position),
+            (Direction::Left, Self::Area { left, .. }) => *left = Some(position),
+            (Direction::Right, Self::Area { right, .. }) => *right = Some(position),
+        }
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/intersection_matrix.rs
+++ b/engine/runtime/geometry/src/predicates/relate/intersection_matrix.rs
@@ -1,8 +1,6 @@
 //! The DE-9IM [`IntersectionMatrix`] and the [`Dimensions`] recorded in it.
 //!
-//! A port of the legacy `algorithm/relate/geomgraph/intersection_matrix.rs`
-//! (itself a JTS port via georust/geo) with the `<T, Z>` generics dropped: the
-//! new relate is 2D-only, so [`Dimensions`] tops out at
+//! This relate is 2D-only, so [`Dimensions`] tops out at
 //! [`TwoDimensional`](Dimensions::TwoDimensional).
 
 use std::str::FromStr;

--- a/engine/runtime/geometry/src/predicates/relate/intersection_matrix.rs
+++ b/engine/runtime/geometry/src/predicates/relate/intersection_matrix.rs
@@ -1,0 +1,534 @@
+//! The DE-9IM [`IntersectionMatrix`] and the [`Dimensions`] recorded in it.
+//!
+//! A port of the legacy `algorithm/relate/geomgraph/intersection_matrix.rs`
+//! (itself a JTS port via georust/geo) with the `<T, Z>` generics dropped: the
+//! new relate is 2D-only, so [`Dimensions`] tops out at
+//! [`TwoDimensional`](Dimensions::TwoDimensional).
+
+use std::str::FromStr;
+
+use crate::predicates::kernel::CoordPos;
+
+/// The dimension of the intersection of two point sets, as recorded in one
+/// cell of the [`IntersectionMatrix`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
+pub enum Dimensions {
+    /// The intersection is empty. Distinct from `ZeroDimensional`: an empty
+    /// collection has no dimension at all.
+    Empty,
+    /// The intersection consists of isolated points.
+    ZeroDimensional,
+    /// The intersection contains curves.
+    OneDimensional,
+    /// The intersection contains surfaces.
+    TwoDimensional,
+}
+
+/// The DE-9IM intersection matrix between two geometries.
+///
+/// For operands `a` and `b`, cell `(pa, pb)` records the [`Dimensions`] of the
+/// intersection of `a`'s `pa` region with `b`'s `pb` region, where each region
+/// is one of interior ([`Inside`](CoordPos::Inside)), boundary
+/// ([`OnBoundary`](CoordPos::OnBoundary)), or exterior
+/// ([`Outside`](CoordPos::Outside)). The named predicates (`is_contains`,
+/// `is_touches`, ...) are pattern matches over the nine cells; arbitrary
+/// DE-9IM patterns like `"T*F**FFF*"` go through [`matches`](Self::matches).
+#[derive(PartialEq, Eq, Clone)]
+pub struct IntersectionMatrix(LocationArray<LocationArray<Dimensions>>);
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+struct LocationArray<T>([T; 3]);
+
+impl<T> LocationArray<T> {
+    fn iter(&self) -> impl Iterator<Item = &T> {
+        self.0.iter()
+    }
+}
+
+impl<T> std::ops::Index<CoordPos> for LocationArray<T> {
+    type Output = T;
+
+    fn index(&self, index: CoordPos) -> &Self::Output {
+        match index {
+            CoordPos::Inside => &self.0[0],
+            CoordPos::OnBoundary => &self.0[1],
+            CoordPos::Outside => &self.0[2],
+        }
+    }
+}
+
+impl<T> std::ops::IndexMut<CoordPos> for LocationArray<T> {
+    fn index_mut(&mut self, index: CoordPos) -> &mut Self::Output {
+        match index {
+            CoordPos::Inside => &mut self.0[0],
+            CoordPos::OnBoundary => &mut self.0[1],
+            CoordPos::Outside => &mut self.0[2],
+        }
+    }
+}
+
+/// A malformed DE-9IM pattern string.
+#[derive(Debug)]
+pub struct InvalidInputError {
+    message: String,
+}
+
+impl InvalidInputError {
+    fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl std::error::Error for InvalidInputError {}
+impl std::fmt::Display for InvalidInputError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid input: {}", self.message)
+    }
+}
+
+impl std::fmt::Debug for IntersectionMatrix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn char_for_dim(dim: &Dimensions) -> &'static str {
+            match dim {
+                Dimensions::Empty => "F",
+                Dimensions::ZeroDimensional => "0",
+                Dimensions::OneDimensional => "1",
+                Dimensions::TwoDimensional => "2",
+            }
+        }
+        let text = self
+            .0
+            .iter()
+            .flat_map(|r| r.iter().map(char_for_dim))
+            .collect::<Vec<&str>>()
+            .join("");
+
+        write!(f, "IntersectionMatrix({})", &text)
+    }
+}
+
+impl FromStr for IntersectionMatrix {
+    type Err = InvalidInputError;
+
+    /// Parse a 9-character DE-9IM string like `"212101212"` (row-major:
+    /// interior/boundary/exterior of `a` against the same of `b`).
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut im = IntersectionMatrix::empty();
+        im.set_at_least_from_string(s)?;
+        Ok(im)
+    }
+}
+
+impl IntersectionMatrix {
+    /// The matrix with every cell empty.
+    pub fn empty() -> Self {
+        IntersectionMatrix(LocationArray([LocationArray([Dimensions::Empty; 3]); 3]))
+    }
+
+    /// Set `dimensions` of the cell specified by the positions.
+    ///
+    /// `position_a`: which position `dimensions` applies to within the first geometry
+    /// `position_b`: which position `dimensions` applies to within the second geometry
+    /// `dimensions`: the dimension of the incident
+    pub(crate) fn set(
+        &mut self,
+        position_a: CoordPos,
+        position_b: CoordPos,
+        dimensions: Dimensions,
+    ) {
+        self.0[position_a][position_b] = dimensions;
+    }
+
+    /// Reports an incident of `dimensions`, which updates the IntersectionMatrix if it's greater
+    /// than what has been reported so far.
+    ///
+    /// `position_a`: which position `minimum_dimensions` applies to within the first geometry
+    /// `position_b`: which position `minimum_dimensions` applies to within the second geometry
+    /// `minimum_dimensions`: the dimension of the incident
+    pub(crate) fn set_at_least(
+        &mut self,
+        position_a: CoordPos,
+        position_b: CoordPos,
+        minimum_dimensions: Dimensions,
+    ) {
+        if self.0[position_a][position_b] < minimum_dimensions {
+            self.0[position_a][position_b] = minimum_dimensions;
+        }
+    }
+
+    /// If both geometries have `Some` position, then changes the specified element to at
+    /// least `minimum_dimensions`.
+    ///
+    /// Else, if either is none, do nothing.
+    ///
+    /// `position_a`: which position `minimum_dimensions` applies to within the first geometry, or
+    ///               `None` if the dimension was not incident with the first geometry.
+    /// `position_b`: which position `minimum_dimensions` applies to within the second geometry, or
+    ///               `None` if the dimension was not incident with the second geometry.
+    /// `minimum_dimensions`: the dimension of the incident
+    pub(crate) fn set_at_least_if_in_both(
+        &mut self,
+        position_a: Option<CoordPos>,
+        position_b: Option<CoordPos>,
+        minimum_dimensions: Dimensions,
+    ) {
+        if let (Some(position_a), Some(position_b)) = (position_a, position_b) {
+            self.set_at_least(position_a, position_b, minimum_dimensions);
+        }
+    }
+
+    pub(crate) fn set_at_least_from_string(
+        &mut self,
+        dimensions: &str,
+    ) -> Result<(), InvalidInputError> {
+        if dimensions.len() != 9 {
+            let message = format!("Expected dimensions length 9, found: {}", dimensions.len());
+            return Err(InvalidInputError::new(message));
+        }
+
+        let mut chars = dimensions.chars();
+        for a in &[CoordPos::Inside, CoordPos::OnBoundary, CoordPos::Outside] {
+            for b in &[CoordPos::Inside, CoordPos::OnBoundary, CoordPos::Outside] {
+                match chars.next().expect("already validated length is 9") {
+                    '0' => self.0[*a][*b] = self.0[*a][*b].max(Dimensions::ZeroDimensional),
+                    '1' => self.0[*a][*b] = self.0[*a][*b].max(Dimensions::OneDimensional),
+                    '2' => self.0[*a][*b] = self.0[*a][*b].max(Dimensions::TwoDimensional),
+                    'F' => {}
+                    other => {
+                        let message = format!("expected '0', '1', '2', or 'F'. Found: {other}");
+                        return Err(InvalidInputError::new(message));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Whether the two geometries share no point: no interior or boundary of
+    /// one meets the interior or boundary of the other.
+    pub fn is_disjoint(&self) -> bool {
+        self.0[CoordPos::Inside][CoordPos::Inside] == Dimensions::Empty
+            && self.0[CoordPos::Inside][CoordPos::OnBoundary] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::Inside] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::OnBoundary] == Dimensions::Empty
+    }
+
+    /// Whether the two geometries share at least one point.
+    pub fn is_intersects(&self) -> bool {
+        !self.is_disjoint()
+    }
+
+    /// Whether the first geometry lies in the second: interiors intersect and
+    /// no part of the first is in the second's exterior. `a.within(b) == b.contains(a)`.
+    pub fn is_within(&self) -> bool {
+        self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
+            && self.0[CoordPos::Inside][CoordPos::Outside] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::Outside] == Dimensions::Empty
+    }
+
+    /// Whether the first geometry contains the second: interiors intersect and
+    /// no part of the second is in the first's exterior.
+    pub fn is_contains(&self) -> bool {
+        self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
+            && self.0[CoordPos::Outside][CoordPos::Inside] == Dimensions::Empty
+            && self.0[CoordPos::Outside][CoordPos::OnBoundary] == Dimensions::Empty
+    }
+
+    /// Whether the two geometries are topologically equal as point sets.
+    pub fn is_equal_topo(&self) -> bool {
+        self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
+            && self.0[CoordPos::Inside][CoordPos::Outside] == Dimensions::Empty
+            && self.0[CoordPos::Outside][CoordPos::Inside] == Dimensions::Empty
+            && self.0[CoordPos::Outside][CoordPos::OnBoundary] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::Outside] == Dimensions::Empty
+    }
+
+    /// Whether every point of the first geometry lies in the closure of the
+    /// second. Unlike [`is_within`](Self::is_within), pure boundary contact
+    /// qualifies.
+    #[allow(clippy::nonminimal_bool)]
+    pub fn is_coveredby(&self) -> bool {
+        // [T*F**F***]
+        self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
+            && self.0[CoordPos::Inside][CoordPos::Outside] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::Outside] == Dimensions::Empty ||
+        // [*TF**F***]
+        self.0[CoordPos::Inside][CoordPos::OnBoundary] != Dimensions::Empty
+            && self.0[CoordPos::Inside][CoordPos::Outside] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::Outside] == Dimensions::Empty ||
+        // [**FT*F***]
+        self.0[CoordPos::Inside][CoordPos::Outside] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::Inside] != Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::Outside] == Dimensions::Empty ||
+        // [**F*TF***]
+        self.0[CoordPos::Inside][CoordPos::Outside] == Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::OnBoundary] != Dimensions::Empty
+            && self.0[CoordPos::OnBoundary][CoordPos::Outside] == Dimensions::Empty
+    }
+
+    /// Whether every point of the second geometry lies in the closure of the
+    /// first. Unlike [`is_contains`](Self::is_contains), pure boundary contact
+    /// qualifies.
+    #[allow(clippy::nonminimal_bool)]
+    pub fn is_covers(&self) -> bool {
+        // [T*****FF*]
+        self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
+        && self.0[CoordPos::Outside][CoordPos::Inside] == Dimensions::Empty
+        && self.0[CoordPos::Outside][CoordPos::OnBoundary] == Dimensions::Empty ||
+        // [*T****FF*]
+        self.0[CoordPos::Inside][CoordPos::OnBoundary] != Dimensions::Empty
+        && self.0[CoordPos::Outside][CoordPos::Inside] == Dimensions::Empty
+        && self.0[CoordPos::Outside][CoordPos::OnBoundary] == Dimensions::Empty ||
+        // [***T**FF*]
+        self.0[CoordPos::OnBoundary][CoordPos::Inside] != Dimensions::Empty
+        && self.0[CoordPos::Outside][CoordPos::Inside] == Dimensions::Empty
+        && self.0[CoordPos::Outside][CoordPos::OnBoundary] == Dimensions::Empty ||
+        // [****T*FF*]
+        self.0[CoordPos::OnBoundary][CoordPos::OnBoundary] != Dimensions::Empty
+        && self.0[CoordPos::Outside][CoordPos::Inside] == Dimensions::Empty
+        && self.0[CoordPos::Outside][CoordPos::OnBoundary] == Dimensions::Empty
+    }
+
+    /// Whether the geometries touch: their boundaries meet but their interiors
+    /// do not.
+    #[allow(clippy::nonminimal_bool)]
+    pub fn is_touches(&self) -> bool {
+        // [FT*******]
+        self.0[CoordPos::Inside][CoordPos::Inside] == Dimensions::Empty
+        && self.0[CoordPos::Inside][CoordPos::OnBoundary] != Dimensions::Empty ||
+        // [F**T*****]
+        self.0[CoordPos::Inside][CoordPos::Inside] == Dimensions::Empty
+        && self.0[CoordPos::OnBoundary][CoordPos::Inside] != Dimensions::Empty ||
+        // [F***T****]
+        self.0[CoordPos::Inside][CoordPos::Inside] == Dimensions::Empty
+        && self.0[CoordPos::OnBoundary][CoordPos::OnBoundary] != Dimensions::Empty
+    }
+
+    /// Whether the geometries cross: interiors intersect, each has interior
+    /// outside the other, and the intersection's dimension is lower than the
+    /// maximum operand dimension.
+    pub fn is_crosses(&self) -> bool {
+        let dims_a = self.0[CoordPos::Inside][CoordPos::Inside]
+            .max(self.0[CoordPos::Inside][CoordPos::OnBoundary])
+            .max(self.0[CoordPos::Inside][CoordPos::Outside]);
+
+        let dims_b = self.0[CoordPos::Inside][CoordPos::Inside]
+            .max(self.0[CoordPos::OnBoundary][CoordPos::Inside])
+            .max(self.0[CoordPos::Outside][CoordPos::Inside]);
+        match (dims_a, dims_b) {
+            // a < b
+            _ if dims_a < dims_b =>
+            // [T*T******]
+            {
+                self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
+                    && self.0[CoordPos::Inside][CoordPos::Outside] != Dimensions::Empty
+            }
+            // a > b
+            _ if dims_a > dims_b =>
+            // [T*****T**]
+            {
+                self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
+                    && self.0[CoordPos::Outside][CoordPos::Inside] != Dimensions::Empty
+            }
+            // a == b, only line / line permitted
+            (Dimensions::OneDimensional, Dimensions::OneDimensional) =>
+            // [0********]
+            {
+                self.0[CoordPos::Inside][CoordPos::Inside] == Dimensions::ZeroDimensional
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether the geometries overlap: same dimension, interiors intersect,
+    /// and each has interior outside the other.
+    #[allow(clippy::nonminimal_bool)]
+    pub fn is_overlaps(&self) -> bool {
+        // dimensions must be non-empty, equal, and line / line is a special case
+        let dims_a = self.0[CoordPos::Inside][CoordPos::Inside]
+            .max(self.0[CoordPos::Inside][CoordPos::OnBoundary])
+            .max(self.0[CoordPos::Inside][CoordPos::Outside]);
+
+        let dims_b = self.0[CoordPos::Inside][CoordPos::Inside]
+            .max(self.0[CoordPos::OnBoundary][CoordPos::Inside])
+            .max(self.0[CoordPos::Outside][CoordPos::Inside]);
+        match (dims_a, dims_b) {
+            // line / line: [1*T***T**]
+            (Dimensions::OneDimensional, Dimensions::OneDimensional) => {
+                self.0[CoordPos::Inside][CoordPos::Inside] == Dimensions::OneDimensional
+                    && self.0[CoordPos::Inside][CoordPos::Outside] != Dimensions::Empty
+                    && self.0[CoordPos::Outside][CoordPos::Inside] != Dimensions::Empty
+            }
+            // point / point or polygon / polygon: [T*T***T**]
+            (Dimensions::ZeroDimensional, Dimensions::ZeroDimensional)
+            | (Dimensions::TwoDimensional, Dimensions::TwoDimensional) => {
+                self.0[CoordPos::Inside][CoordPos::Inside] != Dimensions::Empty
+                    && self.0[CoordPos::Inside][CoordPos::Outside] != Dimensions::Empty
+                    && self.0[CoordPos::Outside][CoordPos::Inside] != Dimensions::Empty
+            }
+            _ => false,
+        }
+    }
+
+    /// The dimension recorded for the intersection of the first geometry's
+    /// `lhs` region with the second geometry's `rhs` region.
+    pub fn get(&self, lhs: CoordPos, rhs: CoordPos) -> Dimensions {
+        self.0[lhs][rhs]
+    }
+
+    /// Whether the matrix satisfies a 9-character DE-9IM pattern such as
+    /// `"T*F**FFF*"`: `T` non-empty, `F` empty, `0`/`1`/`2` an exact
+    /// dimension, `*` anything.
+    pub fn matches(&self, spec: &str) -> Result<bool, InvalidInputError> {
+        if spec.len() != 9 {
+            return Err(InvalidInputError::new(format!(
+                "DE-9IM specification must be exactly 9 characters. Got {len}",
+                len = spec.len()
+            )));
+        }
+
+        let mut chars = spec.chars();
+        for a in &[CoordPos::Inside, CoordPos::OnBoundary, CoordPos::Outside] {
+            for b in &[CoordPos::Inside, CoordPos::OnBoundary, CoordPos::Outside] {
+                let dim_spec = dimension_matcher::DimensionMatcher::try_from(
+                    chars.next().expect("already validated length is 9"),
+                )?;
+                if !dim_spec.matches(self.0[*a][*b]) {
+                    return Ok(false);
+                }
+            }
+        }
+        Ok(true)
+    }
+}
+
+pub(crate) mod dimension_matcher {
+    use super::Dimensions;
+    use super::InvalidInputError;
+
+    /// A single letter from a DE-9IM matching specification like "1*T**FFF*"
+    pub(crate) enum DimensionMatcher {
+        Anything,
+        NonEmpty,
+        Exact(Dimensions),
+    }
+
+    impl DimensionMatcher {
+        pub fn matches(&self, dim: Dimensions) -> bool {
+            match (self, dim) {
+                (Self::Anything, _) => true,
+                (DimensionMatcher::NonEmpty, d) => d != Dimensions::Empty,
+                (DimensionMatcher::Exact(a), b) => a == &b,
+            }
+        }
+    }
+
+    impl TryFrom<char> for DimensionMatcher {
+        type Error = InvalidInputError;
+
+        fn try_from(value: char) -> Result<Self, Self::Error> {
+            Ok(match value {
+                '*' => Self::Anything,
+                't' | 'T' => Self::NonEmpty,
+                'f' | 'F' => Self::Exact(Dimensions::Empty),
+                '0' => Self::Exact(Dimensions::ZeroDimensional),
+                '1' => Self::Exact(Dimensions::OneDimensional),
+                '2' => Self::Exact(Dimensions::TwoDimensional),
+                _ => {
+                    return Err(InvalidInputError::new(format!(
+                        "invalid DE-9IM specification character: {value}"
+                    )))
+                }
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn im(s: &str) -> IntersectionMatrix {
+        s.parse().expect("valid matrix string")
+    }
+
+    #[test]
+    fn parse_roundtrips_through_debug() {
+        let m = im("212101212");
+        assert_eq!(format!("{m:?}"), "IntersectionMatrix(212101212)");
+        assert!(im("FFFFFFFF2").is_disjoint());
+        assert!("21210121".parse::<IntersectionMatrix>().is_err());
+        assert!("21210121X".parse::<IntersectionMatrix>().is_err());
+    }
+
+    #[test]
+    fn ordered_dimensions() {
+        assert!(Dimensions::Empty < Dimensions::ZeroDimensional);
+        assert!(Dimensions::ZeroDimensional < Dimensions::OneDimensional);
+        assert!(Dimensions::OneDimensional < Dimensions::TwoDimensional);
+    }
+
+    #[test]
+    fn predicates_on_canonical_matrices() {
+        // Two properly overlapping polygons.
+        let overlap = im("212101212");
+        assert!(overlap.is_intersects() && !overlap.is_disjoint());
+        assert!(overlap.is_overlaps());
+        assert!(!overlap.is_contains() && !overlap.is_within());
+        assert!(!overlap.is_touches());
+
+        // Polygon strictly containing another.
+        let contains = im("212FF1FF2");
+        assert!(contains.is_contains() && contains.is_covers());
+        assert!(!contains.is_within());
+        assert!(!contains.is_overlaps());
+
+        // Two polygons sharing only a boundary edge.
+        let touches = im("FF2F11212");
+        assert!(touches.is_touches());
+        assert!(touches.is_intersects());
+        assert!(!touches.is_overlaps());
+
+        // A line crossing through a polygon (line = a, polygon = b).
+        let crosses = im("1010F0212");
+        assert!(crosses.is_crosses());
+
+        // Topologically equal polygons.
+        let equal = im("2FFF1FFF2");
+        assert!(equal.is_equal_topo());
+        assert!(equal.is_contains() && equal.is_within());
+        assert!(equal.is_covers() && equal.is_coveredby());
+
+        // A polygon covering a line on its boundary (covers but not contains).
+        let boundary_line = im("FF2F112F2");
+        assert!(!boundary_line.is_contains());
+    }
+
+    #[test]
+    fn set_at_least_never_lowers() {
+        let mut m = im("212101212");
+        m.set_at_least(
+            CoordPos::Inside,
+            CoordPos::Inside,
+            Dimensions::ZeroDimensional,
+        );
+        assert_eq!(
+            m.get(CoordPos::Inside, CoordPos::Inside),
+            Dimensions::TwoDimensional
+        );
+        m.set_at_least_if_in_both(None, Some(CoordPos::Inside), Dimensions::TwoDimensional);
+        assert_eq!(m, im("212101212"));
+    }
+
+    #[test]
+    fn matches_patterns() {
+        let m = im("212101212");
+        assert!(m.matches("T*T***T**").unwrap());
+        assert!(m.matches("212101212").unwrap());
+        assert!(m.matches("*********").unwrap());
+        assert!(!m.matches("FF*FF****").unwrap());
+        assert!(m.matches("bogus").is_err());
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/mod.rs
+++ b/engine/runtime/geometry/src/predicates/relate/mod.rs
@@ -1,0 +1,95 @@
+//! DE-9IM [`relate`] for the new geometry model.
+//!
+//! A port of the in-tree JTS geomgraph (`algorithm/relate/`, itself a
+//! georust/geo port of JTS 1.18) onto the flat `[f64; 2]` layout and the
+//! [`view`](super::view) layer, per phase 3 of the predicates plan. The legacy
+//! copy stays in-tree as the differential-testing oracle until legacy removal.
+//!
+//! Structural differences from the legacy copy:
+//!
+//! - the `GeometryCow` input layer is replaced by `RelateOperand` (see
+//!   `operand`) over flattened [`Leaf2D`] views;
+//! - mesh leaves contribute their **union-boundary rings** (see `boundary`)
+//!   instead of raw faces, so faces sharing edges relate as one area;
+//! - the robust line intersector is the shared phase-1
+//!   [`kernel`](super::kernel);
+//! - graphs are call-local, so edges are `Rc<RefCell<..>>`, not `Arc<RwLock<..>>`.
+//!
+//! Like JTS, `relate` does not support operands whose own members have
+//! overlapping areal interiors **or share boundary edges** (an invalid mesh,
+//! or a collection of overlapping or edge-adjacent polygons — invalid
+//! MultiPolygon topology) and may mislabel them: e.g. a shared edge between
+//! two polygon members stays *boundary* even though it is interior to the
+//! union. Mesh leaves are exempt — their faces dissolve via the `boundary`
+//! pre-pass before graph construction. The phase-2 [`contains`](super::contains()) /
+//! [`covers`](super::covers()) / [`intersects`](super::intersects()) fast
+//! paths are exact point-set-union predicates even on such collections;
+//! prefer them when the full matrix is not needed.
+
+pub(crate) mod boundary;
+mod edge_end_builder;
+mod graph;
+pub mod intersection_matrix;
+pub(crate) mod operand;
+mod relate_operation;
+#[cfg(test)]
+mod tests;
+
+pub use intersection_matrix::{Dimensions, IntersectionMatrix};
+
+use crate::predicates::contains::flatten_geometry;
+use crate::predicates::view::Leaf2D;
+use crate::{Euclidean2DGeometry, Geometry};
+
+use super::{PredicateError, Result};
+use operand::RelateOperand;
+use relate_operation::RelateOperation;
+
+/// The DE-9IM intersection matrix of `a` against `b`.
+///
+/// Operands must share one coordinate frame
+/// ([`MixedFrames`](PredicateError::MixedFrames) otherwise) and both be 2D —
+/// a 2D × 3D pair is
+/// [`CrossDimension`](PredicateError::CrossDimension), a 3D × 3D pair
+/// [`UnsupportedPair`](PredicateError::UnsupportedPair) until the 3D phases
+/// land. `Geometry::None` and empty collections relate as the empty geometry
+/// (every predicate against them is false except `is_disjoint`).
+pub fn relate(a: &Geometry, b: &Geometry) -> Result<IntersectionMatrix> {
+    let (a_leaves, a_3d) = flatten_geometry(a);
+    let (b_leaves, b_3d) = flatten_geometry(b);
+    match (a_3d, b_3d) {
+        (None, None) => {}
+        (Some(left), Some(right)) if a_leaves.is_empty() && b_leaves.is_empty() => {
+            return Err(PredicateError::UnsupportedPair { left, right })
+        }
+        _ => return Err(PredicateError::CrossDimension),
+    }
+    require_common_frame(&a_leaves, &b_leaves)?;
+    let a = RelateOperand::new(a_leaves);
+    let b = RelateOperand::new(b_leaves);
+    Ok(RelateOperation::new(&a, &b).compute_intersection_matrix())
+}
+
+/// [`relate`] over two 2D geometries.
+pub fn relate_2d(a: &Euclidean2DGeometry, b: &Euclidean2DGeometry) -> Result<IntersectionMatrix> {
+    let mut a_leaves = Vec::new();
+    crate::predicates::view::flatten_2d(a, &mut a_leaves);
+    let mut b_leaves = Vec::new();
+    crate::predicates::view::flatten_2d(b, &mut b_leaves);
+    require_common_frame(&a_leaves, &b_leaves)?;
+    let a = RelateOperand::new(a_leaves);
+    let b = RelateOperand::new(b_leaves);
+    Ok(RelateOperation::new(&a, &b).compute_intersection_matrix())
+}
+
+/// Require every leaf across both operands to share one coordinate frame.
+fn require_common_frame(a: &[Leaf2D<'_>], b: &[Leaf2D<'_>]) -> Result<()> {
+    let mut frames = a.iter().chain(b.iter()).map(|leaf| leaf.frame());
+    let Some(first) = frames.next() else {
+        return Ok(());
+    };
+    for frame in frames {
+        super::require_same_frame(first, frame)?;
+    }
+    Ok(())
+}

--- a/engine/runtime/geometry/src/predicates/relate/mod.rs
+++ b/engine/runtime/geometry/src/predicates/relate/mod.rs
@@ -1,31 +1,21 @@
-//! DE-9IM [`relate`] for the new geometry model.
+//! DE-9IM [`relate`] for the geometry model.
 //!
-//! A port of the in-tree JTS geomgraph (`algorithm/relate/`, itself a
-//! georust/geo port of JTS 1.18) onto the flat `[f64; 2]` layout and the
-//! [`view`](super::view) layer, per phase 3 of the predicates plan. The legacy
-//! copy stays in-tree as the differential-testing oracle until legacy removal.
+//! Operands are flattened into [`Leaf2D`](super::view::Leaf2D) views wrapped in
+//! a [`RelateOperand`] (see `operand`). Mesh leaves contribute their
+//! **union-boundary rings** (see `boundary`) instead of raw faces, so faces
+//! sharing edges relate as one area.
 //!
-//! Structural differences from the legacy copy:
-//!
-//! - the `GeometryCow` input layer is replaced by `RelateOperand` (see
-//!   `operand`) over flattened [`Leaf2D`](super::view::Leaf2D) views;
-//! - mesh leaves contribute their **union-boundary rings** (see `boundary`)
-//!   instead of raw faces, so faces sharing edges relate as one area;
-//! - the robust line intersector is the shared phase-1
-//!   [`kernel`](super::kernel);
-//! - graphs are call-local, so edges are `Rc<RefCell<..>>`, not `Arc<RwLock<..>>`.
-//!
-//! Like JTS, `relate` does not support operands whose own members have
-//! overlapping areal interiors **or share boundary edges** (an invalid mesh,
-//! or a collection of overlapping or edge-adjacent polygons — invalid
-//! MultiPolygon topology) and may mislabel them — e.g. a shared edge between
-//! two polygon members stays *boundary* even though it is interior to the
-//! union — or panic on a `debug_assert` in debug builds (JTS's
-//! "side location conflict"). Mesh leaves are exempt — their faces dissolve via the `boundary`
-//! pre-pass before graph construction. The phase-2 [`contains`](super::contains()) /
-//! [`covers`](super::covers()) / [`intersects`](super::intersects()) fast
-//! paths are exact point-set-union predicates even on such collections;
-//! prefer them when the full matrix is not needed.
+//! `relate` does not support operands whose own members have overlapping areal
+//! interiors **or share boundary edges** (an invalid mesh, or a collection of
+//! overlapping or edge-adjacent polygons, invalid MultiPolygon topology) and
+//! may mislabel them (a shared edge between two polygon members stays
+//! *boundary* even though it is interior to the union) or panic on a
+//! `debug_assert` in debug builds (a "side location conflict"). Mesh leaves are
+//! exempt: their faces dissolve via the `boundary` pre-pass before graph
+//! construction. The [`contains`](super::contains()) /
+//! [`covers`](super::covers()) / [`intersects`](super::intersects()) fast paths
+//! are exact point-set-union predicates even on such collections; prefer them
+//! when the full matrix is not needed.
 
 pub(crate) mod boundary;
 mod edge_end_builder;
@@ -48,12 +38,12 @@ use relate_operation::RelateOperation;
 /// The DE-9IM intersection matrix of `a` against `b`.
 ///
 /// Operands must share one coordinate frame
-/// ([`MixedFrames`](super::PredicateError::MixedFrames) otherwise) and both be 2D —
-/// a 2D × 3D pair is
+/// ([`MixedFrames`](super::PredicateError::MixedFrames) otherwise) and both be
+/// 2D: a 2D × 3D pair is
 /// [`CrossDimension`](super::PredicateError::CrossDimension), a 3D × 3D pair
-/// [`UnsupportedPair`](super::PredicateError::UnsupportedPair) until the 3D phases
-/// land. `Geometry::None` and empty collections relate as the empty geometry
-/// (every predicate against them is false except `is_disjoint`).
+/// [`UnsupportedPair`](super::PredicateError::UnsupportedPair). `Geometry::None`
+/// and empty collections relate as the empty geometry (every predicate against
+/// them is false except `is_disjoint`).
 pub fn relate(a: &Geometry, b: &Geometry) -> Result<IntersectionMatrix> {
     let (a_leaves, b_leaves) = crate::predicates::flatten_2d_pair(a, b)?;
     require_common_frame_leaves(&a_leaves, &b_leaves)?;

--- a/engine/runtime/geometry/src/predicates/relate/mod.rs
+++ b/engine/runtime/geometry/src/predicates/relate/mod.rs
@@ -28,7 +28,7 @@ mod tests;
 
 pub use intersection_matrix::{Dimensions, IntersectionMatrix};
 
-use crate::predicates::view::require_common_frame_leaves;
+use crate::predicates::view::{require_common_frame_leaves, Leaf2D};
 use crate::{Euclidean2DGeometry, Geometry};
 
 use super::Result;
@@ -47,9 +47,7 @@ use relate_operation::RelateOperation;
 pub fn relate(a: &Geometry, b: &Geometry) -> Result<IntersectionMatrix> {
     let (a_leaves, b_leaves) = crate::predicates::flatten_2d_pair(a, b)?;
     require_common_frame_leaves(&a_leaves, &b_leaves)?;
-    let a = RelateOperand::new(a_leaves);
-    let b = RelateOperand::new(b_leaves);
-    Ok(RelateOperation::new(&a, &b).compute_intersection_matrix())
+    Ok(relate_leaves(a_leaves, b_leaves))
 }
 
 /// [`relate`] over two 2D geometries.
@@ -59,7 +57,15 @@ pub fn relate_2d(a: &Euclidean2DGeometry, b: &Euclidean2DGeometry) -> Result<Int
     let mut b_leaves = Vec::new();
     crate::predicates::view::flatten_2d(b, &mut b_leaves);
     require_common_frame_leaves(&a_leaves, &b_leaves)?;
+    Ok(relate_leaves(a_leaves, b_leaves))
+}
+
+/// [`relate`] over flattened leaves that already share one coordinate frame.
+pub(crate) fn relate_leaves(
+    a_leaves: Vec<Leaf2D<'_>>,
+    b_leaves: Vec<Leaf2D<'_>>,
+) -> IntersectionMatrix {
     let a = RelateOperand::new(a_leaves);
     let b = RelateOperand::new(b_leaves);
-    Ok(RelateOperation::new(&a, &b).compute_intersection_matrix())
+    RelateOperation::new(&a, &b).compute_intersection_matrix()
 }

--- a/engine/runtime/geometry/src/predicates/relate/mod.rs
+++ b/engine/runtime/geometry/src/predicates/relate/mod.rs
@@ -8,7 +8,7 @@
 //! Structural differences from the legacy copy:
 //!
 //! - the `GeometryCow` input layer is replaced by `RelateOperand` (see
-//!   `operand`) over flattened [`Leaf2D`] views;
+//!   `operand`) over flattened [`Leaf2D`](super::view::Leaf2D) views;
 //! - mesh leaves contribute their **union-boundary rings** (see `boundary`)
 //!   instead of raw faces, so faces sharing edges relate as one area;
 //! - the robust line intersector is the shared phase-1
@@ -18,9 +18,10 @@
 //! Like JTS, `relate` does not support operands whose own members have
 //! overlapping areal interiors **or share boundary edges** (an invalid mesh,
 //! or a collection of overlapping or edge-adjacent polygons — invalid
-//! MultiPolygon topology) and may mislabel them: e.g. a shared edge between
+//! MultiPolygon topology) and may mislabel them — e.g. a shared edge between
 //! two polygon members stays *boundary* even though it is interior to the
-//! union. Mesh leaves are exempt — their faces dissolve via the `boundary`
+//! union — or panic on a `debug_assert` in debug builds (JTS's
+//! "side location conflict"). Mesh leaves are exempt — their faces dissolve via the `boundary`
 //! pre-pass before graph construction. The phase-2 [`contains`](super::contains()) /
 //! [`covers`](super::covers()) / [`intersects`](super::intersects()) fast
 //! paths are exact point-set-union predicates even on such collections;
@@ -37,34 +38,25 @@ mod tests;
 
 pub use intersection_matrix::{Dimensions, IntersectionMatrix};
 
-use crate::predicates::contains::flatten_geometry;
-use crate::predicates::view::Leaf2D;
+use crate::predicates::view::require_common_frame_leaves;
 use crate::{Euclidean2DGeometry, Geometry};
 
-use super::{PredicateError, Result};
+use super::Result;
 use operand::RelateOperand;
 use relate_operation::RelateOperation;
 
 /// The DE-9IM intersection matrix of `a` against `b`.
 ///
 /// Operands must share one coordinate frame
-/// ([`MixedFrames`](PredicateError::MixedFrames) otherwise) and both be 2D —
+/// ([`MixedFrames`](super::PredicateError::MixedFrames) otherwise) and both be 2D —
 /// a 2D × 3D pair is
-/// [`CrossDimension`](PredicateError::CrossDimension), a 3D × 3D pair
-/// [`UnsupportedPair`](PredicateError::UnsupportedPair) until the 3D phases
+/// [`CrossDimension`](super::PredicateError::CrossDimension), a 3D × 3D pair
+/// [`UnsupportedPair`](super::PredicateError::UnsupportedPair) until the 3D phases
 /// land. `Geometry::None` and empty collections relate as the empty geometry
 /// (every predicate against them is false except `is_disjoint`).
 pub fn relate(a: &Geometry, b: &Geometry) -> Result<IntersectionMatrix> {
-    let (a_leaves, a_3d) = flatten_geometry(a);
-    let (b_leaves, b_3d) = flatten_geometry(b);
-    match (a_3d, b_3d) {
-        (None, None) => {}
-        (Some(left), Some(right)) if a_leaves.is_empty() && b_leaves.is_empty() => {
-            return Err(PredicateError::UnsupportedPair { left, right })
-        }
-        _ => return Err(PredicateError::CrossDimension),
-    }
-    require_common_frame(&a_leaves, &b_leaves)?;
+    let (a_leaves, b_leaves) = crate::predicates::flatten_2d_pair(a, b)?;
+    require_common_frame_leaves(&a_leaves, &b_leaves)?;
     let a = RelateOperand::new(a_leaves);
     let b = RelateOperand::new(b_leaves);
     Ok(RelateOperation::new(&a, &b).compute_intersection_matrix())
@@ -76,20 +68,8 @@ pub fn relate_2d(a: &Euclidean2DGeometry, b: &Euclidean2DGeometry) -> Result<Int
     crate::predicates::view::flatten_2d(a, &mut a_leaves);
     let mut b_leaves = Vec::new();
     crate::predicates::view::flatten_2d(b, &mut b_leaves);
-    require_common_frame(&a_leaves, &b_leaves)?;
+    require_common_frame_leaves(&a_leaves, &b_leaves)?;
     let a = RelateOperand::new(a_leaves);
     let b = RelateOperand::new(b_leaves);
     Ok(RelateOperation::new(&a, &b).compute_intersection_matrix())
-}
-
-/// Require every leaf across both operands to share one coordinate frame.
-fn require_common_frame(a: &[Leaf2D<'_>], b: &[Leaf2D<'_>]) -> Result<()> {
-    let mut frames = a.iter().chain(b.iter()).map(|leaf| leaf.frame());
-    let Some(first) = frames.next() else {
-        return Ok(());
-    };
-    for frame in frames {
-        super::require_same_frame(first, frame)?;
-    }
-    Ok(())
 }

--- a/engine/runtime/geometry/src/predicates/relate/operand.rs
+++ b/engine/runtime/geometry/src/predicates/relate/operand.rs
@@ -1,10 +1,10 @@
 //! The operand facade the relate graphs are built from.
 //!
-//! [`RelateOperand`] replaces the legacy `GeometryCow`: a flattened 2D operand
-//! (the phase-1 [`Operand2D`]) plus everything `RelateOperation` asks of a
-//! whole geometry — dimensions, union point position, bounding box — and the
-//! per-mesh union-boundary rings the graph input layer consumes instead of raw
-//! mesh faces (see [`boundary`](super::boundary)).
+//! [`RelateOperand`] is a flattened 2D operand (the [`Operand2D`]) plus
+//! everything `RelateOperation` asks of a whole geometry (dimensions, union
+//! point position, bounding box) and the per-mesh union-boundary rings the
+//! graph input layer consumes instead of raw mesh faces (see
+//! [`boundary`](super::boundary)).
 
 use crate::ops::Aabb;
 use crate::predicates::kernel::CoordPos;

--- a/engine/runtime/geometry/src/predicates/relate/operand.rs
+++ b/engine/runtime/geometry/src/predicates/relate/operand.rs
@@ -1,0 +1,268 @@
+//! The operand facade the relate graphs are built from.
+//!
+//! [`RelateOperand`] replaces the legacy `GeometryCow`: a flattened 2D operand
+//! (the phase-1 [`Operand2D`]) plus everything `RelateOperation` asks of a
+//! whole geometry — dimensions, union point position, bounding box — and the
+//! per-mesh union-boundary rings the graph input layer consumes instead of raw
+//! mesh faces (see [`boundary`](super::boundary)).
+
+use crate::ops::Aabb;
+use crate::predicates::kernel::CoordPos;
+use crate::predicates::position::union_position;
+use crate::predicates::view::{Leaf2D, Operand2D, PreparedLeaf};
+
+use super::boundary::union_boundary_rings;
+use super::intersection_matrix::Dimensions;
+
+pub(crate) struct RelateOperand<'a> {
+    operand: Operand2D<'a>,
+    /// Union-boundary rings per leaf: `Some` for mesh leaves, `None` otherwise.
+    boundaries: Vec<Option<Vec<Vec<[f64; 2]>>>>,
+}
+
+impl<'a> RelateOperand<'a> {
+    pub fn new(leaves: Vec<Leaf2D<'a>>) -> Self {
+        let operand = Operand2D::from_leaves(leaves);
+        let boundaries = operand
+            .leaves
+            .iter()
+            .map(|prepared| match prepared.leaf {
+                Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_) => {
+                    let area = prepared.area.as_ref().expect("meshes are areal");
+                    Some(union_boundary_rings(area))
+                }
+                _ => None,
+            })
+            .collect();
+        Self {
+            operand,
+            boundaries,
+        }
+    }
+
+    pub fn leaves(&self) -> &[PreparedLeaf<'a>] {
+        &self.operand.leaves
+    }
+
+    /// The union-boundary rings of the `i`-th leaf; `None` for non-mesh leaves.
+    pub fn boundary_rings(&self, i: usize) -> Option<&[Vec<[f64; 2]>]> {
+        self.boundaries[i].as_deref()
+    }
+
+    /// Whether the operand contains a mesh leaf. Meshes are the MultiPolygon
+    /// analog, which in JTS switches off the mod-2 boundary determination rule
+    /// for the whole graph.
+    pub fn has_mesh(&self) -> bool {
+        self.boundaries.iter().any(Option::is_some)
+    }
+
+    /// Whether every component is a ring (areal, or a closed chain): the JTS
+    /// cue that self-intersection noding may skip the self-intersecting-edge
+    /// check on valid input.
+    pub fn is_rings(&self) -> bool {
+        self.leaves().iter().all(|prepared| match prepared.leaf {
+            Leaf2D::Point(_) => false,
+            Leaf2D::Line(l) => is_closed(l.coords()),
+            Leaf2D::Polygon(_) | Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_) => true,
+        })
+    }
+
+    /// The union bounding box, `None` when the operand is empty.
+    pub fn bounding_box(&self) -> Option<Aabb> {
+        self.leaves()
+            .iter()
+            .filter_map(|prepared| prepared.bbox)
+            .reduce(Aabb::union)
+    }
+
+    /// The position of a coordinate relative to the operand's point-set union.
+    pub fn coordinate_position(&self, coord: [f64; 2]) -> CoordPos {
+        union_position(coord, &self.operand)
+    }
+
+    /// The point-set dimension: the maximum over the leaves.
+    pub fn dimensions(&self) -> Dimensions {
+        let mut max = Dimensions::Empty;
+        for prepared in self.leaves() {
+            let dimensions = leaf_dimensions(&prepared.leaf);
+            if dimensions == Dimensions::TwoDimensional {
+                // short-circuit since we know none can be larger
+                return Dimensions::TwoDimensional;
+            }
+            max = max.max(dimensions);
+        }
+        max
+    }
+
+    /// The dimension of the point-set boundary: the maximum over the leaves.
+    /// Points have no boundary; a closed chain has none either (SFS mod-2);
+    /// an open chain's endpoints are 0-dimensional; areal boundaries are rings.
+    pub fn boundary_dimensions(&self) -> Dimensions {
+        let mut max = Dimensions::Empty;
+        for prepared in self.leaves() {
+            let dimensions = match prepared.leaf {
+                Leaf2D::Point(_) => Dimensions::Empty,
+                Leaf2D::Line(l) => {
+                    if leaf_dimensions(&prepared.leaf) < Dimensions::OneDimensional
+                        || is_closed(l.coords())
+                    {
+                        Dimensions::Empty
+                    } else {
+                        Dimensions::ZeroDimensional
+                    }
+                }
+                Leaf2D::Polygon(_) | Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_) => {
+                    if leaf_dimensions(&prepared.leaf) == Dimensions::Empty {
+                        Dimensions::Empty
+                    } else {
+                        Dimensions::OneDimensional
+                    }
+                }
+            };
+            max = max.max(dimensions);
+        }
+        max
+    }
+}
+
+fn is_closed(coords: &[[f64; 2]]) -> bool {
+    coords.len() >= 2 && coords.first() == coords.last()
+}
+
+/// The point-set dimension of one leaf. Degenerate leaves collapse: a chain of
+/// coincident vertices is a point, an areal leaf with no rings is empty.
+fn leaf_dimensions(leaf: &Leaf2D<'_>) -> Dimensions {
+    match leaf {
+        Leaf2D::Point(_) => Dimensions::ZeroDimensional,
+        Leaf2D::Line(l) => {
+            let coords = l.coords();
+            match coords {
+                [] => Dimensions::Empty,
+                [first, rest @ ..] => {
+                    if rest.iter().all(|c| c == first) {
+                        Dimensions::ZeroDimensional
+                    } else {
+                        Dimensions::OneDimensional
+                    }
+                }
+            }
+        }
+        Leaf2D::Polygon(p) => {
+            if p.exterior().is_empty() {
+                Dimensions::Empty
+            } else {
+                Dimensions::TwoDimensional
+            }
+        }
+        Leaf2D::PolygonMesh(_) | Leaf2D::TriangularMesh(_) => {
+            let area = leaf.area_view().expect("meshes are areal");
+            if area.num_faces() == 0 {
+                Dimensions::Empty
+            } else {
+                Dimensions::TwoDimensional
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinate::CoordinateFrame;
+    use crate::line_string::LineString2D;
+    use crate::point::Point2D;
+    use crate::polygon::Polygon2D;
+    use crate::polygon_mesh::PolygonMesh2D;
+    use crate::predicates::view::flatten_2d;
+    use crate::Euclidean2DGeometry;
+    use pretty_assertions::assert_eq;
+
+    fn e() -> CoordinateFrame {
+        CoordinateFrame::Euclidean
+    }
+
+    fn operand(geometry: &Euclidean2DGeometry) -> RelateOperand<'_> {
+        let mut leaves = Vec::new();
+        flatten_2d(geometry, &mut leaves);
+        RelateOperand::new(leaves)
+    }
+
+    #[test]
+    fn dimensions_per_leaf_kind() {
+        let point = Euclidean2DGeometry::Point(Point2D::new(e(), [1.0, 1.0]));
+        let p = operand(&point);
+        assert_eq!(p.dimensions(), Dimensions::ZeroDimensional);
+        assert_eq!(p.boundary_dimensions(), Dimensions::Empty);
+
+        let open = Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            e(),
+            [[0.0, 0.0], [2.0, 0.0]],
+        ));
+        let l = operand(&open);
+        assert_eq!(l.dimensions(), Dimensions::OneDimensional);
+        assert_eq!(l.boundary_dimensions(), Dimensions::ZeroDimensional);
+
+        let closed = Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            e(),
+            [[0.0, 0.0], [2.0, 0.0], [1.0, 1.0], [0.0, 0.0]],
+        ));
+        let c = operand(&closed);
+        assert_eq!(c.dimensions(), Dimensions::OneDimensional);
+        assert_eq!(c.boundary_dimensions(), Dimensions::Empty);
+
+        let degenerate = Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            e(),
+            [[1.0, 1.0], [1.0, 1.0]],
+        ));
+        assert_eq!(
+            operand(&degenerate).dimensions(),
+            Dimensions::ZeroDimensional
+        );
+
+        let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
+        let polygon = Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            e(),
+            square,
+            Vec::<Vec<[f64; 2]>>::new(),
+        )));
+        let a = operand(&polygon);
+        assert_eq!(a.dimensions(), Dimensions::TwoDimensional);
+        assert_eq!(a.boundary_dimensions(), Dimensions::OneDimensional);
+        assert!(a.is_rings());
+        assert!(!a.has_mesh());
+    }
+
+    #[test]
+    fn mesh_boundaries_are_extracted_once() {
+        let mesh = PolygonMesh2D::from_parts(
+            e(),
+            vec![
+                [0.0, 0.0],
+                [2.0, 0.0],
+                [2.0, 2.0],
+                [0.0, 2.0],
+                [4.0, 0.0],
+                [4.0, 2.0],
+            ],
+            vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+        )
+        .unwrap();
+        let geometry = Euclidean2DGeometry::PolygonMesh(Box::new(mesh));
+        let m = operand(&geometry);
+        assert!(m.has_mesh());
+        assert!(m.is_rings());
+        let rings = m.boundary_rings(0).expect("mesh leaf has boundary rings");
+        assert_eq!(rings.len(), 1);
+        assert_eq!(m.dimensions(), Dimensions::TwoDimensional);
+        // The union position sees the shared edge as interior.
+        assert_eq!(m.coordinate_position([2.0, 1.0]), CoordPos::Inside);
+    }
+
+    #[test]
+    fn empty_operand() {
+        let o = RelateOperand::new(Vec::new());
+        assert_eq!(o.dimensions(), Dimensions::Empty);
+        assert_eq!(o.boundary_dimensions(), Dimensions::Empty);
+        assert!(o.bounding_box().is_none());
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/relate_operation.rs
+++ b/engine/runtime/geometry/src/predicates/relate/relate_operation.rs
@@ -73,7 +73,7 @@ impl<'a> RelateOperation<'a> {
             }
         }
 
-        // Since changes to topology are inspected at nodes, we must crate a node for each
+        // Since changes to topology are inspected at nodes, we must create a node for each
         // intersection.
         self.graph_a.compute_self_nodes();
         self.graph_b.compute_self_nodes();

--- a/engine/runtime/geometry/src/predicates/relate/relate_operation.rs
+++ b/engine/runtime/geometry/src/predicates/relate/relate_operation.rs
@@ -1,0 +1,354 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::predicates::kernel::CoordPos;
+
+use super::edge_end_builder::EdgeEndBuilder;
+use super::graph::index::SegmentIntersector;
+use super::graph::node_map::{NodeFactory, NodeMap};
+use super::graph::{
+    CoordNode, Edge, EdgeEnd, EdgeEndBundleStar, GeometryGraph, LabeledEdgeEndBundleStar,
+};
+use super::intersection_matrix::Dimensions;
+use super::operand::RelateOperand;
+use super::IntersectionMatrix;
+
+/// Computes an [`IntersectionMatrix`] describing the topological relationship between two
+/// Geometries.
+///
+/// `RelateOperation` does not currently support operands whose own members contain overlapping
+/// Polygons, and may provide surprising results in that case.
+///
+/// This implementation relies heavily on the functionality of [`GeometryGraph`].
+///
+/// Based on [JTS's `RelateComputer` as of 1.18.1](https://github.com/locationtech/jts/blob/jts-1.18.1/modules/core/src/main/java/org/locationtech/jts/operation/relate/RelateComputer.java)
+pub(crate) struct RelateOperation<'a> {
+    graph_a: GeometryGraph<'a>,
+    graph_b: GeometryGraph<'a>,
+    nodes: NodeMap<RelateNodeFactory>,
+    isolated_edges: Vec<Rc<RefCell<Edge>>>,
+}
+
+pub(crate) struct RelateNodeFactory;
+impl NodeFactory for RelateNodeFactory {
+    type Node = (CoordNode, EdgeEndBundleStar);
+    fn create_node(coordinate: [f64; 2]) -> Self::Node {
+        (CoordNode::new(coordinate), EdgeEndBundleStar::new())
+    }
+}
+
+impl<'a> RelateOperation<'a> {
+    pub(crate) fn new(
+        operand_a: &'a RelateOperand<'a>,
+        operand_b: &'a RelateOperand<'a>,
+    ) -> RelateOperation<'a> {
+        Self {
+            graph_a: GeometryGraph::new(0, operand_a),
+            graph_b: GeometryGraph::new(1, operand_b),
+            nodes: NodeMap::new(),
+            isolated_edges: vec![],
+        }
+    }
+
+    pub(crate) fn compute_intersection_matrix(&mut self) -> IntersectionMatrix {
+        let mut intersection_matrix = IntersectionMatrix::empty();
+        // since Geometries are finite and embedded in a 2-D space,
+        // the `(Outside, Outside)` element must always be 2-D
+        intersection_matrix.set(
+            CoordPos::Outside,
+            CoordPos::Outside,
+            Dimensions::TwoDimensional,
+        );
+
+        match (
+            self.graph_a.geometry().bounding_box(),
+            self.graph_b.geometry().bounding_box(),
+        ) {
+            (Some(bounding_box_a), Some(bounding_box_b))
+                if bounding_box_a.intersects(&bounding_box_b) => {}
+            _ => {
+                // since Geometries don't overlap, we can skip most of the work
+                self.compute_disjoint_intersection_matrix(&mut intersection_matrix);
+                return intersection_matrix;
+            }
+        }
+
+        // Since changes to topology are inspected at nodes, we must crate a node for each
+        // intersection.
+        self.graph_a.compute_self_nodes();
+        self.graph_b.compute_self_nodes();
+
+        // compute intersections between edges of the two input geometries
+        let segment_intersector = self.graph_a.compute_edge_intersections(&self.graph_b);
+
+        self.compute_intersection_nodes(0);
+        self.compute_intersection_nodes(1);
+        // Copy the labelling for the nodes in the parent Geometries.  These override any labels
+        // determined by intersections between the geometries.
+        self.copy_nodes_and_labels(0);
+        self.copy_nodes_and_labels(1);
+        // complete the labelling for any nodes which only have a label for a single geometry
+        self.label_isolated_nodes();
+        // If a proper intersection was found, we can set a lower bound on the IM.
+        self.compute_proper_intersection_im(&segment_intersector, &mut intersection_matrix);
+        // Now process improper intersections
+        // (eg where one or other of the geometries has a vertex at the intersection point)
+        // We need to compute the edge graph at all nodes to determine the IM.
+        let edge_end_builder = EdgeEndBuilder::new();
+        let edge_ends_a: Vec<_> = edge_end_builder.compute_ends_for_edges(self.graph_a.edges());
+        self.insert_edge_ends(edge_ends_a);
+        let edge_ends_b: Vec<_> = edge_end_builder.compute_ends_for_edges(self.graph_b.edges());
+        self.insert_edge_ends(edge_ends_b);
+
+        let mut nodes = NodeMap::new();
+        std::mem::swap(&mut self.nodes, &mut nodes);
+        let labeled_node_edges = nodes
+            .into_iter()
+            .map(|(node, edges)| (node, edges.into_labeled(&self.graph_a, &self.graph_b)))
+            .collect();
+
+        // Compute the labeling for "isolated" components
+        //
+        // Isolated components are components that do not touch any other components in the graph.
+        //
+        // They can be identified by the fact that their labels will have only one non-empty
+        // element, the one for their parent geometry.
+        //
+        // We only need to check components contained in the input graphs, since, by definition,
+        // isolated components will not have been replaced by new components formed by
+        // intersections.
+        self.label_isolated_edges(0, 1);
+        self.label_isolated_edges(1, 0);
+        self.update_intersection_matrix(labeled_node_edges, &mut intersection_matrix);
+
+        intersection_matrix
+    }
+
+    fn insert_edge_ends(&mut self, edge_ends: Vec<EdgeEnd>) {
+        for edge_end in edge_ends {
+            let (_node, edges) = self
+                .nodes
+                .insert_node_with_coordinate(*edge_end.coordinate());
+            edges.insert(edge_end);
+        }
+    }
+
+    fn compute_proper_intersection_im(
+        &mut self,
+        segment_intersector: &SegmentIntersector,
+        intersection_matrix: &mut IntersectionMatrix,
+    ) {
+        // If a proper intersection is found, we can set a lower bound on the IM.
+        let dim_a = self.graph_a.geometry().dimensions();
+        let dim_b = self.graph_b.geometry().dimensions();
+
+        let has_proper = segment_intersector.has_proper_intersection();
+        let has_proper_interior = segment_intersector.has_proper_interior_intersection();
+
+        debug_assert!(
+            (dim_a != Dimensions::ZeroDimensional && dim_b != Dimensions::ZeroDimensional)
+                || (!has_proper && !has_proper_interior)
+        );
+
+        match (dim_a, dim_b) {
+            // If edge segments of Areas properly intersect, the areas must properly overlap.
+            (Dimensions::TwoDimensional, Dimensions::TwoDimensional) => {
+                if has_proper {
+                    intersection_matrix
+                        .set_at_least_from_string("212101212")
+                        .expect("error in hardcoded dimensions");
+                }
+            }
+
+            (Dimensions::TwoDimensional, Dimensions::OneDimensional) => {
+                if has_proper {
+                    intersection_matrix
+                        .set_at_least_from_string("FFF0FFFF2")
+                        .expect("error in hardcoded dimensions");
+                }
+
+                if has_proper_interior {
+                    intersection_matrix
+                        .set_at_least_from_string("1FFFFF1FF")
+                        .expect("error in hardcoded dimensions");
+                }
+            }
+
+            (Dimensions::OneDimensional, Dimensions::TwoDimensional) => {
+                if has_proper {
+                    intersection_matrix
+                        .set_at_least_from_string("F0FFFFFF2")
+                        .expect("error in hardcoded dimensions");
+                }
+
+                if has_proper_interior {
+                    intersection_matrix
+                        .set_at_least_from_string("1F1FFFFFF")
+                        .expect("error in hardcoded dimensions");
+                }
+            }
+            (Dimensions::OneDimensional, Dimensions::OneDimensional) => {
+                if has_proper_interior {
+                    intersection_matrix
+                        .set_at_least_from_string("0FFFFFFFF")
+                        .expect("error in hardcoded dimensions");
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn copy_nodes_and_labels(&mut self, geom_index: usize) {
+        let graph = if geom_index == 0 {
+            &self.graph_a
+        } else {
+            assert_eq!(geom_index, 1);
+            &self.graph_b
+        };
+        for graph_node in graph.nodes_iter() {
+            let new_node = self
+                .nodes
+                .insert_node_with_coordinate(*graph_node.coordinate());
+
+            let on_position = graph_node
+                .label()
+                .on_position(geom_index)
+                .expect("node should have been labeled by now");
+
+            new_node.0.set_label_on_position(geom_index, on_position);
+        }
+    }
+
+    fn compute_intersection_nodes(&mut self, geom_index: usize) {
+        let graph = if geom_index == 0 {
+            &self.graph_a
+        } else {
+            assert_eq!(geom_index, 1);
+            &self.graph_b
+        };
+
+        for edge in graph.edges() {
+            let edge = edge.borrow();
+
+            let edge_position = edge.label().on_position(geom_index);
+            for edge_intersection in edge.edge_intersections() {
+                let (new_node, _edges) = self
+                    .nodes
+                    .insert_node_with_coordinate(edge_intersection.coordinate());
+
+                if edge_position == Some(CoordPos::OnBoundary) {
+                    new_node.set_label_boundary(geom_index);
+                } else if new_node.label().is_empty(geom_index) {
+                    new_node.set_label_on_position(geom_index, CoordPos::Inside);
+                }
+            }
+        }
+    }
+
+    fn compute_disjoint_intersection_matrix(&self, intersection_matrix: &mut IntersectionMatrix) {
+        {
+            let geometry_a = self.graph_a.geometry();
+            let dimensions = geometry_a.dimensions();
+            if dimensions != Dimensions::Empty {
+                intersection_matrix.set(CoordPos::Inside, CoordPos::Outside, dimensions);
+
+                let boundary_dimensions = geometry_a.boundary_dimensions();
+                if boundary_dimensions != Dimensions::Empty {
+                    intersection_matrix.set(
+                        CoordPos::OnBoundary,
+                        CoordPos::Outside,
+                        boundary_dimensions,
+                    );
+                }
+            }
+        }
+
+        {
+            let geometry_b = self.graph_b.geometry();
+            let dimensions = geometry_b.dimensions();
+            if dimensions != Dimensions::Empty {
+                intersection_matrix.set(CoordPos::Outside, CoordPos::Inside, dimensions);
+
+                let boundary_dimensions = geometry_b.boundary_dimensions();
+                if boundary_dimensions != Dimensions::Empty {
+                    intersection_matrix.set(
+                        CoordPos::Outside,
+                        CoordPos::OnBoundary,
+                        boundary_dimensions,
+                    );
+                }
+            }
+        }
+    }
+
+    fn update_intersection_matrix(
+        &self,
+        labeled_node_edges: Vec<(CoordNode, LabeledEdgeEndBundleStar)>,
+        intersection_matrix: &mut IntersectionMatrix,
+    ) {
+        for isolated_edge in &self.isolated_edges {
+            let edge = isolated_edge.borrow();
+            Edge::update_intersection_matrix(edge.label(), intersection_matrix);
+        }
+
+        for (node, edges) in labeled_node_edges.iter() {
+            node.update_intersection_matrix(intersection_matrix);
+            edges.update_intersection_matrix(intersection_matrix);
+        }
+    }
+
+    fn label_isolated_edges(&mut self, this_index: usize, target_index: usize) {
+        let (this_graph, target_graph) = if this_index == 0 {
+            (&self.graph_a, &self.graph_b)
+        } else {
+            (&self.graph_b, &self.graph_a)
+        };
+
+        let mut isolated = vec![];
+        for edge in this_graph.edges() {
+            let mut mut_edge = edge.borrow_mut();
+            if mut_edge.is_isolated() {
+                Self::label_isolated_edge(&mut mut_edge, target_index, target_graph.geometry());
+                isolated.push(edge.clone());
+            }
+        }
+        self.isolated_edges.extend(isolated);
+    }
+
+    fn label_isolated_edge(edge: &mut Edge, target_index: usize, target: &RelateOperand<'_>) {
+        if target.dimensions() > Dimensions::ZeroDimensional {
+            let coord = edge.coords().first().expect("can't create empty edge");
+            let position = target.coordinate_position(*coord);
+            edge.label_mut().set_all_positions(target_index, position);
+        } else {
+            edge.label_mut()
+                .set_all_positions(target_index, CoordPos::Outside);
+        }
+    }
+
+    fn label_isolated_nodes(&mut self) {
+        let geometry_a = self.graph_a.geometry();
+        let geometry_b = self.graph_b.geometry();
+        for (node, _edges) in self.nodes.iter_mut() {
+            let label = node.label();
+            // isolated nodes should always have at least one geometry in their label
+            debug_assert!(label.geometry_count() > 0, "node with empty label found");
+            if node.is_isolated() {
+                if label.is_empty(0) {
+                    Self::label_isolated_node(node, 0, geometry_a)
+                } else {
+                    Self::label_isolated_node(node, 1, geometry_b)
+                }
+            }
+        }
+    }
+
+    fn label_isolated_node(
+        node: &mut CoordNode,
+        target_index: usize,
+        geometry: &RelateOperand<'_>,
+    ) {
+        let position = geometry.coordinate_position(*node.coordinate());
+        node.label_mut().set_all_positions(target_index, position);
+    }
+}

--- a/engine/runtime/geometry/src/predicates/relate/tests.rs
+++ b/engine/runtime/geometry/src/predicates/relate/tests.rs
@@ -1,6 +1,5 @@
-//! Relate test suites: canonical DE-9IM matrices, mesh union semantics,
-//! differential parity with the legacy in-tree relate, and consistency with
-//! the phase-2 fast-path predicates.
+//! Relate test suites: canonical DE-9IM matrices, mesh union semantics, and
+//! consistency with the fast-path predicates.
 
 use pretty_assertions::assert_eq;
 
@@ -14,25 +13,12 @@ use crate::predicates::{contains, covers, intersects, relate};
 use crate::triangular_mesh::TriangularMesh2D;
 use crate::{Euclidean2DGeometry, Geometry};
 
-use crate::algorithm::relate::Relate as LegacyRelate;
-use crate::types::coordinate::Coordinate2D;
-use crate::types::geometry::Geometry2D as LegacyGeometry2D;
-use crate::types::line_string::LineString2D as LegacyLineString2D;
-use crate::types::point::Point2D as LegacyPoint2D;
-use crate::types::polygon::Polygon2D as LegacyPolygon2D;
-
 fn e() -> CoordinateFrame {
     CoordinateFrame::Euclidean
 }
 
-/// The 9-char DE-9IM string of a new-path matrix.
+/// The 9-char DE-9IM string of a matrix.
 fn m(im: &super::IntersectionMatrix) -> String {
-    let debug = format!("{im:?}");
-    debug["IntersectionMatrix(".len()..debug.len() - 1].to_string()
-}
-
-/// The 9-char DE-9IM string of a legacy matrix.
-fn legacy_m(im: &crate::algorithm::relate::IntersectionMatrix) -> String {
     let debug = format!("{im:?}");
     debug["IntersectionMatrix(".len()..debug.len() - 1].to_string()
 }
@@ -63,31 +49,6 @@ fn rect(x0: f64, y0: f64, x1: f64, y1: f64) -> Vec<[f64; 2]> {
 /// A clockwise rect ring (hole orientation).
 fn rect_cw(x0: f64, y0: f64, x1: f64, y1: f64) -> Vec<[f64; 2]> {
     vec![[x0, y0], [x0, y1], [x1, y1], [x1, y0], [x0, y0]]
-}
-
-fn legacy_coords(coords: &[[f64; 2]]) -> Vec<Coordinate2D<f64>> {
-    coords
-        .iter()
-        .map(|c| Coordinate2D::new_(c[0], c[1]))
-        .collect()
-}
-
-fn legacy_point(p: [f64; 2]) -> LegacyGeometry2D<f64> {
-    LegacyGeometry2D::Point(LegacyPoint2D::from(Coordinate2D::new_(p[0], p[1])))
-}
-
-fn legacy_line(coords: &[[f64; 2]]) -> LegacyGeometry2D<f64> {
-    LegacyGeometry2D::LineString(LegacyLineString2D::new(legacy_coords(coords)))
-}
-
-fn legacy_polygon(exterior: &[[f64; 2]], holes: &[Vec<[f64; 2]>]) -> LegacyGeometry2D<f64> {
-    LegacyGeometry2D::Polygon(LegacyPolygon2D::new(
-        LegacyLineString2D::new(legacy_coords(exterior)),
-        holes
-            .iter()
-            .map(|h| LegacyLineString2D::new(legacy_coords(h)))
-            .collect(),
-    ))
 }
 
 // --- canonical matrices -------------------------------------------------------
@@ -243,50 +204,37 @@ fn two_quad_mesh() -> Geometry {
 #[test]
 fn mesh_relates_as_its_dissolved_union() {
     let mesh = two_quad_mesh();
-    let dissolved = rect(0.0, 0.0, 4.0, 2.0);
-    let legacy_dissolved = legacy_polygon(&dissolved, &[]);
+    let dissolved = polygon(&rect(0.0, 0.0, 4.0, 2.0), &[]);
 
-    let others: Vec<(Geometry, LegacyGeometry2D<f64>)> = vec![
+    let others: Vec<Geometry> = vec![
         // Crossing the internal shared edge: interior contact, not boundary.
-        (
-            polygon(&rect(1.0, 0.5, 3.0, 1.5), &[]),
-            legacy_polygon(&rect(1.0, 0.5, 3.0, 1.5), &[]),
-        ),
+        polygon(&rect(1.0, 0.5, 3.0, 1.5), &[]),
         // Equal to the union.
-        (polygon(&dissolved, &[]), legacy_polygon(&dissolved, &[])),
+        polygon(&rect(0.0, 0.0, 4.0, 2.0), &[]),
         // Touching the union's outer boundary.
-        (
-            polygon(&rect(4.0, 0.0, 6.0, 2.0), &[]),
-            legacy_polygon(&rect(4.0, 0.0, 6.0, 2.0), &[]),
-        ),
+        polygon(&rect(4.0, 0.0, 6.0, 2.0), &[]),
         // A line along the internal shared edge is interior to the union.
-        (
-            line(&[[2.0, 0.5], [2.0, 1.5]]),
-            legacy_line(&[[2.0, 0.5], [2.0, 1.5]]),
-        ),
+        line(&[[2.0, 0.5], [2.0, 1.5]]),
         // A point on the internal shared edge.
-        (point([2.0, 1.0]), legacy_point([2.0, 1.0])),
+        point([2.0, 1.0]),
         // Overlapping one face only.
-        (
-            polygon(&rect(-1.0, 0.5, 1.0, 1.5), &[]),
-            legacy_polygon(&rect(-1.0, 0.5, 1.0, 1.5), &[]),
-        ),
+        polygon(&rect(-1.0, 0.5, 1.0, 1.5), &[]),
         // Disjoint.
-        (point([9.0, 9.0]), legacy_point([9.0, 9.0])),
+        point([9.0, 9.0]),
     ];
 
-    for (other, legacy_other) in &others {
+    for other in &others {
         let ours = relate(&mesh, other).unwrap();
-        let oracle = legacy_dissolved.relate(legacy_other);
+        let dissolved_union = relate(&dissolved, other).unwrap();
         assert_eq!(
             m(&ours),
-            legacy_m(&oracle),
+            m(&dissolved_union),
             "mesh relate diverges from dissolved-union relate for {other:?}"
         );
         // And in the flipped argument order.
         let ours = relate(other, &mesh).unwrap();
-        let oracle = legacy_other.relate(&legacy_dissolved);
-        assert_eq!(m(&ours), legacy_m(&oracle), "flipped order for {other:?}");
+        let dissolved_union = relate(other, &dissolved).unwrap();
+        assert_eq!(m(&ours), m(&dissolved_union), "flipped order for {other:?}");
     }
 }
 
@@ -346,7 +294,7 @@ fn mesh_specific_matrices() {
     assert!(relate(&annulus, &holey).unwrap().is_equal_topo());
 }
 
-// --- differential + consistency sweeps ----------------------------------------
+// --- consistency sweeps -------------------------------------------------------
 
 /// Deterministic splitmix-style generator.
 struct Rng(u64);
@@ -369,32 +317,32 @@ impl Rng {
     }
 }
 
-/// One random geometry in both representations.
-fn random_pair(rng: &mut Rng) -> (Geometry, LegacyGeometry2D<f64>) {
+/// One random geometry.
+fn random_geometry(rng: &mut Rng) -> Geometry {
     match rng.range(7) {
         0 => {
             let p = rng.coord();
-            (point(p), legacy_point(p))
+            point(p)
         }
         1 => {
             let coords = [rng.coord(), rng.coord()];
-            (line(&coords), legacy_line(&coords))
+            line(&coords)
         }
         2 => {
             let coords = [rng.coord(), rng.coord(), rng.coord(), rng.coord()];
-            (line(&coords), legacy_line(&coords))
+            line(&coords)
         }
         3 => {
             // Closed chain.
             let (a, b, c) = (rng.coord(), rng.coord(), rng.coord());
             let coords = [a, b, c, a];
-            (line(&coords), legacy_line(&coords))
+            line(&coords)
         }
         4 => {
             let (x0, y0) = (rng.range(6) as f64, rng.range(6) as f64);
             let (w, h) = (1 + rng.range(3), 1 + rng.range(3));
             let ring = rect(x0, y0, x0 + w as f64, y0 + h as f64);
-            (polygon(&ring, &[]), legacy_polygon(&ring, &[]))
+            polygon(&ring, &[])
         }
         5 => {
             // Rect with a hole strictly inside.
@@ -405,10 +353,7 @@ fn random_pair(rng: &mut Rng) -> (Geometry, LegacyGeometry2D<f64>) {
             );
             let hole = rect_cw(x0 + 1.0, y0 + 1.0, x1 - 1.0, y1 - 1.0);
             let ring = rect(x0, y0, x1, y1);
-            (
-                polygon(&ring, std::slice::from_ref(&hole)),
-                legacy_polygon(&ring, &[hole]),
-            )
+            polygon(&ring, std::slice::from_ref(&hole))
         }
         _ => {
             // Triangle, arbitrary winding; regenerate until non-collinear.
@@ -417,7 +362,7 @@ fn random_pair(rng: &mut Rng) -> (Geometry, LegacyGeometry2D<f64>) {
                 let doubled_area = (b[0] - a[0]) * (c[1] - a[1]) - (c[0] - a[0]) * (b[1] - a[1]);
                 if doubled_area != 0.0 {
                     let ring = [a, b, c, a];
-                    return (polygon(&ring, &[]), legacy_polygon(&ring, &[]));
+                    return polygon(&ring, &[]);
                 }
             }
         }
@@ -425,27 +370,11 @@ fn random_pair(rng: &mut Rng) -> (Geometry, LegacyGeometry2D<f64>) {
 }
 
 #[test]
-fn differential_against_legacy_relate() {
-    let mut rng = Rng(20260715);
-    for case in 0..500 {
-        let (a, legacy_a) = random_pair(&mut rng);
-        let (b, legacy_b) = random_pair(&mut rng);
-        let ours = relate(&a, &b).unwrap();
-        let oracle = legacy_a.relate(&legacy_b);
-        assert_eq!(
-            m(&ours),
-            legacy_m(&oracle),
-            "case {case}: relate({a:?}, {b:?}) diverges from legacy"
-        );
-    }
-}
-
-#[test]
 fn matrix_agrees_with_fast_path_predicates() {
     let mut rng = Rng(42);
     for case in 0..300 {
-        let (a, _) = random_pair(&mut rng);
-        let (b, _) = random_pair(&mut rng);
+        let a = random_geometry(&mut rng);
+        let b = random_geometry(&mut rng);
         let im = relate(&a, &b).unwrap();
         assert_eq!(
             im.is_intersects(),
@@ -484,7 +413,7 @@ fn mesh_matrix_agrees_with_fast_path_predicates() {
         )
         .unwrap();
         let a = Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(Box::new(mesh)));
-        let (b, _) = random_pair(&mut rng);
+        let b = random_geometry(&mut rng);
         for (left, right) in [(&a, &b), (&b, &a)] {
             let im = relate(left, right).unwrap();
             assert_eq!(
@@ -520,9 +449,8 @@ fn square_collection(rects: &[[f64; 4]]) -> Geometry {
 
 #[test]
 fn collections_of_disjoint_members_relate_as_unions() {
-    // Note: the legacy relate cannot take collections at all (GeometryCow
-    // panics `unimplemented!` on `Geometry::GeometryCollection`); the new path
-    // flattens them into one operand.
+    // A collection flattens into one operand and relates as the union of its
+    // members.
     let two_squares = square_collection(&[[0.0, 0.0, 2.0, 2.0], [6.0, 0.0, 8.0, 2.0]]);
 
     let in_first = relate(&two_squares, &line(&[[0.5, 1.0], [1.5, 1.0]])).unwrap();
@@ -549,7 +477,7 @@ fn collection_with_edge_adjacent_members_is_jts_limited() {
     assert!(im.is_intersects());
     assert!(!im.is_contains()); // JTS limitation, documented in relate/mod.rs
 
-    // The phase-2 split-based predicate is exact on the same input.
+    // The split-based predicate is exact on the same input.
     assert_eq!(contains(&adjacent, &spanning), Ok(true));
 
     // The equivalent mesh gets the union answer from relate as well.

--- a/engine/runtime/geometry/src/predicates/relate/tests.rs
+++ b/engine/runtime/geometry/src/predicates/relate/tests.rs
@@ -1,0 +1,558 @@
+//! Relate test suites: canonical DE-9IM matrices, mesh union semantics,
+//! differential parity with the legacy in-tree relate, and consistency with
+//! the phase-2 fast-path predicates.
+
+use pretty_assertions::assert_eq;
+
+use crate::collection::Collection2D;
+use crate::coordinate::CoordinateFrame;
+use crate::line_string::LineString2D;
+use crate::point::Point2D;
+use crate::polygon::Polygon2D;
+use crate::polygon_mesh::PolygonMesh2D;
+use crate::predicates::{contains, covers, intersects, relate};
+use crate::triangular_mesh::TriangularMesh2D;
+use crate::{Euclidean2DGeometry, Geometry};
+
+use crate::algorithm::relate::Relate as LegacyRelate;
+use crate::types::coordinate::Coordinate2D;
+use crate::types::geometry::Geometry2D as LegacyGeometry2D;
+use crate::types::line_string::LineString2D as LegacyLineString2D;
+use crate::types::point::Point2D as LegacyPoint2D;
+use crate::types::polygon::Polygon2D as LegacyPolygon2D;
+
+fn e() -> CoordinateFrame {
+    CoordinateFrame::Euclidean
+}
+
+/// The 9-char DE-9IM string of a new-path matrix.
+fn m(im: &super::IntersectionMatrix) -> String {
+    let debug = format!("{im:?}");
+    debug["IntersectionMatrix(".len()..debug.len() - 1].to_string()
+}
+
+/// The 9-char DE-9IM string of a legacy matrix.
+fn legacy_m(im: &crate::algorithm::relate::IntersectionMatrix) -> String {
+    let debug = format!("{im:?}");
+    debug["IntersectionMatrix(".len()..debug.len() - 1].to_string()
+}
+
+// --- builders over shared coordinate lists -----------------------------------
+
+fn point(p: [f64; 2]) -> Geometry {
+    Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(e(), p)))
+}
+
+fn line(coords: &[[f64; 2]]) -> Geometry {
+    Geometry::Euclidean2D(Euclidean2DGeometry::LineString(LineString2D::from_coords(
+        e(),
+        coords.to_vec(),
+    )))
+}
+
+fn polygon(exterior: &[[f64; 2]], holes: &[Vec<[f64; 2]>]) -> Geometry {
+    Geometry::Euclidean2D(Euclidean2DGeometry::Polygon(Box::new(
+        Polygon2D::from_rings(e(), exterior.to_vec(), holes.to_vec()),
+    )))
+}
+
+fn rect(x0: f64, y0: f64, x1: f64, y1: f64) -> Vec<[f64; 2]> {
+    vec![[x0, y0], [x1, y0], [x1, y1], [x0, y1], [x0, y0]]
+}
+
+/// A clockwise rect ring (hole orientation).
+fn rect_cw(x0: f64, y0: f64, x1: f64, y1: f64) -> Vec<[f64; 2]> {
+    vec![[x0, y0], [x0, y1], [x1, y1], [x1, y0], [x0, y0]]
+}
+
+fn legacy_coords(coords: &[[f64; 2]]) -> Vec<Coordinate2D<f64>> {
+    coords
+        .iter()
+        .map(|c| Coordinate2D::new_(c[0], c[1]))
+        .collect()
+}
+
+fn legacy_point(p: [f64; 2]) -> LegacyGeometry2D<f64> {
+    LegacyGeometry2D::Point(LegacyPoint2D::from(Coordinate2D::new_(p[0], p[1])))
+}
+
+fn legacy_line(coords: &[[f64; 2]]) -> LegacyGeometry2D<f64> {
+    LegacyGeometry2D::LineString(LegacyLineString2D::new(legacy_coords(coords)))
+}
+
+fn legacy_polygon(exterior: &[[f64; 2]], holes: &[Vec<[f64; 2]>]) -> LegacyGeometry2D<f64> {
+    LegacyGeometry2D::Polygon(LegacyPolygon2D::new(
+        LegacyLineString2D::new(legacy_coords(exterior)),
+        holes
+            .iter()
+            .map(|h| LegacyLineString2D::new(legacy_coords(h)))
+            .collect(),
+    ))
+}
+
+// --- canonical matrices -------------------------------------------------------
+
+#[test]
+fn canonical_polygon_pairs() {
+    let a = polygon(&rect(0.0, 0.0, 4.0, 4.0), &[]);
+
+    let equal = relate(&a, &polygon(&rect(0.0, 0.0, 4.0, 4.0), &[])).unwrap();
+    assert_eq!(m(&equal), "2FFF1FFF2");
+    assert!(equal.is_equal_topo());
+
+    // The 2D entry point gives the same matrix.
+    let b = polygon(&rect(0.0, 0.0, 4.0, 4.0), &[]);
+    let (Geometry::Euclidean2D(a_2d), Geometry::Euclidean2D(b_2d)) = (&a, &b) else {
+        unreachable!("builders produce 2D geometry")
+    };
+    assert_eq!(m(&super::relate_2d(a_2d, b_2d).unwrap()), "2FFF1FFF2");
+
+    let overlapping = relate(&a, &polygon(&rect(2.0, 2.0, 6.0, 6.0), &[])).unwrap();
+    assert_eq!(m(&overlapping), "212101212");
+    assert!(overlapping.is_overlaps());
+
+    let edge_touching = relate(&a, &polygon(&rect(4.0, 0.0, 8.0, 4.0), &[])).unwrap();
+    assert_eq!(m(&edge_touching), "FF2F11212");
+    assert!(edge_touching.is_touches() && !edge_touching.is_overlaps());
+
+    let corner_touching = relate(&a, &polygon(&rect(4.0, 4.0, 8.0, 8.0), &[])).unwrap();
+    assert_eq!(m(&corner_touching), "FF2F01212");
+    assert!(corner_touching.is_touches());
+
+    let containing = relate(&a, &polygon(&rect(1.0, 1.0, 3.0, 3.0), &[])).unwrap();
+    assert_eq!(m(&containing), "212FF1FF2");
+    assert!(containing.is_contains() && containing.is_covers());
+
+    let disjoint = relate(&a, &polygon(&rect(9.0, 9.0, 12.0, 12.0), &[])).unwrap();
+    assert_eq!(m(&disjoint), "FF2FF1212");
+    assert!(disjoint.is_disjoint());
+
+    // Contained but sharing part of the boundary: covered, not contained-by
+    // the strict interior on all sides — still contains under OGC (interiors
+    // intersect, nothing outside).
+    let flush = relate(&a, &polygon(&rect(0.0, 0.0, 2.0, 2.0), &[])).unwrap();
+    assert_eq!(m(&flush), "212F11FF2");
+    assert!(flush.is_contains() && flush.is_covers());
+
+    // A polygon inside the other's hole is disjoint.
+    let holey = polygon(&rect(0.0, 0.0, 8.0, 8.0), &[rect_cw(2.0, 2.0, 6.0, 6.0)]);
+    let in_hole = relate(&holey, &polygon(&rect(3.0, 3.0, 5.0, 5.0), &[])).unwrap();
+    assert_eq!(m(&in_hole), "FF2FF1212");
+}
+
+#[test]
+fn canonical_line_pairs() {
+    let horizontal = line(&[[0.0, 0.0], [4.0, 0.0]]);
+
+    let crossing = relate(&horizontal, &line(&[[2.0, -2.0], [2.0, 2.0]])).unwrap();
+    assert_eq!(m(&crossing), "0F1FF0102");
+    assert!(crossing.is_crosses());
+
+    let overlapping = relate(&horizontal, &line(&[[2.0, 0.0], [6.0, 0.0]])).unwrap();
+    assert_eq!(m(&overlapping), "1010F0102");
+    assert!(overlapping.is_overlaps());
+
+    let endpoint_touch = relate(&horizontal, &line(&[[4.0, 0.0], [6.0, 0.0]])).unwrap();
+    assert!(endpoint_touch.is_touches());
+
+    let equal = relate(&horizontal, &line(&[[0.0, 0.0], [4.0, 0.0]])).unwrap();
+    assert!(equal.is_equal_topo());
+}
+
+#[test]
+fn canonical_mixed_pairs() {
+    let square = polygon(&rect(0.0, 0.0, 4.0, 4.0), &[]);
+
+    let inside_point = relate(&point([2.0, 2.0]), &square).unwrap();
+    assert_eq!(m(&inside_point), "0FFFFF212");
+    assert!(inside_point.is_within());
+
+    let boundary_point = relate(&point([0.0, 2.0]), &square).unwrap();
+    assert_eq!(m(&boundary_point), "F0FFFF212");
+    assert!(boundary_point.is_coveredby() && !boundary_point.is_within());
+    assert!(boundary_point.is_touches());
+
+    let crossing_line = relate(&line(&[[-2.0, 2.0], [6.0, 2.0]]), &square).unwrap();
+    assert_eq!(m(&crossing_line), "101FF0212");
+    assert!(crossing_line.is_crosses());
+
+    let interior_line = relate(&line(&[[1.0, 1.0], [3.0, 3.0]]), &square).unwrap();
+    assert_eq!(m(&interior_line), "1FF0FF212");
+    assert!(interior_line.is_within());
+
+    // A line running along the square's boundary is covered but not within.
+    let boundary_line = relate(&line(&[[1.0, 0.0], [3.0, 0.0]]), &square).unwrap();
+    assert_eq!(m(&boundary_line), "F1FF0F212");
+    assert!(boundary_line.is_coveredby() && !boundary_line.is_within());
+}
+
+#[test]
+fn empty_and_error_operands() {
+    let square = polygon(&rect(0.0, 0.0, 4.0, 4.0), &[]);
+
+    let none = relate(&Geometry::None, &square).unwrap();
+    assert_eq!(m(&none), "FFFFFF212");
+    assert!(none.is_disjoint() && !none.is_intersects());
+
+    let both_empty = relate(&Geometry::None, &Geometry::None).unwrap();
+    assert_eq!(m(&both_empty), "FFFFFFFF2");
+
+    use crate::coordinate::EpsgCode;
+    let other_frame = Geometry::Euclidean2D(Euclidean2DGeometry::Point(Point2D::new(
+        CoordinateFrame::Crs(EpsgCode::new(4326)),
+        [0.0, 0.0],
+    )));
+    assert_eq!(
+        relate(&square, &other_frame),
+        Err(crate::predicates::PredicateError::MixedFrames)
+    );
+
+    let solid_3d = Geometry::Euclidean3D(crate::Euclidean3DGeometry::Point(
+        crate::point::Point3D::new(e(), [0.0, 0.0, 0.0]),
+    ));
+    assert_eq!(
+        relate(&square, &solid_3d),
+        Err(crate::predicates::PredicateError::CrossDimension)
+    );
+    assert!(matches!(
+        relate(&solid_3d, &solid_3d),
+        Err(crate::predicates::PredicateError::UnsupportedPair { .. })
+    ));
+}
+
+// --- mesh union semantics ------------------------------------------------------
+
+/// Two quads sharing the edge x = 2, dissolving to the rect (0,0)-(4,2).
+fn two_quad_mesh() -> Geometry {
+    let mesh = PolygonMesh2D::from_parts(
+        e(),
+        vec![
+            [0.0, 0.0],
+            [2.0, 0.0],
+            [2.0, 2.0],
+            [0.0, 2.0],
+            [4.0, 0.0],
+            [4.0, 2.0],
+        ],
+        vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+    )
+    .unwrap();
+    Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(Box::new(mesh)))
+}
+
+#[test]
+fn mesh_relates_as_its_dissolved_union() {
+    let mesh = two_quad_mesh();
+    let dissolved = rect(0.0, 0.0, 4.0, 2.0);
+    let legacy_dissolved = legacy_polygon(&dissolved, &[]);
+
+    let others: Vec<(Geometry, LegacyGeometry2D<f64>)> = vec![
+        // Crossing the internal shared edge: interior contact, not boundary.
+        (
+            polygon(&rect(1.0, 0.5, 3.0, 1.5), &[]),
+            legacy_polygon(&rect(1.0, 0.5, 3.0, 1.5), &[]),
+        ),
+        // Equal to the union.
+        (polygon(&dissolved, &[]), legacy_polygon(&dissolved, &[])),
+        // Touching the union's outer boundary.
+        (
+            polygon(&rect(4.0, 0.0, 6.0, 2.0), &[]),
+            legacy_polygon(&rect(4.0, 0.0, 6.0, 2.0), &[]),
+        ),
+        // A line along the internal shared edge is interior to the union.
+        (
+            line(&[[2.0, 0.5], [2.0, 1.5]]),
+            legacy_line(&[[2.0, 0.5], [2.0, 1.5]]),
+        ),
+        // A point on the internal shared edge.
+        (point([2.0, 1.0]), legacy_point([2.0, 1.0])),
+        // Overlapping one face only.
+        (
+            polygon(&rect(-1.0, 0.5, 1.0, 1.5), &[]),
+            legacy_polygon(&rect(-1.0, 0.5, 1.0, 1.5), &[]),
+        ),
+        // Disjoint.
+        (point([9.0, 9.0]), legacy_point([9.0, 9.0])),
+    ];
+
+    for (other, legacy_other) in &others {
+        let ours = relate(&mesh, other).unwrap();
+        let oracle = legacy_dissolved.relate(legacy_other);
+        assert_eq!(
+            m(&ours),
+            legacy_m(&oracle),
+            "mesh relate diverges from dissolved-union relate for {other:?}"
+        );
+        // And in the flipped argument order.
+        let ours = relate(other, &mesh).unwrap();
+        let oracle = legacy_other.relate(&legacy_dissolved);
+        assert_eq!(m(&ours), legacy_m(&oracle), "flipped order for {other:?}");
+    }
+}
+
+#[test]
+fn mesh_specific_matrices() {
+    let mesh = two_quad_mesh();
+
+    // A line along the internal shared edge lies in the union's interior.
+    let internal_line = relate(&mesh, &line(&[[2.0, 0.5], [2.0, 1.5]])).unwrap();
+    assert_eq!(m(&internal_line), "102FF1FF2");
+    assert!(internal_line.is_contains());
+
+    // The union equals the dissolved rectangle.
+    let union_rect = relate(&mesh, &polygon(&rect(0.0, 0.0, 4.0, 2.0), &[])).unwrap();
+    assert!(union_rect.is_equal_topo());
+
+    // Triangulated square against the square it triangulates.
+    let tri_mesh = TriangularMesh2D::from_parts(
+        e(),
+        vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0], [0.0, 2.0]],
+        [0u32, 1, 2, 0, 2, 3],
+    )
+    .unwrap();
+    let tri_mesh = Geometry::Euclidean2D(Euclidean2DGeometry::TriangularMesh(Box::new(tri_mesh)));
+    let im = relate(&tri_mesh, &polygon(&rect(0.0, 0.0, 2.0, 2.0), &[])).unwrap();
+    assert!(im.is_equal_topo());
+
+    // An annulus mesh (3x3 grid minus center) vs geometry in its hole.
+    let mut vertices = Vec::new();
+    for y in 0..4 {
+        for x in 0..4 {
+            vertices.push([x as f64, y as f64]);
+        }
+    }
+    let index = |x: u32, y: u32| y * 4 + x;
+    let mut faces = Vec::new();
+    for y in 0..3u32 {
+        for x in 0..3u32 {
+            if x == 1 && y == 1 {
+                continue;
+            }
+            faces.push(vec![
+                index(x, y),
+                index(x + 1, y),
+                index(x + 1, y + 1),
+                index(x, y + 1),
+            ]);
+        }
+    }
+    let annulus = PolygonMesh2D::from_parts(e(), vertices, faces).unwrap();
+    let annulus = Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(Box::new(annulus)));
+
+    let in_hole = relate(&annulus, &point([1.5, 1.5])).unwrap();
+    assert!(in_hole.is_disjoint());
+    // ... and equals the polygon-with-hole it dissolves to.
+    let holey = polygon(&rect(0.0, 0.0, 3.0, 3.0), &[rect_cw(1.0, 1.0, 2.0, 2.0)]);
+    assert!(relate(&annulus, &holey).unwrap().is_equal_topo());
+}
+
+// --- differential + consistency sweeps ----------------------------------------
+
+/// Deterministic splitmix-style generator.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    }
+
+    fn range(&mut self, n: u64) -> u64 {
+        self.next() % n
+    }
+
+    fn coord(&mut self) -> [f64; 2] {
+        [self.range(9) as f64, self.range(9) as f64]
+    }
+}
+
+/// One random geometry in both representations.
+fn random_pair(rng: &mut Rng) -> (Geometry, LegacyGeometry2D<f64>) {
+    match rng.range(7) {
+        0 => {
+            let p = rng.coord();
+            (point(p), legacy_point(p))
+        }
+        1 => {
+            let coords = [rng.coord(), rng.coord()];
+            (line(&coords), legacy_line(&coords))
+        }
+        2 => {
+            let coords = [rng.coord(), rng.coord(), rng.coord(), rng.coord()];
+            (line(&coords), legacy_line(&coords))
+        }
+        3 => {
+            // Closed chain.
+            let (a, b, c) = (rng.coord(), rng.coord(), rng.coord());
+            let coords = [a, b, c, a];
+            (line(&coords), legacy_line(&coords))
+        }
+        4 => {
+            let (x0, y0) = (rng.range(6) as f64, rng.range(6) as f64);
+            let (w, h) = (1 + rng.range(3), 1 + rng.range(3));
+            let ring = rect(x0, y0, x0 + w as f64, y0 + h as f64);
+            (polygon(&ring, &[]), legacy_polygon(&ring, &[]))
+        }
+        5 => {
+            // Rect with a hole strictly inside.
+            let (x0, y0) = (rng.range(4) as f64, rng.range(4) as f64);
+            let (x1, y1) = (
+                x0 + 3.0 + rng.range(2) as f64,
+                y0 + 3.0 + rng.range(2) as f64,
+            );
+            let hole = rect_cw(x0 + 1.0, y0 + 1.0, x1 - 1.0, y1 - 1.0);
+            let ring = rect(x0, y0, x1, y1);
+            (
+                polygon(&ring, std::slice::from_ref(&hole)),
+                legacy_polygon(&ring, &[hole]),
+            )
+        }
+        _ => {
+            // Triangle, arbitrary winding; regenerate until non-collinear.
+            loop {
+                let (a, b, c) = (rng.coord(), rng.coord(), rng.coord());
+                let doubled_area = (b[0] - a[0]) * (c[1] - a[1]) - (c[0] - a[0]) * (b[1] - a[1]);
+                if doubled_area != 0.0 {
+                    let ring = [a, b, c, a];
+                    return (polygon(&ring, &[]), legacy_polygon(&ring, &[]));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn differential_against_legacy_relate() {
+    let mut rng = Rng(20260715);
+    for case in 0..500 {
+        let (a, legacy_a) = random_pair(&mut rng);
+        let (b, legacy_b) = random_pair(&mut rng);
+        let ours = relate(&a, &b).unwrap();
+        let oracle = legacy_a.relate(&legacy_b);
+        assert_eq!(
+            m(&ours),
+            legacy_m(&oracle),
+            "case {case}: relate({a:?}, {b:?}) diverges from legacy"
+        );
+    }
+}
+
+#[test]
+fn matrix_agrees_with_fast_path_predicates() {
+    let mut rng = Rng(42);
+    for case in 0..300 {
+        let (a, _) = random_pair(&mut rng);
+        let (b, _) = random_pair(&mut rng);
+        let im = relate(&a, &b).unwrap();
+        assert_eq!(
+            im.is_intersects(),
+            intersects(&a, &b).unwrap(),
+            "case {case}: is_intersects vs intersects() for {a:?} / {b:?}"
+        );
+        assert_eq!(
+            im.is_contains(),
+            contains(&a, &b).unwrap(),
+            "case {case}: is_contains vs contains() for {a:?} / {b:?}"
+        );
+        assert_eq!(
+            im.is_covers(),
+            covers(&a, &b).unwrap(),
+            "case {case}: is_covers vs covers() for {a:?} / {b:?}"
+        );
+    }
+}
+
+#[test]
+fn mesh_matrix_agrees_with_fast_path_predicates() {
+    let mut rng = Rng(7);
+    for case in 0..150 {
+        let (x0, y0) = (rng.range(4) as f64, rng.range(4) as f64);
+        let mesh = PolygonMesh2D::from_parts(
+            e(),
+            vec![
+                [x0, y0],
+                [x0 + 2.0, y0],
+                [x0 + 2.0, y0 + 2.0],
+                [x0, y0 + 2.0],
+                [x0 + 4.0, y0],
+                [x0 + 4.0, y0 + 2.0],
+            ],
+            vec![vec![0u32, 1, 2, 3], vec![1, 4, 5, 2]],
+        )
+        .unwrap();
+        let a = Geometry::Euclidean2D(Euclidean2DGeometry::PolygonMesh(Box::new(mesh)));
+        let (b, _) = random_pair(&mut rng);
+        for (left, right) in [(&a, &b), (&b, &a)] {
+            let im = relate(left, right).unwrap();
+            assert_eq!(
+                im.is_intersects(),
+                intersects(left, right).unwrap(),
+                "case {case}: is_intersects for {left:?} / {right:?}"
+            );
+            assert_eq!(
+                im.is_contains(),
+                contains(left, right).unwrap(),
+                "case {case}: is_contains for {left:?} / {right:?}"
+            );
+            assert_eq!(
+                im.is_covers(),
+                covers(left, right).unwrap(),
+                "case {case}: is_covers for {left:?} / {right:?}"
+            );
+        }
+    }
+}
+
+fn square_collection(rects: &[[f64; 4]]) -> Geometry {
+    Geometry::Euclidean2D(Euclidean2DGeometry::Collection(Collection2D::new(
+        rects.iter().map(|&[x0, y0, x1, y1]| {
+            Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+                e(),
+                rect(x0, y0, x1, y1),
+                Vec::<Vec<[f64; 2]>>::new(),
+            )))
+        }),
+    )))
+}
+
+#[test]
+fn collections_of_disjoint_members_relate_as_unions() {
+    // Note: the legacy relate cannot take collections at all (GeometryCow
+    // panics `unimplemented!` on `Geometry::GeometryCollection`); the new path
+    // flattens them into one operand.
+    let two_squares = square_collection(&[[0.0, 0.0, 2.0, 2.0], [6.0, 0.0, 8.0, 2.0]]);
+
+    let in_first = relate(&two_squares, &line(&[[0.5, 1.0], [1.5, 1.0]])).unwrap();
+    assert!(in_first.is_contains());
+
+    let in_second = relate(&two_squares, &point([7.0, 1.0])).unwrap();
+    assert!(in_second.is_covers());
+
+    let across_the_gap = relate(&two_squares, &line(&[[1.0, 1.0], [7.0, 1.0]])).unwrap();
+    assert!(across_the_gap.is_intersects() && !across_the_gap.is_contains());
+}
+
+#[test]
+fn collection_with_edge_adjacent_members_is_jts_limited() {
+    // Two squares sharing the edge x = 2. As a *mesh* this dissolves and the
+    // shared edge becomes interior; as a *collection of polygons* it is
+    // invalid MultiPolygon topology, which the JTS graph does not support:
+    // the shared edge stays labeled boundary, so a line crossing it is not
+    // `is_contains` even though it lies in the point-set union.
+    let adjacent = square_collection(&[[0.0, 0.0, 2.0, 2.0], [2.0, 0.0, 4.0, 2.0]]);
+    let spanning = line(&[[1.0, 1.0], [3.0, 1.0]]);
+
+    let im = relate(&adjacent, &spanning).unwrap();
+    assert!(im.is_intersects());
+    assert!(!im.is_contains()); // JTS limitation, documented in relate/mod.rs
+
+    // The phase-2 split-based predicate is exact on the same input.
+    assert_eq!(contains(&adjacent, &spanning), Ok(true));
+
+    // The equivalent mesh gets the union answer from relate as well.
+    let im = relate(&two_quad_mesh(), &spanning).unwrap();
+    assert!(im.is_contains());
+}

--- a/engine/runtime/geometry/src/predicates/view.rs
+++ b/engine/runtime/geometry/src/predicates/view.rs
@@ -1,4 +1,4 @@
-//! Zero-copy coordinate views feeding the [`kernel`](super::kernel).
+//! Zero-copy coordinate views feeding the [`kernel`].
 //!
 //! The predicates operate over lightweight borrows of the new leaves' flat
 //! buffers rather than over the leaf types directly, so a `Polygon` ring, a

--- a/engine/runtime/geometry/src/predicates/view.rs
+++ b/engine/runtime/geometry/src/predicates/view.rs
@@ -1,19 +1,19 @@
 //! Zero-copy coordinate views feeding the [`kernel`].
 //!
-//! The predicates operate over lightweight borrows of the new leaves' flat
+//! The predicates operate over lightweight borrows of the leaves' flat
 //! buffers rather than over the leaf types directly, so a `Polygon` ring, a
 //! `PolygonMesh` face, and a `TriangularMesh` triangle can all reach the same
 //! kernel code without copying coordinates.
 //!
 //! Three layers:
 //!
-//! - [`RingView`] — one boundary ring, contiguous (`Polygon`) or indexed into a
+//! - [`RingView`]: one boundary ring, contiguous (`Polygon`) or indexed into a
 //!   vertex pool (meshes).
-//! - [`FaceView`] / [`AreaView`] — a face as its rings (exterior first), and an
+//! - [`FaceView`] / [`AreaView`]: a face as its rings (exterior first), and an
 //!   areal leaf as its faces. A `Polygon` is one face; the meshes are face sets.
 //!   Mesh views decode the packed CSR index buffers once (indices only, never
 //!   coordinates).
-//! - [`Leaf2D`] — a flattened, collection-free borrow of a 2D geometry: the
+//! - [`Leaf2D`]: a flattened, collection-free borrow of a 2D geometry, the
 //!   normal form the binary predicates dispatch over.
 
 use super::kernel::{self, Orientation};
@@ -26,13 +26,13 @@ use crate::polygon_mesh::PolygonMesh2D;
 use crate::triangular_mesh::TriangularMesh2D;
 use crate::Euclidean2DGeometry;
 
-/// The rings of a 2D polygon — exterior first, then each interior (hole) — as
+/// The rings of a 2D polygon, exterior first then each interior (hole), as
 /// borrowed slices over the polygon's own buffer.
 pub fn polygon2d_rings(polygon: &Polygon2D) -> impl Iterator<Item = &[[f64; 2]]> {
     core::iter::once(polygon.exterior()).chain(polygon.interiors())
 }
 
-/// The rings of a 3D polygon — exterior first, then each interior — as borrowed
+/// The rings of a 3D polygon, exterior first then each interior, as borrowed
 /// slices over the polygon's own buffer.
 pub fn polygon3d_rings(polygon: &Polygon3D) -> impl Iterator<Item = &[[f64; 3]]> {
     core::iter::once(polygon.exterior()).chain(polygon.interiors())

--- a/engine/runtime/geometry/src/predicates/view.rs
+++ b/engine/runtime/geometry/src/predicates/view.rs
@@ -459,6 +459,19 @@ pub(crate) fn require_common_frame(a: &Operand2D<'_>, b: &Operand2D<'_>) -> supe
     Ok(())
 }
 
+/// [`require_common_frame`] over flattened leaf slices, for callers that have
+/// not built [`Operand2D`]s.
+pub(crate) fn require_common_frame_leaves(a: &[Leaf2D<'_>], b: &[Leaf2D<'_>]) -> super::Result<()> {
+    let mut frames = a.iter().chain(b.iter()).map(Leaf2D::frame);
+    let Some(first) = frames.next() else {
+        return Ok(());
+    };
+    for frame in frames {
+        super::require_same_frame(first, frame)?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/predicates/view.rs
+++ b/engine/runtime/geometry/src/predicates/view.rs
@@ -374,6 +374,18 @@ impl<'a> Leaf2D<'a> {
             Leaf2D::TriangularMesh(m) => Some(AreaView::from_triangular_mesh(m)),
         }
     }
+
+    /// The leaf's bounding box, `None` for an empty leaf.
+    pub(crate) fn bbox(&self) -> Option<Aabb> {
+        match self {
+            Leaf2D::Point(p) => p.bounding_box(),
+            Leaf2D::Line(l) => l.bounding_box(),
+            Leaf2D::Polygon(p) => p.bounding_box(),
+            Leaf2D::PolygonMesh(m) => m.bounding_box(),
+            Leaf2D::TriangularMesh(m) => m.bounding_box(),
+        }
+        .ok()
+    }
 }
 
 /// Flatten a 2D geometry into its leaves, recursing into (possibly nested)
@@ -418,20 +430,10 @@ impl<'a> Operand2D<'a> {
     pub fn from_leaves(flat: Vec<Leaf2D<'a>>) -> Self {
         let leaves = flat
             .into_iter()
-            .map(|leaf| {
-                let bbox = match leaf {
-                    Leaf2D::Point(p) => p.bounding_box(),
-                    Leaf2D::Line(l) => l.bounding_box(),
-                    Leaf2D::Polygon(p) => p.bounding_box(),
-                    Leaf2D::PolygonMesh(m) => m.bounding_box(),
-                    Leaf2D::TriangularMesh(m) => m.bounding_box(),
-                }
-                .ok();
-                PreparedLeaf {
-                    leaf,
-                    area: leaf.area_view(),
-                    bbox,
-                }
+            .map(|leaf| PreparedLeaf {
+                leaf,
+                area: leaf.area_view(),
+                bbox: leaf.bbox(),
             })
             .collect();
         Self { leaves }

--- a/engine/runtime/geometry/src/predicates/view.rs
+++ b/engine/runtime/geometry/src/predicates/view.rs
@@ -3,14 +3,28 @@
 //! The predicates operate over lightweight borrows of the new leaves' flat
 //! buffers rather than over the leaf types directly, so a `Polygon` ring, a
 //! `PolygonMesh` face, and a `TriangularMesh` triangle can all reach the same
-//! kernel code without an intermediate copy. A ring view is simply a
-//! `&[[f64; N]]` slice — the leaves' own storage — and a triangle is `[[f64; N]; 3]`.
+//! kernel code without copying coordinates.
 //!
-//! Phase 1 lands the polygon ring views and the triangle primitives; the mesh
-//! face/triangle views build on these as their predicates land.
+//! Three layers:
+//!
+//! - [`RingView`] — one boundary ring, contiguous (`Polygon`) or indexed into a
+//!   vertex pool (meshes).
+//! - [`FaceView`] / [`AreaView`] — a face as its rings (exterior first), and an
+//!   areal leaf as its faces. A `Polygon` is one face; the meshes are face sets.
+//!   Mesh views decode the packed CSR index buffers once (indices only, never
+//!   coordinates).
+//! - [`Leaf2D`] — a flattened, collection-free borrow of a 2D geometry: the
+//!   normal form the binary predicates dispatch over.
 
 use super::kernel::{self, Orientation};
+use crate::coordinate::CoordinateFrame;
+use crate::line_string::LineString2D;
+use crate::ops::{Aabb, BoundingBox};
+use crate::point::Point2D;
 use crate::polygon::{Polygon2D, Polygon3D};
+use crate::polygon_mesh::PolygonMesh2D;
+use crate::triangular_mesh::TriangularMesh2D;
+use crate::Euclidean2DGeometry;
 
 /// The rings of a 2D polygon — exterior first, then each interior (hole) — as
 /// borrowed slices over the polygon's own buffer.
@@ -63,11 +77,402 @@ pub fn point_in_triangle_2d(p: [f64; 2], tri: [[f64; 2]; 3]) -> bool {
     !(has_cw && has_ccw)
 }
 
+// --- ring / face / area views ------------------------------------------------
+
+/// One boundary ring, over either contiguous or indexed storage. The stored
+/// form is verbatim: a well-formed ring is closed (first == last) but an open
+/// one (e.g. a mesh triangle) is closed implicitly by [`edges`](Self::edges).
+#[derive(Clone, Copy, Debug)]
+pub enum RingView<'a> {
+    /// Ring vertices stored contiguously (`Polygon2D` rings).
+    Slice(&'a [[f64; 2]]),
+    /// Ring vertices indexed into a shared pool (mesh rings).
+    Indexed {
+        /// The shared vertex pool.
+        pool: &'a [[f64; 2]],
+        /// This ring's indices into `pool`, in order.
+        indices: &'a [u32],
+    },
+}
+
+impl<'a> RingView<'a> {
+    /// The stored vertex count (including the closing duplicate, if stored).
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            RingView::Slice(s) => s.len(),
+            RingView::Indexed { indices, .. } => indices.len(),
+        }
+    }
+
+    /// Whether the ring stores no vertices.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The `i`-th stored vertex.
+    #[inline]
+    pub fn coord(&self, i: usize) -> [f64; 2] {
+        match self {
+            RingView::Slice(s) => s[i],
+            RingView::Indexed { pool, indices } => pool[indices[i] as usize],
+        }
+    }
+
+    /// The stored vertices, in order.
+    pub fn coords(self) -> impl Iterator<Item = [f64; 2]> + 'a {
+        (0..self.len()).map(move |i| self.coord(i))
+    }
+
+    /// The vertex count with the closing duplicate dropped.
+    #[inline]
+    pub fn open_len(&self) -> usize {
+        let n = self.len();
+        if n >= 2 && self.coord(0) == self.coord(n - 1) {
+            n - 1
+        } else {
+            n
+        }
+    }
+
+    /// The directed edges around the ring, closing it when stored open. A
+    /// single-vertex ring yields one zero-length edge (so an on-vertex test
+    /// still sees it); an empty ring yields nothing.
+    pub fn edges(self) -> impl Iterator<Item = ([f64; 2], [f64; 2])> + 'a {
+        let n = self.open_len();
+        (0..n).map(move |i| {
+            (
+                self.coord(i),
+                self.coord(if i + 1 == n { 0 } else { i + 1 }),
+            )
+        })
+    }
+}
+
+/// A single face: its exterior ring followed by its hole rings.
+#[derive(Clone, Copy, Debug)]
+pub struct FaceView<'a> {
+    repr: FaceRepr<'a>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum FaceRepr<'a> {
+    /// The one face of a polygon, rings borrowed as slices.
+    Polygon(&'a Polygon2D),
+    /// A mesh face: rings indexed into a pool. `bounds` holds `n_rings + 1`
+    /// offsets into `indices`; ring `r` spans `indices[bounds[r]..bounds[r+1]]`.
+    Indexed {
+        pool: &'a [[f64; 2]],
+        indices: &'a [u32],
+        bounds: &'a [u32],
+    },
+}
+
+impl<'a> FaceView<'a> {
+    /// The number of rings (1 exterior + holes).
+    pub fn num_rings(&self) -> usize {
+        match self.repr {
+            FaceRepr::Polygon(p) => 1 + p.interiors().count(),
+            FaceRepr::Indexed { bounds, .. } => bounds.len() - 1,
+        }
+    }
+
+    /// The `r`-th ring: 0 is the exterior, the rest are holes.
+    pub fn ring(self, r: usize) -> RingView<'a> {
+        match self.repr {
+            FaceRepr::Polygon(p) => {
+                if r == 0 {
+                    RingView::Slice(p.exterior())
+                } else {
+                    RingView::Slice(p.interiors().nth(r - 1).expect("ring index in range"))
+                }
+            }
+            FaceRepr::Indexed {
+                pool,
+                indices,
+                bounds,
+            } => RingView::Indexed {
+                pool,
+                indices: &indices[bounds[r] as usize..bounds[r + 1] as usize],
+            },
+        }
+    }
+
+    /// The rings, exterior first.
+    pub fn rings(self) -> impl Iterator<Item = RingView<'a>> {
+        (0..self.num_rings()).map(move |r| self.ring(r))
+    }
+
+    /// The exterior ring.
+    #[inline]
+    pub fn exterior(self) -> RingView<'a> {
+        self.ring(0)
+    }
+
+    /// The hole rings.
+    pub fn interiors(self) -> impl Iterator<Item = RingView<'a>> {
+        (1..self.num_rings()).map(move |r| self.ring(r))
+    }
+
+    /// All directed boundary edges of the face, every ring closed.
+    pub fn edges(self) -> impl Iterator<Item = ([f64; 2], [f64; 2])> + use<'a> {
+        self.rings().flat_map(RingView::edges)
+    }
+}
+
+/// Decoded CSR ring layout of a mesh: the coordinate pool stays borrowed, the
+/// packed index buffers are widened into flat `u32` once at construction.
+#[derive(Debug)]
+pub struct MeshFaces<'a> {
+    pool: &'a [[f64; 2]],
+    /// All rings of all faces, concatenated.
+    indices: Vec<u32>,
+    /// `n_rings + 1` offsets into `indices`.
+    ring_offsets: Vec<u32>,
+    /// `n_faces + 1` offsets into `ring_offsets`.
+    face_offsets: Vec<u32>,
+}
+
+/// An areal leaf as a set of faces: the single face of a `Polygon2D`, or the
+/// decoded faces of a mesh.
+#[derive(Debug)]
+pub enum AreaView<'a> {
+    /// A polygon: one face, rings borrowed as slices.
+    Polygon(&'a Polygon2D),
+    /// A mesh: faces over a decoded CSR layout.
+    Mesh(MeshFaces<'a>),
+}
+
+impl<'a> AreaView<'a> {
+    /// View a polygon as its single face.
+    pub fn from_polygon(polygon: &'a Polygon2D) -> Self {
+        AreaView::Polygon(polygon)
+    }
+
+    /// View a polygon mesh as its faces, decoding the CSR buffers.
+    pub fn from_polygon_mesh(mesh: &'a PolygonMesh2D) -> Self {
+        let (face_indices, face_bounds, interior_offsets) = mesh.csr_buffers();
+        let indices: Vec<u32> = face_indices.iter_u32().map(|[i]| i).collect();
+        let holes: Vec<u32> = interior_offsets.iter_u32().map(|[o]| o).collect();
+        let n = indices.len() as u32;
+
+        // Corner spans of each face: 0, internal boundaries, end.
+        let corner_bounds: Vec<u32> = core::iter::once(0)
+            .chain(face_bounds.iter_u32().map(|[o]| o))
+            .chain(core::iter::once(n))
+            .collect();
+        let n_faces = if n == 0 { 0 } else { corner_bounds.len() - 1 };
+
+        let mut ring_offsets: Vec<u32> = vec![0];
+        let mut face_offsets: Vec<u32> = vec![0];
+        let mut hi = 0;
+        for f in 0..n_faces {
+            let (start, end) = (corner_bounds[f], corner_bounds[f + 1]);
+            // Hole starts strictly inside this face's span split its rings.
+            while hi < holes.len() && holes[hi] <= start {
+                hi += 1;
+            }
+            while hi < holes.len() && holes[hi] < end {
+                ring_offsets.push(holes[hi]);
+                hi += 1;
+            }
+            ring_offsets.push(end);
+            face_offsets.push(ring_offsets.len() as u32 - 1);
+        }
+
+        AreaView::Mesh(MeshFaces {
+            pool: mesh.vertices(),
+            indices,
+            ring_offsets,
+            face_offsets,
+        })
+    }
+
+    /// View a triangular mesh as its faces, one 3-vertex ring each.
+    pub fn from_triangular_mesh(mesh: &'a TriangularMesh2D) -> Self {
+        let n = mesh.num_triangles();
+        let indices: Vec<u32> = mesh.triangles().flatten().collect();
+        AreaView::Mesh(MeshFaces {
+            pool: mesh.vertices(),
+            indices,
+            ring_offsets: (0..=n).map(|i| (3 * i) as u32).collect(),
+            face_offsets: (0..=n).map(|i| i as u32).collect(),
+        })
+    }
+
+    /// The number of faces.
+    pub fn num_faces(&self) -> usize {
+        match self {
+            AreaView::Polygon(_) => 1,
+            AreaView::Mesh(m) => m.face_offsets.len() - 1,
+        }
+    }
+
+    /// The `f`-th face.
+    pub fn face(&self, f: usize) -> FaceView<'_> {
+        match self {
+            AreaView::Polygon(p) => {
+                assert_eq!(f, 0, "a polygon has a single face");
+                FaceView {
+                    repr: FaceRepr::Polygon(p),
+                }
+            }
+            AreaView::Mesh(m) => FaceView {
+                repr: FaceRepr::Indexed {
+                    pool: m.pool,
+                    indices: &m.indices,
+                    bounds: &m.ring_offsets
+                        [m.face_offsets[f] as usize..=m.face_offsets[f + 1] as usize],
+                },
+            },
+        }
+    }
+
+    /// The faces, in order.
+    pub fn faces(&self) -> impl Iterator<Item = FaceView<'_>> + '_ {
+        (0..self.num_faces()).map(move |f| self.face(f))
+    }
+
+    /// All directed boundary edges across all faces, every ring closed.
+    pub fn edges(&self) -> impl Iterator<Item = ([f64; 2], [f64; 2])> + '_ {
+        self.faces().flat_map(FaceView::edges)
+    }
+}
+
+// --- flattened leaf normal form ----------------------------------------------
+
+/// A flattened, collection-free borrow of one 2D leaf: the normal form the
+/// binary predicates dispatch over after [`flatten_2d`] unnests collections.
+#[derive(Clone, Copy, Debug)]
+pub enum Leaf2D<'a> {
+    Point(&'a Point2D),
+    Line(&'a LineString2D),
+    Polygon(&'a Polygon2D),
+    PolygonMesh(&'a PolygonMesh2D),
+    TriangularMesh(&'a TriangularMesh2D),
+}
+
+impl<'a> Leaf2D<'a> {
+    /// The leaf's coordinate frame.
+    pub fn frame(&self) -> &'a CoordinateFrame {
+        match self {
+            Leaf2D::Point(p) => p.frame(),
+            Leaf2D::Line(l) => l.frame(),
+            Leaf2D::Polygon(p) => p.frame(),
+            Leaf2D::PolygonMesh(m) => m.frame(),
+            Leaf2D::TriangularMesh(m) => m.frame(),
+        }
+    }
+
+    /// The areal view, for the areal leaves; `None` for points and lines.
+    pub fn area_view(&self) -> Option<AreaView<'a>> {
+        match self {
+            Leaf2D::Point(_) | Leaf2D::Line(_) => None,
+            Leaf2D::Polygon(p) => Some(AreaView::from_polygon(p)),
+            Leaf2D::PolygonMesh(m) => Some(AreaView::from_polygon_mesh(m)),
+            Leaf2D::TriangularMesh(m) => Some(AreaView::from_triangular_mesh(m)),
+        }
+    }
+}
+
+/// Flatten a 2D geometry into its leaves, recursing into (possibly nested)
+/// collections.
+pub fn flatten_2d<'a>(geometry: &'a Euclidean2DGeometry, out: &mut Vec<Leaf2D<'a>>) {
+    match geometry {
+        Euclidean2DGeometry::Point(p) => out.push(Leaf2D::Point(p)),
+        Euclidean2DGeometry::LineString(l) => out.push(Leaf2D::Line(l)),
+        Euclidean2DGeometry::Polygon(p) => out.push(Leaf2D::Polygon(p)),
+        Euclidean2DGeometry::PolygonMesh(m) => out.push(Leaf2D::PolygonMesh(m)),
+        Euclidean2DGeometry::TriangularMesh(m) => out.push(Leaf2D::TriangularMesh(m)),
+        Euclidean2DGeometry::Collection(c) => {
+            for member in c.members() {
+                flatten_2d(member, out);
+            }
+        }
+    }
+}
+
+/// One flattened leaf prepared for predicate evaluation: the borrow itself,
+/// the decoded areal view (for areal leaves), and the bounding box (`None`
+/// for an empty leaf, which no other geometry intersects).
+pub(crate) struct PreparedLeaf<'a> {
+    pub leaf: Leaf2D<'a>,
+    pub area: Option<AreaView<'a>>,
+    pub bbox: Option<Aabb>,
+}
+
+/// A predicate operand in normal form: a 2D geometry flattened into prepared
+/// leaves (collections unnested, mesh CSR decoded once, boxes precomputed).
+pub(crate) struct Operand2D<'a> {
+    pub leaves: Vec<PreparedLeaf<'a>>,
+}
+
+impl<'a> Operand2D<'a> {
+    pub fn new(geometry: &'a Euclidean2DGeometry) -> Self {
+        let mut flat = Vec::new();
+        flatten_2d(geometry, &mut flat);
+        Self::from_leaves(flat)
+    }
+
+    pub fn from_leaves(flat: Vec<Leaf2D<'a>>) -> Self {
+        let leaves = flat
+            .into_iter()
+            .map(|leaf| {
+                let bbox = match leaf {
+                    Leaf2D::Point(p) => p.bounding_box(),
+                    Leaf2D::Line(l) => l.bounding_box(),
+                    Leaf2D::Polygon(p) => p.bounding_box(),
+                    Leaf2D::PolygonMesh(m) => m.bounding_box(),
+                    Leaf2D::TriangularMesh(m) => m.bounding_box(),
+                }
+                .ok();
+                PreparedLeaf {
+                    leaf,
+                    area: leaf.area_view(),
+                    bbox,
+                }
+            })
+            .collect();
+        Self { leaves }
+    }
+
+    /// The areal views among the leaves, in order.
+    pub fn areas(&self) -> impl Iterator<Item = &AreaView<'a>> + '_ {
+        self.leaves.iter().filter_map(|l| l.area.as_ref())
+    }
+}
+
+/// Require every leaf across both operands to share one coordinate frame.
+pub(crate) fn require_common_frame(a: &Operand2D<'_>, b: &Operand2D<'_>) -> super::Result<()> {
+    let mut frames = a
+        .leaves
+        .iter()
+        .chain(b.leaves.iter())
+        .map(|l| l.leaf.frame());
+    let Some(first) = frames.next() else {
+        return Ok(());
+    };
+    for frame in frames {
+        super::require_same_frame(first, frame)?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::collection::Collection2D;
     use crate::coordinate::CoordinateFrame;
-    use crate::predicates::kernel::{coord_pos_relative_to_ring, CoordPos};
+    use crate::predicates::kernel::{
+        coord_pos_relative_to_edges, coord_pos_relative_to_ring, CoordPos,
+    };
+
+    fn square_poly(e: CoordinateFrame) -> Polygon2D {
+        let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
+        let hole = vec![[1.0, 1.0], [1.0, 3.0], [3.0, 3.0], [3.0, 1.0], [1.0, 1.0]];
+        Polygon2D::from_rings(e, square, vec![hole])
+    }
 
     #[test]
     fn polygon_rings_yield_exterior_then_holes() {
@@ -107,5 +512,111 @@ mod tests {
             resolve_triangle_3d(&verts, [0, 1, 2]),
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
         );
+    }
+
+    #[test]
+    fn ring_view_edges_close_open_rings() {
+        // An open triangle (mesh convention): edges must include the closer.
+        let pool = [[0.0, 0.0], [4.0, 0.0], [0.0, 4.0]];
+        let ring = RingView::Indexed {
+            pool: &pool,
+            indices: &[0, 1, 2],
+        };
+        let edges: Vec<_> = ring.edges().collect();
+        assert_eq!(edges.len(), 3);
+        assert_eq!(edges[2], ([0.0, 4.0], [0.0, 0.0]));
+        // A stored-closed ring adds no extra edge.
+        let closed = [[0.0, 0.0], [4.0, 0.0], [0.0, 4.0], [0.0, 0.0]];
+        let ring = RingView::Slice(&closed);
+        assert_eq!(ring.open_len(), 3);
+        assert_eq!(ring.edges().count(), 3);
+        assert_eq!(
+            coord_pos_relative_to_edges([1.0, 1.0], ring.edges()),
+            CoordPos::Inside
+        );
+    }
+
+    #[test]
+    fn polygon_area_view_exposes_face_and_holes() {
+        let poly = square_poly(CoordinateFrame::Euclidean);
+        let view = AreaView::from_polygon(&poly);
+        assert_eq!(view.num_faces(), 1);
+        let face = view.face(0);
+        assert_eq!(face.num_rings(), 2);
+        assert_eq!(face.exterior().open_len(), 4);
+        assert_eq!(face.interiors().count(), 1);
+        // 4 exterior + 4 hole edges.
+        assert_eq!(view.edges().count(), 8);
+    }
+
+    #[test]
+    fn polygon_mesh_area_view_decodes_faces_and_holes() {
+        // Two faces: a plain quad and a quad with a hole.
+        let mesh = PolygonMesh2D::from_raw_parts(
+            CoordinateFrame::Euclidean,
+            vec![
+                // Face 0: quad [0,0]..[2,2]
+                [0.0, 0.0],
+                [2.0, 0.0],
+                [2.0, 2.0],
+                [0.0, 2.0],
+                // Face 1: quad [3,0]..[9,6] with hole [5,2]..[7,4]
+                [3.0, 0.0],
+                [9.0, 0.0],
+                [9.0, 6.0],
+                [3.0, 6.0],
+                [5.0, 2.0],
+                [5.0, 4.0],
+                [7.0, 4.0],
+                [7.0, 2.0],
+            ],
+            // Rings stored closed: face 0 = [0..5), face 1 = [5..15) with the
+            // hole ring starting at 10.
+            vec![0, 1, 2, 3, 0, 4, 5, 6, 7, 4, 8, 9, 10, 11, 8],
+            vec![5],
+            vec![10],
+        )
+        .unwrap();
+
+        let view = AreaView::from_polygon_mesh(&mesh);
+        assert_eq!(view.num_faces(), 2);
+        assert_eq!(view.face(0).num_rings(), 1);
+        assert_eq!(view.face(1).num_rings(), 2);
+        // Face 1's hole ring resolves to the hole coordinates.
+        let hole: Vec<[f64; 2]> = view.face(1).ring(1).coords().collect();
+        assert!(hole.contains(&[5.0, 2.0]) && hole.contains(&[7.0, 4.0]));
+    }
+
+    #[test]
+    fn triangular_mesh_area_view_faces_are_triangles() {
+        let mesh = crate::triangular_mesh::TriangularMesh2D::from_parts(
+            CoordinateFrame::Euclidean,
+            vec![[0.0, 0.0], [2.0, 0.0], [2.0, 2.0], [0.0, 2.0]],
+            [0u32, 1, 2, 0, 2, 3],
+        )
+        .unwrap();
+        let view = AreaView::from_triangular_mesh(&mesh);
+        assert_eq!(view.num_faces(), 2);
+        assert_eq!(view.face(0).num_rings(), 1);
+        assert_eq!(view.face(0).exterior().open_len(), 3);
+        assert_eq!(view.edges().count(), 6);
+    }
+
+    #[test]
+    fn flatten_recurses_nested_collections() {
+        let e = CoordinateFrame::Euclidean;
+        let inner = Collection2D::new([Euclidean2DGeometry::Point(Point2D::new(
+            e.clone(),
+            [1.0, 1.0],
+        ))]);
+        let outer = Euclidean2DGeometry::Collection(Collection2D::new([
+            Euclidean2DGeometry::Point(Point2D::new(e.clone(), [0.0, 0.0])),
+            Euclidean2DGeometry::Collection(inner),
+        ]));
+        let mut leaves = Vec::new();
+        flatten_2d(&outer, &mut leaves);
+        assert_eq!(leaves.len(), 2);
+        assert!(matches!(leaves[0], Leaf2D::Point(_)));
+        assert!(matches!(leaves[1], Leaf2D::Point(_)));
     }
 }

--- a/engine/runtime/geometry/src/predicates/view.rs
+++ b/engine/runtime/geometry/src/predicates/view.rs
@@ -1,0 +1,111 @@
+//! Zero-copy coordinate views feeding the [`kernel`](super::kernel).
+//!
+//! The predicates operate over lightweight borrows of the new leaves' flat
+//! buffers rather than over the leaf types directly, so a `Polygon` ring, a
+//! `PolygonMesh` face, and a `TriangularMesh` triangle can all reach the same
+//! kernel code without an intermediate copy. A ring view is simply a
+//! `&[[f64; N]]` slice — the leaves' own storage — and a triangle is `[[f64; N]; 3]`.
+//!
+//! Phase 1 lands the polygon ring views and the triangle primitives; the mesh
+//! face/triangle views build on these as their predicates land.
+
+use super::kernel::{self, Orientation};
+use crate::polygon::{Polygon2D, Polygon3D};
+
+/// The rings of a 2D polygon — exterior first, then each interior (hole) — as
+/// borrowed slices over the polygon's own buffer.
+pub fn polygon2d_rings(polygon: &Polygon2D) -> impl Iterator<Item = &[[f64; 2]]> {
+    core::iter::once(polygon.exterior()).chain(polygon.interiors())
+}
+
+/// The rings of a 3D polygon — exterior first, then each interior — as borrowed
+/// slices over the polygon's own buffer.
+pub fn polygon3d_rings(polygon: &Polygon3D) -> impl Iterator<Item = &[[f64; 3]]> {
+    core::iter::once(polygon.exterior()).chain(polygon.interiors())
+}
+
+/// Resolve an indexed triangle into its three 2D corners from a vertex pool.
+#[inline]
+pub fn resolve_triangle_2d(vertices: &[[f64; 2]], tri: [u32; 3]) -> [[f64; 2]; 3] {
+    [
+        vertices[tri[0] as usize],
+        vertices[tri[1] as usize],
+        vertices[tri[2] as usize],
+    ]
+}
+
+/// Resolve an indexed triangle into its three 3D corners from a vertex pool.
+#[inline]
+pub fn resolve_triangle_3d(vertices: &[[f64; 3]], tri: [u32; 3]) -> [[f64; 3]; 3] {
+    [
+        vertices[tri[0] as usize],
+        vertices[tri[1] as usize],
+        vertices[tri[2] as usize],
+    ]
+}
+
+/// Whether a coordinate lies inside or on a 2D triangle, by robust orientation.
+///
+/// A point is inside/on when it is on the same side of (or collinear with) all
+/// three directed edges; this is orientation-independent, so a CW or CCW triangle
+/// gives the same answer.
+pub fn point_in_triangle_2d(p: [f64; 2], tri: [[f64; 2]; 3]) -> bool {
+    let d0 = kernel::orient2d(tri[0], tri[1], p);
+    let d1 = kernel::orient2d(tri[1], tri[2], p);
+    let d2 = kernel::orient2d(tri[2], tri[0], p);
+    let has_cw = d0 == Orientation::Clockwise
+        || d1 == Orientation::Clockwise
+        || d2 == Orientation::Clockwise;
+    let has_ccw = d0 == Orientation::CounterClockwise
+        || d1 == Orientation::CounterClockwise
+        || d2 == Orientation::CounterClockwise;
+    // Inside/on iff it never lies on both sides across the three edges.
+    !(has_cw && has_ccw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinate::CoordinateFrame;
+    use crate::predicates::kernel::{coord_pos_relative_to_ring, CoordPos};
+
+    #[test]
+    fn polygon_rings_yield_exterior_then_holes() {
+        let e = CoordinateFrame::Euclidean;
+        let square = [[0.0, 0.0], [4.0, 0.0], [4.0, 4.0], [0.0, 4.0], [0.0, 0.0]];
+        let hole = vec![[1.0, 1.0], [3.0, 1.0], [3.0, 3.0], [1.0, 3.0], [1.0, 1.0]];
+        let poly = Polygon2D::from_rings(e, square, vec![hole]);
+
+        let rings: Vec<&[[f64; 2]]> = polygon2d_rings(&poly).collect();
+        assert_eq!(rings.len(), 2);
+        assert_eq!(rings[0], poly.exterior());
+        assert_eq!(
+            coord_pos_relative_to_ring([2.0, 2.0], rings[0]),
+            CoordPos::Inside
+        );
+        // Second ring is the hole.
+        assert_eq!(
+            coord_pos_relative_to_ring([2.0, 2.0], rings[1]),
+            CoordPos::Inside
+        );
+    }
+
+    #[test]
+    fn point_in_triangle_inside_edge_outside() {
+        let tri = [[0.0, 0.0], [4.0, 0.0], [0.0, 4.0]];
+        assert!(point_in_triangle_2d([1.0, 1.0], tri));
+        assert!(point_in_triangle_2d([2.0, 0.0], tri)); // on an edge
+        assert!(point_in_triangle_2d([0.0, 0.0], tri)); // on a vertex
+        assert!(!point_in_triangle_2d([3.0, 3.0], tri));
+        assert!(!point_in_triangle_2d([-1.0, 1.0], tri));
+    }
+
+    #[test]
+    fn resolve_triangle_indexes_the_pool() {
+        let verts = vec![[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]];
+        assert_eq!(
+            resolve_triangle_3d(&verts, [0, 1, 2]),
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+        );
+    }
+}

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -80,6 +80,18 @@ impl TriangularMesh3DData {
 }
 
 impl TriangularMesh2D {
+    /// The coordinate frame these vertices are expressed in.
+    #[inline]
+    pub fn frame(&self) -> &CoordinateFrame {
+        &self.frame
+    }
+
+    /// The shared vertex pool.
+    #[inline]
+    pub fn vertices(&self) -> &[[f64; 2]] {
+        &self.vertices
+    }
+
     /// The number of triangles in the mesh.
     #[inline]
     pub fn num_triangles(&self) -> usize {

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.75"
+version = "0.2.76"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.265"
+version = "0.1.266"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR implements 2D predicates and overlay for new-geometry. 

The general path for 2D predicates is DE-9IM backed by `robust` kernel, implemented inside `engine/runtime/geometry/src/predicates/relate`. Most implementation of DE-9IM relate logic is ported from `engine/runtime/geometry/src/algorithm/relate`, which itself is a port of `georust`, which in turn is a faithful port of JTS's `RelateComputer` (java). That said, there are some characteristics that the new implementation adds:
- It is hard 2D and uses f64 (non-generic). This is not a regression; rather, the legacy implementation was using generics for no real abstraction.
- It operates on the new `Geometry` via zero-copy views.
- It support 2D meshes; `TriangularMesh` and `PolygonMesh` are dissolved into polygons, and and get processed accordingly.
- It is fallible.

There are fast paths implemented for 2D predicates (`intersects` / `contains` / `covers`), which are supposed to be used when user knows exactly what kind of predicate they want to compute. Since these paths don't build the heavy overhead objects in relate, they are empirically verified to be much faster on small polygons (i.e. polygons with less than ~64 vertices. See below).

Overlay uses `ioverlay` like legacy geometry. Differences with the old implementation are:
- It is hard 2D and uses f64 (non-generic).
- It operates on the new `Geometry` via zero-copy views.
- It support 2D meshes.
- It is fallible.
- It has frame policy.
- Since overlay is an integer based algorithm (i.e. non-exact), it is guarded by `relate` (see above) to avoid computation on edge cases.
- Independent from `ioverlay`, the legacy geometry was also relying on `clipper-sys`, an ffi binding of C++ `Clipper` library, for 2D boolean operations. It will be unused in the new-geometry world, so it will be automatically dropped after all action migrations are done.
- The custom sweep implementation is dead in the legacy implementation and is unported to the new geometry world.


## Benchmark on fast paths
| Scenario | Double loop | Index | Winner |
|---|--:|--:|---|
| 8-gon × 8-gon, overlapping intersects | 163 ns | 2,871 ns | Double loop, **18×** |
| 8-gon, disjoint bboxes | 58 ns | 227 ns | Double loop, **4×** |
| 8-gon contains inner | 1.7 µs | 2.8 µs | Double loop, **1.6×** |
| 64-gon overlapping intersects | 2.9 µs | 16.2 µs | Double loop, **5.5×** |
| 64-gon contains inner | 38 µs | 16 µs | Index, **2.4×** |
| 512-gon overlapping intersects | 169 µs | 153 µs | ~even |
| 512-gon bbox-overlap but disjoint | 865 µs | 150 µs | Index, **5.8×** |
| 512-gon contains inner | 2,028 µs | 151 µs | Index, **13×** |

## Notes
The legacy paths are removed after the complete migration.