### PR TITLE
feat(engine): 3D predicates for new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4094,7 +4094,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.76"
+version = "0.2.77"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "futures",
  "once_cell",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "approx",
  "async-trait",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "Inflector",
  "approx",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "bytes",
  "clap",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "approx",
  "bvh",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5100,7 +5100,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5182,7 +5182,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "bytes",
  "futures",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "bytes",
  "futures",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "ahash",
  "bytes",
@@ -5314,7 +5314,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.442"
+version = "0.0.443"
 dependencies = [
  "async-trait",
  "axum",
@@ -8047,7 +8047,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.266"
+version = "0.1.267"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.442"
+version = "0.0.443"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/geometry/src/line_string/mod.rs
+++ b/engine/runtime/geometry/src/line_string/mod.rs
@@ -49,6 +49,12 @@ impl LineString2D {
 }
 
 impl LineString3D {
+    /// The coordinate frame these coords are expressed in.
+    #[inline]
+    pub fn frame(&self) -> &CoordinateFrame {
+        &self.frame
+    }
+
     /// The chain's vertices in order.
     #[inline]
     pub fn coords(&self) -> &[[f64; 3]] {

--- a/engine/runtime/geometry/src/overlay/mod.rs
+++ b/engine/runtime/geometry/src/overlay/mod.rs
@@ -17,7 +17,8 @@
 //! frame ([`MixedFrames`](PredicateError::MixedFrames) otherwise, reprojection
 //! is the caller's step), a 2D × 3D pair is
 //! [`CrossDimension`](PredicateError::CrossDimension), a purely 3D pair
-//! [`UnsupportedPair`](PredicateError::UnsupportedPair). Collections flatten to
+//! [`UnsupportedPair`](PredicateError::UnsupportedPair) (boolean overlay is
+//! 2D-only; the only 3D boolean is CSG evaluation). Collections flatten to
 //! their leaves; `Geometry::None` and empty collections are the empty geometry.
 //! Beyond that, each operation constrains the leaf kinds it accepts: an areal
 //! operand takes `Polygon`, `PolygonMesh`, and `TriangularMesh` leaves, a

--- a/engine/runtime/geometry/src/point/mod.rs
+++ b/engine/runtime/geometry/src/point/mod.rs
@@ -42,6 +42,12 @@ impl Point2D {
 }
 
 impl Point3D {
+    /// The coordinate frame this position is expressed in.
+    #[inline]
+    pub fn frame(&self) -> &CoordinateFrame {
+        &self.frame
+    }
+
     /// The `[x, y, z]` position.
     #[inline]
     pub fn position(&self) -> [f64; 3] {

--- a/engine/runtime/geometry/src/polygon_mesh/mod.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/mod.rs
@@ -21,6 +21,8 @@ mod ops;
 #[cfg(feature = "new-geometry")]
 mod validation;
 
+pub(crate) use ops::build_open_rings;
+
 /// A connected, vertex-sharing polygon mesh in 2D space, with optional
 /// per-vertex elevation.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -183,6 +185,12 @@ impl PolygonMesh3D {
         self.data
     }
 
+    /// Borrow the coordinate-free mesh data, for the predicate views.
+    #[inline]
+    pub(crate) fn data(&self) -> &PolygonMesh3DData {
+        &self.data
+    }
+
     /// The number of faces.
     #[inline]
     pub fn num_faces(&self) -> usize {
@@ -205,6 +213,17 @@ impl PolygonMesh3DData {
         } else {
             self.face_offsets.len() + 1
         }
+    }
+
+    /// The CSR ring buffers `(face_indices, face_offsets, interior_offsets)`,
+    /// for the predicate views to decode.
+    #[inline]
+    pub(crate) fn csr_buffers(&self) -> (&IndexBuffer<1>, &IndexBuffer<1>, &IndexBuffer<1>) {
+        (
+            &self.face_indices,
+            &self.face_offsets,
+            &self.interior_offsets,
+        )
     }
 }
 

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -322,7 +322,7 @@ fn decode_into(buf: &IndexBuffer<1>, out: &mut Vec<u32>) {
 /// `face_indices` for triangulation. Fills `open_src` with the face-local position
 /// of each corner (each ring's closing duplicate dropped) and `holes` with the
 /// start offset of each hole ring into `open_src`.
-fn build_open_rings(
+pub(crate) fn build_open_rings(
     face_indices: &[u32],
     interior_offsets: &[u32],
     start: usize,

--- a/engine/runtime/geometry/src/predicates/distance.rs
+++ b/engine/runtime/geometry/src/predicates/distance.rs
@@ -1,0 +1,651 @@
+//! Euclidean [`distance`] between two geometries, 2D or 3D.
+//!
+//! The minimum Euclidean distance between the operands' closed point sets:
+//! `0` exactly when they [`intersects`](super::intersects()) (including a
+//! geometry inside a `Solid` with no shell contact — the upfront check is the
+//! exact phase-5 test), otherwise the minimum over primitive **element**
+//! pairs:
+//!
+//! - 2D leaves decompose into points and segments (an areal leaf contributes
+//!   its ring edges — for disjoint operands the nearest point of a region
+//!   lies on its boundary, and a mesh's internal shared edges lie behind the
+//!   rim, so including them never changes the minimum);
+//! - 3D leaves decompose into points, segments, and triangles (surfaces and
+//!   solid shells through the borrowed triangulation of
+//!   [`view3d`](super::view3d); a solid's void shells are included, so a
+//!   geometry in a hollow measures its distance to the hollow's wall).
+//!
+//! The sweep is rstar-pruned: each element queries the other operand's tree
+//! within the best distance found so far, so far-apart element pairs are
+//! never evaluated. Unlike the boolean predicates, distances are
+//! *constructed* values — plain f64 arithmetic, not exact — but the
+//! intersecting/disjoint decision itself is exact via the upfront check.
+//!
+//! `Ok(None)` when either operand is empty (no leaves, or only leaves that
+//! re-represent as the empty set, e.g. a fully degenerate polygon). The
+//! operands must be of one dimension each and match
+//! ([`CrossDimension`](super::PredicateError::CrossDimension) otherwise);
+//! `Csg` and `PointCloud` are
+//! [`Unsupported`](super::PredicateError::Unsupported). The optional
+//! elevation of 2D leaves is ignored, as everywhere in the predicates.
+
+use rstar::{Point, RTree, RTreeObject, AABB};
+
+use crate::ops::triangulation::Cache;
+use crate::Geometry;
+
+use super::contains::flatten_geometry;
+use super::intersects::intersects;
+use super::kernel::segment_intersection;
+use super::view::Leaf2D;
+use super::view3d::{flatten_geometry_3d, Leaf3D, TriangleSet};
+use super::{PredicateError, Result};
+
+/// The minimum Euclidean distance between two geometries' point sets, or
+/// `None` when either is empty. See the [module docs](self).
+pub fn distance(a: &Geometry, b: &Geometry) -> Result<Option<f64>> {
+    if intersects(a, b)? {
+        return Ok(Some(0.0));
+    }
+
+    let (a2, a3_name) = flatten_geometry(a);
+    let (b2, b3_name) = flatten_geometry(b);
+    // A truly empty operand has no distance to anything.
+    if a2.is_empty() && a3_name.is_none() || b2.is_empty() && b3_name.is_none() {
+        return Ok(None);
+    }
+    match (a3_name, b3_name) {
+        (None, None) => Ok(distance_2d(&a2, &b2)),
+        (Some(_), Some(_)) if a2.is_empty() && b2.is_empty() => {
+            let a3 = leaves_3d(a)?;
+            let b3 = leaves_3d(b)?;
+            Ok(distance_3d(&a3, &b3))
+        }
+        _ => Err(PredicateError::CrossDimension),
+    }
+}
+
+/// The 3D leaves of an operand (2D absence already established).
+fn leaves_3d(geometry: &Geometry) -> Result<Vec<Leaf3D<'_>>> {
+    let (leaves, _, unsupported) = flatten_geometry_3d(geometry);
+    match unsupported {
+        Some(name) => Err(PredicateError::Unsupported { geometry: name }),
+        None => Ok(leaves),
+    }
+}
+
+// --- 2D ------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+enum Element2 {
+    Point([f64; 2]),
+    Segment([[f64; 2]; 2]),
+}
+
+struct Obj2 {
+    elem: Element2,
+    env: AABB<[f64; 2]>,
+}
+
+impl RTreeObject for Obj2 {
+    type Envelope = AABB<[f64; 2]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.env
+    }
+}
+
+fn distance_2d(a: &[Leaf2D<'_>], b: &[Leaf2D<'_>]) -> Option<f64> {
+    let a_objs = elements_2d(a);
+    let b_objs = elements_2d(b);
+    if a_objs.is_empty() || b_objs.is_empty() {
+        return None;
+    }
+    Some(sweep(a_objs, b_objs, element_distance_sq_2d).sqrt())
+}
+
+fn elements_2d(leaves: &[Leaf2D<'_>]) -> Vec<Obj2> {
+    let mut out = Vec::new();
+    let push_point = |p: [f64; 2], out: &mut Vec<Obj2>| {
+        out.push(Obj2 {
+            elem: Element2::Point(p),
+            env: AABB::from_point(p),
+        })
+    };
+    let push_chain = |coords: &[[f64; 2]], out: &mut Vec<Obj2>| match coords {
+        [] => {}
+        [p] => push_point(*p, out),
+        _ => out.extend(coords.windows(2).map(|w| Obj2 {
+            elem: Element2::Segment([w[0], w[1]]),
+            env: AABB::from_corners(w[0], w[1]),
+        })),
+    };
+    for leaf in leaves {
+        match leaf {
+            Leaf2D::Point(p) => push_point(p.position(), &mut out),
+            Leaf2D::Line(l) => push_chain(l.coords(), &mut out),
+            _ => {
+                let area = leaf.area_view().expect("areal leaf");
+                out.extend(area.edges().map(|(u, v)| Obj2 {
+                    elem: Element2::Segment([u, v]),
+                    env: AABB::from_corners(u, v),
+                }));
+            }
+        }
+    }
+    out
+}
+
+fn element_distance_sq_2d(a: &Obj2, b: &Obj2) -> f64 {
+    use Element2::*;
+    match (a.elem, b.elem) {
+        (Point(p), Point(q)) => pp2(p, q),
+        (Point(p), Segment(s)) | (Segment(s), Point(p)) => ps2(p, s),
+        (Segment(s), Segment(t)) => ss2(s, t),
+    }
+}
+
+fn pp2(a: [f64; 2], b: [f64; 2]) -> f64 {
+    let (dx, dy) = (a[0] - b[0], a[1] - b[1]);
+    dx * dx + dy * dy
+}
+
+fn ps2(p: [f64; 2], [a, b]: [[f64; 2]; 2]) -> f64 {
+    let (ex, ey) = (b[0] - a[0], b[1] - a[1]);
+    let len_sq = ex * ex + ey * ey;
+    if len_sq == 0.0 {
+        return pp2(p, a);
+    }
+    let t = (((p[0] - a[0]) * ex + (p[1] - a[1]) * ey) / len_sq).clamp(0.0, 1.0);
+    pp2(p, [a[0] + t * ex, a[1] + t * ey])
+}
+
+fn ss2(s: [[f64; 2]; 2], t: [[f64; 2]; 2]) -> f64 {
+    if segment_intersection(s[0], s[1], t[0], t[1]).is_some() {
+        return 0.0;
+    }
+    ps2(s[0], t)
+        .min(ps2(s[1], t))
+        .min(ps2(t[0], s))
+        .min(ps2(t[1], s))
+}
+
+// --- 3D ------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+enum Element3 {
+    Point([f64; 3]),
+    Segment([[f64; 3]; 2]),
+    Triangle([[f64; 3]; 3]),
+}
+
+struct Obj3 {
+    elem: Element3,
+    env: AABB<[f64; 3]>,
+}
+
+impl RTreeObject for Obj3 {
+    type Envelope = AABB<[f64; 3]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.env
+    }
+}
+
+fn distance_3d(a: &[Leaf3D<'_>], b: &[Leaf3D<'_>]) -> Option<f64> {
+    let mut cache = Cache::new();
+    let a_objs = elements_3d(a, &mut cache);
+    let b_objs = elements_3d(b, &mut cache);
+    if a_objs.is_empty() || b_objs.is_empty() {
+        return None;
+    }
+    Some(sweep(a_objs, b_objs, element_distance_sq_3d).sqrt())
+}
+
+fn elements_3d(leaves: &[Leaf3D<'_>], cache: &mut Cache) -> Vec<Obj3> {
+    let mut out = Vec::new();
+    let push_triangles = |set: &TriangleSet<'_>, out: &mut Vec<Obj3>| {
+        out.extend(set.triangles().map(|t| {
+            let mut min = t[0];
+            let mut max = t[0];
+            for p in &t[1..] {
+                for k in 0..3 {
+                    min[k] = min[k].min(p[k]);
+                    max[k] = max[k].max(p[k]);
+                }
+            }
+            Obj3 {
+                elem: Element3::Triangle(t),
+                env: AABB::from_corners(min, max),
+            }
+        }))
+    };
+    for leaf in leaves {
+        match leaf {
+            Leaf3D::Point(p) => out.push(Obj3 {
+                elem: Element3::Point(p.position()),
+                env: AABB::from_point(p.position()),
+            }),
+            Leaf3D::Line(l) => match l.coords() {
+                [] => {}
+                [p] => out.push(Obj3 {
+                    elem: Element3::Point(*p),
+                    env: AABB::from_point(*p),
+                }),
+                coords => out.extend(coords.windows(2).map(|w| Obj3 {
+                    elem: Element3::Segment([w[0], w[1]]),
+                    env: AABB::from_corners(w[0], w[1]),
+                })),
+            },
+            Leaf3D::Polygon(p) => push_triangles(&TriangleSet::from_polygon(p, cache), &mut out),
+            Leaf3D::PolygonMesh(m) => push_triangles(
+                &TriangleSet::from_polygon_mesh_data(m.data(), cache),
+                &mut out,
+            ),
+            Leaf3D::TriangularMesh(m) => {
+                push_triangles(&TriangleSet::from_triangular_data(m.data()), &mut out)
+            }
+            Leaf3D::Solid(s) => {
+                for shell in core::iter::once(s.exterior()).chain(s.interiors().iter()) {
+                    push_triangles(&TriangleSet::from_shell(shell, cache), &mut out);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn element_distance_sq_3d(a: &Obj3, b: &Obj3) -> f64 {
+    use Element3::*;
+    match (a.elem, b.elem) {
+        (Point(p), Point(q)) => pp3(p, q),
+        (Point(p), Segment(s)) | (Segment(s), Point(p)) => ps3(p, s),
+        (Point(p), Triangle(t)) | (Triangle(t), Point(p)) => pt3(p, t),
+        (Segment(s), Segment(t)) => ss3(s, t),
+        (Segment(s), Triangle(t)) | (Triangle(t), Segment(s)) => st3(s, t),
+        (Triangle(t), Triangle(u)) => tt3(t, u),
+    }
+}
+
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+fn at(a: [f64; 3], d: [f64; 3], t: f64) -> [f64; 3] {
+    [a[0] + t * d[0], a[1] + t * d[1], a[2] + t * d[2]]
+}
+
+fn pp3(a: [f64; 3], b: [f64; 3]) -> f64 {
+    let d = sub(a, b);
+    dot(d, d)
+}
+
+fn ps3(p: [f64; 3], [a, b]: [[f64; 3]; 2]) -> f64 {
+    let e = sub(b, a);
+    let len_sq = dot(e, e);
+    if len_sq == 0.0 {
+        return pp3(p, a);
+    }
+    let t = (dot(sub(p, a), e) / len_sq).clamp(0.0, 1.0);
+    pp3(p, at(a, e, t))
+}
+
+/// Closest distance of two segments: the standard clamped closest-point
+/// parameters.
+fn ss3([p1, p2]: [[f64; 3]; 2], [q1, q2]: [[f64; 3]; 2]) -> f64 {
+    let d1 = sub(p2, p1);
+    let d2 = sub(q2, q1);
+    let r = sub(p1, q1);
+    let a = dot(d1, d1);
+    let e = dot(d2, d2);
+    let f = dot(d2, r);
+    if a == 0.0 {
+        return ps3(p1, [q1, q2]);
+    }
+    if e == 0.0 {
+        return ps3(q1, [p1, p2]);
+    }
+    let c = dot(d1, r);
+    let b = dot(d1, d2);
+    let denom = a * e - b * b;
+    // Parallel segments pick one endpoint's parameter; the clamps below make
+    // the pair consistent.
+    let mut s = if denom != 0.0 {
+        ((b * f - c * e) / denom).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let mut t = (b * s + f) / e;
+    if t < 0.0 {
+        t = 0.0;
+        s = (-c / a).clamp(0.0, 1.0);
+    } else if t > 1.0 {
+        t = 1.0;
+        s = ((b - c) / a).clamp(0.0, 1.0);
+    }
+    pp3(at(p1, d1, s), at(q1, d2, t))
+}
+
+/// Point × triangle: the plane distance when the foot of the perpendicular
+/// lands inside, else the nearest edge.
+fn pt3(p: [f64; 3], t: [[f64; 3]; 3]) -> f64 {
+    let edges = [[t[0], t[1]], [t[1], t[2]], [t[2], t[0]]];
+    let n = cross(sub(t[1], t[0]), sub(t[2], t[0]));
+    let n_sq = dot(n, n);
+    let edge_min = |p: [f64; 3]| {
+        edges
+            .iter()
+            .map(|&e| ps3(p, e))
+            .fold(f64::INFINITY, f64::min)
+    };
+    if n_sq == 0.0 {
+        // Degenerate triangle: its edges cover its point set.
+        return edge_min(p);
+    }
+    let offset = dot(sub(p, t[0]), n);
+    let foot = at(p, n, -offset / n_sq);
+    // Foot-inside test via consistent signs of the edge cross products
+    // (plain f64: a misclassification near an edge is harmless — the edge
+    // distance converges to the plane distance there).
+    let inside = edges
+        .iter()
+        .all(|&[a, b]| dot(cross(sub(b, a), sub(foot, a)), n) >= 0.0)
+        || edges
+            .iter()
+            .all(|&[a, b]| dot(cross(sub(b, a), sub(foot, a)), n) <= 0.0);
+    if inside {
+        offset * offset / n_sq
+    } else {
+        edge_min(p)
+    }
+}
+
+/// Segment × triangle: both endpoints against the face plus the segment
+/// against each edge (complete for disjoint operands: an interior–interior
+/// closest pair forces the segment parallel to the plane, where an endpoint
+/// projects inside or the segment passes over an edge).
+fn st3(s: [[f64; 3]; 2], t: [[f64; 3]; 3]) -> f64 {
+    let edges = [[t[0], t[1]], [t[1], t[2]], [t[2], t[0]]];
+    let mut best = pt3(s[0], t).min(pt3(s[1], t));
+    for e in edges {
+        best = best.min(ss3(s, e));
+    }
+    best
+}
+
+/// Triangle × triangle: each edge against the other triangle (complete for
+/// disjoint triangles — the closest pair is edge × edge or vertex × face).
+fn tt3(t: [[f64; 3]; 3], u: [[f64; 3]; 3]) -> f64 {
+    let mut best = f64::INFINITY;
+    for e in [[t[0], t[1]], [t[1], t[2]], [t[2], t[0]]] {
+        best = best.min(st3(e, u));
+    }
+    for e in [[u[0], u[1]], [u[1], u[2]], [u[2], u[0]]] {
+        best = best.min(st3(e, t));
+    }
+    best
+}
+
+// --- the pruned sweep ----------------------------------------------------------
+
+/// The minimum squared element-pair distance: each left element queries the
+/// right tree within the best distance found so far.
+fn sweep<O: RTreeObject<Envelope = AABB<P>>, P: rstar::Point<Scalar = f64>>(
+    a: Vec<O>,
+    b: Vec<O>,
+    dist_sq: impl Fn(&O, &O) -> f64,
+) -> f64 {
+    let tree = RTree::bulk_load(b);
+    let mut best = f64::INFINITY;
+    for ea in &a {
+        if best == 0.0 {
+            break;
+        }
+        if best.is_finite() {
+            let radius = best.sqrt();
+            let query = inflate(&ea.envelope(), radius);
+            for eb in tree.locate_in_envelope_intersecting(&query) {
+                best = best.min(dist_sq(ea, eb));
+            }
+        } else {
+            for eb in tree.iter() {
+                best = best.min(dist_sq(ea, eb));
+            }
+        }
+    }
+    best
+}
+
+/// The AABB grown by `radius` on every axis.
+fn inflate<P: Point<Scalar = f64>>(env: &AABB<P>, radius: f64) -> AABB<P> {
+    let lower = P::generate(|i| env.lower().nth(i) - radius);
+    let upper = P::generate(|i| env.upper().nth(i) + radius);
+    AABB::from_corners(lower, upper)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collection::Collection3D;
+    use crate::line_string::{LineString2D, LineString3D};
+    use crate::point::{Point2D, Point3D};
+    use crate::polygon::Polygon2D;
+    use crate::predicates::test3d::{
+        box_solid, box_solid_with_void, e, g3, solid_geometry, tetra_solid, Rng,
+    };
+    use crate::triangular_mesh::TriangularMesh3D;
+    use crate::{Euclidean2DGeometry, Euclidean3DGeometry};
+    use pretty_assertions::assert_eq;
+
+    fn g2(g: Euclidean2DGeometry) -> Geometry {
+        Geometry::Euclidean2D(g)
+    }
+
+    fn p3(p: [f64; 3]) -> Geometry {
+        g3(Euclidean3DGeometry::Point(Point3D::new(e(), p)))
+    }
+
+    fn tri3(t: [[f64; 3]; 3]) -> Geometry {
+        g3(Euclidean3DGeometry::TriangularMesh(Box::new(
+            TriangularMesh3D::from_parts(e(), t.to_vec(), [0u32, 1, 2]).unwrap(),
+        )))
+    }
+
+    const TRI: [[f64; 3]; 3] = [[0.0, 0.0, 0.0], [4.0, 0.0, 0.0], [0.0, 4.0, 0.0]];
+
+    #[test]
+    fn point_to_triangle_regions() {
+        // Above the interior: the plane distance.
+        assert_eq!(distance(&p3([1.0, 1.0, 3.0]), &tri3(TRI)), Ok(Some(3.0)));
+        // Beyond an edge: distance to the edge.
+        assert_eq!(distance(&p3([2.0, -3.0, 4.0]), &tri3(TRI)), Ok(Some(5.0)));
+        // Beyond a vertex: distance to the vertex.
+        assert_eq!(distance(&p3([-2.0, -1.0, 2.0]), &tri3(TRI)), Ok(Some(3.0)));
+        // Touching counts as zero.
+        assert_eq!(distance(&p3([1.0, 1.0, 0.0]), &tri3(TRI)), Ok(Some(0.0)));
+    }
+
+    #[test]
+    fn segment_parallel_over_a_triangle_interior() {
+        // The segment's interior hovers over the face; neither endpoint
+        // projects inside, so the edge-crossing terms must capture it.
+        let seg = g3(Euclidean3DGeometry::LineString(LineString3D::from_coords(
+            e(),
+            [[-2.0, 1.0, 5.0], [6.0, 1.0, 5.0]],
+        )));
+        assert_eq!(distance(&seg, &tri3(TRI)), Ok(Some(5.0)));
+    }
+
+    #[test]
+    fn solids_measure_from_their_shells() {
+        let cube = solid_geometry(box_solid([0.0; 3], [2.0; 3]));
+        // Face-to-face gap along one axis.
+        let other = solid_geometry(box_solid([5.0, 0.0, 0.0], [2.0; 3]));
+        assert_eq!(distance(&g3(cube.clone()), &g3(other)), Ok(Some(3.0)));
+        // Corner-to-corner gap across all three axes.
+        let corner = solid_geometry(box_solid([3.0, 3.0, 3.0], [2.0; 3]));
+        assert_eq!(
+            distance(&g3(cube.clone()), &g3(corner)),
+            Ok(Some(3.0f64.sqrt()))
+        );
+        // Containment is intersection: distance zero.
+        let inner = solid_geometry(box_solid([0.5; 3], [1.0; 3]));
+        assert_eq!(distance(&g3(cube), &g3(inner)), Ok(Some(0.0)));
+
+        // A point in a hollow measures its distance to the void's wall.
+        let hollow = solid_geometry(box_solid_with_void([0.0; 3], [6.0; 3], [2.0; 3], [2.0; 3]));
+        assert_eq!(distance(&p3([3.0, 3.0, 3.0]), &g3(hollow)), Ok(Some(1.0)));
+    }
+
+    #[test]
+    fn two_d_pairs_and_hole_distances() {
+        let square =
+            |x: f64, y: f64, s: f64| vec![[x, y], [x + s, y], [x + s, y + s], [x, y + s], [x, y]];
+        let with_hole = g2(Euclidean2DGeometry::Polygon(Box::new(
+            Polygon2D::from_rings(e(), square(0.0, 0.0, 8.0), vec![square(2.0, 2.0, 4.0)]),
+        )));
+        // A point in the hole measures to the hole ring.
+        let p = g2(Euclidean2DGeometry::Point(Point2D::new(e(), [4.0, 5.0])));
+        assert_eq!(distance(&p, &with_hole), Ok(Some(1.0)));
+        // Inside the material: zero.
+        let q = g2(Euclidean2DGeometry::Point(Point2D::new(e(), [1.0, 1.0])));
+        assert_eq!(distance(&q, &with_hole), Ok(Some(0.0)));
+        // Disjoint lines.
+        let l1 = g2(Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            e(),
+            [[0.0, 10.0], [4.0, 10.0]],
+        )));
+        assert_eq!(distance(&l1, &with_hole), Ok(Some(2.0)));
+    }
+
+    #[test]
+    fn empty_and_error_operands() {
+        let cube = g3(solid_geometry(box_solid([0.0; 3], [1.0; 3])));
+        assert_eq!(distance(&Geometry::None, &cube), Ok(None));
+        let empty = g3(Euclidean3DGeometry::Collection(Collection3D::new([])));
+        assert_eq!(distance(&empty, &cube), Ok(None));
+        let flat = g2(Euclidean2DGeometry::Point(Point2D::new(e(), [0.0, 0.0])));
+        assert_eq!(distance(&flat, &cube), Err(PredicateError::CrossDimension));
+        use crate::csg::{Csg, ThreeDimensional};
+        let solid = || Box::new(box_solid([0.0; 3], [1.0; 3]));
+        let csg = g3(Euclidean3DGeometry::Csg(Csg::Union(
+            Box::new(ThreeDimensional::Solid(solid())),
+            Box::new(ThreeDimensional::Solid(solid())),
+        )));
+        assert_eq!(
+            distance(&csg, &cube),
+            Err(PredicateError::Unsupported { geometry: "Csg" })
+        );
+    }
+
+    #[test]
+    fn axis_aligned_boxes_match_the_gap_oracle() {
+        let mut rng = Rng(20260719);
+        for case in 0..120 {
+            let random_box = |rng: &mut Rng| {
+                let min = [
+                    rng.int(-6, 5) as f64,
+                    rng.int(-6, 5) as f64,
+                    rng.int(-6, 5) as f64,
+                ];
+                let size = [
+                    rng.int(1, 3) as f64,
+                    rng.int(1, 3) as f64,
+                    rng.int(1, 3) as f64,
+                ];
+                (min, size)
+            };
+            let (a_min, a_size) = random_box(&mut rng);
+            let (b_min, b_size) = random_box(&mut rng);
+            let gap_sq: f64 = (0..3)
+                .map(|k| {
+                    let gap = (b_min[k] - (a_min[k] + a_size[k]))
+                        .max(a_min[k] - (b_min[k] + b_size[k]))
+                        .max(0.0);
+                    gap * gap
+                })
+                .sum();
+            let a = g3(solid_geometry(box_solid(a_min, a_size)));
+            let b = g3(solid_geometry(box_solid(b_min, b_size)));
+            let d = distance(&a, &b).unwrap().unwrap();
+            assert!(
+                (d - gap_sq.sqrt()).abs() < 1e-12,
+                "case {case}: got {d}, expected {}",
+                gap_sq.sqrt()
+            );
+            // Zero exactly when the exact intersects test says so.
+            assert_eq!(d == 0.0, crate::predicates::intersects(&a, &b).unwrap());
+        }
+    }
+
+    #[test]
+    fn pruned_sweep_matches_brute_force() {
+        let mut rng = Rng(20260720);
+        for case in 0..60 {
+            // Two random tetra solids plus a random polyline each: mixed
+            // element kinds, many elements.
+            let tetra = |rng: &mut Rng, offset: f64| loop {
+                let v = [
+                    rng.grid_point(-4, 4),
+                    rng.grid_point(-4, 4),
+                    rng.grid_point(-4, 4),
+                    rng.grid_point(-4, 4),
+                ];
+                let v: [[f64; 3]; 4] = v.map(|p| [p[0] + offset, p[1], p[2]]);
+                use crate::predicates::kernel::{orient3d, Orientation};
+                if orient3d(v[0], v[1], v[2], v[3]) != Orientation::Collinear {
+                    return v;
+                }
+            };
+            let chain = |rng: &mut Rng, offset: f64| {
+                let coords: Vec<[f64; 3]> = (0..4)
+                    .map(|_| {
+                        let p = rng.grid_point(-4, 4);
+                        [p[0] + offset, p[1], p[2]]
+                    })
+                    .collect();
+                Euclidean3DGeometry::LineString(LineString3D::from_coords(e(), coords))
+            };
+            let a = g3(Euclidean3DGeometry::Collection(Collection3D::new([
+                Euclidean3DGeometry::Solid(Box::new(tetra_solid(tetra(&mut rng, 0.0)))),
+                chain(&mut rng, 0.0),
+            ])));
+            let b = g3(Euclidean3DGeometry::Collection(Collection3D::new([
+                Euclidean3DGeometry::Solid(Box::new(tetra_solid(tetra(&mut rng, 12.0)))),
+                chain(&mut rng, 12.0),
+            ])));
+
+            let expected = brute_force(&a, &b);
+            let actual = distance(&a, &b).unwrap().unwrap();
+            assert_eq!(actual, expected, "case {case}");
+        }
+    }
+
+    /// The un-pruned all-pairs minimum over the same elements.
+    fn brute_force(a: &Geometry, b: &Geometry) -> f64 {
+        let (a3, _, _) = flatten_geometry_3d(a);
+        let (b3, _, _) = flatten_geometry_3d(b);
+        let mut cache = Cache::new();
+        let a_objs = elements_3d(&a3, &mut cache);
+        let b_objs = elements_3d(&b3, &mut cache);
+        let mut best = f64::INFINITY;
+        for ea in &a_objs {
+            for eb in &b_objs {
+                best = best.min(element_distance_sq_3d(ea, eb));
+            }
+        }
+        best.sqrt()
+    }
+}

--- a/engine/runtime/geometry/src/predicates/distance.rs
+++ b/engine/runtime/geometry/src/predicates/distance.rs
@@ -2,12 +2,12 @@
 //!
 //! The minimum Euclidean distance between the operands' closed point sets:
 //! `0` exactly when they [`intersects`](super::intersects()) (including a
-//! geometry inside a `Solid` with no shell contact — the upfront check is the
-//! exact phase-5 test), otherwise the minimum over primitive **element**
+//! geometry inside a `Solid` with no shell contact; the upfront check is the
+//! exact intersection test), otherwise the minimum over primitive **element**
 //! pairs:
 //!
 //! - 2D leaves decompose into points and segments (an areal leaf contributes
-//!   its ring edges — for disjoint operands the nearest point of a region
+//!   its ring edges: for disjoint operands the nearest point of a region
 //!   lies on its boundary, and a mesh's internal shared edges lie behind the
 //!   rim, so including them never changes the minimum);
 //! - 3D leaves decompose into points, segments, and triangles (surfaces and
@@ -18,7 +18,7 @@
 //! The sweep is rstar-pruned: each element queries the other operand's tree
 //! within the best distance found so far, so far-apart element pairs are
 //! never evaluated. Unlike the boolean predicates, distances are
-//! *constructed* values — plain f64 arithmetic, not exact — but the
+//! *constructed* values (plain f64 arithmetic, not exact), but the
 //! intersecting/disjoint decision itself is exact via the upfront check.
 //!
 //! `Ok(None)` when either operand is empty (no leaves, or only leaves that
@@ -357,7 +357,7 @@ fn pt3(p: [f64; 3], t: [[f64; 3]; 3]) -> f64 {
     let offset = dot(sub(p, t[0]), n);
     let foot = at(p, n, -offset / n_sq);
     // Foot-inside test via consistent signs of the edge cross products
-    // (plain f64: a misclassification near an edge is harmless — the edge
+    // (plain f64: a misclassification near an edge is harmless; the edge
     // distance converges to the plane distance there).
     let inside = edges
         .iter()
@@ -386,7 +386,7 @@ fn st3(s: [[f64; 3]; 2], t: [[f64; 3]; 3]) -> f64 {
 }
 
 /// Triangle × triangle: each edge against the other triangle (complete for
-/// disjoint triangles — the closest pair is edge × edge or vertex × face).
+/// disjoint triangles: the closest pair is edge × edge or vertex × face).
 fn tt3(t: [[f64; 3]; 3], u: [[f64; 3]; 3]) -> f64 {
     let mut best = f64::INFINITY;
     for e in [[t[0], t[1]], [t[1], t[2]], [t[2], t[0]]] {

--- a/engine/runtime/geometry/src/predicates/intersects.rs
+++ b/engine/runtime/geometry/src/predicates/intersects.rs
@@ -25,20 +25,20 @@ pub fn intersects(a: &Geometry, b: &Geometry) -> Result<bool> {
     match (a, b) {
         (Geometry::None, _) | (_, Geometry::None) => Ok(false),
         (Geometry::GeometryCollection(c), other) => {
+            // Every member is evaluated even after a hit, so an error from a
+            // later member wins regardless of member order.
+            let mut hit = false;
             for member in c.members() {
-                if intersects(member, other)? {
-                    return Ok(true);
-                }
+                hit |= intersects(member, other)?;
             }
-            Ok(false)
+            Ok(hit)
         }
         (other, Geometry::GeometryCollection(c)) => {
+            let mut hit = false;
             for member in c.members() {
-                if intersects(other, member)? {
-                    return Ok(true);
-                }
+                hit |= intersects(other, member)?;
             }
-            Ok(false)
+            Ok(hit)
         }
         (Geometry::Euclidean2D(a), Geometry::Euclidean2D(b)) => intersects_2d(a, b),
         (Geometry::Euclidean2D(_), Geometry::Euclidean3D(_))

--- a/engine/runtime/geometry/src/predicates/intersects.rs
+++ b/engine/runtime/geometry/src/predicates/intersects.rs
@@ -5,26 +5,50 @@
 //! pair intersecting suffices). Every leaf pair goes through a bounding-box
 //! quick reject first.
 //!
-//! Scope: 2D × 2D pairs. A 2D × 3D pair is a
-//! [`CrossDimension`](PredicateError::CrossDimension) error, a 3D × 3D pair an
-//! [`UnsupportedPair`](PredicateError::UnsupportedPair). `Geometry::None`
-//! intersects nothing.
+//! 2D × 2D pairs dispatch here; 3D × 3D pairs dispatch to
+//! [`intersects3d`](super::intersects3d). A 2D × 3D pair is a
+//! [`CrossDimension`](PredicateError::CrossDimension) error (members of a
+//! [`GeometryCollection`](crate::GeometryCollection) pair per member, so
+//! same-dimension member pairs still evaluate). `Geometry::None` intersects
+//! nothing.
 
 use super::edge_set::{operand_edges, operand_segment_count, should_index, EdgeSet};
 use super::kernel::segment_intersection;
 use super::kernel::CoordPos;
 use super::position::{face_position, line_position};
 use super::view::{require_common_frame, AreaView, Leaf2D, Operand2D, PreparedLeaf};
-use super::Result;
+use super::{PredicateError, Result};
 use crate::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
 
 /// Whether `a` and `b` share at least one point.
 pub fn intersects(a: &Geometry, b: &Geometry) -> Result<bool> {
-    let (a_leaves, b_leaves) = super::flatten_2d_pair(a, b)?;
-    let a = Operand2D::from_leaves(a_leaves);
-    let b = Operand2D::from_leaves(b_leaves);
-    require_common_frame(&a, &b)?;
-    Ok(intersects_operands(&a, &b))
+    match (a, b) {
+        (Geometry::None, _) | (_, Geometry::None) => Ok(false),
+        (Geometry::GeometryCollection(c), other) => {
+            for member in c.members() {
+                if intersects(member, other)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        (other, Geometry::GeometryCollection(c)) => {
+            for member in c.members() {
+                if intersects(other, member)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        (Geometry::Euclidean2D(a), Geometry::Euclidean2D(b)) => intersects_2d(a, b),
+        (Geometry::Euclidean2D(_), Geometry::Euclidean3D(_))
+        | (Geometry::Euclidean3D(_), Geometry::Euclidean2D(_)) => {
+            Err(PredicateError::CrossDimension)
+        }
+        (Geometry::Euclidean3D(a), Geometry::Euclidean3D(b)) => {
+            super::intersects3d::intersects_3d(a, b)
+        }
+    }
 }
 
 /// `intersects` over two 2D geometries.
@@ -424,17 +448,15 @@ mod tests {
     }
 
     #[test]
-    fn cross_dimension_and_3d_errors() {
+    fn cross_dimension_errors_and_3d_dispatches() {
         let a = unit_square_at(0.0, 0.0, 1.0);
         let b3 = Geometry::Euclidean3D(Euclidean3DGeometry::LineString(LineString3D::from_coords(
             e(),
             [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
         )));
         assert_eq!(intersects(&a, &b3), Err(PredicateError::CrossDimension));
-        assert!(matches!(
-            intersects(&b3, &b3),
-            Err(PredicateError::UnsupportedPair { .. })
-        ));
+        // 3D × 3D pairs evaluate through the 3D dispatch.
+        assert_eq!(intersects(&b3, &b3), Ok(true));
     }
 
     #[test]

--- a/engine/runtime/geometry/src/predicates/intersects3d.rs
+++ b/engine/runtime/geometry/src/predicates/intersects3d.rs
@@ -1,0 +1,573 @@
+//! The `intersects` predicate over 3D × 3D pairs.
+//!
+//! The 3D continuation of [`intersects`](super::intersects()): whether two 3D
+//! geometries share at least one point, with boundary contact counting.
+//! Surface-bearing leaves (`Polygon3D`, the meshes, `Solid` shells) are
+//! re-expressed as triangle sets (see [`view3d`](super::view3d)) and tested
+//! with the **exact** [`kernel3d`](super::kernel3d) primitives; candidate
+//! triangle pairs come from an rstar tree over per-triangle bounding boxes, so
+//! mesh × mesh work scales with the contact region rather than the pair
+//! product.
+//!
+//! A `Solid` is volumetric: a geometry with no shell contact still intersects
+//! it when it lies inside (decided by the exact ray parity of
+//! [`position3d`](super::position3d), one representative vertex per connected
+//! component — with no boundary contact a component is entirely on one side).
+//! Every other pair is a surface/curve point-set test. `Csg` and `PointCloud`
+//! leaves are [`Unsupported`](super::PredicateError::Unsupported).
+
+use rstar::{RTree, RTreeObject, AABB};
+
+use crate::ops::triangulation::Cache;
+use crate::ops::{Aabb, BoundingBox};
+use crate::solid::Solid;
+use crate::Euclidean3DGeometry;
+
+use super::kernel::CoordPos;
+use super::kernel3d::{
+    point_in_triangle_3d, segment_intersects_triangle_3d, segments_intersect_3d,
+    triangles_intersect_3d,
+};
+use super::position3d::{on_chain_3d, solid_position_sets};
+use super::view3d::{flatten_3d, require_common_frame_3d, Leaf3D, TriangleSet};
+use super::{PredicateError, Result};
+
+/// [`intersects`](super::intersects()) over two 3D geometries.
+pub fn intersects_3d(a: &Euclidean3DGeometry, b: &Euclidean3DGeometry) -> Result<bool> {
+    let (a_leaves, b_leaves) = flatten_3d_pair(a, b)?;
+    require_common_frame_3d(&a_leaves, &b_leaves)?;
+
+    let mut cache = Cache::new();
+    let a_prepared: Vec<Prepared3D<'_>> = a_leaves
+        .iter()
+        .map(|l| Prepared3D::new(*l, &mut cache))
+        .collect();
+    let b_prepared: Vec<Prepared3D<'_>> = b_leaves
+        .iter()
+        .map(|l| Prepared3D::new(*l, &mut cache))
+        .collect();
+
+    for pa in &a_prepared {
+        for pb in &b_prepared {
+            if leaf_intersects(pa, pb) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+/// Flatten both operands of a 3D binary operation into their leaves, erring on
+/// a leaf kind the 3D operations do not support.
+pub(crate) fn flatten_3d_pair<'a>(
+    a: &'a Euclidean3DGeometry,
+    b: &'a Euclidean3DGeometry,
+) -> Result<(Vec<Leaf3D<'a>>, Vec<Leaf3D<'a>>)> {
+    let mut unsupported = None;
+    let mut a_leaves = Vec::new();
+    flatten_3d(a, &mut a_leaves, &mut unsupported);
+    let mut b_leaves = Vec::new();
+    flatten_3d(b, &mut b_leaves, &mut unsupported);
+    match unsupported {
+        Some(name) => Err(PredicateError::Unsupported { geometry: name }),
+        None => Ok((a_leaves, b_leaves)),
+    }
+}
+
+// --- prepared operands --------------------------------------------------------
+
+/// One triangle's index and precomputed rstar envelope.
+struct TriObj {
+    idx: u32,
+    envelope: AABB<[f64; 3]>,
+}
+
+impl RTreeObject for TriObj {
+    type Envelope = AABB<[f64; 3]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.envelope
+    }
+}
+
+/// A triangle set with an rstar tree over its triangles' bounding boxes.
+struct Surface<'a> {
+    set: TriangleSet<'a>,
+    tree: RTree<TriObj>,
+}
+
+impl<'a> Surface<'a> {
+    fn new(set: TriangleSet<'a>) -> Self {
+        let objs = (0..set.len())
+            .map(|i| {
+                let t = set.triangle(i);
+                let mut min = t[0];
+                let mut max = t[0];
+                for p in &t[1..] {
+                    for k in 0..3 {
+                        min[k] = min[k].min(p[k]);
+                        max[k] = max[k].max(p[k]);
+                    }
+                }
+                TriObj {
+                    idx: i as u32,
+                    envelope: AABB::from_corners(min, max),
+                }
+            })
+            .collect();
+        Surface {
+            set,
+            tree: RTree::bulk_load(objs),
+        }
+    }
+
+    /// Whether the coordinate lies on any triangle.
+    fn contains_point(&self, p: [f64; 3]) -> bool {
+        self.tree
+            .locate_in_envelope_intersecting(&AABB::from_point(p))
+            .any(|obj| point_in_triangle_3d(p, self.set.triangle(obj.idx as usize)))
+    }
+
+    /// Whether the closed segment shares a point with any triangle.
+    fn meets_segment(&self, a: [f64; 3], b: [f64; 3]) -> bool {
+        let mut min = a;
+        let mut max = a;
+        for k in 0..3 {
+            min[k] = min[k].min(b[k]);
+            max[k] = max[k].max(b[k]);
+        }
+        self.tree
+            .locate_in_envelope_intersecting(&AABB::from_corners(min, max))
+            .any(|obj| segment_intersects_triangle_3d(a, b, self.set.triangle(obj.idx as usize)))
+    }
+
+    /// Whether any triangle of `self` shares a point with any of `other`,
+    /// through a tree × tree candidate traversal.
+    fn meets_surface(&self, other: &Surface<'_>) -> bool {
+        self.tree
+            .intersection_candidates_with_other_tree(&other.tree)
+            .any(|(oa, ob)| {
+                triangles_intersect_3d(
+                    self.set.triangle(oa.idx as usize),
+                    other.set.triangle(ob.idx as usize),
+                )
+            })
+    }
+
+    /// One vertex per connected component (triangles connected through shared
+    /// pool indices). With no boundary contact against another operand, each
+    /// component lies entirely on one side of it, so these decide containment.
+    fn component_reps(&self) -> Vec<[f64; 3]> {
+        let n = self.set.pool().len();
+        let mut parent: Vec<u32> = (0..n as u32).collect();
+        fn find(parent: &mut [u32], mut x: u32) -> u32 {
+            while parent[x as usize] != x {
+                parent[x as usize] = parent[parent[x as usize] as usize];
+                x = parent[x as usize];
+            }
+            x
+        }
+        for i in 0..self.set.len() {
+            let [a, b, c] = self.set.indices(i);
+            let ra = find(&mut parent, a);
+            let rb = find(&mut parent, b);
+            parent[rb as usize] = ra;
+            let rc = find(&mut parent, c);
+            parent[rc as usize] = ra;
+        }
+        let mut seen: Vec<u32> = Vec::new();
+        let mut reps: Vec<[f64; 3]> = Vec::new();
+        for i in 0..self.set.len() {
+            let root = find(&mut parent, self.set.indices(i)[0]);
+            if !seen.contains(&root) {
+                seen.push(root);
+                reps.push(self.set.triangle(i)[0]);
+            }
+        }
+        reps
+    }
+}
+
+/// A leaf's point set in dispatch form.
+enum Body<'a> {
+    Point([f64; 3]),
+    Line(&'a [[f64; 3]]),
+    Surface(Surface<'a>),
+    /// The shells, exterior first.
+    Solid(Vec<Surface<'a>>),
+}
+
+/// One flattened leaf prepared for the pair tests: its body and bounding box
+/// (`None` for an empty point set, which intersects nothing).
+struct Prepared3D<'a> {
+    body: Body<'a>,
+    bbox: Option<Aabb>,
+}
+
+impl<'a> Prepared3D<'a> {
+    fn new(leaf: Leaf3D<'a>, cache: &mut Cache) -> Self {
+        let bbox = match leaf {
+            Leaf3D::Point(p) => p.bounding_box(),
+            Leaf3D::Line(l) => l.bounding_box(),
+            Leaf3D::Polygon(p) => p.bounding_box(),
+            Leaf3D::PolygonMesh(m) => m.bounding_box(),
+            Leaf3D::TriangularMesh(m) => m.bounding_box(),
+            Leaf3D::Solid(s) => s.bounding_box(),
+        }
+        .ok();
+        let body = match leaf {
+            Leaf3D::Point(p) => Body::Point(p.position()),
+            Leaf3D::Line(l) => Body::Line(l.coords()),
+            Leaf3D::Polygon(p) => Body::Surface(Surface::new(TriangleSet::from_polygon(p, cache))),
+            Leaf3D::PolygonMesh(m) => Body::Surface(Surface::new(
+                TriangleSet::from_polygon_mesh_data(m.data(), cache),
+            )),
+            Leaf3D::TriangularMesh(m) => {
+                Body::Surface(Surface::new(TriangleSet::from_triangular_data(m.data())))
+            }
+            Leaf3D::Solid(s) => Body::Solid(shells(s, cache)),
+        };
+        // A surface whose faces are all degenerate re-represents as no
+        // triangles: an empty point set, like an empty line.
+        let empty = match &body {
+            Body::Point(_) => false,
+            Body::Line(l) => l.is_empty(),
+            Body::Surface(s) => s.set.is_empty(),
+            Body::Solid(shells) => shells[0].set.is_empty(),
+        };
+        Prepared3D {
+            body,
+            bbox: if empty { None } else { bbox },
+        }
+    }
+}
+
+/// The shells of a solid as surfaces, exterior first.
+fn shells<'a>(solid: &'a Solid, cache: &mut Cache) -> Vec<Surface<'a>> {
+    core::iter::once(solid.exterior())
+        .chain(solid.interiors().iter())
+        .map(|shell| Surface::new(TriangleSet::from_shell(shell, cache)))
+        .collect()
+}
+
+/// Whether a coordinate lies in a solid's closed point set.
+fn solid_has_point(shells: &[Surface<'_>], p: [f64; 3]) -> bool {
+    solid_position_sets(p, &shells[0].set, shells[1..].iter().map(|s| &s.set)) != CoordPos::Outside
+}
+
+// --- pair dispatch -------------------------------------------------------------
+
+/// Whether two prepared leaves intersect, after a bounding-box quick reject.
+fn leaf_intersects(a: &Prepared3D<'_>, b: &Prepared3D<'_>) -> bool {
+    let (Some(box_a), Some(box_b)) = (&a.bbox, &b.bbox) else {
+        return false;
+    };
+    if !box_a.intersects(box_b) {
+        return false;
+    }
+    match (&a.body, &b.body) {
+        (Body::Point(p), _) => body_has_point(&b.body, *p),
+        (_, Body::Point(p)) => body_has_point(&a.body, *p),
+        (Body::Line(la), Body::Line(lb)) => line_vs_line(la, lb),
+        (Body::Line(l), _) => line_vs_body(l, &b.body),
+        (_, Body::Line(l)) => line_vs_body(l, &a.body),
+        (Body::Surface(sa), Body::Surface(sb)) => sa.meets_surface(sb),
+        (Body::Surface(s), Body::Solid(shells)) | (Body::Solid(shells), Body::Surface(s)) => {
+            shells.iter().any(|shell| shell.meets_surface(s))
+                || s.component_reps()
+                    .into_iter()
+                    .any(|p| solid_has_point(shells, p))
+        }
+        (Body::Solid(sa), Body::Solid(sb)) => {
+            sa.iter().any(|x| sb.iter().any(|y| x.meets_surface(y)))
+                || solid_has_point(sb, sa[0].set.triangle(0)[0])
+                || solid_has_point(sa, sb[0].set.triangle(0)[0])
+        }
+    }
+}
+
+/// Whether the coordinate lies in the body's closed point set.
+fn body_has_point(body: &Body<'_>, p: [f64; 3]) -> bool {
+    match body {
+        Body::Point(q) => p == *q,
+        Body::Line(l) => on_chain_3d(p, l),
+        Body::Surface(s) => s.contains_point(p),
+        Body::Solid(shells) => solid_has_point(shells, p),
+    }
+}
+
+fn line_vs_line(a: &[[f64; 3]], b: &[[f64; 3]]) -> bool {
+    // A single-vertex chain is point-like.
+    if a.len() == 1 {
+        return on_chain_3d(a[0], b);
+    }
+    if b.len() == 1 {
+        return on_chain_3d(b[0], a);
+    }
+    a.windows(2).any(|sa| {
+        b.windows(2)
+            .any(|sb| segments_intersect_3d(sa[0], sa[1], sb[0], sb[1]))
+    })
+}
+
+/// Line versus a surface or solid body.
+fn line_vs_body(coords: &[[f64; 3]], body: &Body<'_>) -> bool {
+    if coords.len() == 1 {
+        return body_has_point(body, coords[0]);
+    }
+    match body {
+        Body::Surface(s) => coords.windows(2).any(|w| s.meets_segment(w[0], w[1])),
+        Body::Solid(shells) => {
+            // Any shell contact intersects; otherwise the chain never crosses
+            // the boundary, so it lies entirely in one region: one vertex
+            // decides.
+            coords
+                .windows(2)
+                .any(|w| shells.iter().any(|s| s.meets_segment(w[0], w[1])))
+                || coords.first().is_some_and(|&p| solid_has_point(shells, p))
+        }
+        Body::Point(_) | Body::Line(_) => unreachable!("handled by the dispatch above"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collection::Collection3D;
+    use crate::coordinate::{CoordinateFrame, EpsgCode};
+    use crate::line_string::LineString3D;
+    use crate::point::Point3D;
+    use crate::polygon::Polygon3D;
+    use crate::predicates::intersects;
+    use crate::predicates::test3d::{box_solid, box_solid_with_void, e, g3, solid_geometry, Rng};
+    use crate::triangular_mesh::TriangularMesh3D;
+    use pretty_assertions::assert_eq;
+
+    fn point(p: [f64; 3]) -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Point(Point3D::new(e(), p))
+    }
+
+    fn line(coords: impl IntoIterator<Item = [f64; 3]>) -> Euclidean3DGeometry {
+        Euclidean3DGeometry::LineString(LineString3D::from_coords(e(), coords))
+    }
+
+    fn triangle(t: [[f64; 3]; 3]) -> Euclidean3DGeometry {
+        Euclidean3DGeometry::TriangularMesh(Box::new(
+            TriangularMesh3D::from_parts(e(), t.to_vec(), [0u32, 1, 2]).unwrap(),
+        ))
+    }
+
+    #[test]
+    fn point_line_and_surface_pairs() {
+        let tri = triangle([[0.0, 0.0, 0.0], [4.0, 0.0, 0.0], [0.0, 4.0, 0.0]]);
+        assert_eq!(intersects_3d(&point([1.0, 1.0, 0.0]), &tri), Ok(true));
+        assert_eq!(intersects_3d(&point([1.0, 1.0, 0.5]), &tri), Ok(false));
+        assert_eq!(
+            intersects_3d(&point([1.0, 1.0, 1.0]), &point([1.0, 1.0, 1.0])),
+            Ok(true)
+        );
+        assert_eq!(
+            intersects_3d(
+                &point([2.0, 2.0, 2.0]),
+                &line([[0.0, 0.0, 0.0], [4.0, 4.0, 4.0]])
+            ),
+            Ok(true)
+        );
+        // Skew lines miss; coplanar crossing lines meet.
+        assert_eq!(
+            intersects_3d(
+                &line([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+                &line([[0.0, 1.0, 1.0], [0.0, -1.0, 1.0]])
+            ),
+            Ok(false)
+        );
+        assert_eq!(
+            intersects_3d(
+                &line([[0.0, 0.0, 0.0], [2.0, 2.0, 2.0]]),
+                &line([[2.0, 0.0, 0.0], [0.0, 2.0, 2.0]])
+            ),
+            Ok(true)
+        );
+        // A line piercing a triangle, resting on it, and missing it.
+        assert_eq!(
+            intersects_3d(&line([[1.0, 1.0, -1.0], [1.0, 1.0, 1.0]]), &tri),
+            Ok(true)
+        );
+        assert_eq!(
+            intersects_3d(&line([[0.5, 0.5, 0.0], [1.5, 1.5, 0.0]]), &tri),
+            Ok(true)
+        );
+        assert_eq!(
+            intersects_3d(&line([[1.0, 1.0, 1.0], [1.0, 1.0, 2.0]]), &tri),
+            Ok(false)
+        );
+        // Surface × surface: shared edge counts.
+        let folded = triangle([[0.0, 0.0, 0.0], [4.0, 0.0, 0.0], [0.0, -4.0, 4.0]]);
+        assert_eq!(intersects_3d(&tri, &folded), Ok(true));
+    }
+
+    #[test]
+    fn solids_are_volumetric() {
+        let solid = solid_geometry(box_solid([0.0; 3], [6.0, 6.0, 6.0]));
+        // Strictly inside, without any shell contact.
+        assert_eq!(intersects_3d(&point([3.0, 3.0, 3.0]), &solid), Ok(true));
+        assert_eq!(
+            intersects_3d(&line([[2.0, 2.0, 2.0], [4.0, 4.0, 4.0]]), &solid),
+            Ok(true)
+        );
+        let inner_tri = triangle([[2.0, 2.0, 2.0], [4.0, 2.0, 2.0], [2.0, 4.0, 2.0]]);
+        assert_eq!(intersects_3d(&inner_tri, &solid), Ok(true));
+        let inner_solid = solid_geometry(box_solid([2.0; 3], [2.0, 2.0, 2.0]));
+        assert_eq!(intersects_3d(&inner_solid, &solid), Ok(true));
+        assert_eq!(intersects_3d(&solid, &inner_solid), Ok(true));
+        // Crossing the shell.
+        assert_eq!(
+            intersects_3d(&line([[-1.0, 3.0, 3.0], [1.0, 3.0, 3.0]]), &solid),
+            Ok(true)
+        );
+        // Entirely outside.
+        assert_eq!(intersects_3d(&point([7.0, 3.0, 3.0]), &solid), Ok(false));
+        assert_eq!(
+            intersects_3d(
+                &triangle([[7.0, 0.0, 0.0], [8.0, 0.0, 0.0], [7.0, 1.0, 0.0]]),
+                &solid
+            ),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn voids_are_outside_the_solid() {
+        let hollow = solid_geometry(box_solid_with_void(
+            [0.0; 3],
+            [6.0, 6.0, 6.0],
+            [2.0; 3],
+            [2.0, 2.0, 2.0],
+        ));
+        // Geometry fully inside the hollow does not intersect.
+        assert_eq!(intersects_3d(&point([3.0, 3.0, 3.0]), &hollow), Ok(false));
+        let in_void = solid_geometry(box_solid([2.5; 3], [1.0, 1.0, 1.0]));
+        assert_eq!(intersects_3d(&in_void, &hollow), Ok(false));
+        assert_eq!(intersects_3d(&hollow, &in_void), Ok(false));
+        // Touching the void shell intersects (it is the solid's boundary).
+        assert_eq!(intersects_3d(&point([2.0, 3.0, 3.0]), &hollow), Ok(true));
+        // In the wall.
+        assert_eq!(intersects_3d(&point([1.0, 1.0, 1.0]), &hollow), Ok(true));
+    }
+
+    #[test]
+    fn containment_is_per_connected_component() {
+        // Two disjoint triangles in one mesh: one deep inside the solid, one
+        // far outside; neither touches the shell.
+        let mesh = Euclidean3DGeometry::TriangularMesh(Box::new(
+            TriangularMesh3D::from_parts(
+                e(),
+                vec![
+                    [20.0, 0.0, 0.0],
+                    [21.0, 0.0, 0.0],
+                    [20.0, 1.0, 0.0],
+                    [2.0, 2.0, 2.0],
+                    [3.0, 2.0, 2.0],
+                    [2.0, 3.0, 2.0],
+                ],
+                [0u32, 1, 2, 3, 4, 5],
+            )
+            .unwrap(),
+        ));
+        let solid = solid_geometry(box_solid([0.0; 3], [6.0, 6.0, 6.0]));
+        assert_eq!(intersects_3d(&mesh, &solid), Ok(true));
+        assert_eq!(intersects_3d(&solid, &mesh), Ok(true));
+
+        // With only the far component, no intersection.
+        let far_only = triangle([[20.0, 0.0, 0.0], [21.0, 0.0, 0.0], [20.0, 1.0, 0.0]]);
+        assert_eq!(intersects_3d(&far_only, &solid), Ok(false));
+    }
+
+    #[test]
+    fn axis_aligned_boxes_match_the_interval_oracle() {
+        let mut rng = Rng(20260716);
+        for case in 0..200 {
+            let (a_min, a_size) = random_box(&mut rng);
+            let (b_min, b_size) = random_box(&mut rng);
+            let expected = (0..3)
+                .all(|k| a_min[k] <= b_min[k] + b_size[k] && b_min[k] <= a_min[k] + a_size[k]);
+            let a = solid_geometry(box_solid(a_min, a_size));
+            let b = solid_geometry(box_solid(b_min, b_size));
+            assert_eq!(
+                intersects_3d(&a, &b),
+                Ok(expected),
+                "case {case}: {a_min:?}+{a_size:?} vs {b_min:?}+{b_size:?}"
+            );
+            assert_eq!(intersects_3d(&b, &a), Ok(expected), "case {case} swapped");
+
+            // A grid point against a closed box has the same exact oracle.
+            let p = rng.grid_point(-6, 6);
+            let p_expected = (0..3).all(|k| p[k] >= a_min[k] && p[k] <= a_min[k] + a_size[k]);
+            assert_eq!(
+                intersects_3d(&point(p), &a),
+                Ok(p_expected),
+                "case {case}: point {p:?} vs {a_min:?}+{a_size:?}"
+            );
+        }
+    }
+
+    fn random_box(rng: &mut Rng) -> ([f64; 3], [f64; 3]) {
+        let min = [
+            rng.int(-5, 4) as f64,
+            rng.int(-5, 4) as f64,
+            rng.int(-5, 4) as f64,
+        ];
+        let size = [
+            rng.int(1, 4) as f64,
+            rng.int(1, 4) as f64,
+            rng.int(1, 4) as f64,
+        ];
+        (min, size)
+    }
+
+    #[test]
+    fn empty_and_degenerate_operands() {
+        let solid = solid_geometry(box_solid([0.0; 3], [4.0; 3]));
+        let empty = Euclidean3DGeometry::Collection(Collection3D::new([]));
+        assert_eq!(intersects_3d(&empty, &solid), Ok(false));
+        // A degenerate polygon (collinear ring) re-represents as no
+        // triangles: an empty point set.
+        let degenerate = Euclidean3DGeometry::Polygon(Box::new(Polygon3D::from_rings(
+            e(),
+            [
+                [1.0, 1.0, 1.0],
+                [2.0, 2.0, 2.0],
+                [3.0, 3.0, 3.0],
+                [1.0, 1.0, 1.0],
+            ],
+            Vec::<Vec<[f64; 3]>>::new(),
+        )));
+        assert_eq!(intersects_3d(&degenerate, &solid), Ok(false));
+        // Through the public entry: None and cross-dimension policy.
+        assert_eq!(intersects(&Geometry::None, &g3(solid.clone())), Ok(false));
+    }
+
+    #[test]
+    fn unsupported_and_mixed_frame_errors() {
+        use crate::csg::{Csg, ThreeDimensional};
+        let solid = || Box::new(box_solid([0.0; 3], [1.0; 3]));
+        let csg = Euclidean3DGeometry::Csg(Csg::Union(
+            Box::new(ThreeDimensional::Solid(solid())),
+            Box::new(ThreeDimensional::Solid(solid())),
+        ));
+        assert_eq!(
+            intersects_3d(&csg, &point([0.0; 3])),
+            Err(PredicateError::Unsupported { geometry: "Csg" })
+        );
+        let far_point = Euclidean3DGeometry::Point(Point3D::new(
+            CoordinateFrame::Crs(EpsgCode::new(4979)),
+            [0.0; 3],
+        ));
+        assert_eq!(
+            intersects_3d(&far_point, &point([0.0; 3])),
+            Err(PredicateError::MixedFrames)
+        );
+    }
+
+    use crate::Geometry;
+}

--- a/engine/runtime/geometry/src/predicates/intersects3d.rs
+++ b/engine/runtime/geometry/src/predicates/intersects3d.rs
@@ -12,7 +12,7 @@
 //! A `Solid` is volumetric: a geometry with no shell contact still intersects
 //! it when it lies inside (decided by the exact ray parity of
 //! [`position3d`](super::position3d), one representative vertex per connected
-//! component — with no boundary contact a component is entirely on one side).
+//! component; with no boundary contact a component is entirely on one side).
 //! Every other pair is a surface/curve point-set test. `Csg` and `PointCloud`
 //! leaves are [`Unsupported`](super::PredicateError::Unsupported).
 

--- a/engine/runtime/geometry/src/predicates/intersects3d.rs
+++ b/engine/runtime/geometry/src/predicates/intersects3d.rs
@@ -16,7 +16,7 @@
 //! Every other pair is a surface/curve point-set test. `Csg` and `PointCloud`
 //! leaves are [`Unsupported`](super::PredicateError::Unsupported).
 
-use rstar::{RTree, RTreeObject, AABB};
+use rstar::{RTree, AABB};
 
 use crate::ops::triangulation::Cache;
 use crate::ops::{Aabb, BoundingBox};
@@ -28,8 +28,8 @@ use super::kernel3d::{
     point_in_triangle_3d, segment_intersects_triangle_3d, segments_intersect_3d,
     triangles_intersect_3d,
 };
-use super::position3d::{on_chain_3d, solid_position_sets};
-use super::view3d::{flatten_3d, require_common_frame_3d, Leaf3D, TriangleSet};
+use super::position3d::{on_chain_3d, solid_position_indexed};
+use super::view3d::{flatten_3d, require_common_frame_3d, Leaf3D, TriBox, TriangleSet};
 use super::{PredicateError, Result};
 
 /// [`intersects`](super::intersects()) over two 3D geometries.
@@ -76,49 +76,16 @@ pub(crate) fn flatten_3d_pair<'a>(
 
 // --- prepared operands --------------------------------------------------------
 
-/// One triangle's index and precomputed rstar envelope.
-struct TriObj {
-    idx: u32,
-    envelope: AABB<[f64; 3]>,
-}
-
-impl RTreeObject for TriObj {
-    type Envelope = AABB<[f64; 3]>;
-
-    fn envelope(&self) -> Self::Envelope {
-        self.envelope
-    }
-}
-
 /// A triangle set with an rstar tree over its triangles' bounding boxes.
 struct Surface<'a> {
     set: TriangleSet<'a>,
-    tree: RTree<TriObj>,
+    tree: RTree<TriBox>,
 }
 
 impl<'a> Surface<'a> {
     fn new(set: TriangleSet<'a>) -> Self {
-        let objs = (0..set.len())
-            .map(|i| {
-                let t = set.triangle(i);
-                let mut min = t[0];
-                let mut max = t[0];
-                for p in &t[1..] {
-                    for k in 0..3 {
-                        min[k] = min[k].min(p[k]);
-                        max[k] = max[k].max(p[k]);
-                    }
-                }
-                TriObj {
-                    idx: i as u32,
-                    envelope: AABB::from_corners(min, max),
-                }
-            })
-            .collect();
-        Surface {
-            set,
-            tree: RTree::bulk_load(objs),
-        }
+        let tree = set.rtree();
+        Surface { set, tree }
     }
 
     /// Whether the coordinate lies on any triangle.
@@ -250,9 +217,14 @@ fn shells<'a>(solid: &'a Solid, cache: &mut Cache) -> Vec<Surface<'a>> {
         .collect()
 }
 
-/// Whether a coordinate lies in a solid's closed point set.
+/// Whether a coordinate lies in a solid's closed point set, reusing each
+/// shell's prebuilt tree for the parity probe instead of scanning its triangles.
 fn solid_has_point(shells: &[Surface<'_>], p: [f64; 3]) -> bool {
-    solid_position_sets(p, &shells[0].set, shells[1..].iter().map(|s| &s.set)) != CoordPos::Outside
+    solid_position_indexed(
+        p,
+        (&shells[0].set, &shells[0].tree),
+        shells[1..].iter().map(|s| (&s.set, &s.tree)),
+    ) != CoordPos::Outside
 }
 
 // --- pair dispatch -------------------------------------------------------------

--- a/engine/runtime/geometry/src/predicates/kernel.rs
+++ b/engine/runtime/geometry/src/predicates/kernel.rs
@@ -540,12 +540,12 @@ fn point_segment_distance(point: [f64; 2], start: [f64; 2], end: [f64; 2]) -> f6
 // --- 3D vector helpers ------------------------------------------------------
 
 #[inline]
-fn sub3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+pub(crate) fn sub3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
     [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
 }
 
 #[inline]
-fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+pub(crate) fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
     [
         a[1] * b[2] - a[2] * b[1],
         a[2] * b[0] - a[0] * b[2],
@@ -554,7 +554,7 @@ fn cross3(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
 }
 
 #[inline]
-fn dot3(a: [f64; 3], b: [f64; 3]) -> f64 {
+pub(crate) fn dot3(a: [f64; 3], b: [f64; 3]) -> f64 {
     a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
 }
 

--- a/engine/runtime/geometry/src/predicates/kernel3d.rs
+++ b/engine/runtime/geometry/src/predicates/kernel3d.rs
@@ -1,12 +1,10 @@
 //! Exact 3D intersection tests over the robust [`kernel`](super::kernel).
 //!
 //! Boolean primitives for the 3D predicates: point × segment / triangle,
-//! segment × segment / triangle, and triangle × triangle, all **exact** — every
+//! segment × segment / triangle, and triangle × triangle, all **exact**: every
 //! decision is a robust [`orient2d`] / [`orient3d`] sign, with no epsilon
-//! thresholds. Unlike the legacy `triangle_intersection` helpers (which treat
-//! coplanar and edge contacts as non-intersections within an epsilon), these
-//! are closed point-set tests: shared vertices, edge touches, and coplanar
-//! overlaps all intersect.
+//! thresholds. These are closed point-set tests: shared vertices, edge
+//! touches, and coplanar overlaps all intersect.
 //!
 //! Degenerate configurations reduce exactly instead of erroring: a collinear
 //! "triangle" is tested as the segment it spans, coplanar cases drop to 2D
@@ -15,7 +13,7 @@
 //! onto one line, which is detectable with `orient2d` alone).
 //!
 //! The *constructed* counterpart (ray casting with hit coordinates) lives in
-//! [`ray`](super::ray) and is deliberately not exact — see there.
+//! [`ray`](super::ray) and is deliberately not exact; see there.
 
 use super::kernel::{orient2d, orient3d, segment_intersection, Orientation};
 use super::view::point_in_triangle_2d;
@@ -24,7 +22,7 @@ use super::view::point_in_triangle_2d;
 ///
 /// The three components of the cross product `(b - a) × (p - a)` are the signed
 /// areas of the three axis projections, so the points are collinear in 3D iff
-/// every axis projection is collinear in 2D — three robust [`orient2d`] calls.
+/// every axis projection is collinear in 2D: three robust [`orient2d`] calls.
 pub fn collinear_3d(a: [f64; 3], b: [f64; 3], p: [f64; 3]) -> bool {
     (0..3).all(|axis| {
         orient2d(drop_axis(a, axis), drop_axis(b, axis), drop_axis(p, axis))
@@ -138,7 +136,7 @@ pub fn segment_intersects_triangle_3d(p: [f64; 3], q: [f64; 3], t: [[f64; 3]; 3]
         (Orientation::Collinear, _) => point_in_triangle_3d(p, t),
         (_, Orientation::Collinear) => point_in_triangle_3d(q, t),
         // The segment straddles the plane: it meets the closed triangle iff
-        // the line through `p, q` does not pass strictly outside any edge —
+        // the line through `p, q` does not pass strictly outside any edge,
         // i.e. no two of the three edge orientations strictly disagree.
         _ => {
             let u = orient3d(p, q, t[0], t[1]);

--- a/engine/runtime/geometry/src/predicates/kernel3d.rs
+++ b/engine/runtime/geometry/src/predicates/kernel3d.rs
@@ -1,0 +1,490 @@
+//! Exact 3D intersection tests over the robust [`kernel`](super::kernel).
+//!
+//! Boolean primitives for the 3D predicates: point × segment / triangle,
+//! segment × segment / triangle, and triangle × triangle, all **exact** — every
+//! decision is a robust [`orient2d`] / [`orient3d`] sign, with no epsilon
+//! thresholds. Unlike the legacy `triangle_intersection` helpers (which treat
+//! coplanar and edge contacts as non-intersections within an epsilon), these
+//! are closed point-set tests: shared vertices, edge touches, and coplanar
+//! overlaps all intersect.
+//!
+//! Degenerate configurations reduce exactly instead of erroring: a collinear
+//! "triangle" is tested as the segment it spans, coplanar cases drop to 2D
+//! through an axis projection that is injective on the carrying plane (an axis
+//! projection of coplanar points is degenerate exactly when it maps them all
+//! onto one line, which is detectable with `orient2d` alone).
+//!
+//! The *constructed* counterpart (ray casting with hit coordinates) lives in
+//! [`ray`](super::ray) and is deliberately not exact — see there.
+
+use super::kernel::{orient2d, orient3d, segment_intersection, Orientation};
+use super::view::point_in_triangle_2d;
+
+/// Whether the three points are collinear, exactly.
+///
+/// The three components of the cross product `(b - a) × (p - a)` are the signed
+/// areas of the three axis projections, so the points are collinear in 3D iff
+/// every axis projection is collinear in 2D — three robust [`orient2d`] calls.
+pub fn collinear_3d(a: [f64; 3], b: [f64; 3], p: [f64; 3]) -> bool {
+    (0..3).all(|axis| {
+        orient2d(drop_axis(a, axis), drop_axis(b, axis), drop_axis(p, axis))
+            == Orientation::Collinear
+    })
+}
+
+/// Whether `p` lies on the closed segment `[a, b]`, exactly.
+pub fn point_on_segment_3d(p: [f64; 3], a: [f64; 3], b: [f64; 3]) -> bool {
+    collinear_3d(a, b, p) && (0..3).all(|k| value_in_between(p[k], a[k], b[k]))
+}
+
+/// Whether the four points lie in one plane, exactly ([`orient3d`]).
+#[inline]
+pub fn coplanar(a: [f64; 3], b: [f64; 3], c: [f64; 3], d: [f64; 3]) -> bool {
+    orient3d(a, b, c, d) == Orientation::Collinear
+}
+
+/// Whether `p` lies on the closed triangle `t` (interior, edge, or vertex),
+/// exactly. A degenerate triangle is tested as the segment or point it spans.
+pub fn point_in_triangle_3d(p: [f64; 3], t: [[f64; 3]; 3]) -> bool {
+    match classify_triangle(t) {
+        TriangleShape::Proper => {
+            if !coplanar(t[0], t[1], t[2], p) {
+                return false;
+            }
+            let axis = projection_axis(t);
+            point_in_triangle_2d(drop_axis(p, axis), project_triangle(t, axis))
+        }
+        TriangleShape::Segment([a, b]) => point_on_segment_3d(p, a, b),
+        TriangleShape::Point(q) => p == q,
+    }
+}
+
+/// Whether the closed segments `[p1, p2]` and `[q1, q2]` share at least one
+/// point, exactly. Collinear overlaps and endpoint touches intersect; skew and
+/// parallel-disjoint segments do not.
+pub fn segments_intersect_3d(p1: [f64; 3], p2: [f64; 3], q1: [f64; 3], q2: [f64; 3]) -> bool {
+    if p1 == p2 {
+        return if q1 == q2 {
+            p1 == q1
+        } else {
+            point_on_segment_3d(p1, q1, q2)
+        };
+    }
+    if q1 == q2 {
+        return point_on_segment_3d(q1, p1, p2);
+    }
+    // Two proper segments only meet if all four endpoints are coplanar.
+    if !coplanar(p1, p2, q1, q2) {
+        return false;
+    }
+    // Drop to 2D through an axis projection that is injective on the carrying
+    // plane: one where the four projected points do not all collapse onto a
+    // line. If every projection collapses, the points were collinear in 3D and
+    // the question is a 1D overlap.
+    for axis in [2, 1, 0] {
+        let (a, b, c, d) = (
+            drop_axis(p1, axis),
+            drop_axis(p2, axis),
+            drop_axis(q1, axis),
+            drop_axis(q2, axis),
+        );
+        let collapsed = orient2d(a, b, c) == Orientation::Collinear
+            && orient2d(a, b, d) == Orientation::Collinear
+            && orient2d(a, c, d) == Orientation::Collinear;
+        if !collapsed {
+            return segment_intersection(a, b, c, d).is_some();
+        }
+    }
+    // All four points collinear in 3D: closed intervals on one line overlap
+    // iff some endpoint of either segment lies on the other.
+    point_on_segment_3d(q1, p1, p2)
+        || point_on_segment_3d(q2, p1, p2)
+        || point_on_segment_3d(p1, q1, q2)
+        || point_on_segment_3d(p2, q1, q2)
+}
+
+/// Whether the closed segment `[p, q]` shares at least one point with the
+/// closed triangle `t`, exactly. Endpoint touches, edge grazes, and coplanar
+/// crossings all intersect; degenerate inputs reduce to the lower-dimensional
+/// tests.
+pub fn segment_intersects_triangle_3d(p: [f64; 3], q: [f64; 3], t: [[f64; 3]; 3]) -> bool {
+    match classify_triangle(t) {
+        TriangleShape::Proper => {}
+        TriangleShape::Segment([a, b]) => return segments_intersect_3d(p, q, a, b),
+        TriangleShape::Point(v) => return point_on_segment_3d(v, p, q),
+    }
+    if p == q {
+        return point_in_triangle_3d(p, t);
+    }
+
+    let side_p = orient3d(t[0], t[1], t[2], p);
+    let side_q = orient3d(t[0], t[1], t[2], q);
+    match (side_p, side_q) {
+        // Both endpoints strictly on one side of the triangle's plane.
+        (Orientation::Clockwise, Orientation::Clockwise)
+        | (Orientation::CounterClockwise, Orientation::CounterClockwise) => false,
+        // The segment lies in the plane: a 2D segment × triangle problem.
+        (Orientation::Collinear, Orientation::Collinear) => {
+            let axis = projection_axis(t);
+            let tri = project_triangle(t, axis);
+            let (a, b) = (drop_axis(p, axis), drop_axis(q, axis));
+            point_in_triangle_2d(a, tri)
+                || point_in_triangle_2d(b, tri)
+                || triangle_edges_2d(tri)
+                    .iter()
+                    .any(|&(u, v)| segment_intersection(a, b, u, v).is_some())
+        }
+        // One endpoint in the plane: the plane intersection is that endpoint.
+        (Orientation::Collinear, _) => point_in_triangle_3d(p, t),
+        (_, Orientation::Collinear) => point_in_triangle_3d(q, t),
+        // The segment straddles the plane: it meets the closed triangle iff
+        // the line through `p, q` does not pass strictly outside any edge —
+        // i.e. no two of the three edge orientations strictly disagree.
+        _ => {
+            let u = orient3d(p, q, t[0], t[1]);
+            let v = orient3d(p, q, t[1], t[2]);
+            let w = orient3d(p, q, t[2], t[0]);
+            !has_strict_disagreement(u, v, w)
+        }
+    }
+}
+
+/// Whether the two closed triangles share at least one point, exactly.
+/// Coplanar overlaps (including full containment) and boundary contacts all
+/// intersect; degenerate triangles reduce to segment / point tests.
+pub fn triangles_intersect_3d(t: [[f64; 3]; 3], s: [[f64; 3]; 3]) -> bool {
+    match classify_triangle(t) {
+        TriangleShape::Proper => {}
+        TriangleShape::Segment([a, b]) => return segment_intersects_triangle_3d(a, b, s),
+        TriangleShape::Point(p) => return point_in_triangle_3d(p, s),
+    }
+    match classify_triangle(s) {
+        TriangleShape::Proper => {}
+        TriangleShape::Segment([a, b]) => return segment_intersects_triangle_3d(a, b, t),
+        TriangleShape::Point(p) => return point_in_triangle_3d(p, t),
+    }
+
+    // Early reject: all of `s` strictly on one side of `t`'s plane (or vice
+    // versa) cannot intersect.
+    let sides = s.map(|p| orient3d(t[0], t[1], t[2], p));
+    if sides.iter().all(|&o| o == Orientation::CounterClockwise)
+        || sides.iter().all(|&o| o == Orientation::Clockwise)
+    {
+        return false;
+    }
+
+    if sides.iter().all(|&o| o == Orientation::Collinear) {
+        // Coplanar triangles: a 2D overlap test in a projection injective on
+        // the shared plane (`t` is proper, so its own projection axis works).
+        let axis = projection_axis(t);
+        let (pt, ps) = (project_triangle(t, axis), project_triangle(s, axis));
+        return ps.iter().any(|&p| point_in_triangle_2d(p, pt))
+            || pt.iter().any(|&p| point_in_triangle_2d(p, ps))
+            || triangle_edges_2d(pt).iter().any(|&(a, b)| {
+                triangle_edges_2d(ps)
+                    .iter()
+                    .any(|&(c, d)| segment_intersection(a, b, c, d).is_some())
+            });
+    }
+
+    // Non-coplanar: a non-empty intersection is a segment whose endpoints lie
+    // where one triangle's boundary crosses the other's closed region, so an
+    // edge of one intersects the other.
+    triangle_edges_3d(t)
+        .iter()
+        .any(|&(a, b)| segment_intersects_triangle_3d(a, b, s))
+        || triangle_edges_3d(s)
+            .iter()
+            .any(|&(a, b)| segment_intersects_triangle_3d(a, b, t))
+}
+
+/// The true point-set shape of a possibly-degenerate triangle.
+pub(crate) enum TriangleShape {
+    /// Three non-collinear corners: a genuine triangle.
+    Proper,
+    /// Collinear but not coincident corners: the spanned segment.
+    Segment([[f64; 3]; 2]),
+    /// All corners coincident.
+    Point([f64; 3]),
+}
+
+/// Classify a triangle by the point set its corners span, exactly.
+pub(crate) fn classify_triangle(t: [[f64; 3]; 3]) -> TriangleShape {
+    if !collinear_3d(t[0], t[1], t[2]) {
+        return TriangleShape::Proper;
+    }
+    if t[0] == t[1] && t[1] == t[2] {
+        return TriangleShape::Point(t[0]);
+    }
+    // Collinear: the spanned segment is the pair containing the third point.
+    for (a, b, c) in [(0, 1, 2), (0, 2, 1), (1, 2, 0)] {
+        if point_on_segment_3d(t[c], t[a], t[b]) {
+            return TriangleShape::Segment([t[a], t[b]]);
+        }
+    }
+    // Unreachable for exact arithmetic; be safe rather than panic.
+    TriangleShape::Segment([t[0], t[1]])
+}
+
+/// An axis whose drop projection keeps a **proper** triangle non-degenerate
+/// (injective on the triangle's plane). At least one exists: the cross
+/// product's components are the three projected signed areas, and a proper
+/// triangle has a non-zero cross product.
+pub(crate) fn projection_axis(t: [[f64; 3]; 3]) -> usize {
+    for axis in [2, 1, 0] {
+        if orient2d(
+            drop_axis(t[0], axis),
+            drop_axis(t[1], axis),
+            drop_axis(t[2], axis),
+        ) != Orientation::Collinear
+        {
+            return axis;
+        }
+    }
+    unreachable!("a proper triangle projects non-degenerately along some axis")
+}
+
+/// Drop the given axis: the remaining two coordinates, in cyclic order.
+#[inline]
+pub(crate) fn drop_axis(p: [f64; 3], axis: usize) -> [f64; 2] {
+    [p[(axis + 1) % 3], p[(axis + 2) % 3]]
+}
+
+/// The triangle's corners with the given axis dropped.
+#[inline]
+pub(crate) fn project_triangle(t: [[f64; 3]; 3], axis: usize) -> [[f64; 2]; 3] {
+    t.map(|p| drop_axis(p, axis))
+}
+
+/// The three directed edges of a 3D triangle.
+#[inline]
+fn triangle_edges_3d(t: [[f64; 3]; 3]) -> [([f64; 3], [f64; 3]); 3] {
+    [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])]
+}
+
+/// The three directed edges of a 2D triangle.
+#[inline]
+fn triangle_edges_2d(t: [[f64; 2]; 3]) -> [([f64; 2], [f64; 2]); 3] {
+    [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])]
+}
+
+/// Whether two of the three orientations strictly disagree (one clockwise and
+/// one counter-clockwise); collinear entries never disagree.
+fn has_strict_disagreement(u: Orientation, v: Orientation, w: Orientation) -> bool {
+    let has_cw = [u, v, w].contains(&Orientation::Clockwise);
+    let has_ccw = [u, v, w].contains(&Orientation::CounterClockwise);
+    has_cw && has_ccw
+}
+
+/// Whether `value` lies within `[min(a, b), max(a, b)]` (inclusive).
+#[inline]
+fn value_in_between(value: f64, a: f64, b: f64) -> bool {
+    let (lo, hi) = if a < b { (a, b) } else { (b, a) };
+    value >= lo && value <= hi
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TRI: [[f64; 3]; 3] = [[0.0, 0.0, 0.0], [4.0, 0.0, 0.0], [0.0, 4.0, 0.0]];
+    /// The same triangle in a tilted plane (z = x).
+    const TILTED: [[f64; 3]; 3] = [[0.0, 0.0, 0.0], [4.0, 0.0, 4.0], [0.0, 4.0, 0.0]];
+
+    #[test]
+    fn collinear_and_on_segment() {
+        assert!(collinear_3d(
+            [0.0, 0.0, 0.0],
+            [2.0, 2.0, 2.0],
+            [5.0, 5.0, 5.0]
+        ));
+        assert!(!collinear_3d(
+            [0.0, 0.0, 0.0],
+            [2.0, 2.0, 2.0],
+            [5.0, 5.0, 5.1]
+        ));
+        assert!(point_on_segment_3d(
+            [1.0, 1.0, 1.0],
+            [0.0, 0.0, 0.0],
+            [2.0, 2.0, 2.0]
+        ));
+        // Collinear but beyond the endpoint.
+        assert!(!point_on_segment_3d(
+            [3.0, 3.0, 3.0],
+            [0.0, 0.0, 0.0],
+            [2.0, 2.0, 2.0]
+        ));
+        // Degenerate segment.
+        assert!(point_on_segment_3d(
+            [1.0, 1.0, 1.0],
+            [1.0, 1.0, 1.0],
+            [1.0, 1.0, 1.0]
+        ));
+    }
+
+    #[test]
+    fn point_in_triangle_cases() {
+        assert!(point_in_triangle_3d([1.0, 1.0, 0.0], TRI));
+        assert!(point_in_triangle_3d([2.0, 0.0, 0.0], TRI)); // edge
+        assert!(point_in_triangle_3d([0.0, 4.0, 0.0], TRI)); // vertex
+        assert!(!point_in_triangle_3d([1.0, 1.0, 0.5], TRI)); // off plane
+        assert!(!point_in_triangle_3d([3.0, 3.0, 0.0], TRI)); // in plane, outside
+        assert!(point_in_triangle_3d([1.0, 1.0, 1.0], TILTED));
+        assert!(!point_in_triangle_3d([1.0, 1.0, 0.0], TILTED));
+
+        // A vertical triangle (constant y) exercises the projection choice.
+        let vertical = [[0.0, 1.0, 0.0], [4.0, 1.0, 0.0], [0.0, 1.0, 4.0]];
+        assert!(point_in_triangle_3d([1.0, 1.0, 1.0], vertical));
+        assert!(!point_in_triangle_3d([1.0, 1.5, 1.0], vertical));
+
+        // A degenerate (collinear) triangle is its spanned segment.
+        let flat = [[0.0, 0.0, 0.0], [4.0, 0.0, 0.0], [2.0, 0.0, 0.0]];
+        assert!(point_in_triangle_3d([3.0, 0.0, 0.0], flat));
+        assert!(!point_in_triangle_3d([3.0, 0.1, 0.0], flat));
+    }
+
+    #[test]
+    fn segment_pairs() {
+        // Proper coplanar crossing.
+        assert!(segments_intersect_3d(
+            [0.0, 0.0, 0.0],
+            [2.0, 2.0, 2.0],
+            [2.0, 0.0, 0.0],
+            [0.0, 2.0, 2.0]
+        ));
+        // Skew.
+        assert!(!segments_intersect_3d(
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0],
+            [0.0, -1.0, 1.0]
+        ));
+        // Endpoint touch.
+        assert!(segments_intersect_3d(
+            [0.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0],
+            [1.0, 1.0, 1.0],
+            [2.0, 0.0, 5.0]
+        ));
+        // Collinear overlap.
+        assert!(segments_intersect_3d(
+            [0.0, 0.0, 0.0],
+            [4.0, 4.0, 4.0],
+            [2.0, 2.0, 2.0],
+            [6.0, 6.0, 6.0]
+        ));
+        // Collinear disjoint.
+        assert!(!segments_intersect_3d(
+            [0.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0],
+            [2.0, 2.0, 2.0],
+            [3.0, 3.0, 3.0]
+        ));
+        // Parallel in one plane.
+        assert!(!segments_intersect_3d(
+            [0.0, 0.0, 0.0],
+            [4.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [4.0, 1.0, 0.0]
+        ));
+        // A vertical plane (all x equal) exercises the projection fallback.
+        assert!(segments_intersect_3d(
+            [1.0, 0.0, 0.0],
+            [1.0, 2.0, 2.0],
+            [1.0, 0.0, 2.0],
+            [1.0, 2.0, 0.0]
+        ));
+    }
+
+    #[test]
+    fn segment_triangle_cases() {
+        // Straddling pierce through the interior.
+        assert!(segment_intersects_triangle_3d(
+            [1.0, 1.0, -1.0],
+            [1.0, 1.0, 1.0],
+            TRI
+        ));
+        // Straddling the plane but passing outside.
+        assert!(!segment_intersects_triangle_3d(
+            [5.0, 5.0, -1.0],
+            [5.0, 5.0, 1.0],
+            TRI
+        ));
+        // Pierce exactly through a vertex.
+        assert!(segment_intersects_triangle_3d(
+            [0.0, 0.0, -1.0],
+            [0.0, 0.0, 1.0],
+            TRI
+        ));
+        // Pierce exactly through an edge.
+        assert!(segment_intersects_triangle_3d(
+            [2.0, 0.0, -1.0],
+            [2.0, 0.0, 1.0],
+            TRI
+        ));
+        // Through the edge's extension (outside the triangle).
+        assert!(!segment_intersects_triangle_3d(
+            [5.0, 0.0, -1.0],
+            [5.0, 0.0, 1.0],
+            TRI
+        ));
+        // Endpoint resting on the triangle.
+        assert!(segment_intersects_triangle_3d(
+            [1.0, 1.0, 0.0],
+            [1.0, 1.0, 5.0],
+            TRI
+        ));
+        // Entirely above.
+        assert!(!segment_intersects_triangle_3d(
+            [1.0, 1.0, 1.0],
+            [1.0, 1.0, 5.0],
+            TRI
+        ));
+        // Coplanar: crossing, contained, and disjoint.
+        assert!(segment_intersects_triangle_3d(
+            [-1.0, 1.0, 0.0],
+            [5.0, 1.0, 0.0],
+            TRI
+        ));
+        assert!(segment_intersects_triangle_3d(
+            [0.5, 0.5, 0.0],
+            [1.0, 1.0, 0.0],
+            TRI
+        ));
+        assert!(!segment_intersects_triangle_3d(
+            [5.0, 5.0, 0.0],
+            [6.0, 5.0, 0.0],
+            TRI
+        ));
+    }
+
+    #[test]
+    fn triangle_pairs() {
+        // Piercing cross.
+        let pierce = [[1.0, 1.0, -1.0], [1.0, 1.0, 1.0], [3.0, 3.0, 1.0]];
+        assert!(triangles_intersect_3d(TRI, pierce));
+        assert!(triangles_intersect_3d(pierce, TRI));
+        // Strictly above.
+        let above = TRI.map(|[x, y, _]| [x, y, 1.0]);
+        assert!(!triangles_intersect_3d(TRI, above));
+        // Shared edge only.
+        let folded = [[0.0, 0.0, 0.0], [4.0, 0.0, 0.0], [0.0, -4.0, 4.0]];
+        assert!(triangles_intersect_3d(TRI, folded));
+        // Shared vertex only.
+        let corner = [[0.0, 0.0, 0.0], [-4.0, 0.0, 1.0], [0.0, -4.0, 1.0]];
+        assert!(triangles_intersect_3d(TRI, corner));
+        // Coplanar overlap.
+        let coplanar_overlap = [[1.0, 1.0, 0.0], [5.0, 1.0, 0.0], [1.0, 5.0, 0.0]];
+        assert!(triangles_intersect_3d(TRI, coplanar_overlap));
+        // Coplanar containment (small triangle strictly inside).
+        let inside = [[0.5, 0.5, 0.0], [1.5, 0.5, 0.0], [0.5, 1.5, 0.0]];
+        assert!(triangles_intersect_3d(TRI, inside));
+        assert!(triangles_intersect_3d(inside, TRI));
+        // Coplanar disjoint.
+        let coplanar_far = [[10.0, 10.0, 0.0], [14.0, 10.0, 0.0], [10.0, 14.0, 0.0]];
+        assert!(!triangles_intersect_3d(TRI, coplanar_far));
+        // Degenerate triangle acting as a segment.
+        let needle = [[1.0, 1.0, -1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 0.5]];
+        assert!(triangles_intersect_3d(TRI, needle));
+    }
+}

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -23,20 +23,44 @@
 //! The 2D leaves' optional per-vertex elevation is ignored throughout. The
 //! constructed counterparts, boolean overlay, line clipping, segment
 //! intersection points, live in [`overlay`](crate::overlay) over the same
-//! views and kernel. Ray casting and 3D pairs are not yet supported.
+//! views and kernel.
+//!
+//! The 3D family covers intersection *tests* and queries, not a volumetric
+//! DE-9IM:
+//!
+//! - [`intersects()`] also takes 3D × 3D pairs, through the exact
+//!   [`kernel3d`] primitives over triangle-set views ([`view3d`]); a `Solid`
+//!   is volumetric (containment without shell contact intersects).
+//! - [`point_position_3d`]: coordinate vs. 3D geometry, including exact
+//!   ray-parity **point-in-solid**.
+//! - [`ray_cast`] / [`closest_ray_hit`]: [`Ray3D`] casting against every
+//!   surface, with Möller–Trumbore semantics.
+//!
+//! `contains` / `covers` / `relate` remain 2D-only; `Csg` and `PointCloud`
+//! leaves are not supported by the 3D operations.
 
 pub mod contains;
 mod edge_set;
 pub mod intersects;
+pub mod intersects3d;
 pub mod kernel;
+pub mod kernel3d;
 pub mod position;
+pub mod position3d;
+pub mod ray;
 pub mod relate;
+#[cfg(test)]
+pub(crate) mod test3d;
 pub mod view;
+pub mod view3d;
 
 pub use contains::{contains, covers};
 pub use intersects::intersects;
+pub use intersects3d::intersects_3d;
 pub use kernel::CoordPos;
 pub use position::point_position_2d;
+pub use position3d::point_position_3d;
+pub use ray::{closest_ray_hit, ray_cast, Ray3D, RayHit};
 pub use relate::{relate, Dimensions, IntersectionMatrix};
 
 use crate::coordinate::CoordinateFrame;
@@ -67,6 +91,12 @@ pub enum PredicateError {
         /// The right operand's concrete type name.
         right: &'static str,
     },
+    /// The operation is not defined for a concrete geometry type an operand
+    /// contains (a `Csg` or `PointCloud` leaf in the 3D operations).
+    Unsupported {
+        /// The offending concrete type name.
+        geometry: &'static str,
+    },
 }
 
 impl core::fmt::Display for PredicateError {
@@ -83,6 +113,9 @@ impl core::fmt::Display for PredicateError {
             }
             PredicateError::UnsupportedPair { left, right } => {
                 write!(f, "operation is not defined for `{left}` and `{right}`")
+            }
+            PredicateError::Unsupported { geometry } => {
+                write!(f, "operation is not defined for `{geometry}`")
             }
         }
     }
@@ -104,11 +137,13 @@ pub fn require_same_frame(a: &CoordinateFrame, b: &CoordinateFrame) -> Result<()
     }
 }
 
-/// Flatten both operands of a binary 2D operation into their 2D leaves under
-/// the shared dimension policy: a 2D × 3D pair is
-/// [`CrossDimension`](PredicateError::CrossDimension), a purely 3D pair is
-/// [`UnsupportedPair`](PredicateError::UnsupportedPair). `Geometry::None` and
-/// empty collections flatten to no leaves.
+/// Flatten both operands of a **2D-only** binary operation (`contains`,
+/// `relate`, the overlays) into their 2D leaves under the shared dimension
+/// policy: a 2D × 3D pair is
+/// [`CrossDimension`](PredicateError::CrossDimension), a purely 3D pair
+/// [`UnsupportedPair`](PredicateError::UnsupportedPair): these operations
+/// have no 3D counterpart (there is no volumetric DE-9IM or overlay).
+/// `Geometry::None` and empty collections flatten to no leaves.
 pub(crate) fn flatten_2d_pair<'a>(
     a: &'a Geometry,
     b: &'a Geometry,
@@ -152,5 +187,7 @@ mod tests {
             right: "Solid",
         };
         assert!(up.to_string().contains("Point2D") && up.to_string().contains("Solid"));
+        let u = PredicateError::Unsupported { geometry: "Csg" };
+        assert!(u.to_string().contains("Csg"));
     }
 }

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -33,8 +33,10 @@
 //!   is volumetric (containment without shell contact intersects).
 //! - [`point_position_3d`]: coordinate vs. 3D geometry, including exact
 //!   ray-parity **point-in-solid**.
-//! - [`ray_cast`] / [`closest_ray_hit`]: [`Ray3D`] casting against every
-//!   surface, with Möller–Trumbore semantics.
+//! - [`ray_cast`] / [`closest_ray_hit`]: one-shot [`Ray3D`] casting against
+//!   every surface, with Möller–Trumbore semantics; [`RayCaster`] prepares a
+//!   geometry once (bounding-volume hierarchy over large surfaces) for casting
+//!   many rays.
 //! - [`relate_coplanar`] / [`relate_xy`]: the DE-9IM matrix of mutually
 //!   coplanar 3D geometries in their shared plane, and of `(x, y)`
 //!   footprints.
@@ -69,7 +71,7 @@ pub use kernel::CoordPos;
 pub use position::point_position_2d;
 pub use position3d::point_position_3d;
 pub use projection::{relate_coplanar, relate_xy};
-pub use ray::{closest_ray_hit, ray_cast, Ray3D, RayHit};
+pub use ray::{closest_ray_hit, ray_cast, Ray3D, RayCaster, RayHit};
 pub use relate::{relate, Dimensions, IntersectionMatrix};
 
 use crate::coordinate::CoordinateFrame;

--- a/engine/runtime/geometry/src/predicates/mod.rs
+++ b/engine/runtime/geometry/src/predicates/mod.rs
@@ -25,8 +25,8 @@
 //! intersection points, live in [`overlay`](crate::overlay) over the same
 //! views and kernel.
 //!
-//! The 3D family covers intersection *tests* and queries, not a volumetric
-//! DE-9IM:
+//! The 3D family covers intersection *tests*, projections, and metric
+//! queries, not a volumetric DE-9IM:
 //!
 //! - [`intersects()`] also takes 3D × 3D pairs, through the exact
 //!   [`kernel3d`] primitives over triangle-set views ([`view3d`]); a `Solid`
@@ -35,11 +35,17 @@
 //!   ray-parity **point-in-solid**.
 //! - [`ray_cast`] / [`closest_ray_hit`]: [`Ray3D`] casting against every
 //!   surface, with Möller–Trumbore semantics.
+//! - [`relate_coplanar`] / [`relate_xy`]: the DE-9IM matrix of mutually
+//!   coplanar 3D geometries in their shared plane, and of `(x, y)`
+//!   footprints.
+//! - [`distance()`]: the minimum Euclidean distance between two 2D or two
+//!   3D geometries, `0` exactly when they intersect.
 //!
 //! `contains` / `covers` / `relate` remain 2D-only; `Csg` and `PointCloud`
 //! leaves are not supported by the 3D operations.
 
 pub mod contains;
+pub mod distance;
 mod edge_set;
 pub mod intersects;
 pub mod intersects3d;
@@ -47,6 +53,7 @@ pub mod kernel;
 pub mod kernel3d;
 pub mod position;
 pub mod position3d;
+pub mod projection;
 pub mod ray;
 pub mod relate;
 #[cfg(test)]
@@ -55,11 +62,13 @@ pub mod view;
 pub mod view3d;
 
 pub use contains::{contains, covers};
+pub use distance::distance;
 pub use intersects::intersects;
 pub use intersects3d::intersects_3d;
 pub use kernel::CoordPos;
 pub use position::point_position_2d;
 pub use position3d::point_position_3d;
+pub use projection::{relate_coplanar, relate_xy};
 pub use ray::{closest_ray_hit, ray_cast, Ray3D, RayHit};
 pub use relate::{relate, Dimensions, IntersectionMatrix};
 
@@ -92,11 +101,16 @@ pub enum PredicateError {
         right: &'static str,
     },
     /// The operation is not defined for a concrete geometry type an operand
-    /// contains (a `Csg` or `PointCloud` leaf in the 3D operations).
+    /// contains (e.g. a `Csg` or `PointCloud` leaf in the 3D operations, or a
+    /// `Solid` in the projection relates).
     Unsupported {
         /// The offending concrete type name.
         geometry: &'static str,
     },
+    /// The operands of an in-plane operation do not lie in one common plane.
+    /// [`relate_coplanar`] is defined only for mutually coplanar 3D
+    /// geometries; there is no volumetric DE-9IM to fall back to.
+    NotCoplanar,
 }
 
 impl core::fmt::Display for PredicateError {
@@ -116,6 +130,9 @@ impl core::fmt::Display for PredicateError {
             }
             PredicateError::Unsupported { geometry } => {
                 write!(f, "operation is not defined for `{geometry}`")
+            }
+            PredicateError::NotCoplanar => {
+                write!(f, "operands do not lie in one common plane")
             }
         }
     }

--- a/engine/runtime/geometry/src/predicates/position3d.rs
+++ b/engine/runtime/geometry/src/predicates/position3d.rs
@@ -1,0 +1,561 @@
+//! Point position relative to 3D geometry, including **point-in-solid**.
+//!
+//! [`point_position_3d`] classifies a coordinate against any 3D geometry as
+//! [`Inside`](CoordPos::Inside) / [`OnBoundary`](CoordPos::OnBoundary) /
+//! [`Outside`](CoordPos::Outside), with the per-leaf semantics graded by
+//! codimension:
+//!
+//! - **Point** — the interior is the point itself (as in 2D).
+//! - **LineString** — the chain minus its endpoints is interior, open-chain
+//!   endpoints are boundary (as in 2D, counted mod 2 across collection
+//!   members).
+//! - **Polygon / meshes** — a surface embedded in 3D has no volumetric
+//!   interior: every point of it classifies as `OnBoundary`.
+//! - **Solid** — the genuinely volumetric case, which 2D has no analog of and
+//!   the legacy geometry never implemented: on any shell is `OnBoundary`,
+//!   enclosed by the exterior shell and outside every interior (void) shell is
+//!   `Inside`.
+//! - **Collections** — the union: the highest member classification wins.
+//!
+//! Point-in-solid is decided by **exact ray-crossing parity**: a probe segment
+//! is cast from the coordinate to a point outside the shell's bounding box and
+//! the strict crossings through shell triangles are counted, every sign coming
+//! from robust [`orient3d`]. A probe that grazes the shell — hitting an edge,
+//! a vertex, or a triangle's plane tangentially, where naive parity counters
+//! silently double-count — is *detected exactly* (some orientation sign is
+//! zero) and retried with a different probe target instead of being fudged
+//! with an epsilon. Shells are assumed closed and non-self-intersecting (the
+//! [`Validate`](crate::validation_next) contract); parity over an open shell
+//! is meaningless.
+
+use crate::ops::triangulation::Cache;
+use crate::solid::Solid;
+use crate::Euclidean3DGeometry;
+
+use super::kernel::{orient3d, CoordPos, Orientation};
+use super::kernel3d::{point_in_triangle_3d, point_on_segment_3d};
+use super::view3d::{flatten_3d, require_common_frame_3d, Leaf3D, TriangleSet};
+use super::{PredicateError, Result};
+
+/// Position of a coordinate relative to a 3D geometry, treating collections as
+/// point-set unions of their members. The coordinate is taken to be in the
+/// geometry's own frame; the geometry's leaves must agree on one
+/// ([`MixedFrames`](PredicateError::MixedFrames) otherwise), and a `Csg` or
+/// `PointCloud` leaf is
+/// [`Unsupported`](PredicateError::Unsupported).
+pub fn point_position_3d(coord: [f64; 3], geometry: &Euclidean3DGeometry) -> Result<CoordPos> {
+    let mut leaves = Vec::new();
+    let mut unsupported = None;
+    flatten_3d(geometry, &mut leaves, &mut unsupported);
+    if let Some(name) = unsupported {
+        return Err(PredicateError::Unsupported { geometry: name });
+    }
+    require_common_frame_3d(&leaves, &[])?;
+
+    let mut cache = Cache::new();
+    let mut best = CoordPos::Outside;
+    let mut boundary_endpoints = 0usize;
+    let mut on_any_line = false;
+    for leaf in &leaves {
+        let pos = match leaf {
+            Leaf3D::Point(p) => {
+                if coord == p.position() {
+                    CoordPos::Inside
+                } else {
+                    CoordPos::Outside
+                }
+            }
+            Leaf3D::Line(l) => {
+                let coords = l.coords();
+                if on_chain_3d(coord, coords) {
+                    on_any_line = true;
+                }
+                let closed = coords.len() >= 2 && coords.first() == coords.last();
+                if !closed && coords.len() >= 2 {
+                    if coord == coords[0] {
+                        boundary_endpoints += 1;
+                    }
+                    if coord == coords[coords.len() - 1] {
+                        boundary_endpoints += 1;
+                    }
+                }
+                CoordPos::Outside // combined below, mod 2 across members
+            }
+            Leaf3D::Polygon(p) => {
+                surface_position(coord, &TriangleSet::from_polygon(p, &mut cache))
+            }
+            Leaf3D::PolygonMesh(m) => surface_position(
+                coord,
+                &TriangleSet::from_polygon_mesh_data(m.data(), &mut cache),
+            ),
+            Leaf3D::TriangularMesh(m) => {
+                surface_position(coord, &TriangleSet::from_triangular_data(m.data()))
+            }
+            Leaf3D::Solid(s) => solid_position(coord, s, &mut cache),
+        };
+        best = max_pos(best, pos);
+        if best == CoordPos::Inside {
+            return Ok(CoordPos::Inside);
+        }
+    }
+
+    let line_pos = if !on_any_line {
+        CoordPos::Outside
+    } else if boundary_endpoints % 2 == 1 {
+        CoordPos::OnBoundary
+    } else {
+        CoordPos::Inside
+    };
+    Ok(max_pos(best, line_pos))
+}
+
+/// Position relative to one solid: on any shell is boundary; inside the
+/// exterior shell and outside every void shell is inside.
+pub(crate) fn solid_position(coord: [f64; 3], solid: &Solid, cache: &mut Cache) -> CoordPos {
+    let exterior = TriangleSet::from_shell(solid.exterior(), cache);
+    let voids: Vec<TriangleSet<'_>> = solid
+        .interiors()
+        .iter()
+        .map(|shell| TriangleSet::from_shell(shell, cache))
+        .collect();
+    solid_position_sets(coord, &exterior, voids.iter())
+}
+
+/// [`solid_position`] over already-extracted shell triangle sets, for callers
+/// that hold them (the 3D `intersects` keeps them for its boundary tests).
+pub(crate) fn solid_position_sets<'a, 'b>(
+    coord: [f64; 3],
+    exterior: &TriangleSet<'a>,
+    voids: impl Iterator<Item = &'b TriangleSet<'a>>,
+) -> CoordPos
+where
+    'a: 'b,
+{
+    match shell_position(coord, exterior) {
+        CoordPos::OnBoundary => return CoordPos::OnBoundary,
+        CoordPos::Outside => return CoordPos::Outside,
+        CoordPos::Inside => {}
+    }
+    for void in voids {
+        match shell_position(coord, void) {
+            CoordPos::OnBoundary => return CoordPos::OnBoundary,
+            CoordPos::Inside => return CoordPos::Outside, // in a hollow
+            CoordPos::Outside => {}
+        }
+    }
+    CoordPos::Inside
+}
+
+/// On-surface position: `OnBoundary` anywhere on the triangle set, else
+/// `Outside` (a surface embedded in 3D has no volumetric interior).
+pub(crate) fn surface_position(coord: [f64; 3], set: &TriangleSet<'_>) -> CoordPos {
+    if set.triangles().any(|t| point_in_triangle_3d(coord, t)) {
+        CoordPos::OnBoundary
+    } else {
+        CoordPos::Outside
+    }
+}
+
+/// Position relative to one closed shell, by exact ray-crossing parity.
+pub(crate) fn shell_position(coord: [f64; 3], shell: &TriangleSet<'_>) -> CoordPos {
+    if shell.is_empty() {
+        return CoordPos::Outside;
+    }
+    let (min, max) = pool_bounds(shell.pool());
+    if (0..3).any(|k| coord[k] < min[k] || coord[k] > max[k]) {
+        return CoordPos::Outside;
+    }
+    if shell.triangles().any(|t| point_in_triangle_3d(coord, t)) {
+        return CoordPos::OnBoundary;
+    }
+
+    'attempt: for attempt in 0..MAX_PROBE_ATTEMPTS {
+        let target = probe_target(min, max, attempt);
+        let mut crossings = 0usize;
+        for t in shell.triangles() {
+            match probe_crossing(coord, target, t) {
+                ProbeCrossing::Miss => {}
+                ProbeCrossing::Cross => crossings += 1,
+                ProbeCrossing::Degenerate => continue 'attempt,
+            }
+        }
+        return if crossings % 2 == 1 {
+            CoordPos::Inside
+        } else {
+            CoordPos::Outside
+        };
+    }
+    // Every probe grazed the shell — possible only for wildly degenerate
+    // input. Degrade to the boundary answer rather than guess a side.
+    CoordPos::OnBoundary
+}
+
+/// How the probe segment relates to one shell triangle.
+enum ProbeCrossing {
+    /// No shared point.
+    Miss,
+    /// One strict crossing through the triangle's interior.
+    Cross,
+    /// A graze (edge, vertex, or coplanar contact): the parity of this probe
+    /// direction is unreliable — retry with another.
+    Degenerate,
+}
+
+/// Exact classification of the probe segment `[p, target]` against a shell
+/// triangle. `p` is known to be off the shell and `target` outside its
+/// bounding box.
+fn probe_crossing(p: [f64; 3], target: [f64; 3], t: [[f64; 3]; 3]) -> ProbeCrossing {
+    let side_p = orient3d(t[0], t[1], t[2], p);
+    let side_q = orient3d(t[0], t[1], t[2], target);
+    match (side_p, side_q) {
+        // A degenerate triangle contributes no plane crossing; parity ignores
+        // it exactly as its zero-area face bounds no volume.
+        _ if side_p == Orientation::Collinear && side_q == Orientation::Collinear => {
+            // Both endpoints in the triangle's plane: either the triangle is
+            // degenerate or the probe runs inside the plane; both are grazes
+            // unless the probe misses the triangle's bounding box entirely.
+            if probe_meets_triangle_in_plane(p, target, t) {
+                ProbeCrossing::Degenerate
+            } else {
+                ProbeCrossing::Miss
+            }
+        }
+        // The probe touches the plane only at an endpoint: `p` itself is off
+        // the triangle (pre-checked) and `target` is outside the shell's box,
+        // so a touch at either endpoint cannot be on the triangle.
+        (Orientation::Collinear, _) | (_, Orientation::Collinear) => ProbeCrossing::Miss,
+        (a, b) if a == b => ProbeCrossing::Miss,
+        // A strict straddle: classify by the three edge orientations.
+        _ => {
+            let u = orient3d(p, target, t[0], t[1]);
+            let v = orient3d(p, target, t[1], t[2]);
+            let w = orient3d(p, target, t[2], t[0]);
+            if u == Orientation::Collinear
+                || v == Orientation::Collinear
+                || w == Orientation::Collinear
+            {
+                // The crossing would sit exactly on a triangle edge or vertex,
+                // shared with a neighboring face: unreliable to count.
+                return ProbeCrossing::Degenerate;
+            }
+            if u == v && v == w {
+                ProbeCrossing::Cross
+            } else {
+                ProbeCrossing::Miss
+            }
+        }
+    }
+}
+
+/// Whether a coplanar probe segment shares a point with the triangle (used
+/// only to decide graze vs. clean miss when both probe endpoints land in a
+/// triangle's plane).
+fn probe_meets_triangle_in_plane(p: [f64; 3], q: [f64; 3], t: [[f64; 3]; 3]) -> bool {
+    super::kernel3d::segment_intersects_triangle_3d(p, q, t)
+}
+
+const MAX_PROBE_ATTEMPTS: u32 = 32;
+
+/// The probe target for one attempt: a point strictly outside the shell's
+/// bounding box, varied across attempts (corner choice from the attempt's low
+/// bits, offsets jittered by a splitmix64 stream) so that consecutive
+/// attempts take genuinely different directions.
+fn probe_target(min: [f64; 3], max: [f64; 3], attempt: u32) -> [f64; 3] {
+    let extent = (0..3).map(|k| max[k] - min[k]).fold(1.0f64, f64::max);
+    let mut state = 0x9E37_79B9_7F4A_7C15u64.wrapping_mul(u64::from(attempt) + 1);
+    let mut coord = [0.0f64; 3];
+    for (k, c) in coord.iter_mut().enumerate() {
+        state = splitmix64(state);
+        // Offset in [1, 2) times the extent, beyond the box on this axis.
+        let offset = (1.0 + unit_f64(state)) * extent;
+        *c = if attempt >> k & 1 == 0 {
+            max[k] + offset
+        } else {
+            min[k] - offset
+        };
+    }
+    coord
+}
+
+/// One step of the splitmix64 generator.
+fn splitmix64(state: u64) -> u64 {
+    let mut z = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Map 64 random bits to a float in `[0, 1)`.
+fn unit_f64(bits: u64) -> f64 {
+    (bits >> 11) as f64 / (1u64 << 53) as f64
+}
+
+/// The bounding box of a vertex pool (which is non-empty for a non-empty
+/// triangle set).
+fn pool_bounds(pool: &[[f64; 3]]) -> ([f64; 3], [f64; 3]) {
+    let mut min = [f64::INFINITY; 3];
+    let mut max = [f64::NEG_INFINITY; 3];
+    for p in pool {
+        for k in 0..3 {
+            min[k] = min[k].min(p[k]);
+            max[k] = max[k].max(p[k]);
+        }
+    }
+    (min, max)
+}
+
+/// Whether the coordinate lies anywhere on the 3D chain.
+pub(crate) fn on_chain_3d(coord: [f64; 3], coords: &[[f64; 3]]) -> bool {
+    match coords {
+        [] => false,
+        [single] => coord == *single,
+        _ => coords
+            .windows(2)
+            .any(|e| point_on_segment_3d(coord, e[0], e[1])),
+    }
+}
+
+/// The higher of two classifications (`Inside` > `OnBoundary` > `Outside`).
+fn max_pos(a: CoordPos, b: CoordPos) -> CoordPos {
+    fn rank(p: CoordPos) -> u8 {
+        match p {
+            CoordPos::Outside => 0,
+            CoordPos::OnBoundary => 1,
+            CoordPos::Inside => 2,
+        }
+    }
+    if rank(a) >= rank(b) {
+        a
+    } else {
+        b
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collection::Collection3D;
+    use crate::coordinate::{CoordinateFrame, EpsgCode};
+    use crate::line_string::LineString3D;
+    use crate::point::Point3D;
+    use crate::polygon::Polygon3D;
+    use crate::predicates::test3d::{
+        box_solid, box_solid_with_void, e, solid_geometry, tetra_solid, Rng,
+    };
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn box_solid_positions() {
+        let s = solid_geometry(box_solid([0.0, 0.0, 0.0], [4.0, 4.0, 4.0]));
+        assert_eq!(point_position_3d([2.0, 2.0, 2.0], &s), Ok(CoordPos::Inside));
+        assert_eq!(
+            point_position_3d([5.0, 2.0, 2.0], &s),
+            Ok(CoordPos::Outside)
+        );
+        // Face interior, edge, and vertex are all boundary.
+        assert_eq!(
+            point_position_3d([0.0, 1.0, 2.0], &s),
+            Ok(CoordPos::OnBoundary)
+        );
+        assert_eq!(
+            point_position_3d([0.0, 0.0, 2.0], &s),
+            Ok(CoordPos::OnBoundary)
+        );
+        assert_eq!(
+            point_position_3d([4.0, 4.0, 4.0], &s),
+            Ok(CoordPos::OnBoundary)
+        );
+        // On a face's internal triangulation diagonal: still boundary.
+        assert_eq!(
+            point_position_3d([0.0, 2.0, 2.0], &s),
+            Ok(CoordPos::OnBoundary)
+        );
+        // Just inside a corner (probes graze many vertices; parity must
+        // survive the retries).
+        assert_eq!(point_position_3d([1.0, 1.0, 1.0], &s), Ok(CoordPos::Inside));
+    }
+
+    #[test]
+    fn hollow_solid_positions() {
+        let s = solid_geometry(box_solid_with_void(
+            [0.0, 0.0, 0.0],
+            [6.0, 6.0, 6.0],
+            [2.0, 2.0, 2.0],
+            [2.0, 2.0, 2.0],
+        ));
+        // In the wall between the shells.
+        assert_eq!(point_position_3d([1.0, 1.0, 1.0], &s), Ok(CoordPos::Inside));
+        // In the hollow.
+        assert_eq!(
+            point_position_3d([3.0, 3.0, 3.0], &s),
+            Ok(CoordPos::Outside)
+        );
+        // On the void shell.
+        assert_eq!(
+            point_position_3d([2.0, 3.0, 3.0], &s),
+            Ok(CoordPos::OnBoundary)
+        );
+    }
+
+    #[test]
+    fn surface_leaves_are_all_boundary() {
+        let square = Euclidean3DGeometry::Polygon(Box::new(Polygon3D::from_rings(
+            e(),
+            [
+                [0.0, 0.0, 1.0],
+                [4.0, 0.0, 1.0],
+                [4.0, 4.0, 1.0],
+                [0.0, 4.0, 1.0],
+                [0.0, 0.0, 1.0],
+            ],
+            Vec::<Vec<[f64; 3]>>::new(),
+        )));
+        assert_eq!(
+            point_position_3d([2.0, 2.0, 1.0], &square),
+            Ok(CoordPos::OnBoundary)
+        );
+        assert_eq!(
+            point_position_3d([0.0, 0.0, 1.0], &square),
+            Ok(CoordPos::OnBoundary)
+        );
+        assert_eq!(
+            point_position_3d([2.0, 2.0, 2.0], &square),
+            Ok(CoordPos::Outside)
+        );
+    }
+
+    #[test]
+    fn line_and_point_leaves_mirror_2d_semantics() {
+        let l = Euclidean3DGeometry::LineString(LineString3D::from_coords(
+            e(),
+            [[0.0, 0.0, 0.0], [4.0, 0.0, 0.0], [4.0, 4.0, 4.0]],
+        ));
+        assert_eq!(point_position_3d([2.0, 0.0, 0.0], &l), Ok(CoordPos::Inside));
+        assert_eq!(point_position_3d([4.0, 0.0, 0.0], &l), Ok(CoordPos::Inside)); // mid vertex
+        assert_eq!(
+            point_position_3d([0.0, 0.0, 0.0], &l),
+            Ok(CoordPos::OnBoundary)
+        );
+        assert_eq!(
+            point_position_3d([1.0, 1.0, 1.0], &l),
+            Ok(CoordPos::Outside)
+        );
+
+        let p = Euclidean3DGeometry::Point(Point3D::new(e(), [1.0, 2.0, 3.0]));
+        assert_eq!(point_position_3d([1.0, 2.0, 3.0], &p), Ok(CoordPos::Inside));
+        assert_eq!(
+            point_position_3d([1.0, 2.0, 3.5], &p),
+            Ok(CoordPos::Outside)
+        );
+
+        // Two chains joined at an endpoint make it interior (mod-2 union).
+        let a = Euclidean3DGeometry::LineString(LineString3D::from_coords(
+            e(),
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+        ));
+        let b = Euclidean3DGeometry::LineString(LineString3D::from_coords(
+            e(),
+            [[1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+        ));
+        let c = Euclidean3DGeometry::Collection(Collection3D::new([a, b]));
+        assert_eq!(point_position_3d([1.0, 0.0, 0.0], &c), Ok(CoordPos::Inside));
+        assert_eq!(
+            point_position_3d([0.0, 0.0, 0.0], &c),
+            Ok(CoordPos::OnBoundary)
+        );
+    }
+
+    #[test]
+    fn unsupported_and_mixed_frame_errors() {
+        use crate::csg::{Csg, ThreeDimensional};
+        let solid = || Box::new(box_solid([0.0; 3], [1.0; 3]));
+        let csg = Euclidean3DGeometry::Csg(Csg::Union(
+            Box::new(ThreeDimensional::Solid(solid())),
+            Box::new(ThreeDimensional::Solid(solid())),
+        ));
+        assert_eq!(
+            point_position_3d([0.0; 3], &csg),
+            Err(PredicateError::Unsupported { geometry: "Csg" })
+        );
+
+        let mixed = Euclidean3DGeometry::Collection(Collection3D::new([
+            Euclidean3DGeometry::Point(Point3D::new(e(), [0.0; 3])),
+            Euclidean3DGeometry::Point(Point3D::new(
+                CoordinateFrame::Crs(EpsgCode::new(4979)),
+                [0.0; 3],
+            )),
+        ]));
+        assert_eq!(
+            point_position_3d([0.0; 3], &mixed),
+            Err(PredicateError::MixedFrames)
+        );
+
+        // An empty collection is outside everything.
+        let empty = Euclidean3DGeometry::Collection(Collection3D::new([]));
+        assert_eq!(point_position_3d([0.0; 3], &empty), Ok(CoordPos::Outside));
+    }
+
+    /// Half-space oracle for a (non-degenerate) tetrahedron.
+    fn tetra_oracle(v: [[f64; 3]; 4], p: [f64; 3]) -> CoordPos {
+        let faces = [(0, 1, 2, 3), (0, 1, 3, 2), (0, 2, 3, 1), (1, 2, 3, 0)];
+        let mut on_boundary = false;
+        for (a, b, c, d) in faces {
+            let side_p = orient3d(v[a], v[b], v[c], p);
+            let side_d = orient3d(v[a], v[b], v[c], v[d]);
+            if side_p == Orientation::Collinear {
+                on_boundary = true;
+            } else if side_p != side_d {
+                return CoordPos::Outside;
+            }
+        }
+        if on_boundary {
+            CoordPos::OnBoundary
+        } else {
+            CoordPos::Inside
+        }
+    }
+
+    #[test]
+    fn tetra_parity_matches_half_space_oracle() {
+        let mut rng = Rng(20260716);
+        let mut tested = 0usize;
+        for _ in 0..150 {
+            let v = [
+                rng.grid_point(-3, 3),
+                rng.grid_point(-3, 3),
+                rng.grid_point(-3, 3),
+                rng.grid_point(-3, 3),
+            ];
+            if orient3d(v[0], v[1], v[2], v[3]) == Orientation::Collinear {
+                continue; // degenerate tetrahedron
+            }
+            let solid = solid_geometry(tetra_solid(v));
+
+            // Vertices and edge midpoints land exactly on the boundary;
+            // integer grid points exercise faces, edges, and both sides.
+            let mut queries: Vec<[f64; 3]> = v.to_vec();
+            for i in 0..4 {
+                for j in (i + 1)..4 {
+                    queries.push([
+                        (v[i][0] + v[j][0]) / 2.0,
+                        (v[i][1] + v[j][1]) / 2.0,
+                        (v[i][2] + v[j][2]) / 2.0,
+                    ]);
+                }
+            }
+            for _ in 0..20 {
+                queries.push(rng.grid_point(-4, 4));
+            }
+
+            for q in queries {
+                assert_eq!(
+                    point_position_3d(q, &solid),
+                    Ok(tetra_oracle(v, q)),
+                    "tetra {v:?}, query {q:?}"
+                );
+                tested += 1;
+            }
+        }
+        assert!(tested > 3000, "the sweep should exercise many cases");
+    }
+}

--- a/engine/runtime/geometry/src/predicates/position3d.rs
+++ b/engine/runtime/geometry/src/predicates/position3d.rs
@@ -5,28 +5,26 @@
 //! [`Outside`](CoordPos::Outside), with the per-leaf semantics graded by
 //! codimension:
 //!
-//! - **Point** — the interior is the point itself (as in 2D).
-//! - **LineString** — the chain minus its endpoints is interior, open-chain
+//! - **Point**: the interior is the point itself (as in 2D).
+//! - **LineString**: the chain minus its endpoints is interior, open-chain
 //!   endpoints are boundary (as in 2D, counted mod 2 across collection
 //!   members).
-//! - **Polygon / meshes** — a surface embedded in 3D has no volumetric
+//! - **Polygon / meshes**: a surface embedded in 3D has no volumetric
 //!   interior: every point of it classifies as `OnBoundary`.
-//! - **Solid** — the genuinely volumetric case, which 2D has no analog of and
-//!   the legacy geometry never implemented: on any shell is `OnBoundary`,
+//! - **Solid**: the genuinely volumetric case. On any shell is `OnBoundary`;
 //!   enclosed by the exterior shell and outside every interior (void) shell is
 //!   `Inside`.
-//! - **Collections** — the union: the highest member classification wins.
+//! - **Collections**: the union: the highest member classification wins.
 //!
 //! Point-in-solid is decided by **exact ray-crossing parity**: a probe segment
 //! is cast from the coordinate to a point outside the shell's bounding box and
 //! the strict crossings through shell triangles are counted, every sign coming
-//! from robust [`orient3d`]. A probe that grazes the shell — hitting an edge,
+//! from robust [`orient3d`]. A probe that grazes the shell (hitting an edge,
 //! a vertex, or a triangle's plane tangentially, where naive parity counters
-//! silently double-count — is *detected exactly* (some orientation sign is
+//! silently double-count) is *detected exactly* (some orientation sign is
 //! zero) and retried with a different probe target instead of being fudged
 //! with an epsilon. Shells are assumed closed and non-self-intersecting (the
-//! [`Validate`](crate::validation_next) contract); parity over an open shell
-//! is meaningless.
+//! `Validate` contract); parity over an open shell is meaningless.
 
 use crate::ops::triangulation::Cache;
 use crate::solid::Solid;
@@ -185,7 +183,7 @@ pub(crate) fn shell_position(coord: [f64; 3], shell: &TriangleSet<'_>) -> CoordP
             CoordPos::Outside
         };
     }
-    // Every probe grazed the shell — possible only for wildly degenerate
+    // Every probe grazed the shell, possible only for wildly degenerate
     // input. Degrade to the boundary answer rather than guess a side.
     CoordPos::OnBoundary
 }
@@ -197,7 +195,7 @@ enum ProbeCrossing {
     /// One strict crossing through the triangle's interior.
     Cross,
     /// A graze (edge, vertex, or coplanar contact): the parity of this probe
-    /// direction is unreliable — retry with another.
+    /// direction is unreliable; retry with another.
     Degenerate,
 }
 

--- a/engine/runtime/geometry/src/predicates/position3d.rs
+++ b/engine/runtime/geometry/src/predicates/position3d.rs
@@ -26,13 +26,17 @@
 //! with an epsilon. Shells are assumed closed and non-self-intersecting (the
 //! `Validate` contract); parity over an open shell is meaningless.
 
+use rstar::{RTree, AABB};
+
 use crate::ops::triangulation::Cache;
 use crate::solid::Solid;
 use crate::Euclidean3DGeometry;
 
 use super::kernel::{orient3d, CoordPos, Orientation};
 use super::kernel3d::{point_in_triangle_3d, point_on_segment_3d};
-use super::view3d::{flatten_3d, require_common_frame_3d, Leaf3D, TriangleSet};
+use super::view3d::{
+    flatten_3d, require_common_frame_3d, Leaf3D, SlabSelection, TriBox, TriangleSet,
+};
 use super::{PredicateError, Result};
 
 /// Position of a coordinate relative to a 3D geometry, treating collections as
@@ -123,25 +127,79 @@ pub(crate) fn solid_position(coord: [f64; 3], solid: &Solid, cache: &mut Cache) 
 /// that hold them (the 3D `intersects` keeps them for its boundary tests).
 pub(crate) fn solid_position_sets<'a, 'b>(
     coord: [f64; 3],
-    exterior: &TriangleSet<'a>,
+    exterior: &'b TriangleSet<'a>,
     voids: impl Iterator<Item = &'b TriangleSet<'a>>,
 ) -> CoordPos
 where
     'a: 'b,
 {
-    match shell_position(coord, exterior) {
+    solid_position_from(coord, &Shell::linear(exterior), voids.map(Shell::linear))
+}
+
+/// [`solid_position_sets`] over shells that carry their [`TriangleSet::rtree`],
+/// reusing the index the caller already built (the 3D `intersects` keeps one
+/// per shell for its boundary tests). The parity probe and the on-boundary test
+/// both prune through the tree instead of scanning every triangle.
+pub(crate) fn solid_position_indexed<'a, 'b>(
+    coord: [f64; 3],
+    exterior: (&TriangleSet<'a>, &RTree<TriBox>),
+    voids: impl Iterator<Item = (&'b TriangleSet<'a>, &'b RTree<TriBox>)>,
+) -> CoordPos
+where
+    'a: 'b,
+{
+    solid_position_from(
+        coord,
+        &Shell::indexed(exterior.0, exterior.1),
+        voids.map(|(set, tree)| Shell::indexed(set, tree)),
+    )
+}
+
+/// The shared solid-position walk over a boundary-first classification of each
+/// shell: on the exterior is boundary, inside it and outside every void is
+/// inside, inside a void is a hollow (outside).
+fn solid_position_from<'a, 'b>(
+    coord: [f64; 3],
+    exterior: &Shell<'a, 'b>,
+    voids: impl Iterator<Item = Shell<'a, 'b>>,
+) -> CoordPos {
+    match exterior.position(coord) {
         CoordPos::OnBoundary => return CoordPos::OnBoundary,
         CoordPos::Outside => return CoordPos::Outside,
         CoordPos::Inside => {}
     }
     for void in voids {
-        match shell_position(coord, void) {
+        match void.position(coord) {
             CoordPos::OnBoundary => return CoordPos::OnBoundary,
             CoordPos::Inside => return CoordPos::Outside, // in a hollow
             CoordPos::Outside => {}
         }
     }
     CoordPos::Inside
+}
+
+/// One shell with the strategy to classify a coordinate against it: a linear
+/// scan, or a traversal of the shell's prebuilt triangle-box tree.
+struct Shell<'a, 'b> {
+    set: &'b TriangleSet<'a>,
+    tree: Option<&'b RTree<TriBox>>,
+}
+
+impl<'a, 'b> Shell<'a, 'b> {
+    fn linear(set: &'b TriangleSet<'a>) -> Self {
+        Shell { set, tree: None }
+    }
+
+    fn indexed(set: &'b TriangleSet<'a>, tree: &'b RTree<TriBox>) -> Self {
+        Shell {
+            set,
+            tree: Some(tree),
+        }
+    }
+
+    fn position(&self, coord: [f64; 3]) -> CoordPos {
+        shell_position_impl(coord, self.set, self.tree)
+    }
 }
 
 /// On-surface position: `OnBoundary` anywhere on the triangle set, else
@@ -155,7 +213,15 @@ pub(crate) fn surface_position(coord: [f64; 3], set: &TriangleSet<'_>) -> CoordP
 }
 
 /// Position relative to one closed shell, by exact ray-crossing parity.
-pub(crate) fn shell_position(coord: [f64; 3], shell: &TriangleSet<'_>) -> CoordPos {
+/// Scans every triangle when `tree` is `None` or prunes through the shell's
+/// prebuilt triangle-box tree when it is `Some`. Both visit a superset of the
+/// triangles the probe segment crosses, so the exact parity they count is
+/// identical; the tree only skips triangles the probe cannot reach.
+fn shell_position_impl(
+    coord: [f64; 3],
+    shell: &TriangleSet<'_>,
+    tree: Option<&RTree<TriBox>>,
+) -> CoordPos {
     if shell.is_empty() {
         return CoordPos::Outside;
     }
@@ -163,29 +229,68 @@ pub(crate) fn shell_position(coord: [f64; 3], shell: &TriangleSet<'_>) -> CoordP
     if (0..3).any(|k| coord[k] < min[k] || coord[k] > max[k]) {
         return CoordPos::Outside;
     }
-    if shell.triangles().any(|t| point_in_triangle_3d(coord, t)) {
+    if on_boundary(coord, shell, tree) {
         return CoordPos::OnBoundary;
     }
 
-    'attempt: for attempt in 0..MAX_PROBE_ATTEMPTS {
+    for attempt in 0..MAX_PROBE_ATTEMPTS {
         let target = probe_target(min, max, attempt);
-        let mut crossings = 0usize;
-        for t in shell.triangles() {
-            match probe_crossing(coord, target, t) {
-                ProbeCrossing::Miss => {}
-                ProbeCrossing::Cross => crossings += 1,
-                ProbeCrossing::Degenerate => continue 'attempt,
-            }
+        if let Some(crossings) = count_crossings(coord, target, shell, tree) {
+            return if crossings % 2 == 1 {
+                CoordPos::Inside
+            } else {
+                CoordPos::Outside
+            };
         }
-        return if crossings % 2 == 1 {
-            CoordPos::Inside
-        } else {
-            CoordPos::Outside
-        };
     }
     // Every probe grazed the shell, possible only for wildly degenerate
     // input. Degrade to the boundary answer rather than guess a side.
     CoordPos::OnBoundary
+}
+
+/// Whether the coordinate lies on any shell triangle: a scan, or (indexed) only
+/// the triangles whose box contains the coordinate.
+fn on_boundary(coord: [f64; 3], shell: &TriangleSet<'_>, tree: Option<&RTree<TriBox>>) -> bool {
+    match tree {
+        None => shell.triangles().any(|t| point_in_triangle_3d(coord, t)),
+        Some(tree) => tree
+            .locate_in_envelope_intersecting(&AABB::from_point(coord))
+            .any(|tb| point_in_triangle_3d(coord, shell.triangle(tb.idx as usize))),
+    }
+}
+
+/// Count the probe segment's strict crossings through shell triangles, or
+/// `None` if any is a graze (an unreliable probe direction, to be retried). The
+/// indexed path visits only the triangles the segment's slab reaches, a
+/// superset of those it crosses, so the count matches the scan.
+fn count_crossings(
+    p: [f64; 3],
+    target: [f64; 3],
+    shell: &TriangleSet<'_>,
+    tree: Option<&RTree<TriBox>>,
+) -> Option<usize> {
+    let mut crossings = 0usize;
+    let mut tally = |t: [[f64; 3]; 3]| match probe_crossing(p, target, t) {
+        ProbeCrossing::Miss => Some(()),
+        ProbeCrossing::Cross => {
+            crossings += 1;
+            Some(())
+        }
+        ProbeCrossing::Degenerate => None,
+    };
+    match tree {
+        None => {
+            for t in shell.triangles() {
+                tally(t)?;
+            }
+        }
+        Some(tree) => {
+            for tb in tree.locate_with_selection_function(SlabSelection::segment(p, target)) {
+                tally(shell.triangle(tb.idx as usize))?;
+            }
+        }
+    }
+    Some(crossings)
 }
 
 /// How the probe segment relates to one shell triangle.
@@ -338,9 +443,99 @@ mod tests {
     use crate::point::Point3D;
     use crate::polygon::Polygon3D;
     use crate::predicates::test3d::{
-        box_solid, box_solid_with_void, e, solid_geometry, tetra_solid, Rng,
+        box_solid, box_solid_with_void, e, solid_geometry, subdivided_box_solid, tetra_solid, Rng,
     };
     use pretty_assertions::assert_eq;
+
+    /// Calibration benchmark for the point-in-solid strategies: per-query cost
+    /// of the linear scan versus the reused-tree traversal across shell sizes.
+    /// Run manually:
+    /// `cargo test -p reearth-flow-geometry --features new-geometry \
+    ///  predicates::position3d::tests::scan_vs_indexed_point_in_solid -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "timing benchmark; point-in-solid linear scan vs reused tree"]
+    fn scan_vs_indexed_point_in_solid() {
+        let mut cache = Cache::new();
+        println!("\n  tris | linear ns/query | indexed ns/query | speedup");
+        for w in [2usize, 4, 8, 12, 16, 24] {
+            let solid = subdivided_box_solid(w);
+            let set = TriangleSet::from_shell(solid.exterior(), &mut cache);
+            let tree = set.rtree();
+            let mut rng = Rng(20260722);
+            // Half-integer points in [-1, w+1]^3: a mix of inside and outside,
+            // off the integer face planes so probes rarely need a retry.
+            let queries: Vec<[f64; 3]> = (0..3000)
+                .map(|_| core::array::from_fn(|_| rng.int(-2, 2 * w as i64 + 2) as f64 * 0.5))
+                .collect();
+
+            let time = |f: &dyn Fn([f64; 3]) -> CoordPos| {
+                let mut guard = 0u64;
+                let start = std::time::Instant::now();
+                for &q in &queries {
+                    if f(q) != CoordPos::Outside {
+                        guard += 1;
+                    }
+                }
+                std::hint::black_box(guard);
+                start.elapsed().as_nanos() as f64 / queries.len() as f64
+            };
+            let linear = time(&|q| solid_position_sets(q, &set, core::iter::empty()));
+            let indexed = time(&|q| {
+                solid_position_indexed(
+                    q,
+                    (&set, &tree),
+                    core::iter::empty::<(&TriangleSet, &RTree<TriBox>)>(),
+                )
+            });
+            println!(
+                "{:6} | {:15.1} | {:16.1} | {:.1}x",
+                set.len(),
+                linear,
+                indexed,
+                linear / indexed
+            );
+        }
+    }
+
+    #[test]
+    fn indexed_parity_matches_the_linear_scan() {
+        // The tree-pruned shell classification must agree with the full scan on
+        // every query, over solids with and without voids, at grid points that
+        // land inside, outside, and exactly on faces/edges/vertices.
+        let mut cache = Cache::new();
+        let solids = [
+            box_solid([0.0; 3], [6.0, 6.0, 6.0]),
+            box_solid_with_void([0.0; 3], [6.0, 6.0, 6.0], [2.0; 3], [2.0, 2.0, 2.0]),
+            tetra_solid([
+                [0.0, 0.0, 0.0],
+                [6.0, 0.0, 0.0],
+                [0.0, 6.0, 0.0],
+                [0.0, 0.0, 6.0],
+            ]),
+        ];
+        let mut rng = Rng(20260721);
+        for solid in &solids {
+            let exterior = TriangleSet::from_shell(solid.exterior(), &mut cache);
+            let voids: Vec<TriangleSet<'_>> = solid
+                .interiors()
+                .iter()
+                .map(|shell| TriangleSet::from_shell(shell, &mut cache))
+                .collect();
+            let ext_tree = exterior.rtree();
+            let void_trees: Vec<_> = voids.iter().map(|v| v.rtree()).collect();
+
+            for _ in 0..400 {
+                let q = rng.grid_point(-1, 7);
+                let linear = solid_position_sets(q, &exterior, voids.iter());
+                let indexed = solid_position_indexed(
+                    q,
+                    (&exterior, &ext_tree),
+                    voids.iter().zip(&void_trees),
+                );
+                assert_eq!(linear, indexed, "query {q:?}");
+            }
+        }
+    }
 
     #[test]
     fn box_solid_positions() {

--- a/engine/runtime/geometry/src/predicates/projection.rs
+++ b/engine/runtime/geometry/src/predicates/projection.rs
@@ -1,0 +1,711 @@
+//! DE-9IM relates for 3D geometry through planar projection.
+//!
+//! There is no volumetric DE-9IM (plan §7); what 3D offers beyond the exact
+//! [`intersects`](super::intersects()) tests are two projections into the 2D
+//! [`relate`](super::relate()) machinery:
+//!
+//! - [`relate_coplanar`] — for **mutually coplanar** 3D geometries (a shared
+//!   wall, a floor and its furniture footprints): verifies coplanarity
+//!   exactly, projects both operands onto the shared plane, and relates
+//!   in-plane. Non-coplanar operands are a
+//!   [`NotCoplanar`](super::PredicateError::NotCoplanar) error.
+//! - [`relate_xy`] — the legacy-compatible SpatialFilter semantics: every
+//!   leaf, 2D or 3D, is taken by its `(x, y)` footprint and related in 2D.
+//!   This is the explicit XY-projection opt-in; nothing else in the
+//!   predicates crosses dimensions.
+//!
+//! Both project by **dropping a coordinate axis**, not by rotating onto a
+//! tangent plane: an axis drop copies coordinates verbatim, so the 2D relate's
+//! robust predicates see exact inputs and the matrix is exact for the 3D
+//! configuration. (`relate_coplanar` picks an axis along which the shared
+//! plane does not collapse — one always exists — and DE-9IM is invariant
+//! under a linear bijection of the plane, so the skew of an axis drop is
+//! harmless.) The projected operands are materialized as owned 2D leaves per
+//! call.
+//!
+//! Because a projection may mirror orientation, mesh faces are re-normalized
+//! to the validated 2D winding (exterior counter-clockwise) before the relate
+//! — the mesh dissolve depends on it. Caveats carried over from `relate`:
+//! leaves whose *projections* overlap areally (e.g. the faces of a closed
+//! shell under `relate_xy`) are the documented unsupported relate input, and
+//! a face that projects to zero area degrades like any other degenerate ring.
+//! `Solid`, `Csg`, and `PointCloud` leaves are
+//! [`Unsupported`](super::PredicateError::Unsupported).
+
+use crate::collection::Collection2D;
+use crate::line_string::LineString2D;
+use crate::point::Point2D;
+use crate::polygon::Polygon2D;
+use crate::polygon_mesh::{PolygonMesh2D, PolygonMesh3D};
+use crate::triangular_mesh::TriangularMesh2D;
+use crate::{Euclidean2DGeometry, Geometry};
+
+use super::kernel::{orient2d, Orientation};
+use super::kernel3d::{collinear_3d, coplanar, drop_axis};
+use super::relate::{relate_2d, IntersectionMatrix};
+use super::view::{flatten_2d, Leaf2D};
+use super::view3d::{flatten_3d, flatten_geometry_3d, Leaf3D};
+use super::{PredicateError, Result};
+
+/// The DE-9IM matrix of two mutually coplanar 3D geometries, related in their
+/// shared plane.
+///
+/// Coplanarity is verified exactly (every vertex against a reference plane
+/// through the first three non-collinear vertices);
+/// [`NotCoplanar`](PredicateError::NotCoplanar) otherwise. Operands must both
+/// be 3D ([`CrossDimension`](PredicateError::CrossDimension) if a 2D leaf
+/// appears) and share one frame; `Point`, `LineString`, `Polygon`, and the
+/// meshes are supported, while `Solid` (never planar), `Csg`, and
+/// `PointCloud` are [`Unsupported`](PredicateError::Unsupported).
+/// `Geometry::None` and empty collections relate as the empty geometry.
+pub fn relate_coplanar(a: &Geometry, b: &Geometry) -> Result<IntersectionMatrix> {
+    let a_leaves = planar_leaves(a)?;
+    let b_leaves = planar_leaves(b)?;
+    require_common_frame(&a_leaves, &b_leaves)?;
+
+    let axis = shared_plane_axis(a_leaves.iter().chain(&b_leaves))?;
+    relate_2d(&project(&a_leaves, axis), &project(&b_leaves, axis))
+}
+
+/// The DE-9IM matrix of the `(x, y)` footprints of two geometries — the
+/// explicit XY-projection opt-in matching legacy SpatialFilter 3D semantics.
+///
+/// Each operand may be 2D, 3D, or a mixed collection: 2D leaves are taken
+/// as-is (their optional elevation ignored, as everywhere), 3D leaves drop
+/// `z`. All leaves must share one frame. `Solid`, `Csg`, and `PointCloud`
+/// leaves are [`Unsupported`](PredicateError::Unsupported); note that a 3D
+/// mesh whose faces overlap in `(x, y)` (any closed surface) is the
+/// documented unsupported input of [`relate`](super::relate()) itself.
+pub fn relate_xy(a: &Geometry, b: &Geometry) -> Result<IntersectionMatrix> {
+    let a_members = xy_members(a)?;
+    let b_members = xy_members(b)?;
+    relate_2d(
+        &Euclidean2DGeometry::Collection(Collection2D::new(a_members)),
+        &Euclidean2DGeometry::Collection(Collection2D::new(b_members)),
+    )
+}
+
+// --- operand gathering ---------------------------------------------------------
+
+/// The 3D leaves of a planar-relate operand, with the kinds the projection
+/// cannot take rejected.
+fn planar_leaves(geometry: &Geometry) -> Result<Vec<Leaf3D<'_>>> {
+    let (leaves, saw_2d, unsupported) = flatten_geometry_3d(geometry);
+    if let Some(name) = unsupported {
+        return Err(PredicateError::Unsupported { geometry: name });
+    }
+    if saw_2d {
+        return Err(PredicateError::CrossDimension);
+    }
+    if leaves.iter().any(|l| matches!(l, Leaf3D::Solid(_))) {
+        return Err(PredicateError::Unsupported { geometry: "Solid" });
+    }
+    Ok(leaves)
+}
+
+/// The projected-or-cloned 2D members of an XY-relate operand.
+fn xy_members(geometry: &Geometry) -> Result<Vec<Euclidean2DGeometry>> {
+    fn walk<'a>(
+        geometry: &'a Geometry,
+        two_d: &mut Vec<Leaf2D<'a>>,
+        three_d: &mut Vec<Leaf3D<'a>>,
+        unsupported: &mut Option<&'static str>,
+    ) {
+        match geometry {
+            Geometry::None => {}
+            Geometry::Euclidean2D(g) => flatten_2d(g, two_d),
+            Geometry::Euclidean3D(g) => flatten_3d(g, three_d, unsupported),
+            Geometry::GeometryCollection(c) => {
+                for member in c.members() {
+                    walk(member, two_d, three_d, unsupported);
+                }
+            }
+        }
+    }
+    let mut two_d = Vec::new();
+    let mut three_d = Vec::new();
+    let mut unsupported = None;
+    walk(geometry, &mut two_d, &mut three_d, &mut unsupported);
+    if let Some(name) = unsupported {
+        return Err(PredicateError::Unsupported { geometry: name });
+    }
+    if three_d.iter().any(|l| matches!(l, Leaf3D::Solid(_))) {
+        return Err(PredicateError::Unsupported { geometry: "Solid" });
+    }
+    Ok(two_d
+        .iter()
+        .map(owned_2d)
+        .chain(three_d.iter().map(|l| project_leaf(l, 2)))
+        .collect())
+}
+
+/// Clone a 2D leaf into an owned member.
+fn owned_2d(leaf: &Leaf2D<'_>) -> Euclidean2DGeometry {
+    match leaf {
+        Leaf2D::Point(p) => Euclidean2DGeometry::Point((*p).clone()),
+        Leaf2D::Line(l) => Euclidean2DGeometry::LineString((*l).clone()),
+        Leaf2D::Polygon(p) => Euclidean2DGeometry::Polygon(Box::new((*p).clone())),
+        Leaf2D::PolygonMesh(m) => Euclidean2DGeometry::PolygonMesh(Box::new((*m).clone())),
+        Leaf2D::TriangularMesh(m) => Euclidean2DGeometry::TriangularMesh(Box::new((*m).clone())),
+    }
+}
+
+/// Require every leaf across both operands to share one coordinate frame.
+fn require_common_frame(a: &[Leaf3D<'_>], b: &[Leaf3D<'_>]) -> Result<()> {
+    super::view3d::require_common_frame_3d(a, b)
+}
+
+// --- the shared plane ----------------------------------------------------------
+
+/// Verify all leaves' vertices lie in one plane (exactly) and return the axis
+/// to drop: one along which that plane — or line, or point — does not
+/// collapse, so the projection is injective on it.
+fn shared_plane_axis<'a, 'b>(leaves: impl Iterator<Item = &'b Leaf3D<'a>> + Clone) -> Result<usize>
+where
+    'a: 'b,
+{
+    // The first vertex, the first distinct vertex, and the first vertex not
+    // collinear with them span the affine hull (up to a plane).
+    let mut first = None;
+    let mut second = None;
+    let mut triple = None;
+    for leaf in leaves.clone() {
+        for v in leaf_coords(leaf) {
+            match (first, second) {
+                (None, _) => first = Some(v),
+                (Some(a), None) if v != a => second = Some(v),
+                (Some(a), Some(b)) => {
+                    if !collinear_3d(a, b, v) {
+                        triple = Some([a, b, v]);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if triple.is_some() {
+            break;
+        }
+    }
+
+    match (first, second, triple) {
+        // A genuine plane: every vertex must lie in it, exactly.
+        (_, _, Some([a, b, c])) => {
+            for leaf in leaves {
+                for v in leaf_coords(leaf) {
+                    if !coplanar(a, b, c, v) {
+                        return Err(PredicateError::NotCoplanar);
+                    }
+                }
+            }
+            for axis in [2, 1, 0] {
+                if orient2d(drop_axis(a, axis), drop_axis(b, axis), drop_axis(c, axis))
+                    != Orientation::Collinear
+                {
+                    return Ok(axis);
+                }
+            }
+            unreachable!("a non-collinear triple projects non-degenerately along some axis")
+        }
+        // All vertices collinear: coplanar trivially; keep the line's
+        // direction visible.
+        (Some(a), Some(b), None) => {
+            for axis in [2, 1, 0] {
+                if drop_axis(a, axis) != drop_axis(b, axis) {
+                    return Ok(axis);
+                }
+            }
+            unreachable!("distinct points project distinctly along some axis")
+        }
+        // At most one distinct vertex: any axis will do.
+        _ => Ok(2),
+    }
+}
+
+/// All vertices of a leaf (mesh leaves iterate their pools).
+fn leaf_coords<'a>(leaf: &Leaf3D<'a>) -> Box<dyn Iterator<Item = [f64; 3]> + 'a> {
+    match leaf {
+        Leaf3D::Point(p) => Box::new(core::iter::once(p.position())),
+        Leaf3D::Line(l) => Box::new(l.coords().iter().copied()),
+        Leaf3D::Polygon(p) => {
+            Box::new(super::view::polygon3d_rings(p).flat_map(|ring| ring.iter().copied()))
+        }
+        Leaf3D::PolygonMesh(m) => Box::new(m.vertices().iter().copied()),
+        Leaf3D::TriangularMesh(m) => Box::new(m.vertices().iter().copied()),
+        Leaf3D::Solid(_) => unreachable!("solids are rejected before projection"),
+    }
+}
+
+// --- projection ----------------------------------------------------------------
+
+/// Project leaves along `axis` into one owned 2D collection.
+fn project(leaves: &[Leaf3D<'_>], axis: usize) -> Euclidean2DGeometry {
+    Euclidean2DGeometry::Collection(Collection2D::new(
+        leaves.iter().map(|l| project_leaf(l, axis)),
+    ))
+}
+
+/// Project one leaf along `axis`, re-normalizing mesh face winding (a
+/// projection may mirror, and the relate's mesh dissolve assumes the
+/// validated exterior-counter-clockwise winding).
+fn project_leaf(leaf: &Leaf3D<'_>, axis: usize) -> Euclidean2DGeometry {
+    let drop = |p: [f64; 3]| drop_axis(p, axis);
+    match leaf {
+        Leaf3D::Point(p) => {
+            Euclidean2DGeometry::Point(Point2D::new(p.frame().clone(), drop(p.position())))
+        }
+        Leaf3D::Line(l) => Euclidean2DGeometry::LineString(LineString2D::from_coords(
+            l.frame().clone(),
+            l.coords().iter().copied().map(drop),
+        )),
+        Leaf3D::Polygon(p) => Euclidean2DGeometry::Polygon(Box::new(Polygon2D::from_rings(
+            p.frame().clone(),
+            p.exterior().iter().copied().map(drop),
+            p.interiors().map(|ring| ring.iter().copied().map(drop)),
+        ))),
+        Leaf3D::PolygonMesh(m) => {
+            Euclidean2DGeometry::PolygonMesh(Box::new(project_polygon_mesh(m, axis)))
+        }
+        Leaf3D::TriangularMesh(m) => {
+            let vertices: Vec<[f64; 2]> = m.vertices().iter().copied().map(drop).collect();
+            let indices = m.triangles().flat_map(|[a, b, c]| {
+                // Normalize each triangle to counter-clockwise.
+                let tri = [
+                    vertices[a as usize],
+                    vertices[b as usize],
+                    vertices[c as usize],
+                ];
+                if orient2d(tri[0], tri[1], tri[2]) == Orientation::Clockwise {
+                    [a, c, b]
+                } else {
+                    [a, b, c]
+                }
+            });
+            let mesh = TriangularMesh2D::from_parts(m.frame().clone(), vertices.clone(), indices)
+                .expect("projected indices stay valid");
+            Euclidean2DGeometry::TriangularMesh(Box::new(mesh))
+        }
+        Leaf3D::Solid(_) => unreachable!("solids are rejected before projection"),
+    }
+}
+
+/// Project a polygon mesh, reversing the rings of any face whose projected
+/// exterior comes out clockwise.
+fn project_polygon_mesh(mesh: &PolygonMesh3D, axis: usize) -> PolygonMesh2D {
+    let (face_indices, face_offsets, interior_offsets) = mesh.data().csr_buffers();
+    let mut indices: Vec<u32> = face_indices.iter_u32().map(|[i]| i).collect();
+    let offsets: Vec<u32> = face_offsets.iter_u32().map(|[o]| o).collect();
+    let holes: Vec<u32> = interior_offsets.iter_u32().map(|[o]| o).collect();
+    let vertices: Vec<[f64; 2]> = mesh
+        .vertices()
+        .iter()
+        .map(|&p| drop_axis(p, axis))
+        .collect();
+
+    let n = indices.len();
+    if n != 0 {
+        let n_faces = offsets.len() + 1;
+        let mut start = 0usize;
+        for fi in 0..n_faces {
+            let end = offsets.get(fi).map_or(n, |&o| o as usize);
+            // This face's ring boundaries: start, its holes, end.
+            let mut bounds: Vec<usize> = vec![start];
+            bounds.extend(
+                holes
+                    .iter()
+                    .map(|&h| h as usize)
+                    .filter(|&h| h > start && h < end),
+            );
+            bounds.push(end);
+
+            let exterior: Vec<[f64; 2]> = indices[bounds[0]..bounds[1]]
+                .iter()
+                .map(|&i| vertices[i as usize])
+                .collect();
+            if ring_orientation(&exterior) == Orientation::Clockwise {
+                for w in bounds.windows(2) {
+                    indices[w[0]..w[1]].reverse();
+                }
+            }
+            start = end;
+        }
+    }
+
+    PolygonMesh2D::from_raw_parts(mesh.frame().clone(), vertices, indices, offsets, holes)
+        .expect("projected CSR stays valid")
+}
+
+/// The winding of a stored ring (closing duplicate tolerated): the robust
+/// orientation at the lexicographically extreme vertex, falling back to the
+/// shoelace sign when that corner is degenerate. `Collinear` for a
+/// zero-area ring.
+fn ring_orientation(ring: &[[f64; 2]]) -> Orientation {
+    let open = if ring.len() >= 2 && ring.first() == ring.last() {
+        &ring[..ring.len() - 1]
+    } else {
+        ring
+    };
+    let n = open.len();
+    if n < 3 {
+        return Orientation::Collinear;
+    }
+    let lex = |p: [f64; 2], q: [f64; 2]| (p[1], p[0]) < (q[1], q[0]);
+    let mut min = 0;
+    for i in 1..n {
+        if lex(open[i], open[min]) {
+            min = i;
+        }
+    }
+    let distinct = |from: usize, step: usize| {
+        (1..n)
+            .map(|k| open[(from + k * step) % n])
+            .find(|&p| p != open[min])
+    };
+    let (Some(next), Some(prev)) = (distinct(min, 1), distinct(min, n - 1)) else {
+        return Orientation::Collinear;
+    };
+    match orient2d(prev, open[min], next) {
+        Orientation::Collinear => shoelace_orientation(open),
+        o => o,
+    }
+}
+
+/// The shoelace-sign orientation (not robust; only the fallback for a
+/// degenerate extreme corner).
+fn shoelace_orientation(open: &[[f64; 2]]) -> Orientation {
+    let mut sum = 0.0;
+    for i in 0..open.len() {
+        let p = open[i];
+        let q = open[(i + 1) % open.len()];
+        sum += (q[0] - p[0]) * (q[1] + p[1]);
+    }
+    if sum < 0.0 {
+        Orientation::CounterClockwise
+    } else if sum > 0.0 {
+        Orientation::Clockwise
+    } else {
+        Orientation::Collinear
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::coordinate::CoordinateFrame;
+    use crate::line_string::LineString3D;
+    use crate::point::{Point2D, Point3D};
+    use crate::polygon::Polygon3D;
+    use crate::polygon_mesh::PolygonMesh3D;
+    use crate::predicates::relate::relate;
+    use crate::predicates::test3d::{box_solid, e, g3, solid_geometry, Rng};
+    use crate::triangular_mesh::TriangularMesh3D;
+    use pretty_assertions::assert_eq;
+
+    fn g2(g: Euclidean2DGeometry) -> Geometry {
+        Geometry::Euclidean2D(g)
+    }
+
+    /// An exactly-representable lift of the XY plane onto `z = px*x + py*y + pz`
+    /// (small integer coefficients over integer coordinates stay exact).
+    fn lift(plane: [f64; 3]) -> impl Fn([f64; 2]) -> [f64; 3] {
+        move |[x, y]| [x, y, plane[0] * x + plane[1] * y + plane[2]]
+    }
+
+    fn poly_2d(ring: Vec<[f64; 2]>, holes: Vec<Vec<[f64; 2]>>) -> Euclidean2DGeometry {
+        Euclidean2DGeometry::Polygon(Box::new(crate::polygon::Polygon2D::from_rings(
+            e(),
+            ring,
+            holes,
+        )))
+    }
+
+    fn poly_3d(
+        ring: Vec<[f64; 2]>,
+        holes: Vec<Vec<[f64; 2]>>,
+        up: &impl Fn([f64; 2]) -> [f64; 3],
+    ) -> Euclidean3DGeometry {
+        Euclidean3DGeometry::Polygon(Box::new(Polygon3D::from_rings(
+            e(),
+            ring.into_iter().map(up),
+            holes
+                .into_iter()
+                .map(|h| h.into_iter().map(up).collect::<Vec<_>>()),
+        )))
+    }
+
+    fn square(x: f64, y: f64, s: f64) -> Vec<[f64; 2]> {
+        vec![[x, y], [x + s, y], [x + s, y + s], [x, y + s], [x, y]]
+    }
+
+    use crate::Euclidean3DGeometry;
+
+    #[test]
+    fn coplanar_relate_matches_the_2d_relate_exactly() {
+        let mut rng = Rng(20260717);
+        // Planes with negative coefficients also exercise mirrored
+        // projections.
+        let planes = [
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 5.0],
+            [1.0, 0.0, 0.0],
+            [-1.0, 0.0, 3.0],
+            [2.0, -3.0, 1.0],
+            [-1.0, -1.0, -4.0],
+        ];
+        for case in 0..300 {
+            let plane = planes[case % planes.len()];
+            let up = lift(plane);
+            let (a2, a3) = random_member(&mut rng, &up);
+            let (b2, b3) = random_member(&mut rng, &up);
+            let expected = relate(&g2(a2), &g2(b2)).unwrap();
+            let actual = relate_coplanar(&g3(a3), &g3(b3)).unwrap();
+            assert_eq!(actual, expected, "case {case} on plane {plane:?}");
+        }
+    }
+
+    /// One random operand as matching 2D and lifted-3D geometry: a point, a
+    /// line, or a polygon (with an occasional hole).
+    fn random_member(
+        rng: &mut Rng,
+        up: &impl Fn([f64; 2]) -> [f64; 3],
+    ) -> (Euclidean2DGeometry, Euclidean3DGeometry) {
+        let p = |rng: &mut Rng| [rng.int(0, 8) as f64, rng.int(0, 8) as f64];
+        match rng.int(0, 3) {
+            0 => {
+                let pos = p(rng);
+                (
+                    Euclidean2DGeometry::Point(Point2D::new(e(), pos)),
+                    Euclidean3DGeometry::Point(Point3D::new(e(), up(pos))),
+                )
+            }
+            1 => {
+                let coords: Vec<[f64; 2]> = (0..rng.int(2, 4)).map(|_| p(rng)).collect();
+                (
+                    Euclidean2DGeometry::LineString(crate::line_string::LineString2D::from_coords(
+                        e(),
+                        coords.clone(),
+                    )),
+                    Euclidean3DGeometry::LineString(LineString3D::from_coords(
+                        e(),
+                        coords.into_iter().map(up),
+                    )),
+                )
+            }
+            _ => {
+                let (x, y, s) = (
+                    rng.int(0, 5) as f64,
+                    rng.int(0, 5) as f64,
+                    rng.int(2, 4) as f64,
+                );
+                let holes = if s >= 3.0 && rng.int(0, 1) == 1 {
+                    // A hole wound opposite to the exterior.
+                    vec![vec![
+                        [x + 1.0, y + 1.0],
+                        [x + 1.0, y + 2.0],
+                        [x + 2.0, y + 2.0],
+                        [x + 2.0, y + 1.0],
+                        [x + 1.0, y + 1.0],
+                    ]]
+                } else {
+                    Vec::new()
+                };
+                (
+                    poly_2d(square(x, y, s), holes.clone()),
+                    poly_3d(square(x, y, s), holes, up),
+                )
+            }
+        }
+    }
+
+    #[test]
+    fn meshes_relate_in_a_mirrored_plane() {
+        // Two quads sharing an edge in the plane z = 5 - x - y, whose
+        // axis-drop projection mirrors: the dissolve must still see the shared
+        // edge as interior.
+        let up = lift([-1.0, -1.0, 5.0]);
+        // Faces wound CW in (x, y) so their 3D canonical normals face away
+        // from +z; the projected mesh must be re-normalized per face.
+        let quad = |x0: f64| {
+            vec![
+                [x0, 0.0],
+                [x0, 2.0],
+                [x0 + 2.0, 2.0],
+                [x0 + 2.0, 0.0],
+                [x0, 0.0],
+            ]
+        };
+        let faces = [
+            Polygon3D::from_rings(
+                e(),
+                quad(0.0).into_iter().map(&up),
+                Vec::<Vec<[f64; 3]>>::new(),
+            ),
+            Polygon3D::from_rings(
+                e(),
+                quad(2.0).into_iter().map(&up),
+                Vec::<Vec<[f64; 3]>>::new(),
+            ),
+        ];
+        let mesh = PolygonMesh3D::from_polygons(e(), faces.iter()).unwrap();
+        let mesh = g3(Euclidean3DGeometry::PolygonMesh(Box::new(mesh)));
+
+        // A segment crossing the shared edge x = 2 strictly inside the union:
+        // it must relate as interior-interior with no boundary contact.
+        let probe = g3(Euclidean3DGeometry::LineString(LineString3D::from_coords(
+            e(),
+            [up([1.0, 1.0]), up([3.0, 1.0])],
+        )));
+        let matrix = relate_coplanar(&probe, &mesh).unwrap();
+        assert!(matrix.is_within());
+        // And the equivalent triangular mesh agrees.
+        let tri_mesh = TriangularMesh3D::from_parts(
+            e(),
+            vec![
+                up([0.0, 0.0]),
+                up([2.0, 0.0]),
+                up([2.0, 2.0]),
+                up([0.0, 2.0]),
+                up([4.0, 0.0]),
+                up([4.0, 2.0]),
+            ],
+            // Mixed windings on purpose.
+            [0u32, 1, 2, 2, 3, 0, 1, 4, 5, 1, 5, 2],
+        )
+        .unwrap();
+        let tri_mesh = g3(Euclidean3DGeometry::TriangularMesh(Box::new(tri_mesh)));
+        let matrix = relate_coplanar(&probe, &tri_mesh).unwrap();
+        assert!(matrix.is_within());
+    }
+
+    #[test]
+    fn vertical_plane_picks_a_usable_axis() {
+        // Two squares in the plane x = 5 sharing the edge y = 2.
+        let sq = |y0: f64| {
+            Euclidean3DGeometry::Polygon(Box::new(Polygon3D::from_rings(
+                e(),
+                [
+                    [5.0, y0, 0.0],
+                    [5.0, y0 + 2.0, 0.0],
+                    [5.0, y0 + 2.0, 2.0],
+                    [5.0, y0, 2.0],
+                    [5.0, y0, 0.0],
+                ],
+                Vec::<Vec<[f64; 3]>>::new(),
+            )))
+        };
+        let matrix = relate_coplanar(&g3(sq(0.0)), &g3(sq(2.0))).unwrap();
+        assert!(matrix.is_touches());
+    }
+
+    #[test]
+    fn collinear_and_degenerate_hulls_are_coplanar() {
+        let line = |a: [f64; 3], b: [f64; 3]| {
+            g3(Euclidean3DGeometry::LineString(LineString3D::from_coords(
+                e(),
+                [a, b],
+            )))
+        };
+        // Two overlapping collinear segments along a skew 3D line.
+        let m = relate_coplanar(
+            &line([0.0, 0.0, 0.0], [4.0, 4.0, 4.0]),
+            &line([2.0, 2.0, 2.0], [6.0, 6.0, 6.0]),
+        )
+        .unwrap();
+        assert!(m.is_overlaps());
+        // A vertical line (the z axis) must not collapse under projection.
+        let m = relate_coplanar(
+            &line([0.0, 0.0, 0.0], [0.0, 0.0, 4.0]),
+            &line([0.0, 0.0, 2.0], [0.0, 0.0, 6.0]),
+        )
+        .unwrap();
+        assert!(m.is_overlaps());
+        // Coincident points.
+        let p = g3(Euclidean3DGeometry::Point(Point3D::new(e(), [1.0; 3])));
+        assert!(relate_coplanar(&p, &p).unwrap().is_equal_topo());
+    }
+
+    #[test]
+    fn not_coplanar_and_unsupported_errors() {
+        let up0 = lift([0.0, 0.0, 0.0]);
+        let up1 = lift([0.0, 0.0, 1.0]);
+        let a = g3(poly_3d(square(0.0, 0.0, 4.0), Vec::new(), &up0));
+        let b = g3(poly_3d(square(1.0, 1.0, 4.0), Vec::new(), &up1));
+        assert_eq!(relate_coplanar(&a, &b), Err(PredicateError::NotCoplanar));
+        // A non-planar operand on its own is caught too.
+        let bent = g3(Euclidean3DGeometry::Polygon(Box::new(
+            Polygon3D::from_rings(
+                e(),
+                [
+                    [0.0, 0.0, 0.0],
+                    [4.0, 0.0, 0.0],
+                    [4.0, 4.0, 1.0],
+                    [0.0, 4.0, 0.0],
+                    [0.0, 0.0, 0.0],
+                ],
+                Vec::<Vec<[f64; 3]>>::new(),
+            ),
+        )));
+        assert_eq!(relate_coplanar(&bent, &a), Err(PredicateError::NotCoplanar));
+
+        let solid = g3(solid_geometry(box_solid([0.0; 3], [1.0; 3])));
+        assert_eq!(
+            relate_coplanar(&solid, &a),
+            Err(PredicateError::Unsupported { geometry: "Solid" })
+        );
+        assert_eq!(
+            relate_xy(&solid, &a),
+            Err(PredicateError::Unsupported { geometry: "Solid" })
+        );
+        // 2D × 3D is cross-dimension for the in-plane relate...
+        let flat = g2(poly_2d(square(0.0, 0.0, 4.0), Vec::new()));
+        assert_eq!(
+            relate_coplanar(&flat, &a),
+            Err(PredicateError::CrossDimension)
+        );
+        // ...but exactly what relate_xy is for.
+        assert!(relate_xy(&flat, &a).unwrap().is_intersects());
+    }
+
+    #[test]
+    fn relate_xy_matches_the_footprint_relate() {
+        let mut rng = Rng(20260718);
+        for case in 0..150 {
+            // Independent lifts per operand: XY relate ignores z entirely.
+            let up_a = lift([
+                rng.int(-2, 2) as f64,
+                rng.int(-2, 2) as f64,
+                rng.int(-3, 3) as f64,
+            ]);
+            let up_b = lift([
+                rng.int(-2, 2) as f64,
+                rng.int(-2, 2) as f64,
+                rng.int(-3, 3) as f64,
+            ]);
+            let (a2, a3) = random_member(&mut rng, &up_a);
+            let (b2, b3) = random_member(&mut rng, &up_b);
+            let expected = relate(&g2(a2.clone()), &g2(b2)).unwrap();
+            assert_eq!(
+                relate_xy(&g3(a3.clone()), &g3(b3.clone())).unwrap(),
+                expected,
+                "case {case}"
+            );
+            // Mixed 2D × 3D operands agree as well.
+            assert_eq!(
+                relate_xy(&g2(a2), &g3(b3)).unwrap(),
+                expected,
+                "case {case} mixed"
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_frames_error() {
+        let a = g3(Euclidean3DGeometry::Point(Point3D::new(e(), [0.0; 3])));
+        let b = g3(Euclidean3DGeometry::Point(Point3D::new(
+            CoordinateFrame::Crs(crate::coordinate::EpsgCode::new(4979)),
+            [0.0; 3],
+        )));
+        assert_eq!(relate_coplanar(&a, &b), Err(PredicateError::MixedFrames));
+        assert_eq!(relate_xy(&a, &b), Err(PredicateError::MixedFrames));
+    }
+}

--- a/engine/runtime/geometry/src/predicates/projection.rs
+++ b/engine/runtime/geometry/src/predicates/projection.rs
@@ -1,31 +1,30 @@
 //! DE-9IM relates for 3D geometry through planar projection.
 //!
-//! There is no volumetric DE-9IM (plan §7); what 3D offers beyond the exact
+//! There is no volumetric DE-9IM; what 3D offers beyond the exact
 //! [`intersects`](super::intersects()) tests are two projections into the 2D
 //! [`relate`](super::relate()) machinery:
 //!
-//! - [`relate_coplanar`] — for **mutually coplanar** 3D geometries (a shared
+//! - [`relate_coplanar`]: for **mutually coplanar** 3D geometries (a shared
 //!   wall, a floor and its furniture footprints): verifies coplanarity
 //!   exactly, projects both operands onto the shared plane, and relates
 //!   in-plane. Non-coplanar operands are a
 //!   [`NotCoplanar`](super::PredicateError::NotCoplanar) error.
-//! - [`relate_xy`] — the legacy-compatible SpatialFilter semantics: every
-//!   leaf, 2D or 3D, is taken by its `(x, y)` footprint and related in 2D.
-//!   This is the explicit XY-projection opt-in; nothing else in the
-//!   predicates crosses dimensions.
+//! - [`relate_xy`]: every leaf, 2D or 3D, is taken by its `(x, y)` footprint
+//!   and related in 2D. This is the explicit XY-projection opt-in; nothing
+//!   else in the predicates crosses dimensions.
 //!
 //! Both project by **dropping a coordinate axis**, not by rotating onto a
 //! tangent plane: an axis drop copies coordinates verbatim, so the 2D relate's
 //! robust predicates see exact inputs and the matrix is exact for the 3D
 //! configuration. (`relate_coplanar` picks an axis along which the shared
-//! plane does not collapse — one always exists — and DE-9IM is invariant
+//! plane does not collapse, which always exists, and DE-9IM is invariant
 //! under a linear bijection of the plane, so the skew of an axis drop is
 //! harmless.) The projected operands are materialized as owned 2D leaves per
 //! call.
 //!
 //! Because a projection may mirror orientation, mesh faces are re-normalized
-//! to the validated 2D winding (exterior counter-clockwise) before the relate
-//! — the mesh dissolve depends on it. Caveats carried over from `relate`:
+//! to the validated 2D winding (exterior counter-clockwise) before the relate;
+//! the mesh dissolve depends on it. Caveats carried over from `relate`:
 //! leaves whose *projections* overlap areally (e.g. the faces of a closed
 //! shell under `relate_xy`) are the documented unsupported relate input, and
 //! a face that projects to zero area degrades like any other degenerate ring.
@@ -67,8 +66,8 @@ pub fn relate_coplanar(a: &Geometry, b: &Geometry) -> Result<IntersectionMatrix>
     relate_2d(&project(&a_leaves, axis), &project(&b_leaves, axis))
 }
 
-/// The DE-9IM matrix of the `(x, y)` footprints of two geometries — the
-/// explicit XY-projection opt-in matching legacy SpatialFilter 3D semantics.
+/// The DE-9IM matrix of the `(x, y)` footprints of two geometries: the
+/// explicit XY-projection opt-in.
 ///
 /// Each operand may be 2D, 3D, or a mixed collection: 2D leaves are taken
 /// as-is (their optional elevation ignored, as everywhere), 3D leaves drop
@@ -158,8 +157,8 @@ fn require_common_frame(a: &[Leaf3D<'_>], b: &[Leaf3D<'_>]) -> Result<()> {
 // --- the shared plane ----------------------------------------------------------
 
 /// Verify all leaves' vertices lie in one plane (exactly) and return the axis
-/// to drop: one along which that plane — or line, or point — does not
-/// collapse, so the projection is injective on it.
+/// to drop: one along which that plane (or line, or point) does not collapse,
+/// so the projection is injective on it.
 fn shared_plane_axis<'a, 'b>(leaves: impl Iterator<Item = &'b Leaf3D<'a>> + Clone) -> Result<usize>
 where
     'a: 'b,

--- a/engine/runtime/geometry/src/predicates/ray.rs
+++ b/engine/runtime/geometry/src/predicates/ray.rs
@@ -1,17 +1,17 @@
 //! Ray casting against 3D geometry.
 //!
 //! [`ray_cast`] intersects a [`Ray3D`] with every surface a 3D geometry
-//! carries — a `TriangularMesh` verbatim, `Polygon` / `PolygonMesh` faces and
+//! carries (a `TriangularMesh` verbatim, `Polygon` / `PolygonMesh` faces and
 //! `Solid` shells through the borrowed triangulation of
-//! [`view3d`](super::view3d) — and returns the [`RayHit`]s sorted by distance.
-//! `Point` and `LineString` leaves yield no hits (a ray almost never meets a
-//! measure-zero target; this matches the legacy `RayIntersection3D`).
+//! [`view3d`](super::view3d)) and returns the [`RayHit`]s sorted by distance.
+//! `Point` and `LineString` leaves yield no hits: a ray almost never meets a
+//! measure-zero target.
 //!
 //! Unlike the exact boolean tests in [`kernel3d`](super::kernel3d), ray
-//! casting *constructs* hit coordinates, so it keeps the legacy Möller–
-//! Trumbore formulation with an explicit `tolerance` (the legacy default is
-//! `1e-10`, see [`DEFAULT_RAY_TOLERANCE`]): near-parallel rays are rejected by
-//! the determinant test and hits are accepted from `t >= -tolerance`. A ray
+//! casting *constructs* hit coordinates, so it uses the Möller–Trumbore
+//! formulation with an explicit `tolerance` (see [`DEFAULT_RAY_TOLERANCE`]):
+//! near-parallel rays are rejected by the determinant test and hits are
+//! accepted from `t >= -tolerance`. A ray
 //! passing exactly through an edge shared by two triangles reports one hit per
 //! triangle; callers that need one crossing per surface point can collapse
 //! equal `(t, point)` pairs.
@@ -27,7 +27,7 @@ use super::kernel::{cross3, dot3, sub3};
 use super::view3d::{flatten_3d, require_common_frame_3d, Leaf3D, TriangleSet};
 use super::{PredicateError, Result};
 
-/// The tolerance the legacy ray casting defaulted to.
+/// The default `tolerance` for ray casting.
 pub const DEFAULT_RAY_TOLERANCE: f64 = 1e-10;
 
 /// A ray: an origin and a unit direction, extending infinitely in the
@@ -187,11 +187,10 @@ fn cast_into(set: &TriangleSet<'_>, ray: &Ray3D, tolerance: f64, hits: &mut Vec<
     );
 }
 
-/// Möller–Trumbore ray × triangle intersection, preserving the legacy
-/// `RayIntersection3D` semantics: rays parallel to the triangle within the
-/// (raw-determinant) `tolerance` miss, boundary hits (`u`/`v` at their bounds)
-/// count, and hits from `t >= -tolerance` are accepted so a ray starting on
-/// the surface still reports it.
+/// Möller–Trumbore ray × triangle intersection: rays parallel to the triangle
+/// within the (raw-determinant) `tolerance` miss, boundary hits (`u`/`v` at
+/// their bounds) count, and hits from `t >= -tolerance` are accepted so a ray
+/// starting on the surface still reports it.
 pub fn ray_triangle_intersection(
     ray: &Ray3D,
     triangle: [[f64; 3]; 3],
@@ -235,13 +234,8 @@ pub fn ray_triangle_intersection(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::algorithm::ray_intersection::{
-        Ray3D as LegacyRay3D, RayIntersection3D as LegacyRayIntersection3D,
-    };
     use crate::point::Point3D;
-    use crate::predicates::test3d::{box_solid, e, g3, solid_geometry, Rng};
-    use crate::types::coordinate::Coordinate3D;
-    use crate::types::triangle::Triangle3D;
+    use crate::predicates::test3d::{box_solid, e, g3, solid_geometry};
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -306,65 +300,6 @@ mod tests {
         assert_eq!(
             ray_cast(&square_2d, &ray, DEFAULT_RAY_TOLERANCE),
             Err(PredicateError::CrossDimension)
-        );
-    }
-
-    #[test]
-    fn differential_against_legacy_moller_trumbore() {
-        let mut rng = Rng(20260716);
-        let mut hit_count = 0usize;
-        for case in 0..2000 {
-            let coord = |rng: &mut Rng| {
-                [
-                    rng.f64(-10.0, 10.0),
-                    rng.f64(-10.0, 10.0),
-                    rng.f64(-10.0, 10.0),
-                ]
-            };
-            let tri = [coord(&mut rng), coord(&mut rng), coord(&mut rng)];
-            let origin = coord(&mut rng);
-            // Aim near the triangle's centroid half the time so hits are
-            // frequent; otherwise a random direction.
-            let target = if case % 2 == 0 {
-                let c = [
-                    (tri[0][0] + tri[1][0] + tri[2][0]) / 3.0 + rng.f64(-2.0, 2.0),
-                    (tri[0][1] + tri[1][1] + tri[2][1]) / 3.0 + rng.f64(-2.0, 2.0),
-                    (tri[0][2] + tri[1][2] + tri[2][2]) / 3.0 + rng.f64(-2.0, 2.0),
-                ];
-                [c[0] - origin[0], c[1] - origin[1], c[2] - origin[2]]
-            } else {
-                coord(&mut rng)
-            };
-
-            let Some(ray) = Ray3D::new(origin, target) else {
-                continue;
-            };
-            let ours = ray_triangle_intersection(&ray, tri, DEFAULT_RAY_TOLERANCE);
-
-            let legacy_ray = LegacyRay3D::new(
-                Coordinate3D::new__(origin[0], origin[1], origin[2]),
-                Coordinate3D::new__(target[0], target[1], target[2]),
-            );
-            let legacy_tri = Triangle3D::new(
-                Coordinate3D::new__(tri[0][0], tri[0][1], tri[0][2]),
-                Coordinate3D::new__(tri[1][0], tri[1][1], tri[1][2]),
-                Coordinate3D::new__(tri[2][0], tri[2][1], tri[2][2]),
-            );
-            let legacy = legacy_tri.ray_intersections(&legacy_ray, DEFAULT_RAY_TOLERANCE);
-
-            match (ours, legacy.as_slice()) {
-                (None, []) => {}
-                (Some(hit), [l]) => {
-                    assert_eq!(hit.t, l.t, "case {case}: t");
-                    assert_eq!(hit.point, [l.point.x, l.point.y, l.point.z], "case {case}");
-                    hit_count += 1;
-                }
-                (ours, legacy) => panic!("case {case}: {ours:?} vs legacy {legacy:?}"),
-            }
-        }
-        assert!(
-            hit_count > 400,
-            "sweep should produce many hits: {hit_count}"
         );
     }
 }

--- a/engine/runtime/geometry/src/predicates/ray.rs
+++ b/engine/runtime/geometry/src/predicates/ray.rs
@@ -1,0 +1,370 @@
+//! Ray casting against 3D geometry.
+//!
+//! [`ray_cast`] intersects a [`Ray3D`] with every surface a 3D geometry
+//! carries — a `TriangularMesh` verbatim, `Polygon` / `PolygonMesh` faces and
+//! `Solid` shells through the borrowed triangulation of
+//! [`view3d`](super::view3d) — and returns the [`RayHit`]s sorted by distance.
+//! `Point` and `LineString` leaves yield no hits (a ray almost never meets a
+//! measure-zero target; this matches the legacy `RayIntersection3D`).
+//!
+//! Unlike the exact boolean tests in [`kernel3d`](super::kernel3d), ray
+//! casting *constructs* hit coordinates, so it keeps the legacy Möller–
+//! Trumbore formulation with an explicit `tolerance` (the legacy default is
+//! `1e-10`, see [`DEFAULT_RAY_TOLERANCE`]): near-parallel rays are rejected by
+//! the determinant test and hits are accepted from `t >= -tolerance`. A ray
+//! passing exactly through an edge shared by two triangles reports one hit per
+//! triangle; callers that need one crossing per surface point can collapse
+//! equal `(t, point)` pairs.
+//!
+//! The ray is taken to be in the geometry's own coordinate frame; the
+//! geometry's leaves must agree on one
+//! ([`MixedFrames`](super::PredicateError::MixedFrames) otherwise).
+
+use crate::ops::triangulation::Cache;
+use crate::{Euclidean3DGeometry, Geometry};
+
+use super::kernel::{cross3, dot3, sub3};
+use super::view3d::{flatten_3d, require_common_frame_3d, Leaf3D, TriangleSet};
+use super::{PredicateError, Result};
+
+/// The tolerance the legacy ray casting defaulted to.
+pub const DEFAULT_RAY_TOLERANCE: f64 = 1e-10;
+
+/// A ray: an origin and a unit direction, extending infinitely in the
+/// positive direction. `t` parameters are therefore Euclidean distances.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Ray3D {
+    origin: [f64; 3],
+    /// Normalized at construction.
+    direction: [f64; 3],
+}
+
+impl Ray3D {
+    /// A ray from `origin` along `direction` (normalized here). `None` when
+    /// the direction is zero or not finite, which defines no ray.
+    pub fn new(origin: [f64; 3], direction: [f64; 3]) -> Option<Self> {
+        let norm = dot3(direction, direction).sqrt();
+        if !norm.is_finite() || norm == 0.0 || origin.iter().any(|c| !c.is_finite()) {
+            return None;
+        }
+        Some(Ray3D {
+            origin,
+            direction: direction.map(|c| c / norm),
+        })
+    }
+
+    /// The ray's origin.
+    #[inline]
+    pub fn origin(&self) -> [f64; 3] {
+        self.origin
+    }
+
+    /// The ray's unit direction.
+    #[inline]
+    pub fn direction(&self) -> [f64; 3] {
+        self.direction
+    }
+
+    /// The point at distance `t` along the ray.
+    #[inline]
+    pub fn point_at(&self, t: f64) -> [f64; 3] {
+        [
+            self.origin[0] + self.direction[0] * t,
+            self.origin[1] + self.direction[1] * t,
+            self.origin[2] + self.direction[2] * t,
+        ]
+    }
+}
+
+/// One ray × surface intersection.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RayHit {
+    /// Distance along the ray (`point = origin + t * direction`).
+    pub t: f64,
+    /// The intersection point.
+    pub point: [f64; 3],
+}
+
+/// All intersections of the ray with the geometry's surfaces, sorted by `t`
+/// (then point, for a total order). `Geometry::None` yields no hits;
+/// collections are the union of their members' hits; a 2D geometry is
+/// [`CrossDimension`](PredicateError::CrossDimension).
+pub fn ray_cast(geometry: &Geometry, ray: &Ray3D, tolerance: f64) -> Result<Vec<RayHit>> {
+    let mut hits = collect_hits(geometry, ray, tolerance)?;
+    hits.sort_by(|a, b| {
+        a.t.total_cmp(&b.t).then_with(|| {
+            a.point
+                .iter()
+                .zip(&b.point)
+                .map(|(x, y)| x.total_cmp(y))
+                .find(|o| o.is_ne())
+                .unwrap_or(core::cmp::Ordering::Equal)
+        })
+    });
+    Ok(hits)
+}
+
+/// The closest forward hit (`t >= 0`), if any.
+pub fn closest_ray_hit(geometry: &Geometry, ray: &Ray3D, tolerance: f64) -> Result<Option<RayHit>> {
+    Ok(ray_cast(geometry, ray, tolerance)?
+        .into_iter()
+        .find(|hit| hit.t >= 0.0))
+}
+
+/// [`ray_cast`] over a 3D geometry, unsorted.
+fn collect_hits(geometry: &Geometry, ray: &Ray3D, tolerance: f64) -> Result<Vec<RayHit>> {
+    match geometry {
+        Geometry::None => Ok(Vec::new()),
+        Geometry::GeometryCollection(c) => {
+            let mut hits = Vec::new();
+            for member in c.members() {
+                hits.extend(collect_hits(member, ray, tolerance)?);
+            }
+            Ok(hits)
+        }
+        Geometry::Euclidean2D(_) => Err(PredicateError::CrossDimension),
+        Geometry::Euclidean3D(g) => ray_cast_3d(g, ray, tolerance),
+    }
+}
+
+/// [`ray_cast`] over a 3D geometry.
+pub fn ray_cast_3d(
+    geometry: &Euclidean3DGeometry,
+    ray: &Ray3D,
+    tolerance: f64,
+) -> Result<Vec<RayHit>> {
+    let mut leaves = Vec::new();
+    let mut unsupported = None;
+    flatten_3d(geometry, &mut leaves, &mut unsupported);
+    if let Some(name) = unsupported {
+        return Err(PredicateError::Unsupported { geometry: name });
+    }
+    require_common_frame_3d(&leaves, &[])?;
+
+    let mut cache = Cache::new();
+    let mut hits = Vec::new();
+    for leaf in &leaves {
+        match leaf {
+            Leaf3D::Point(_) | Leaf3D::Line(_) => {}
+            Leaf3D::Polygon(p) => cast_into(
+                &TriangleSet::from_polygon(p, &mut cache),
+                ray,
+                tolerance,
+                &mut hits,
+            ),
+            Leaf3D::PolygonMesh(m) => cast_into(
+                &TriangleSet::from_polygon_mesh_data(m.data(), &mut cache),
+                ray,
+                tolerance,
+                &mut hits,
+            ),
+            Leaf3D::TriangularMesh(m) => cast_into(
+                &TriangleSet::from_triangular_data(m.data()),
+                ray,
+                tolerance,
+                &mut hits,
+            ),
+            Leaf3D::Solid(s) => {
+                for shell in core::iter::once(s.exterior()).chain(s.interiors().iter()) {
+                    cast_into(
+                        &TriangleSet::from_shell(shell, &mut cache),
+                        ray,
+                        tolerance,
+                        &mut hits,
+                    );
+                }
+            }
+        }
+    }
+    Ok(hits)
+}
+
+/// Append the ray's hits on every triangle of the set.
+fn cast_into(set: &TriangleSet<'_>, ray: &Ray3D, tolerance: f64, hits: &mut Vec<RayHit>) {
+    hits.extend(
+        set.triangles()
+            .filter_map(|t| ray_triangle_intersection(ray, t, tolerance)),
+    );
+}
+
+/// Möller–Trumbore ray × triangle intersection, preserving the legacy
+/// `RayIntersection3D` semantics: rays parallel to the triangle within the
+/// (raw-determinant) `tolerance` miss, boundary hits (`u`/`v` at their bounds)
+/// count, and hits from `t >= -tolerance` are accepted so a ray starting on
+/// the surface still reports it.
+pub fn ray_triangle_intersection(
+    ray: &Ray3D,
+    triangle: [[f64; 3]; 3],
+    tolerance: f64,
+) -> Option<RayHit> {
+    let [v0, v1, v2] = triangle;
+    let edge1 = sub3(v1, v0);
+    let edge2 = sub3(v2, v0);
+
+    let h = cross3(ray.direction, edge2);
+    let a = dot3(edge1, h);
+    // Ray parallel to the triangle's plane.
+    if a.abs() < tolerance {
+        return None;
+    }
+
+    let f = 1.0 / a;
+    let s = sub3(ray.origin, v0);
+    let u = f * dot3(s, h);
+    if !(0.0..=1.0).contains(&u) {
+        return None;
+    }
+
+    let q = cross3(s, edge1);
+    let v = f * dot3(ray.direction, q);
+    if v < 0.0 || u + v > 1.0 {
+        return None;
+    }
+
+    let t = f * dot3(edge2, q);
+    if t >= -tolerance {
+        Some(RayHit {
+            t,
+            point: ray.point_at(t),
+        })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::ray_intersection::{
+        Ray3D as LegacyRay3D, RayIntersection3D as LegacyRayIntersection3D,
+    };
+    use crate::point::Point3D;
+    use crate::predicates::test3d::{box_solid, e, g3, solid_geometry, Rng};
+    use crate::types::coordinate::Coordinate3D;
+    use crate::types::triangle::Triangle3D;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn ray_through_a_box_hits_entry_and_exit() {
+        // (y, z) = (1, 2) avoids the faces' triangulation diagonals.
+        let solid = g3(solid_geometry(box_solid([0.0; 3], [4.0; 3])));
+        let ray = Ray3D::new([-1.0, 1.0, 2.0], [1.0, 0.0, 0.0]).unwrap();
+        let hits = ray_cast(&solid, &ray, DEFAULT_RAY_TOLERANCE).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].t, 1.0);
+        assert_eq!(hits[0].point, [0.0, 1.0, 2.0]);
+        assert_eq!(hits[1].t, 5.0);
+        assert_eq!(hits[1].point, [4.0, 1.0, 2.0]);
+        assert_eq!(
+            closest_ray_hit(&solid, &ray, DEFAULT_RAY_TOLERANCE).unwrap(),
+            Some(hits[0])
+        );
+        // Pointing away: no hits.
+        let away = Ray3D::new([-1.0, 1.0, 2.0], [-1.0, 0.0, 0.0]).unwrap();
+        assert_eq!(
+            ray_cast(&solid, &away, DEFAULT_RAY_TOLERANCE).unwrap(),
+            vec![]
+        );
+    }
+
+    #[test]
+    fn direction_is_normalized_so_t_is_distance() {
+        let solid = g3(solid_geometry(box_solid([0.0; 3], [4.0; 3])));
+        let fast = Ray3D::new([-2.0, 1.0, 2.0], [10.0, 0.0, 0.0]).unwrap();
+        let hits = ray_cast(&solid, &fast, DEFAULT_RAY_TOLERANCE).unwrap();
+        assert_eq!(hits[0].t, 2.0);
+        assert!(Ray3D::new([0.0; 3], [0.0; 3]).is_none());
+        assert!(Ray3D::new([0.0; 3], [f64::NAN, 0.0, 0.0]).is_none());
+    }
+
+    #[test]
+    fn ray_starting_on_the_surface_reports_t_zero() {
+        let solid = g3(solid_geometry(box_solid([0.0; 3], [4.0; 3])));
+        let inward = Ray3D::new([0.0, 1.0, 2.0], [1.0, 0.0, 0.0]).unwrap();
+        let hits = ray_cast(&solid, &inward, DEFAULT_RAY_TOLERANCE).unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].t, 0.0);
+        assert_eq!(hits[1].t, 4.0);
+    }
+
+    #[test]
+    fn point_and_line_leaves_yield_no_hits_and_errors_propagate() {
+        let p = g3(crate::Euclidean3DGeometry::Point(Point3D::new(
+            e(),
+            [0.0; 3],
+        )));
+        let ray = Ray3D::new([-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]).unwrap();
+        assert_eq!(ray_cast(&p, &ray, DEFAULT_RAY_TOLERANCE).unwrap(), vec![]);
+        assert_eq!(
+            ray_cast(&Geometry::None, &ray, DEFAULT_RAY_TOLERANCE).unwrap(),
+            vec![]
+        );
+
+        let square_2d = Geometry::Euclidean2D(crate::Euclidean2DGeometry::Point(
+            crate::point::Point2D::new(e(), [0.0, 0.0]),
+        ));
+        assert_eq!(
+            ray_cast(&square_2d, &ray, DEFAULT_RAY_TOLERANCE),
+            Err(PredicateError::CrossDimension)
+        );
+    }
+
+    #[test]
+    fn differential_against_legacy_moller_trumbore() {
+        let mut rng = Rng(20260716);
+        let mut hit_count = 0usize;
+        for case in 0..2000 {
+            let coord = |rng: &mut Rng| {
+                [
+                    rng.f64(-10.0, 10.0),
+                    rng.f64(-10.0, 10.0),
+                    rng.f64(-10.0, 10.0),
+                ]
+            };
+            let tri = [coord(&mut rng), coord(&mut rng), coord(&mut rng)];
+            let origin = coord(&mut rng);
+            // Aim near the triangle's centroid half the time so hits are
+            // frequent; otherwise a random direction.
+            let target = if case % 2 == 0 {
+                let c = [
+                    (tri[0][0] + tri[1][0] + tri[2][0]) / 3.0 + rng.f64(-2.0, 2.0),
+                    (tri[0][1] + tri[1][1] + tri[2][1]) / 3.0 + rng.f64(-2.0, 2.0),
+                    (tri[0][2] + tri[1][2] + tri[2][2]) / 3.0 + rng.f64(-2.0, 2.0),
+                ];
+                [c[0] - origin[0], c[1] - origin[1], c[2] - origin[2]]
+            } else {
+                coord(&mut rng)
+            };
+
+            let Some(ray) = Ray3D::new(origin, target) else {
+                continue;
+            };
+            let ours = ray_triangle_intersection(&ray, tri, DEFAULT_RAY_TOLERANCE);
+
+            let legacy_ray = LegacyRay3D::new(
+                Coordinate3D::new__(origin[0], origin[1], origin[2]),
+                Coordinate3D::new__(target[0], target[1], target[2]),
+            );
+            let legacy_tri = Triangle3D::new(
+                Coordinate3D::new__(tri[0][0], tri[0][1], tri[0][2]),
+                Coordinate3D::new__(tri[1][0], tri[1][1], tri[1][2]),
+                Coordinate3D::new__(tri[2][0], tri[2][1], tri[2][2]),
+            );
+            let legacy = legacy_tri.ray_intersections(&legacy_ray, DEFAULT_RAY_TOLERANCE);
+
+            match (ours, legacy.as_slice()) {
+                (None, []) => {}
+                (Some(hit), [l]) => {
+                    assert_eq!(hit.t, l.t, "case {case}: t");
+                    assert_eq!(hit.point, [l.point.x, l.point.y, l.point.z], "case {case}");
+                    hit_count += 1;
+                }
+                (ours, legacy) => panic!("case {case}: {ours:?} vs legacy {legacy:?}"),
+            }
+        }
+        assert!(
+            hit_count > 400,
+            "sweep should produce many hits: {hit_count}"
+        );
+    }
+}

--- a/engine/runtime/geometry/src/predicates/ray.rs
+++ b/engine/runtime/geometry/src/predicates/ray.rs
@@ -19,12 +19,26 @@
 //! The ray is taken to be in the geometry's own coordinate frame; the
 //! geometry's leaves must agree on one
 //! ([`MixedFrames`](super::PredicateError::MixedFrames) otherwise).
+//!
+//! The one-shot [`ray_cast`] scans every triangle: for a single ray that beats
+//! any index, because building one costs more than the scan it would save. To
+//! cast **many** rays at one geometry, build a [`RayCaster`] once; its
+//! large surfaces carry a bounding-volume hierarchy (an rstar tree over
+//! per-triangle boxes) that descends only the nodes the ray's slab test
+//! pierces, gated on triangle count ([`BVH_MIN_TRIANGLES`]). Both strategies
+//! run the same exact [`ray_triangle_intersection`] on every triangle they
+//! reach, so acceleration never changes which hits are reported.
+
+use rstar::RTree;
 
 use crate::ops::triangulation::Cache;
 use crate::{Euclidean3DGeometry, Geometry};
 
 use super::kernel::{cross3, dot3, sub3};
-use super::view3d::{flatten_3d, require_common_frame_3d, Leaf3D, TriangleSet};
+use super::view3d::{
+    flatten_3d, flatten_geometry_3d, require_common_frame_3d, Leaf3D, SlabSelection, TriBox,
+    TriangleSet,
+};
 use super::{PredicateError, Result};
 
 /// The default `tolerance` for ray casting.
@@ -89,8 +103,20 @@ pub struct RayHit {
 /// (then point, for a total order). `Geometry::None` yields no hits;
 /// collections are the union of their members' hits; a 2D geometry is
 /// [`CrossDimension`](PredicateError::CrossDimension).
+///
+/// This is the one-shot entry: it scans every triangle (no acceleration
+/// structure), which is the right choice for a single ray. To cast **many**
+/// rays at one geometry, build a [`RayCaster`] once and reuse it; it amortizes
+/// a bounding-volume hierarchy over the queries.
 pub fn ray_cast(geometry: &Geometry, ray: &Ray3D, tolerance: f64) -> Result<Vec<RayHit>> {
     let mut hits = collect_hits(geometry, ray, tolerance)?;
+    sort_by_distance(&mut hits);
+    Ok(hits)
+}
+
+/// Sort hits by `t`, then by point for a total order (the order every entry
+/// returns them in).
+fn sort_by_distance(hits: &mut [RayHit]) {
     hits.sort_by(|a, b| {
         a.t.total_cmp(&b.t).then_with(|| {
             a.point
@@ -101,7 +127,6 @@ pub fn ray_cast(geometry: &Geometry, ray: &Ray3D, tolerance: f64) -> Result<Vec<
                 .unwrap_or(core::cmp::Ordering::Equal)
         })
     });
-    Ok(hits)
 }
 
 /// The closest forward hit (`t >= 0`), if any.
@@ -146,19 +171,19 @@ pub fn ray_cast_3d(
     for leaf in &leaves {
         match leaf {
             Leaf3D::Point(_) | Leaf3D::Line(_) => {}
-            Leaf3D::Polygon(p) => cast_into(
+            Leaf3D::Polygon(p) => cast_linear(
                 &TriangleSet::from_polygon(p, &mut cache),
                 ray,
                 tolerance,
                 &mut hits,
             ),
-            Leaf3D::PolygonMesh(m) => cast_into(
+            Leaf3D::PolygonMesh(m) => cast_linear(
                 &TriangleSet::from_polygon_mesh_data(m.data(), &mut cache),
                 ray,
                 tolerance,
                 &mut hits,
             ),
-            Leaf3D::TriangularMesh(m) => cast_into(
+            Leaf3D::TriangularMesh(m) => cast_linear(
                 &TriangleSet::from_triangular_data(m.data()),
                 ray,
                 tolerance,
@@ -166,7 +191,7 @@ pub fn ray_cast_3d(
             ),
             Leaf3D::Solid(s) => {
                 for shell in core::iter::once(s.exterior()).chain(s.interiors().iter()) {
-                    cast_into(
+                    cast_linear(
                         &TriangleSet::from_shell(shell, &mut cache),
                         ray,
                         tolerance,
@@ -179,12 +204,135 @@ pub fn ray_cast_3d(
     Ok(hits)
 }
 
-/// Append the ray's hits on every triangle of the set.
-fn cast_into(set: &TriangleSet<'_>, ray: &Ray3D, tolerance: f64, hits: &mut Vec<RayHit>) {
+/// Triangle count at or above which a [`RayCaster`] surface builds a
+/// bounding-volume hierarchy for its ray queries instead of scanning every
+/// triangle. Below it the scan wins even with the tree already built: the
+/// traversal overhead exceeds the handful of Möller-Trumbore tests it saves.
+/// Calibrated by the `bvh_vs_linear_crossover` benchmark
+/// (`cargo test -p reearth-flow-geometry --features new-geometry
+/// predicates::ray::tests::bvh_vs_linear_crossover -- --ignored --nocapture`):
+/// the prebuilt-tree query overtakes the linear scan between 8 and 18
+/// triangles.
+pub(crate) const BVH_MIN_TRIANGLES: usize = 16;
+
+/// The linear strategy: the ray against every triangle. The one-shot
+/// [`ray_cast`] always uses this; a single ray cannot amortize a tree build.
+fn cast_linear(set: &TriangleSet<'_>, ray: &Ray3D, tolerance: f64, hits: &mut Vec<RayHit>) {
     hits.extend(
         set.triangles()
             .filter_map(|t| ray_triangle_intersection(ray, t, tolerance)),
     );
+}
+
+/// A geometry prepared for repeated ray casting: its surfaces triangulated once
+/// and, for large ones, indexed by a bounding-volume hierarchy. Build it once
+/// and call [`cast`](Self::cast) / [`closest`](Self::closest) many times; that
+/// is where the hierarchy pays off (a per-ray rebuild is strictly slower than a
+/// linear scan, so the one-shot [`ray_cast`] never builds one).
+///
+/// Same contract as [`ray_cast`]: `Point` / `LineString` leaves contribute no
+/// hits, a 2D leaf is [`CrossDimension`](PredicateError::CrossDimension), and
+/// `Csg` / `PointCloud` are [`Unsupported`](PredicateError::Unsupported). The
+/// geometry's leaves must share one coordinate frame. Borrows the geometry for
+/// the caster's lifetime.
+pub struct RayCaster<'a> {
+    surfaces: Vec<PreparedSurface<'a>>,
+}
+
+/// One triangulated surface, with an optional BVH over its triangles (present
+/// only when the triangle count clears [`BVH_MIN_TRIANGLES`]).
+struct PreparedSurface<'a> {
+    set: TriangleSet<'a>,
+    accel: Option<RTree<TriBox>>,
+}
+
+impl<'a> RayCaster<'a> {
+    /// Prepare a geometry for repeated casting: flatten its leaves, triangulate
+    /// each surface once, and index the large ones. The `tolerance` is supplied
+    /// per cast, not here.
+    pub fn new(geometry: &'a Geometry) -> Result<Self> {
+        let (leaves, saw_2d, unsupported) = flatten_geometry_3d(geometry);
+        if let Some(name) = unsupported {
+            return Err(PredicateError::Unsupported { geometry: name });
+        }
+        if saw_2d {
+            return Err(PredicateError::CrossDimension);
+        }
+        require_common_frame_3d(&leaves, &[])?;
+
+        let mut cache = Cache::new();
+        let mut surfaces = Vec::new();
+        for leaf in &leaves {
+            match leaf {
+                Leaf3D::Point(_) | Leaf3D::Line(_) => {}
+                Leaf3D::Polygon(p) => {
+                    push_surface(TriangleSet::from_polygon(p, &mut cache), &mut surfaces)
+                }
+                Leaf3D::PolygonMesh(m) => push_surface(
+                    TriangleSet::from_polygon_mesh_data(m.data(), &mut cache),
+                    &mut surfaces,
+                ),
+                Leaf3D::TriangularMesh(m) => {
+                    push_surface(TriangleSet::from_triangular_data(m.data()), &mut surfaces)
+                }
+                Leaf3D::Solid(s) => {
+                    for shell in core::iter::once(s.exterior()).chain(s.interiors().iter()) {
+                        push_surface(TriangleSet::from_shell(shell, &mut cache), &mut surfaces);
+                    }
+                }
+            }
+        }
+        Ok(RayCaster { surfaces })
+    }
+
+    /// All intersections of the ray with the prepared surfaces, sorted by `t`
+    /// then point, exactly as [`ray_cast`] returns them.
+    pub fn cast(&self, ray: &Ray3D, tolerance: f64) -> Vec<RayHit> {
+        let mut hits = Vec::new();
+        for surface in &self.surfaces {
+            match &surface.accel {
+                Some(tree) => query_tree(tree, &surface.set, ray, tolerance, &mut hits),
+                None => cast_linear(&surface.set, ray, tolerance, &mut hits),
+            }
+        }
+        sort_by_distance(&mut hits);
+        hits
+    }
+
+    /// The closest forward hit (`t >= 0`), if any.
+    pub fn closest(&self, ray: &Ray3D, tolerance: f64) -> Option<RayHit> {
+        self.cast(ray, tolerance)
+            .into_iter()
+            .find(|hit| hit.t >= 0.0)
+    }
+}
+
+/// Push a non-empty surface, building its BVH when it clears the size gate.
+fn push_surface<'a>(set: TriangleSet<'a>, out: &mut Vec<PreparedSurface<'a>>) {
+    if set.is_empty() {
+        return;
+    }
+    let accel = (set.len() >= BVH_MIN_TRIANGLES).then(|| set.rtree());
+    out.push(PreparedSurface { set, accel });
+}
+
+/// Query a prebuilt tree: the exact triangle test only on the triangles whose
+/// box the ray's slab test pierces (the shared [`SlabSelection`]).
+fn query_tree(
+    tree: &RTree<TriBox>,
+    set: &TriangleSet<'_>,
+    ray: &Ray3D,
+    tolerance: f64,
+    hits: &mut Vec<RayHit>,
+) {
+    let selection = SlabSelection::ray(ray.origin(), ray.direction(), tolerance);
+    for candidate in tree.locate_with_selection_function(selection) {
+        if let Some(hit) =
+            ray_triangle_intersection(ray, set.triangle(candidate.idx as usize), tolerance)
+        {
+            hits.push(hit);
+        }
+    }
 }
 
 /// Möller–Trumbore ray × triangle intersection: rays parallel to the triangle
@@ -301,5 +449,230 @@ mod tests {
             ray_cast(&square_2d, &ray, DEFAULT_RAY_TOLERANCE),
             Err(PredicateError::CrossDimension)
         );
+    }
+
+    /// A `w x w` grid of quads in `z = 0`, each split into two triangles:
+    /// `(w + 1)^2` vertices, `2 * w^2` triangles.
+    fn grid_mesh(w: usize) -> crate::triangular_mesh::TriangularMesh3D {
+        let mut verts = Vec::with_capacity((w + 1) * (w + 1));
+        for j in 0..=w {
+            for i in 0..=w {
+                verts.push([i as f64, j as f64, 0.0]);
+            }
+        }
+        let idx = |i: usize, j: usize| (j * (w + 1) + i) as u32;
+        let mut tris = Vec::with_capacity(w * w * 6);
+        for j in 0..w {
+            for i in 0..w {
+                tris.extend_from_slice(&[
+                    idx(i, j),
+                    idx(i + 1, j),
+                    idx(i + 1, j + 1),
+                    idx(i, j),
+                    idx(i + 1, j + 1),
+                    idx(i, j + 1),
+                ]);
+            }
+        }
+        crate::triangular_mesh::TriangularMesh3D::from_parts(e(), verts, tris).unwrap()
+    }
+
+    /// Sort hits into the total order [`ray_cast`] uses, so two strategies'
+    /// outputs compare directly.
+    fn sort_hits(hits: &mut [RayHit]) {
+        hits.sort_by(|a, b| {
+            a.t.total_cmp(&b.t).then_with(|| {
+                a.point
+                    .iter()
+                    .zip(&b.point)
+                    .map(|(x, y)| x.total_cmp(y))
+                    .find(|o| o.is_ne())
+                    .unwrap_or(core::cmp::Ordering::Equal)
+            })
+        });
+    }
+
+    /// The BVH strategy with the tree built inline: only the benchmark's
+    /// rebuild-per-ray column and the low-level equivalence test use it, since
+    /// production never rebuilds per ray.
+    fn cast_bvh(set: &TriangleSet<'_>, ray: &Ray3D, tolerance: f64, hits: &mut Vec<RayHit>) {
+        let tree = set.rtree();
+        query_tree(&tree, set, ray, tolerance, hits);
+    }
+
+    #[test]
+    fn bvh_and_linear_report_identical_hits() {
+        // 288 triangles, above BVH_MIN_TRIANGLES, so both strategies are live.
+        let mesh = grid_mesh(12);
+        let set = TriangleSet::from_triangular_data(mesh.data());
+
+        let mut rays = Vec::new();
+        for j in 0..12 {
+            for i in 0..12 {
+                let (x, y) = (i as f64, j as f64);
+                // Cell interior (one face), the split diagonal (a shared edge,
+                // two faces), and a grid vertex (several faces): the boundary
+                // cases where a too-tight box test would drop a hit.
+                rays.push(Ray3D::new([x + 0.7, y + 0.3, 5.0], [0.0, 0.0, -1.0]).unwrap());
+                rays.push(Ray3D::new([x + 0.5, y + 0.5, 5.0], [0.0, 0.0, -1.0]).unwrap());
+                rays.push(Ray3D::new([x, y, 5.0], [0.0, 0.0, -1.0]).unwrap());
+            }
+        }
+        // Oblique, in-plane (grazes every triangle it crosses), reversed, and a
+        // clean miss.
+        rays.push(Ray3D::new([-1.0, -1.0, 5.0], [1.0, 1.0, -1.0]).unwrap());
+        rays.push(Ray3D::new([-1.0, 3.0, 0.0], [1.0, 0.0, 0.0]).unwrap());
+        rays.push(Ray3D::new([5.5, 5.5, -5.0], [0.0, 0.0, 1.0]).unwrap());
+        rays.push(Ray3D::new([100.0, 100.0, 5.0], [0.0, 0.0, -1.0]).unwrap());
+
+        for ray in &rays {
+            let mut linear = Vec::new();
+            cast_linear(&set, ray, DEFAULT_RAY_TOLERANCE, &mut linear);
+            let mut bvh = Vec::new();
+            cast_bvh(&set, ray, DEFAULT_RAY_TOLERANCE, &mut bvh);
+            sort_hits(&mut linear);
+            sort_hits(&mut bvh);
+            assert_eq!(linear, bvh, "ray {ray:?}");
+        }
+    }
+
+    #[test]
+    fn raycaster_matches_the_one_shot_entry() {
+        // A mesh over the BVH gate (288 triangles) and a solid: the caster's
+        // indexed path must agree with the linear one-shot for every ray.
+        let mesh = g3(Euclidean3DGeometry::TriangularMesh(Box::new(grid_mesh(12))));
+        let solid = g3(solid_geometry(box_solid([0.0; 3], [4.0; 3])));
+        for geometry in [&mesh, &solid] {
+            let caster = RayCaster::new(geometry).unwrap();
+            for (ox, oy) in [(1.7, 2.3), (2.0, 2.0), (0.0, 0.0), (3.5, 1.5)] {
+                let ray = Ray3D::new([ox, oy, 9.0], [0.0, 0.0, -1.0]).unwrap();
+                let one_shot = ray_cast(geometry, &ray, DEFAULT_RAY_TOLERANCE).unwrap();
+                assert_eq!(caster.cast(&ray, DEFAULT_RAY_TOLERANCE), one_shot);
+                assert_eq!(
+                    caster.closest(&ray, DEFAULT_RAY_TOLERANCE),
+                    closest_ray_hit(geometry, &ray, DEFAULT_RAY_TOLERANCE).unwrap()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn raycaster_propagates_the_same_errors() {
+        use crate::csg::{Csg, ThreeDimensional};
+        let two_d = Geometry::Euclidean2D(crate::Euclidean2DGeometry::Point(
+            crate::point::Point2D::new(e(), [0.0, 0.0]),
+        ));
+        assert_eq!(
+            RayCaster::new(&two_d).err(),
+            Some(PredicateError::CrossDimension)
+        );
+        let csg = g3(Euclidean3DGeometry::Csg(Csg::Union(
+            Box::new(ThreeDimensional::Solid(Box::new(box_solid(
+                [0.0; 3], [1.0; 3],
+            )))),
+            Box::new(ThreeDimensional::Solid(Box::new(box_solid(
+                [0.0; 3], [1.0; 3],
+            )))),
+        )));
+        assert_eq!(
+            RayCaster::new(&csg).err(),
+            Some(PredicateError::Unsupported { geometry: "Csg" })
+        );
+    }
+
+    /// Deterministic fractions in `[0.05, 0.95)^2` (xorshift64), reused across
+    /// grid sizes so every mesh is probed at the same relative positions.
+    fn probe_fractions(n: usize) -> Vec<(f64, f64)> {
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        let mut next = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state >> 11) as f64 / (1u64 << 53) as f64
+        };
+        (0..n)
+            .map(|_| (0.05 + 0.9 * next(), 0.05 + 0.9 * next()))
+            .collect()
+    }
+
+    /// Mean nanoseconds per ray for one strategy (tree build included in the
+    /// BVH path, since each ray builds its own).
+    fn time_strategy(set: &TriangleSet<'_>, rays: &[Ray3D], bvh: bool) -> f64 {
+        let mut sink = Vec::new();
+        let mut guard = 0u64;
+        let start = std::time::Instant::now();
+        for ray in rays {
+            sink.clear();
+            if bvh {
+                cast_bvh(set, ray, DEFAULT_RAY_TOLERANCE, &mut sink);
+            } else {
+                cast_linear(set, ray, DEFAULT_RAY_TOLERANCE, &mut sink);
+            }
+            guard = guard.wrapping_add(sink.len() as u64);
+        }
+        let elapsed = start.elapsed().as_nanos() as f64;
+        std::hint::black_box(guard);
+        elapsed / rays.len() as f64
+    }
+
+    /// Mean nanoseconds per ray querying a tree built once and reused: the
+    /// amortized BVH cost when the same mesh serves many rays.
+    fn time_query_only(set: &TriangleSet<'_>, rays: &[Ray3D]) -> f64 {
+        let tree = set.rtree();
+        let mut sink = Vec::new();
+        let mut guard = 0u64;
+        let start = std::time::Instant::now();
+        for ray in rays {
+            sink.clear();
+            query_tree(&tree, set, ray, DEFAULT_RAY_TOLERANCE, &mut sink);
+            guard = guard.wrapping_add(sink.len() as u64);
+        }
+        let elapsed = start.elapsed().as_nanos() as f64;
+        std::hint::black_box(guard);
+        elapsed / rays.len() as f64
+    }
+
+    /// Calibration benchmark for [`BVH_MIN_TRIANGLES`]: prints per-ray cost of
+    /// each strategy across triangle counts. Run manually:
+    /// `cargo test -p reearth-flow-geometry --features new-geometry \
+    ///  predicates::ray::tests::bvh_vs_linear_crossover -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "timing benchmark; run manually to calibrate BVH_MIN_TRIANGLES"]
+    fn bvh_vs_linear_crossover() {
+        let widths = [2usize, 3, 4, 5, 6, 8, 11, 16, 23, 32, 45];
+        let fracs = probe_fractions(3000);
+        println!("\n  tris | linear ns/ray | bvh rebuild ns/ray | bvh query ns/ray | query winner");
+        for w in widths {
+            let mesh = grid_mesh(w);
+            let set = TriangleSet::from_triangular_data(mesh.data());
+            let rays: Vec<Ray3D> = fracs
+                .iter()
+                .map(|&(fx, fy)| {
+                    Ray3D::new(
+                        [fx * w as f64, fy * w as f64, w as f64 + 5.0],
+                        [0.0, 0.0, -1.0],
+                    )
+                    .unwrap()
+                })
+                .collect();
+            // Warm up before timing.
+            let _ = time_strategy(&set, &rays, false);
+            let _ = time_strategy(&set, &rays, true);
+            let linear = time_strategy(&set, &rays, false);
+            let bvh_rebuild = time_strategy(&set, &rays, true);
+            let bvh_query = time_query_only(&set, &rays);
+            println!(
+                "{:6} | {:13.1} | {:15.1} | {:13.1} | {}",
+                set.len(),
+                linear,
+                bvh_rebuild,
+                bvh_query,
+                if bvh_query < linear {
+                    "bvh(query)"
+                } else {
+                    "linear"
+                }
+            );
+        }
     }
 }

--- a/engine/runtime/geometry/src/predicates/relate/mod.rs
+++ b/engine/runtime/geometry/src/predicates/relate/mod.rs
@@ -41,9 +41,12 @@ use relate_operation::RelateOperation;
 /// ([`MixedFrames`](super::PredicateError::MixedFrames) otherwise) and both be
 /// 2D: a 2D × 3D pair is
 /// [`CrossDimension`](super::PredicateError::CrossDimension), a 3D × 3D pair
-/// [`UnsupportedPair`](super::PredicateError::UnsupportedPair). `Geometry::None`
-/// and empty collections relate as the empty geometry (every predicate against
-/// them is false except `is_disjoint`).
+/// [`UnsupportedPair`](super::PredicateError::UnsupportedPair) (there is no
+/// volumetric DE-9IM; the 3D family offers
+/// [`intersects`](super::intersects()) and
+/// [`point_position_3d`](super::point_position_3d) instead). `Geometry::None`
+/// and empty collections relate as the empty geometry (every predicate
+/// against them is false except `is_disjoint`).
 pub fn relate(a: &Geometry, b: &Geometry) -> Result<IntersectionMatrix> {
     let (a_leaves, b_leaves) = crate::predicates::flatten_2d_pair(a, b)?;
     require_common_frame_leaves(&a_leaves, &b_leaves)?;

--- a/engine/runtime/geometry/src/predicates/test3d.rs
+++ b/engine/runtime/geometry/src/predicates/test3d.rs
@@ -60,6 +60,60 @@ pub(crate) fn box_solid_with_void(
     )
 }
 
+/// A closed triangle shell over the unit-scaled box `[0, w]^3`, each of the six
+/// faces subdivided into a `w x w` grid: `12 * w^2` triangles. Seam vertices are
+/// duplicated per face, which is immaterial to ray-crossing parity. For sizing
+/// the point-in-solid benchmark.
+#[cfg(test)]
+pub(crate) fn subdivided_box_shell(w: usize) -> TriangularMesh3DData {
+    let s = w as f64;
+    // (origin, du, dv) per face; winding is irrelevant to parity.
+    let faces: [([f64; 3], [f64; 3], [f64; 3]); 6] = [
+        ([0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 0.0, 0.0]),
+        ([0.0, 0.0, s], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]),
+        ([0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]),
+        ([0.0, s, 0.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0]),
+        ([0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0]),
+        ([s, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]),
+    ];
+    let mut verts: Vec<[f64; 3]> = Vec::new();
+    let mut tris: Vec<u32> = Vec::new();
+    let stride = (w + 1) as u32;
+    for (origin, du, dv) in faces {
+        let base = verts.len() as u32;
+        for i in 0..=w {
+            for j in 0..=w {
+                let (fi, fj) = (i as f64, j as f64);
+                verts.push([
+                    origin[0] + du[0] * fi + dv[0] * fj,
+                    origin[1] + du[1] * fi + dv[1] * fj,
+                    origin[2] + du[2] * fi + dv[2] * fj,
+                ]);
+            }
+        }
+        let at = |i: usize, j: usize| base + i as u32 * stride + j as u32;
+        for i in 0..w {
+            for j in 0..w {
+                tris.extend([
+                    at(i, j),
+                    at(i + 1, j),
+                    at(i + 1, j + 1),
+                    at(i, j),
+                    at(i + 1, j + 1),
+                    at(i, j + 1),
+                ]);
+            }
+        }
+    }
+    TriangularMesh3DData::from_parts(verts, tris).unwrap()
+}
+
+/// A solid over [`subdivided_box_shell`].
+#[cfg(test)]
+pub(crate) fn subdivided_box_solid(w: usize) -> Solid {
+    Solid::from_exterior(e(), Shell::TriangularMesh(subdivided_box_shell(w)))
+}
+
 /// A solid tetrahedron over the four vertices.
 pub(crate) fn tetra_solid(v: [[f64; 3]; 4]) -> Solid {
     let shell =

--- a/engine/runtime/geometry/src/predicates/test3d.rs
+++ b/engine/runtime/geometry/src/predicates/test3d.rs
@@ -1,0 +1,101 @@
+//! Shared fixtures for the 3D predicate tests.
+
+use crate::coordinate::CoordinateFrame;
+use crate::solid::{Shell, Solid};
+use crate::triangular_mesh::TriangularMesh3DData;
+use crate::{Euclidean3DGeometry, Geometry};
+
+pub(crate) fn e() -> CoordinateFrame {
+    CoordinateFrame::Euclidean
+}
+
+pub(crate) fn g3(g: Euclidean3DGeometry) -> Geometry {
+    Geometry::Euclidean3D(g)
+}
+
+pub(crate) fn solid_geometry(solid: Solid) -> Euclidean3DGeometry {
+    Euclidean3DGeometry::Solid(Box::new(solid))
+}
+
+/// A closed triangle shell over the axis-aligned box `[min, min + size]`:
+/// 8 corners, 12 triangles.
+pub(crate) fn box_shell(min: [f64; 3], size: [f64; 3]) -> TriangularMesh3DData {
+    let corners: Vec<[f64; 3]> = (0..8u32)
+        .map(|i| {
+            [
+                min[0] + if i & 1 != 0 { size[0] } else { 0.0 },
+                min[1] + if i & 2 != 0 { size[1] } else { 0.0 },
+                min[2] + if i & 4 != 0 { size[2] } else { 0.0 },
+            ]
+        })
+        .collect();
+    #[rustfmt::skip]
+    const TRIS: [u32; 36] = [
+        0, 1, 3,  0, 3, 2, // z = min
+        4, 7, 5,  4, 6, 7, // z = max
+        0, 4, 5,  0, 5, 1, // y = min
+        2, 3, 7,  2, 7, 6, // y = max
+        0, 2, 6,  0, 6, 4, // x = min
+        1, 5, 7,  1, 7, 3, // x = max
+    ];
+    TriangularMesh3DData::from_parts(corners, TRIS).unwrap()
+}
+
+/// A solid axis-aligned box.
+pub(crate) fn box_solid(min: [f64; 3], size: [f64; 3]) -> Solid {
+    Solid::from_exterior(e(), Shell::TriangularMesh(box_shell(min, size)))
+}
+
+/// A solid box with a hollow box-shaped void.
+pub(crate) fn box_solid_with_void(
+    min: [f64; 3],
+    size: [f64; 3],
+    void_min: [f64; 3],
+    void_size: [f64; 3],
+) -> Solid {
+    Solid::new(
+        e(),
+        Shell::TriangularMesh(box_shell(min, size)),
+        vec![Shell::TriangularMesh(box_shell(void_min, void_size))],
+    )
+}
+
+/// A solid tetrahedron over the four vertices.
+pub(crate) fn tetra_solid(v: [[f64; 3]; 4]) -> Solid {
+    let shell =
+        TriangularMesh3DData::from_parts(v.to_vec(), [0u32, 1, 2, 0, 1, 3, 0, 2, 3, 1, 2, 3])
+            .unwrap();
+    Solid::from_exterior(e(), Shell::TriangularMesh(shell))
+}
+
+/// A tiny deterministic splitmix64 generator for property tests.
+pub(crate) struct Rng(pub u64);
+
+impl Rng {
+    pub fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// A uniform integer in `[lo, hi]` (inclusive).
+    pub fn int(&mut self, lo: i64, hi: i64) -> i64 {
+        lo + (self.next_u64() % (hi - lo + 1) as u64) as i64
+    }
+
+    /// A uniform float in `[lo, hi)`.
+    pub fn f64(&mut self, lo: f64, hi: f64) -> f64 {
+        lo + (hi - lo) * ((self.next_u64() >> 11) as f64 / (1u64 << 53) as f64)
+    }
+
+    /// A point with integer coordinates in `[lo, hi]^3`.
+    pub fn grid_point(&mut self, lo: i64, hi: i64) -> [f64; 3] {
+        [
+            self.int(lo, hi) as f64,
+            self.int(lo, hi) as f64,
+            self.int(lo, hi) as f64,
+        ]
+    }
+}

--- a/engine/runtime/geometry/src/predicates/test3d.rs
+++ b/engine/runtime/geometry/src/predicates/test3d.rs
@@ -85,11 +85,6 @@ impl Rng {
         lo + (self.next_u64() % (hi - lo + 1) as u64) as i64
     }
 
-    /// A uniform float in `[lo, hi)`.
-    pub fn f64(&mut self, lo: f64, hi: f64) -> f64 {
-        lo + (hi - lo) * ((self.next_u64() >> 11) as f64 / (1u64 << 53) as f64)
-    }
-
     /// A point with integer coordinates in `[lo, hi]^3`.
     pub fn grid_point(&mut self, lo: i64, hi: i64) -> [f64; 3] {
         [

--- a/engine/runtime/geometry/src/predicates/view3d.rs
+++ b/engine/runtime/geometry/src/predicates/view3d.rs
@@ -1,0 +1,379 @@
+//! Flattened 3D leaf views and triangle-set extraction.
+//!
+//! The 3D counterpart of [`view`](super::view): [`Leaf3D`] is the
+//! collection-free normal form the 3D operations dispatch over, and the
+//! crate-internal `TriangleSet` re-expresses every surface-bearing leaf as one flat triangle
+//! soup — a `TriangularMesh` verbatim, a `Polygon` / `PolygonMesh` / `Solid`
+//! shell through the same per-face earcut used by
+//! [`Triangulate`](crate::ops::Triangulate), but **borrowing** the source
+//! buffers instead of consuming them.
+//!
+//! For planar faces the triangulation is an exact re-representation: earcut
+//! only connects existing vertices, so the union of the triangles is the face.
+//! Non-planar faces are triangulated through their best-fit plane (the same
+//! approximation `Triangulate` makes), and a degenerate face — one whose
+//! exterior cannot define a plane — contributes no triangles at all, exactly
+//! as in `Triangulate`.
+
+use std::borrow::Cow;
+
+use crate::coordinate::CoordinateFrame;
+use crate::index::IndexBuffer;
+use crate::line_string::LineString3D;
+use crate::ops::triangulation::{triangulate_3d, Cache};
+use crate::point::Point3D;
+use crate::polygon::Polygon3D;
+use crate::polygon_mesh::{build_open_rings, PolygonMesh3D, PolygonMesh3DData};
+use crate::solid::{Shell, Solid};
+use crate::triangular_mesh::{TriangularMesh3D, TriangularMesh3DData};
+use crate::Euclidean3DGeometry;
+
+use super::view::polygon3d_rings;
+
+/// A flattened, collection-free borrow of one 3D leaf: the normal form the 3D
+/// operations dispatch over after flattening unnests collections.
+#[derive(Clone, Copy, Debug)]
+pub enum Leaf3D<'a> {
+    Point(&'a Point3D),
+    Line(&'a LineString3D),
+    Polygon(&'a Polygon3D),
+    PolygonMesh(&'a PolygonMesh3D),
+    TriangularMesh(&'a TriangularMesh3D),
+    Solid(&'a Solid),
+}
+
+impl<'a> Leaf3D<'a> {
+    /// The leaf's coordinate frame.
+    pub fn frame(&self) -> &'a CoordinateFrame {
+        match self {
+            Leaf3D::Point(p) => p.frame(),
+            Leaf3D::Line(l) => l.frame(),
+            Leaf3D::Polygon(p) => p.frame(),
+            Leaf3D::PolygonMesh(m) => m.frame(),
+            Leaf3D::TriangularMesh(m) => m.frame(),
+            Leaf3D::Solid(s) => s.frame(),
+        }
+    }
+}
+
+/// Flatten a 3D geometry into its leaves, recursing into (possibly nested)
+/// collections. A leaf kind the 3D operations do not support (`Csg`,
+/// `PointCloud`) is not collected; instead its type name is recorded in
+/// `unsupported` (first occurrence wins) for the caller's error.
+pub(crate) fn flatten_3d<'a>(
+    geometry: &'a Euclidean3DGeometry,
+    out: &mut Vec<Leaf3D<'a>>,
+    unsupported: &mut Option<&'static str>,
+) {
+    match geometry {
+        Euclidean3DGeometry::Point(p) => out.push(Leaf3D::Point(p)),
+        Euclidean3DGeometry::LineString(l) => out.push(Leaf3D::Line(l)),
+        Euclidean3DGeometry::Polygon(p) => out.push(Leaf3D::Polygon(p)),
+        Euclidean3DGeometry::PolygonMesh(m) => out.push(Leaf3D::PolygonMesh(m)),
+        Euclidean3DGeometry::TriangularMesh(m) => out.push(Leaf3D::TriangularMesh(m)),
+        Euclidean3DGeometry::Solid(s) => out.push(Leaf3D::Solid(s)),
+        Euclidean3DGeometry::PointCloud(_) => {
+            unsupported.get_or_insert("PointCloud");
+        }
+        Euclidean3DGeometry::Csg(_) => {
+            unsupported.get_or_insert("Csg");
+        }
+        Euclidean3DGeometry::Collection(c) => {
+            for member in c.members() {
+                flatten_3d(member, out, unsupported);
+            }
+        }
+    }
+}
+
+/// Require every leaf across both slices to share one coordinate frame.
+pub(crate) fn require_common_frame_3d(a: &[Leaf3D<'_>], b: &[Leaf3D<'_>]) -> super::Result<()> {
+    let mut frames = a.iter().chain(b.iter()).map(Leaf3D::frame);
+    let Some(first) = frames.next() else {
+        return Ok(());
+    };
+    for frame in frames {
+        super::require_same_frame(first, frame)?;
+    }
+    Ok(())
+}
+
+/// A surface as a flat triangle soup: a vertex pool (borrowed from the source
+/// leaf where its layout allows, owned where the rings had to be gathered) and
+/// index triples into it.
+pub(crate) struct TriangleSet<'a> {
+    pool: Cow<'a, [[f64; 3]]>,
+    tris: Vec<[u32; 3]>,
+}
+
+impl<'a> TriangleSet<'a> {
+    /// The number of triangles.
+    pub fn len(&self) -> usize {
+        self.tris.len()
+    }
+
+    /// Whether the set has no triangles.
+    pub fn is_empty(&self) -> bool {
+        self.tris.is_empty()
+    }
+
+    /// The `i`-th triangle's corner coordinates.
+    #[inline]
+    pub fn triangle(&self, i: usize) -> [[f64; 3]; 3] {
+        self.tris[i].map(|v| self.pool[v as usize])
+    }
+
+    /// The `i`-th triangle's corner indices into the pool.
+    #[inline]
+    pub fn indices(&self, i: usize) -> [u32; 3] {
+        self.tris[i]
+    }
+
+    /// The vertex pool. May contain vertices no triangle references.
+    pub fn pool(&self) -> &[[f64; 3]] {
+        &self.pool
+    }
+
+    /// The triangles' corner coordinates, in order.
+    pub fn triangles(&self) -> impl Iterator<Item = [[f64; 3]; 3]> + '_ {
+        (0..self.len()).map(|i| self.triangle(i))
+    }
+
+    /// View a triangular mesh's data verbatim: borrowed pool, widened indices.
+    pub fn from_triangular_data(data: &'a TriangularMesh3DData) -> Self {
+        TriangleSet {
+            pool: Cow::Borrowed(data.vertices()),
+            tris: data.triangles().collect(),
+        }
+    }
+
+    /// Triangulate a polygon mesh's faces without consuming them: the same
+    /// per-face best-fit-plane earcut as its
+    /// [`Triangulate`](crate::ops::Triangulate), reading through the CSR
+    /// buffers and mapping every output corner back into the borrowed pool.
+    pub fn from_polygon_mesh_data(data: &'a PolygonMesh3DData, cache: &mut Cache) -> Self {
+        let (face_indices, face_offsets, interior_offsets) = data.csr_buffers();
+        let indices = decode(face_indices);
+        let offsets = decode(face_offsets);
+        let holes_global = decode(interior_offsets);
+
+        let earcut = &mut cache.earcut;
+        let buffers = &mut cache.buffers;
+        let mut tris: Vec<[u32; 3]> = Vec::new();
+        let n = indices.len();
+        if n != 0 {
+            let n_faces = offsets.len() + 1;
+            let mut start = 0usize;
+            for fi in 0..n_faces {
+                let end = offsets.get(fi).map_or(n, |&o| o as usize);
+                build_open_rings(
+                    &indices,
+                    &holes_global,
+                    start,
+                    end,
+                    &mut buffers.open_src,
+                    &mut buffers.holes,
+                );
+                let face = &indices[start..end];
+                let num_outer = buffers
+                    .holes
+                    .first()
+                    .map_or(buffers.open_src.len(), |&h| h as usize);
+                buffers.verts3.clear();
+                buffers.verts3.extend(
+                    buffers
+                        .open_src
+                        .iter()
+                        .map(|&p| data.vertices()[face[p as usize] as usize]),
+                );
+                buffers.out.clear();
+                if triangulate_3d(
+                    earcut,
+                    &buffers.verts3,
+                    num_outer,
+                    &buffers.holes,
+                    &mut buffers.out,
+                )
+                .is_some()
+                {
+                    tris.extend(buffers.out.chunks_exact(3).map(|c| {
+                        [
+                            face[buffers.open_src[c[0] as usize] as usize],
+                            face[buffers.open_src[c[1] as usize] as usize],
+                            face[buffers.open_src[c[2] as usize] as usize],
+                        ]
+                    }));
+                }
+                start = end;
+            }
+        }
+
+        TriangleSet {
+            pool: Cow::Borrowed(data.vertices()),
+            tris,
+        }
+    }
+
+    /// Triangulate a polygon without consuming it: its open rings are gathered
+    /// into an owned pool (exterior first, then holes) and earcut through the
+    /// exterior's best-fit plane.
+    pub fn from_polygon(polygon: &'a Polygon3D, cache: &mut Cache) -> Self {
+        let mut pool: Vec<[f64; 3]> = Vec::new();
+        let mut holes: Vec<u32> = Vec::new();
+        for (r, ring) in polygon3d_rings(polygon).enumerate() {
+            if r > 0 {
+                holes.push(pool.len() as u32);
+            }
+            if r == 0 && ring.len() < 3 {
+                // An exterior that cannot define a plane: no triangles.
+                return TriangleSet {
+                    pool: Cow::Owned(pool),
+                    tris: Vec::new(),
+                };
+            }
+            let open = if ring.len() >= 2 && ring.first() == ring.last() {
+                &ring[..ring.len() - 1]
+            } else {
+                ring
+            };
+            pool.extend_from_slice(open);
+        }
+        let num_outer = holes.first().map_or(pool.len(), |&h| h as usize);
+
+        let earcut = &mut cache.earcut;
+        let out = &mut cache.buffers.out;
+        out.clear();
+        triangulate_3d(earcut, &pool, num_outer, &holes, out);
+        let tris = out.chunks_exact(3).map(|c| [c[0], c[1], c[2]]).collect();
+        TriangleSet {
+            pool: Cow::Owned(pool),
+            tris,
+        }
+    }
+
+    /// View one solid shell as its triangle set.
+    pub fn from_shell(shell: &'a Shell, cache: &mut Cache) -> Self {
+        match shell {
+            Shell::PolygonMesh(d) => TriangleSet::from_polygon_mesh_data(d, cache),
+            Shell::TriangularMesh(d) => TriangleSet::from_triangular_data(d),
+        }
+    }
+}
+
+/// Widen a packed index buffer into flat `u32`.
+fn decode(buffer: &IndexBuffer<1>) -> Vec<u32> {
+    buffer.iter_u32().map(|[i]| i).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::collection::Collection3D;
+    use crate::coordinate::CoordinateFrame;
+    use crate::polygon_mesh::PolygonMesh3D;
+
+    fn e() -> CoordinateFrame {
+        CoordinateFrame::Euclidean
+    }
+
+    #[test]
+    fn flatten_recurses_and_records_unsupported() {
+        let inner = Collection3D::new([Euclidean3DGeometry::Point(Point3D::new(
+            e(),
+            [1.0, 1.0, 1.0],
+        ))]);
+        let outer = Euclidean3DGeometry::Collection(Collection3D::new([
+            Euclidean3DGeometry::Point(Point3D::new(e(), [0.0, 0.0, 0.0])),
+            Euclidean3DGeometry::Collection(inner),
+        ]));
+        let mut leaves = Vec::new();
+        let mut unsupported = None;
+        flatten_3d(&outer, &mut leaves, &mut unsupported);
+        assert_eq!(leaves.len(), 2);
+        assert_eq!(unsupported, None);
+    }
+
+    #[test]
+    fn polygon_triangulation_covers_the_face() {
+        // A unit square in the plane z = 5, with a closing duplicate.
+        let square = Polygon3D::from_rings(
+            e(),
+            [
+                [0.0, 0.0, 5.0],
+                [4.0, 0.0, 5.0],
+                [4.0, 4.0, 5.0],
+                [0.0, 4.0, 5.0],
+                [0.0, 0.0, 5.0],
+            ],
+            Vec::<Vec<[f64; 3]>>::new(),
+        );
+        let mut cache = Cache::new();
+        let set = TriangleSet::from_polygon(&square, &mut cache);
+        assert_eq!(set.len(), 2);
+        // Triangle corners are original vertices, all at z = 5.
+        for t in set.triangles() {
+            for p in t {
+                assert_eq!(p[2], 5.0);
+            }
+        }
+    }
+
+    #[test]
+    fn polygon_with_hole_leaves_the_hole_open() {
+        let outer = [
+            [0.0, 0.0, 0.0],
+            [8.0, 0.0, 0.0],
+            [8.0, 8.0, 0.0],
+            [0.0, 8.0, 0.0],
+            [0.0, 0.0, 0.0],
+        ];
+        let hole = vec![
+            [2.0, 2.0, 0.0],
+            [2.0, 6.0, 0.0],
+            [6.0, 6.0, 0.0],
+            [6.0, 2.0, 0.0],
+            [2.0, 2.0, 0.0],
+        ];
+        let poly = Polygon3D::from_rings(e(), outer, vec![hole]);
+        let mut cache = Cache::new();
+        let set = TriangleSet::from_polygon(&poly, &mut cache);
+        assert!(!set.is_empty());
+        use crate::predicates::kernel3d::point_in_triangle_3d;
+        // The hole's center is covered by no triangle; the rim area is.
+        assert!(!set
+            .triangles()
+            .any(|t| point_in_triangle_3d([4.0, 4.0, 0.0], t)));
+        assert!(set
+            .triangles()
+            .any(|t| point_in_triangle_3d([1.0, 1.0, 0.0], t)));
+    }
+
+    #[test]
+    fn polygon_mesh_faces_triangulate_in_place() {
+        // Two unit quads sharing an edge, in the plane z = 0, rings stored
+        // closed.
+        let mesh = PolygonMesh3D::from_raw_parts(
+            e(),
+            vec![
+                [0.0, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+                [2.0, 2.0, 0.0],
+                [0.0, 2.0, 0.0],
+                [4.0, 0.0, 0.0],
+                [4.0, 2.0, 0.0],
+            ],
+            vec![0, 1, 2, 3, 0, 1, 4, 5, 2, 1],
+            vec![5],
+            vec![],
+        )
+        .unwrap();
+        let mut cache = Cache::new();
+        let set = TriangleSet::from_polygon_mesh_data(mesh.data(), &mut cache);
+        assert_eq!(set.len(), 4);
+        // Indices reference the mesh's own pool.
+        assert!(set
+            .triangles()
+            .flat_map(|t| t.into_iter())
+            .all(|p| mesh.vertices().contains(&p)));
+    }
+}

--- a/engine/runtime/geometry/src/predicates/view3d.rs
+++ b/engine/runtime/geometry/src/predicates/view3d.rs
@@ -3,7 +3,7 @@
 //! The 3D counterpart of [`view`](super::view): [`Leaf3D`] is the
 //! collection-free normal form the 3D operations dispatch over, and the
 //! crate-internal `TriangleSet` re-expresses every surface-bearing leaf as one flat triangle
-//! soup — a `TriangularMesh` verbatim, a `Polygon` / `PolygonMesh` / `Solid`
+//! soup: a `TriangularMesh` verbatim, a `Polygon` / `PolygonMesh` / `Solid`
 //! shell through the same per-face earcut used by
 //! [`Triangulate`](crate::ops::Triangulate), but **borrowing** the source
 //! buffers instead of consuming them.
@@ -11,8 +11,8 @@
 //! For planar faces the triangulation is an exact re-representation: earcut
 //! only connects existing vertices, so the union of the triangles is the face.
 //! Non-planar faces are triangulated through their best-fit plane (the same
-//! approximation `Triangulate` makes), and a degenerate face — one whose
-//! exterior cannot define a plane — contributes no triangles at all, exactly
+//! approximation `Triangulate` makes), and a degenerate face (one whose
+//! exterior cannot define a plane) contributes no triangles at all, exactly
 //! as in `Triangulate`.
 
 use std::borrow::Cow;

--- a/engine/runtime/geometry/src/predicates/view3d.rs
+++ b/engine/runtime/geometry/src/predicates/view3d.rs
@@ -86,6 +86,36 @@ pub(crate) fn flatten_3d<'a>(
     }
 }
 
+/// Flatten a [`Geometry`](crate::Geometry) into its 3D leaves, recursing into
+/// `GeometryCollection`s. Returns the leaves, the first 2D leaf's presence,
+/// and the first unsupported 3D leaf kind (`Csg`, `PointCloud`).
+pub(crate) fn flatten_geometry_3d(
+    geometry: &crate::Geometry,
+) -> (Vec<Leaf3D<'_>>, bool, Option<&'static str>) {
+    fn walk<'a>(
+        geometry: &'a crate::Geometry,
+        out: &mut Vec<Leaf3D<'a>>,
+        saw_2d: &mut bool,
+        unsupported: &mut Option<&'static str>,
+    ) {
+        match geometry {
+            crate::Geometry::None => {}
+            crate::Geometry::Euclidean2D(_) => *saw_2d = true,
+            crate::Geometry::Euclidean3D(g) => flatten_3d(g, out, unsupported),
+            crate::Geometry::GeometryCollection(c) => {
+                for member in c.members() {
+                    walk(member, out, saw_2d, unsupported);
+                }
+            }
+        }
+    }
+    let mut leaves = Vec::new();
+    let mut saw_2d = false;
+    let mut unsupported = None;
+    walk(geometry, &mut leaves, &mut saw_2d, &mut unsupported);
+    (leaves, saw_2d, unsupported)
+}
+
 /// Require every leaf across both slices to share one coordinate frame.
 pub(crate) fn require_common_frame_3d(a: &[Leaf3D<'_>], b: &[Leaf3D<'_>]) -> super::Result<()> {
     let mut frames = a.iter().chain(b.iter()).map(Leaf3D::frame);

--- a/engine/runtime/geometry/src/predicates/view3d.rs
+++ b/engine/runtime/geometry/src/predicates/view3d.rs
@@ -17,6 +17,8 @@
 
 use std::borrow::Cow;
 
+use rstar::{RTree, RTreeObject, SelectionFunction, AABB};
+
 use crate::coordinate::CoordinateFrame;
 use crate::index::IndexBuffer;
 use crate::line_string::LineString3D;
@@ -164,6 +166,31 @@ impl<'a> TriangleSet<'a> {
         &self.pool
     }
 
+    /// A bulk-loaded rstar tree over the set's per-triangle boxes, keyed by
+    /// pool-triangle index. The shared acceleration structure behind every 3D
+    /// operation that reuses a surface across many probes (mesh intersection,
+    /// point-in-solid parity, repeated ray casting).
+    pub fn rtree(&self) -> RTree<TriBox> {
+        let objs = (0..self.len())
+            .map(|i| {
+                let t = self.triangle(i);
+                let mut min = t[0];
+                let mut max = t[0];
+                for p in &t[1..] {
+                    for k in 0..3 {
+                        min[k] = min[k].min(p[k]);
+                        max[k] = max[k].max(p[k]);
+                    }
+                }
+                TriBox {
+                    idx: i as u32,
+                    envelope: AABB::from_corners(min, max),
+                }
+            })
+            .collect();
+        RTree::bulk_load(objs)
+    }
+
     /// The triangles' corner coordinates, in order.
     pub fn triangles(&self) -> impl Iterator<Item = [[f64; 3]; 3]> + '_ {
         (0..self.len()).map(|i| self.triangle(i))
@@ -287,6 +314,111 @@ impl<'a> TriangleSet<'a> {
             Shell::PolygonMesh(d) => TriangleSet::from_polygon_mesh_data(d, cache),
             Shell::TriangularMesh(d) => TriangleSet::from_triangular_data(d),
         }
+    }
+}
+
+/// One triangle's pool index and precomputed axis-aligned box, the element
+/// type of [`TriangleSet::rtree`].
+pub(crate) struct TriBox {
+    pub(crate) idx: u32,
+    pub(crate) envelope: AABB<[f64; 3]>,
+}
+
+impl RTreeObject for TriBox {
+    type Envelope = AABB<[f64; 3]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.envelope
+    }
+}
+
+/// An rstar [`SelectionFunction`] that descends only the tree nodes a ray or
+/// segment reaches: a node is unpacked when the primitive's parameter range
+/// overlaps the node's box (the slab test). A box the primitive misses cannot
+/// hold a triangle it meets, so pruning it never drops a crossing. The test is
+/// inclusive at the box faces, so a graze along a face still counts.
+pub(crate) struct SlabSelection {
+    origin: [f64; 3],
+    /// `1 / direction` per axis; unused where the axis is `parallel`.
+    inv_dir: [f64; 3],
+    /// Whether the direction is exactly zero on this axis (no slab there).
+    parallel: [bool; 3],
+    t_min: f64,
+    t_max: f64,
+}
+
+impl SlabSelection {
+    /// A ray from `origin` along `direction`, valid for `t >= -tolerance` (so a
+    /// primitive starting on a face is not pruned). `direction` need not be
+    /// unit; the slab test only compares parameter intervals.
+    pub(crate) fn ray(origin: [f64; 3], direction: [f64; 3], tolerance: f64) -> Self {
+        Self::new(origin, direction, -tolerance, f64::INFINITY)
+    }
+
+    /// The closed segment `[a, b]` (parameter range `[0, 1]`).
+    pub(crate) fn segment(a: [f64; 3], b: [f64; 3]) -> Self {
+        let dir = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+        Self::new(a, dir, 0.0, 1.0)
+    }
+
+    fn new(origin: [f64; 3], direction: [f64; 3], t_min: f64, t_max: f64) -> Self {
+        let mut inv_dir = [0.0; 3];
+        let mut parallel = [false; 3];
+        for k in 0..3 {
+            if direction[k] == 0.0 {
+                parallel[k] = true;
+            } else {
+                inv_dir[k] = 1.0 / direction[k];
+            }
+        }
+        SlabSelection {
+            origin,
+            inv_dir,
+            parallel,
+            t_min,
+            t_max,
+        }
+    }
+
+    fn hits(&self, env: &AABB<[f64; 3]>) -> bool {
+        let lo = env.lower();
+        let hi = env.upper();
+        let mut t_enter = self.t_min;
+        let mut t_exit = self.t_max;
+        for k in 0..3 {
+            if self.parallel[k] {
+                if self.origin[k] < lo[k] || self.origin[k] > hi[k] {
+                    return false;
+                }
+                continue;
+            }
+            let inv = self.inv_dir[k];
+            let mut t1 = (lo[k] - self.origin[k]) * inv;
+            let mut t2 = (hi[k] - self.origin[k]) * inv;
+            if t1 > t2 {
+                core::mem::swap(&mut t1, &mut t2);
+            }
+            if t1 > t_enter {
+                t_enter = t1;
+            }
+            if t2 < t_exit {
+                t_exit = t2;
+            }
+            if t_enter > t_exit {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl SelectionFunction<TriBox> for SlabSelection {
+    fn should_unpack_parent(&self, envelope: &AABB<[f64; 3]>) -> bool {
+        self.hits(envelope)
+    }
+
+    fn should_unpack_leaf(&self, leaf: &TriBox) -> bool {
+        self.hits(&leaf.envelope)
     }
 }
 

--- a/engine/runtime/geometry/src/triangular_mesh/mod.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/mod.rs
@@ -126,6 +126,12 @@ impl TriangularMesh3DData {
 }
 
 impl TriangularMesh3D {
+    /// The coordinate frame the mesh data is expressed in.
+    #[inline]
+    pub fn frame(&self) -> &CoordinateFrame {
+        &self.frame
+    }
+
     /// The number of triangles in the mesh.
     #[inline]
     pub fn num_triangles(&self) -> usize {
@@ -156,6 +162,12 @@ impl TriangularMesh3D {
     #[inline]
     pub fn into_data(self) -> TriangularMesh3DData {
         self.data
+    }
+
+    /// Borrow the coordinate-free mesh data, for the predicate views.
+    #[inline]
+    pub(crate) fn data(&self) -> &TriangularMesh3DData {
+        &self.data
     }
 
     /// The shared vertex pool.

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.76"
+version = "0.2.77"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.266"
+version = "0.1.267"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR implements some 3D predicates for new geometry.

## Algorithms implemented in this PR
- predicate kernel for 3D: wraps `robust`'s exact predicates.
- 3D intersections of geometries: Exact intersection predicates between `Euclidean3DGeometry`, which is embedded as part of `intersects()`. For polygons and meshes, it is "exact" only in terms of its triangulation.
- Point position in 3D: Exact predicates for point-containment in solid.
- Ray casting: will be used by `Rayintersector3D`.
- Distance: the dimension-wise closest-pair distance for the the geometries implemented. 

## Limitations
The full 3D predicates and 3D binary operations need a highly complex library like CGAL (C++, paid license for commercial use). The algorithms implemented in this PR are only a tiny subset of it, which are usually enough for GIS computations.

## Scope
- CSG evaluation is intentionally out of scope for this PR, as it deserves its own PR.

## Notes
Legacy paths for the algorithms above aren't removed yet. They will be removed having migrated everything to new geometry.