### PR TITLE
feat(engine): new cesium writer appearance, flip uv convention, and lod handling

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "futures",
  "once_cell",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "approx",
  "async-trait",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "Inflector",
  "approx",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "bytes",
  "clap",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "approx",
  "bvh",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5193,7 +5193,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "bytes",
  "futures",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "bytes",
  "futures",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5243,7 +5243,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "ahash",
  "bytes",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.440"
+version = "0.0.441"
 dependencies = [
  "async-trait",
  "axum",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.440"
+version = "0.0.441"
 
 [profile.dev]
 opt-level = 0

--- a/engine/runtime/action-processor/src/citygml_parser/appearance.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/appearance.rs
@@ -717,6 +717,10 @@ fn resolve_uri(source_url: &Url, image: &str) -> Option<Uri> {
 
 /// Parse whitespace-separated `u v` pairs; `None` if any token is unparseable or
 /// the count is not even.
+///
+/// CityGML texture coordinates are bottom-left (v up); flow's canonical UV origin
+/// is top-left (see [`reearth_flow_geometry::appearance::uv`]). This ingest
+/// boundary is where the two reconcile, so `v` is flipped to `1 - v` here.
 fn parse_uv(text: &str) -> Option<Vec<[f64; 2]>> {
     let values: Option<Vec<f64>> = text
         .split_whitespace()
@@ -726,7 +730,7 @@ fn parse_uv(text: &str) -> Option<Vec<[f64; 2]>> {
     if values.is_empty() || !values.len().is_multiple_of(2) {
         return None;
     }
-    Some(values.chunks_exact(2).map(|c| [c[0], c[1]]).collect())
+    Some(values.chunks_exact(2).map(|c| [c[0], 1.0 - c[1]]).collect())
 }
 
 /// Iterate a node's element children.
@@ -880,7 +884,8 @@ mod tests {
         };
         // The ring's four (closed) vertices each carry a UV pair.
         assert_eq!(coords.len(), 4);
-        assert_eq!(coords[1], [1.0, 0.0]);
+        // Source `1 0` (bottom-left); flipped to top-left at ingest.
+        assert_eq!(coords[1], [1.0, 1.0]);
     }
 
     /// The sampler of the polygon's diffuse texture when its `ParameterizedTexture`
@@ -1343,7 +1348,8 @@ mod tests {
         let UvSource::Explicit(coords) = &back.uv else {
             panic!("explicit");
         };
-        assert_eq!(coords[0], [0.1, 0.1], "back side keeps its own UV");
+        // Source `0.1 0.1` (bottom-left); flipped to top-left at ingest.
+        assert_eq!(coords[0], [0.1, 0.9], "back side keeps its own UV");
     }
 
     #[test]
@@ -1458,7 +1464,8 @@ mod tests {
             panic!("expected explicit UV");
         };
         assert_eq!(coords.len(), 4);
-        assert_eq!(coords[1], [1.0, 0.0]);
+        // Source `1 0` (bottom-left); flipped to top-left at ingest.
+        assert_eq!(coords[1], [1.0, 1.0]);
     }
 
     /// The `TriangularMesh` of a feature whose sole geometry is a
@@ -1542,7 +1549,8 @@ mod tests {
         };
         // One UV per triangle corner: the two triangles' first three coordinates.
         assert_eq!(coords.len(), 6);
-        assert_eq!(coords[3], [1.0, 0.0], "second triangle's first corner");
+        // Source `1 0` (bottom-left); flipped to top-left at ingest.
+        assert_eq!(coords[3], [1.0, 1.0], "second triangle's first corner");
     }
 
     /// A texture targeting the surface but referencing a ring id no triangle carries

--- a/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
+++ b/engine/runtime/action-processor/src/citygml_parser/pipeline.rs
@@ -16,6 +16,10 @@ use super::{
     xlink,
 };
 
+/// Per-member attribute key under which the new-geometry path records each
+/// `GeometryCollection` member's source LOD (absent for a `tin`, which has none).
+pub const MEMBER_LOD_KEY: &str = "lod";
+
 /// Resolves the parsed document (xlink + codespace) and returns one feature per top-level city
 /// object, or — when `extract_tags` is non-empty — one feature per matching flattened node.
 /// `base_attributes` maps a source file URL to the input feature's attributes (e.g. `package`),
@@ -159,8 +163,11 @@ mod build_next {
     use reearth_flow_geometry::coordinate::EpsgCode;
     use reearth_flow_geometry::{Geometry, GeometryCollection};
     use reearth_flow_types::{
-        AttributeValue, Attributes, Feature, CITYGML_PARENT_GML_ID_KEY, CITYGML_ROOT_GML_ID_KEY,
+        Attribute, AttributeValue, Attributes, Feature, CITYGML_PARENT_GML_ID_KEY,
+        CITYGML_ROOT_GML_ID_KEY,
     };
+
+    use super::MEMBER_LOD_KEY;
 
     use crate::citygml_parser::{
         appearance::{self, AppearanceIndex},
@@ -291,17 +298,31 @@ mod build_next {
         appearance: &AppearanceIndex,
         srs_by_file: &HashMap<String, EpsgCode>,
     ) {
-        // TODO: carry each geometry's LOD and gml:id in the collection's per-member attributes.
-        let members: Vec<Geometry> = geoms
-            .into_iter()
-            .filter_map(|pending| {
+        // Each member records its source LOD (a `tin` has none) so downstream
+        // sinks can select a single LOD; gml:id is still TODO.
+        let mut members: Vec<Geometry> = Vec::new();
+        let mut attrs: Vec<Attributes> = Vec::new();
+        for pending in geoms {
+            let Some(member) =
                 resolver::resolve_root(&pending.node, registry, appearance, srs_by_file)
                     .map(Geometry::Euclidean3D)
-            })
-            .collect();
+            else {
+                continue;
+            };
+            let mut member_attrs = Attributes::new();
+            if let Some(lod) = pending.lod {
+                member_attrs.insert(
+                    Attribute::new(MEMBER_LOD_KEY),
+                    AttributeValue::Number(lod.into()),
+                );
+            }
+            members.push(member);
+            attrs.push(member_attrs);
+        }
         if !members.is_empty() {
-            *feature.geometry_mut() =
-                Geometry::GeometryCollection(GeometryCollection::new(members));
+            let collection = GeometryCollection::with_attributes(members, attrs)
+                .expect("attrs is built one-per-resolved-member");
+            *feature.geometry_mut() = Geometry::GeometryCollection(collection);
         }
     }
 

--- a/engine/runtime/action-sink/Cargo.toml
+++ b/engine/runtime/action-sink/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace = true
 # TODO: Remove after migration.
 new-geometry = [
   "reearth-flow-action-processor/new-geometry",
+  "reearth-flow-atlas/new-geometry",
   "reearth-flow-geometry/new-geometry",
   "reearth-flow-gltf/new-geometry",
   "reearth-flow-types/new-geometry",

--- a/engine/runtime/action-sink/examples/gml_to_3dtiles.rs
+++ b/engine/runtime/action-sink/examples/gml_to_3dtiles.rs
@@ -4,17 +4,21 @@
 //!
 //! ```sh
 //! cargo run -p reearth-flow-action-sink --features new-geometry \
-//!     --example gml_to_3dtiles -- <input.gml> <output_dir> [draco] [compute_flat_normal]
+//!     --example gml_to_3dtiles -- <input.gml> <output_dir> [draco] [compute_flat_normal] [lod]
 //! ```
 //!
 //! `draco` and `compute_flat_normal` are optional `1`/`0` flags, both default `1`.
+//! `lod` (optional) keeps only geometry from that LOD; without it every LOD is
+//! written (LODs then overlap in the viewer).
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use reearth_flow_action_processor::citygml_parser::parser::Parser;
-use reearth_flow_action_processor::citygml_parser::pipeline;
+use reearth_flow_action_processor::citygml_parser::pipeline::{self, MEMBER_LOD_KEY};
 use reearth_flow_action_sink::file::cesium3dtiles::next;
+use reearth_flow_geometry::{Geometry, GeometryCollection};
+use reearth_flow_types::{Attribute, Feature};
 use url::Url;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -26,6 +30,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let flag = |arg: Option<std::ffi::OsString>| arg.is_none_or(|a| a != "0");
     let draco = flag(args.next());
     let compute_flat_normal = flag(args.next());
+    let lod: Option<u8> = args
+        .next()
+        .and_then(|a| a.to_str().and_then(|s| s.parse().ok()));
 
     let input_path = PathBuf::from(input);
     let output_dir = PathBuf::from(output);
@@ -38,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut parser = Parser::new();
     parser.parse(&bytes, &source_url)?;
 
-    let features = pipeline::build_features(
+    let mut features = pipeline::build_features(
         parser,
         &HashSet::new(),
         &HashMap::new(),
@@ -48,6 +55,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         false,
     );
     println!("parsed {} feature(s)", features.len());
+
+    if let Some(lod) = lod {
+        for feature in &mut features {
+            keep_lod(feature, lod);
+        }
+        println!("filtered to LOD {lod}");
+    }
 
     let built = next::build(
         &features,
@@ -71,4 +85,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     Ok(())
+}
+
+/// Drop every `GeometryCollection` member whose recorded LOD (see
+/// [`MEMBER_LOD_KEY`]) isn't `lod`, so only that LOD is written and LODs no
+/// longer overlap. Features whose geometry isn't a collection are left as-is.
+fn keep_lod(feature: &mut Feature, lod: u8) {
+    let Geometry::GeometryCollection(collection) = feature.geometry_mut() else {
+        return;
+    };
+    let key = Attribute::new(MEMBER_LOD_KEY);
+    let (members, attrs): (Vec<_>, Vec<_>) = collection
+        .members()
+        .iter()
+        .zip(collection.member_attributes())
+        .filter(|(_, attr)| attr.get(&key).and_then(|v| v.as_i64()) == Some(lod as i64))
+        .map(|(member, attr)| (member.clone(), attr.clone()))
+        .unzip();
+    *feature.geometry_mut() = Geometry::GeometryCollection(
+        GeometryCollection::with_attributes(members, attrs)
+            .expect("attrs stay parallel to members"),
+    );
 }

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/appearance.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/appearance.rs
@@ -1,0 +1,206 @@
+//! Resolve a triangulated mesh's [`Appearance`] into the flat, per-triangle /
+//! per-corner form this writer consumes.
+//!
+//! A single-theme sink paints exactly one theme (see [`Appearance`]'s
+//! `default_theme`) and, for now, only the front side. Resolving collapses the
+//! appearance graph to three parallel arrays aligned to the triangulated mesh:
+//! a small palette of [`ResolvedMaterial`]s (glTF PBR factors plus an optional
+//! local base-colour texture), the per-triangle palette index each triangle
+//! binds to, and the per-corner base-map UV. Phong materials are folded to PBR
+//! the same lossy way the old writer's `X3DMaterial` path did (diffuse →
+//! base colour, fixed metallic/roughness).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use reearth_flow_common::uri::Protocol;
+use reearth_flow_geometry::appearance::{
+    Appearance, ChannelId, FaceBinding, Material, Raster, Side, Texture, UvSource,
+};
+
+/// A material resolved for the writer: glTF PBR metallic-roughness factors plus
+/// an optional base-colour texture drawn from a local file.
+#[derive(Clone)]
+pub(super) struct ResolvedMaterial {
+    pub(super) base_color_factor: [f32; 4],
+    pub(super) metallic_factor: f32,
+    pub(super) roughness_factor: f32,
+    /// `Some` only when the base map's raster is a readable local file *and* the
+    /// theme supplies an explicit UV set for the channel it samples; otherwise
+    /// the material renders colour-only (see [`resolve`]).
+    pub(super) base_texture: Option<TextureSource>,
+}
+
+/// A base-colour texture backed by a local file, ready to feed the atlas packer.
+#[derive(Clone)]
+pub(super) struct TextureSource {
+    pub(super) path: PathBuf,
+}
+
+/// A triangulated mesh's appearance, flattened onto its triangles and corners.
+pub(super) struct ResolvedAppearance {
+    /// Material palette; `triangle_material` indexes it.
+    pub(super) materials: Vec<ResolvedMaterial>,
+    /// Per output-triangle palette index; `None` = unbound (bare) face.
+    pub(super) triangle_material: Vec<Option<u32>>,
+    /// Per output-corner base-map UV, length `3 * triangle_count`. `[0.0, 0.0]`
+    /// for a corner whose triangle is untextured.
+    pub(super) corner_uv: Vec<[f64; 2]>,
+}
+
+/// Resolve `appearance` (already expanded onto the triangulated mesh, so its
+/// bindings are per output triangle and its `Explicit` UV sets per output
+/// corner) under the default theme, front side, for `triangle_count` triangles.
+pub(super) fn resolve(appearance: &Appearance, triangle_count: usize) -> ResolvedAppearance {
+    // Single-theme sink: paint the default theme, falling back to the first (a
+    // sealed `Appearance` always has at least one) if it is somehow absent.
+    let theme = appearance
+        .themes()
+        .iter()
+        .find(|binding| binding.theme == *appearance.default_theme())
+        .unwrap_or(&appearance.themes()[0]);
+
+    // Front-side UV pool, keyed by channel. A `WorldToTexture` matrix has no
+    // per-corner samples to atlas, so only `Explicit` sets are usable here.
+    let front_channels: HashMap<ChannelId, &[[f64; 2]]> = theme
+        .uv_sets
+        .iter()
+        .filter(|set| set.side == Side::Front)
+        .filter_map(|set| match &set.uv {
+            UvSource::Explicit(coords) => Some((set.channel, &coords[..])),
+            UvSource::WorldToTexture(_) => None,
+        })
+        .collect();
+
+    let mut materials = Vec::with_capacity(appearance.materials().len());
+    // The channel each textured material samples, parallel to `materials`;
+    // `None` for a colour-only material (drives `corner_uv` below).
+    let mut material_channel: Vec<Option<ChannelId>> = Vec::with_capacity(materials.capacity());
+    for material in appearance.materials() {
+        let (resolved, channel) = convert_material(material, &front_channels);
+        materials.push(resolved);
+        material_channel.push(channel);
+    }
+
+    let triangle_material = resolve_binding(&theme.front, triangle_count);
+
+    let mut corner_uv = vec![[0.0, 0.0]; triangle_count * 3];
+    for (triangle, bound) in triangle_material.iter().enumerate() {
+        let Some(channel) = bound.and_then(|mi| material_channel[mi as usize]) else {
+            continue;
+        };
+        let coords = front_channels[&channel];
+        for corner in triangle * 3..triangle * 3 + 3 {
+            corner_uv[corner] = coords[corner];
+        }
+    }
+
+    ResolvedAppearance {
+        materials,
+        triangle_material,
+        corner_uv,
+    }
+}
+
+/// Expand a per-triangle front binding to one palette index per triangle.
+fn resolve_binding(binding: &FaceBinding, triangle_count: usize) -> Vec<Option<u32>> {
+    match binding {
+        FaceBinding::Uniform(index) => vec![Some(index.get()); triangle_count],
+        FaceBinding::PerFace(faces) => {
+            if faces.len() != triangle_count {
+                tracing::error!(
+                    "Cesium3DTilesWriter: per-face binding has {} entries but the mesh has {} \
+                     triangles; unmatched triangles left unbound",
+                    faces.len(),
+                    triangle_count
+                );
+            }
+            (0..triangle_count)
+                .map(|t| faces.get(t).copied().flatten().map(|mi| mi.get()))
+                .collect()
+        }
+    }
+}
+
+/// Convert one geometry [`Material`] to a [`ResolvedMaterial`], returning also
+/// the UV channel its base map samples when that map is usable as a texture
+/// here (readable local file + an `Explicit` UV set for its channel).
+fn convert_material(
+    material: &Material,
+    front_channels: &HashMap<ChannelId, &[[f64; 2]]>,
+) -> (ResolvedMaterial, Option<ChannelId>) {
+    let (base_color_factor, metallic_factor, roughness_factor, base_map) = match material {
+        Material::Phong(m) => (
+            [
+                m.diffuse[0],
+                m.diffuse[1],
+                m.diffuse[2],
+                1.0 - m.transparency,
+            ],
+            // The old writer's Phong→PBR path fixed these; keep parity.
+            0.0,
+            0.9,
+            &m.diffuse_map,
+        ),
+        Material::Pbr(m) => (m.base_color, m.metallic, m.roughness, &m.base_color_map),
+    };
+
+    let (base_texture, channel) = base_map
+        .as_ref()
+        .and_then(|tex| texture_source(tex, front_channels))
+        .map_or((None, None), |(src, channel)| (Some(src), Some(channel)));
+
+    (
+        ResolvedMaterial {
+            base_color_factor,
+            metallic_factor,
+            roughness_factor,
+            base_texture,
+        },
+        channel,
+    )
+}
+
+/// A base map's local-file texture source and sampled channel, or `None` when
+/// the raster isn't a readable local file or the theme supplies no explicit UV
+/// for its channel — in either case the material falls back to colour-only.
+fn texture_source(
+    texture: &Texture,
+    front_channels: &HashMap<ChannelId, &[[f64; 2]]>,
+) -> Option<(TextureSource, ChannelId)> {
+    let channel = texture.uv_channel;
+    if !front_channels.contains_key(&channel) {
+        tracing::warn!(
+            "Cesium3DTilesWriter: textured material samples UV channel {} but the theme has no \
+             explicit UV set for it; rendering colour-only",
+            channel.0
+        );
+        return None;
+    }
+
+    match &*texture.raster {
+        Raster::Uri(uri) if uri.protocol() == Protocol::File => Some((
+            TextureSource {
+                path: uri.as_path(),
+            },
+            channel,
+        )),
+        Raster::Uri(uri) => {
+            // Remote/in-memory rasters are a separate concern (a downloader
+            // action materializes them locally first); the writer is local-only.
+            tracing::error!(
+                "Cesium3DTilesWriter: texture {uri} is not a local file ({:?}); rendering \
+                 colour-only",
+                uri.protocol()
+            );
+            None
+        }
+        Raster::InMemory(_) => {
+            tracing::error!(
+                "Cesium3DTilesWriter: in-memory rasters are not supported yet; rendering \
+                 colour-only"
+            );
+            None
+        }
+    }
+}

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/appearance.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/appearance.rs
@@ -90,9 +90,8 @@ pub(super) fn resolve(appearance: &Appearance, triangle_count: usize) -> Resolve
             continue;
         };
         let coords = front_channels[&channel];
-        for corner in triangle * 3..triangle * 3 + 3 {
-            corner_uv[corner] = coords[corner];
-        }
+        let range = triangle * 3..triangle * 3 + 3;
+        corner_uv[range.clone()].copy_from_slice(&coords[range]);
     }
 
     ResolvedAppearance {

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mesh.rs
@@ -7,6 +7,8 @@ use reearth_flow_geometry::polygon_mesh::PolygonMesh3D;
 use reearth_flow_geometry::solid::Shell;
 use reearth_flow_geometry::{Euclidean3DGeometry, Geometry};
 
+use super::appearance::{self, ResolvedMaterial};
+
 /// WGS84, 3D geographic (lat, lon, height) — used for the tileset's bounding region.
 const WGS84_GEOGRAPHIC: EpsgCode = EpsgCode::new(4979);
 /// WGS84, geocentric (ECEF) — used for glTF vertex positions.
@@ -39,6 +41,15 @@ pub(super) struct ExtractedMesh {
     pub(super) polygon_normals: Vec<[f64; 3]>,
     /// Output triangle count per source polygon, parallel to `polygon_normals`.
     pub(super) polygon_tris: Vec<u32>,
+    /// Material palette resolved under the default theme, front side (empty when
+    /// the mesh carries no appearance); `triangle_material` indexes it.
+    pub(super) materials: Vec<ResolvedMaterial>,
+    /// Per output-triangle palette index (parallel to `indices`); `None` =
+    /// unbound face, which renders with the writer's default material.
+    pub(super) triangle_material: Vec<Option<u32>>,
+    /// Per output-corner base-map UV, length `3 * indices.len()`; `[0.0, 0.0]`
+    /// where the triangle is untextured.
+    pub(super) corner_uv: Vec<[f64; 2]>,
 }
 
 /// Extract and reproject every `PolygonMesh` reachable from `geometry`, merged
@@ -57,6 +68,9 @@ pub(super) fn extract(geometry: &Geometry, caches: &mut ExtractCaches) -> Option
         indices: Vec::new(),
         polygon_normals: Vec::new(),
         polygon_tris: Vec::new(),
+        materials: Vec::new(),
+        triangle_material: Vec::new(),
+        corner_uv: Vec::new(),
     };
 
     for mesh in meshes {
@@ -76,6 +90,16 @@ pub(super) fn extract(geometry: &Geometry, caches: &mut ExtractCaches) -> Option
             .extend(extracted.geographic_vertices);
         combined.polygon_normals.extend(extracted.polygon_normals);
         combined.polygon_tris.extend(extracted.polygon_tris);
+        // Offset this mesh's binding indices into the running merged palette.
+        let material_base = combined.materials.len() as u32;
+        combined.triangle_material.extend(
+            extracted
+                .triangle_material
+                .into_iter()
+                .map(|opt| opt.map(|m| m + material_base)),
+        );
+        combined.materials.extend(extracted.materials);
+        combined.corner_uv.extend(extracted.corner_uv);
     }
 
     if combined.ecef_vertices.is_empty() {
@@ -171,12 +195,34 @@ fn extract_one(mut mesh: PolygonMesh3D, caches: &mut ExtractCaches) -> Option<Ex
         }
     };
 
+    let indices: Vec<[u32; 3]> = result.mesh.triangles().collect();
+    // Resolve appearance onto the triangulated mesh, or fall back to a fully
+    // unbound / untextured mesh so the merge in `extract` stays uniform.
+    let (materials, triangle_material, corner_uv) = match result.mesh.appearance() {
+        Some(app) => {
+            let resolved = appearance::resolve(app, indices.len());
+            (
+                resolved.materials,
+                resolved.triangle_material,
+                resolved.corner_uv,
+            )
+        }
+        None => (
+            Vec::new(),
+            vec![None; indices.len()],
+            vec![[0.0, 0.0]; indices.len() * 3],
+        ),
+    };
+
     Some(ExtractedMesh {
         ecef_vertices: result.mesh.vertices().to_vec(),
         geographic_vertices,
-        indices: result.mesh.triangles().collect(),
+        indices,
         polygon_normals: result.polygon_normals,
         polygon_tris: result.polygon_tris,
+        materials,
+        triangle_material,
+        corner_uv,
     })
 }
 

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
@@ -461,7 +461,8 @@ fn uv_wraps(cell: &CellMesh, triangle: usize) -> bool {
     cell.corner_uv[triangle * 3..triangle * 3 + 3]
         .iter()
         .any(|&[u, v]| {
-            u < -TOLERANCE || u > 1.0 + TOLERANCE || v < -TOLERANCE || v > 1.0 + TOLERANCE
+            let unit = -TOLERANCE..=1.0 + TOLERANCE;
+            !unit.contains(&u) || !unit.contains(&v)
         })
 }
 

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
@@ -1,16 +1,25 @@
-//! Minimal, from-scratch Cesium 3D Tiles writer for the new geometry type.
-//! Handles a bare `PolygonMesh` leaf per feature; no appearance/materials/
-//! textures, no same-tile content splitting or texture atlasing.
+//! From-scratch Cesium 3D Tiles writer for the new geometry type.
+//!
+//! Appearance is painted for the default theme, front side only. Textured
+//! materials across a tile share one embedded atlas; wrapping textures and
+//! remote/in-memory rasters aren't handled yet and fall back to colour-only.
 
+mod appearance;
 mod mesh;
 mod quadtree;
 mod subtree;
 mod tileset;
 
 use std::collections::{BTreeSet, HashMap};
+use std::io::Cursor;
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use reearth_flow_gltf::next::{glb, metadata};
+use reearth_flow_atlas::{build_atlas, TextureInput};
+use reearth_flow_gltf::next::glb::{self, Granularity};
+use reearth_flow_gltf::next::metadata;
+
+use appearance::ResolvedMaterial;
 use reearth_flow_runtime::executor_operation::{ExecutorContext, NodeContext};
 use reearth_flow_runtime::node::FEATURES_PORT;
 use reearth_flow_types::Feature;
@@ -193,21 +202,88 @@ fn subtree_path(cell: Cell) -> String {
     format!("subtrees/{}.{}.{}.subtree", cell.level, cell.x, cell.y)
 }
 
-/// Merge one occupied cell's features into a single glb, index-offset
-/// concatenated, tagging each vertex with its feature's row in the cell's
-/// property table. `compute_flat_normal` attaches per-polygon flat normals; `draco`
-/// Draco-compresses the output.
-fn build_cell_glb(
-    cell_members: &[&(&Feature, mesh::ExtractedMesh)],
-    options: MetadataOptions,
-    draco: bool,
-    compute_flat_normal: bool,
-) -> crate::errors::Result<Vec<u8>> {
+/// Largest atlas the packer may emit; inherited from the old writer. Textures
+/// exceeding this are globally downsampled (see [`reearth_flow_atlas`]).
+const MAX_ATLAS_SIZE: u32 = 8192;
+
+/// Fallback for a face bound to no material: flat gray (the old writer's
+/// X3DMaterial default), which keeps adjacent buildings from merging into the
+/// glTF-default white.
+const DEFAULT_MATERIAL: MaterialFactors = MaterialFactors {
+    base_color_factor: [0.7, 0.7, 0.7, 1.0],
+    metallic_factor: 0.0,
+    roughness_factor: 0.9,
+};
+
+/// The atlas holds many textures side by side, so a repeating wrap would bleed
+/// across sub-images; clamp instead.
+const ATLAS_SAMPLER: glb::SamplerDesc = glb::SamplerDesc {
+    wrap_s: glb::Wrap::ClampToEdge,
+    wrap_t: glb::Wrap::ClampToEdge,
+    mag: glb::MagFilter::Linear,
+    min: glb::MinFilter::LinearMipmap,
+};
+
+/// The PBR factors that key a colour-only primitive; textures multiply these.
+#[derive(Clone, Copy, PartialEq)]
+struct MaterialFactors {
+    base_color_factor: [f32; 4],
+    metallic_factor: f32,
+    roughness_factor: f32,
+}
+
+impl MaterialFactors {
+    fn of(material: Option<&ResolvedMaterial>) -> Self {
+        match material {
+            Some(m) => Self {
+                base_color_factor: m.base_color_factor,
+                metallic_factor: m.metallic_factor,
+                roughness_factor: m.roughness_factor,
+            },
+            None => DEFAULT_MATERIAL,
+        }
+    }
+
+    /// A hashable identity for grouping (f32 has no `Eq`/`Hash`).
+    fn key(&self) -> [u32; 6] {
+        let [r, g, b, a] = self.base_color_factor;
+        [
+            r.to_bits(),
+            g.to_bits(),
+            b.to_bits(),
+            a.to_bits(),
+            self.metallic_factor.to_bits(),
+            self.roughness_factor.to_bits(),
+        ]
+    }
+}
+
+/// Merged, tile-local geometry plus its resolved appearance, all in glTF
+/// convention (Z-up pre-rotated, positions localized to the tile origin).
+struct CellMesh {
+    positions: Vec<[f32; 3]>,
+    origin: [f64; 3],
+    indices: Vec<[u32; 3]>,
+    /// Per-vertex feature row in the tile's property table.
+    feature_ids: Vec<u32>,
+    /// Per-triangle flat normal.
+    triangle_normals: Vec<[f32; 3]>,
+    /// Per-triangle resolved material (`None` = unbound → [`DEFAULT_MATERIAL`]).
+    triangle_material: Vec<Option<ResolvedMaterial>>,
+    /// Per-corner base-map UV, length `3 * indices.len()`.
+    corner_uv: Vec<[f32; 2]>,
+}
+
+/// Concatenate one occupied cell's features (index-offset) and flatten their
+/// per-triangle appearance, converting to glTF convention.
+fn merge_cell(cell_members: &[&(&Feature, mesh::ExtractedMesh)]) -> CellMesh {
     let mut ecef_vertices: Vec<[f64; 3]> = Vec::new();
     let mut indices: Vec<[u32; 3]> = Vec::new();
     let mut feature_ids: Vec<u32> = Vec::new();
-    let mut polygon_normals: Vec<[f64; 3]> = Vec::new();
-    let mut polygon_tris: Vec<u32> = Vec::new();
+    let mut triangle_normals: Vec<[f32; 3]> = Vec::new();
+    let mut triangle_material: Vec<Option<ResolvedMaterial>> = Vec::new();
+    let mut corner_uv: Vec<[f32; 2]> = Vec::new();
+
     for (row, (_, m)) in cell_members.iter().enumerate() {
         let base = ecef_vertices.len() as u32;
         indices.extend(
@@ -217,68 +293,156 @@ fn build_cell_glb(
         );
         ecef_vertices.extend(&m.ecef_vertices);
         feature_ids.extend(std::iter::repeat_n(row as u32, m.ecef_vertices.len()));
-        polygon_normals.extend(&m.polygon_normals);
-        polygon_tris.extend(&m.polygon_tris);
+        // A source polygon's flat normal is shared by all the triangles it
+        // split into; expand it to one per triangle.
+        for (polygon, &count) in m.polygon_tris.iter().enumerate() {
+            let [x, y, z] = m.polygon_normals[polygon];
+            triangle_normals.extend(std::iter::repeat_n(
+                [x as f32, z as f32, -y as f32],
+                count as usize,
+            ));
+        }
+        triangle_material.extend(
+            m.triangle_material
+                .iter()
+                .map(|&bound| bound.and_then(|mi| m.materials.get(mi as usize).cloned())),
+        );
+        corner_uv.extend(m.corner_uv.iter().map(|&[u, v]| [u as f32, v as f32]));
     }
 
-    // Per-tile local origin: keeps the f32 GLB positions small relative to
-    // ECEF's ~6.378e6 m magnitude.
+    // Per-tile local origin keeps the f32 positions small next to ECEF's
+    // ~6.378e6 m magnitude. 3D Tiles renderers rotate bare-glTF content
+    // Y-up -> Z-up on load; our input is already Z-up (ECEF-relative), so
+    // pre-apply the inverse and the renderer's rotation cancels out.
     let origin = centroid(&ecef_vertices);
-    let local_positions: Vec<[f32; 3]> = ecef_vertices
+    let positions: Vec<[f32; 3]> = ecef_vertices
         .iter()
         .map(|p| {
             [
                 (p[0] - origin[0]) as f32,
-                (p[1] - origin[1]) as f32,
                 (p[2] - origin[2]) as f32,
+                -((p[1] - origin[1]) as f32),
             ]
         })
         .collect();
 
-    // 3D Tiles renderers rotate bare-glTF content Y-up -> Z-up on load; our
-    // input is already Z-up (ECEF-relative), so pre-apply the inverse here
-    // and the renderer's rotation cancels out.
-    let gltf_positions: Vec<[f32; 3]> = local_positions
-        .iter()
-        .map(|&[x, y, z]| [x, z, -y])
-        .collect();
-    let gltf_origin = [origin[0], origin[2], -origin[1]];
+    CellMesh {
+        positions,
+        origin,
+        indices,
+        feature_ids,
+        triangle_normals,
+        triangle_material,
+        corner_uv,
+    }
+}
+
+/// Render one occupied cell's merged mesh to a glb: one primitive per resolved
+/// colour-only material, plus one shared atlas primitive for all textured
+/// faces. `compute_flat_normal` attaches per-triangle flat normals; `draco`
+/// Draco-compresses the output.
+fn build_cell_glb(
+    cell_members: &[&(&Feature, mesh::ExtractedMesh)],
+    options: MetadataOptions,
+    draco: bool,
+    compute_flat_normal: bool,
+) -> crate::errors::Result<Vec<u8>> {
+    let cell = merge_cell(cell_members);
 
     let cell_features: Vec<&Feature> = cell_members.iter().map(|(f, _)| *f).collect();
     let table = metadata::build_table(&cell_features, options);
 
     let mut builder = glb::Builder::new();
-    let material = glb::MaterialDesc {
-        // No appearance data is read yet, so every feature would otherwise get
-        // the glTF spec's white default, making adjacent buildings visually
-        // merge together. Flat gray (matching the old writer's X3DMaterial
-        // default) keeps features distinguishable until real appearance
-        // support lands.
-        base_color_factor: [0.7, 0.7, 0.7, 1.0],
-        metallic_factor: 0.0,
-        roughness_factor: 0.9,
-    };
-    // The per-polygon normal is also the dedup key that splits vertices at hard
-    // edges, so omitting it dedups on position alone: no `NORMAL`, no seams.
-    let dedup_attrs = if compute_flat_normal {
-        // Same axis swap as position, no translation (a normal is a direction).
-        let normal_values: Vec<[f32; 3]> = polygon_normals
-            .iter()
-            .map(|&[x, y, z]| [x as f32, z as f32, -y as f32])
-            .collect();
-        vec![glb::normal(glb::Granularity::PerPolygon, normal_values)]
-    } else {
-        Vec::new()
-    };
-    let primitive = builder.push_primitive(
-        gltf_positions,
-        indices,
-        material,
-        &polygon_tris,
-        &[],
-        dedup_attrs,
-    );
-    metadata::encode(&table, &mut builder, primitive, &feature_ids);
+    let mut primitives = Vec::new();
+
+    // Partition triangles into the shared atlas (textured, non-wrapping) and
+    // colour-only groups keyed by PBR factors.
+    let mut atlas = AtlasBatch::default();
+    let mut color_groups: HashMap<[u32; 6], (MaterialFactors, Vec<usize>)> = HashMap::new();
+    for triangle in 0..cell.indices.len() {
+        let material = cell.triangle_material[triangle].as_ref();
+        let texture = material
+            .and_then(|m| m.base_texture.as_ref())
+            .filter(|_| !uv_wraps(&cell, triangle));
+        match texture {
+            Some(source) => {
+                let uvs: Vec<[f64; 2]> = cell.corner_uv[triangle * 3..triangle * 3 + 3]
+                    .iter()
+                    .map(|&[u, v]| [u as f64, v as f64])
+                    .collect();
+                atlas.push(triangle, source, uvs);
+            }
+            None => {
+                let factors = MaterialFactors::of(material);
+                color_groups
+                    .entry(factors.key())
+                    .or_insert_with(|| (factors, Vec::new()))
+                    .1
+                    .push(triangle);
+            }
+        }
+    }
+
+    // Build the atlas primitive, or fold its triangles back into colour-only
+    // groups if packing yields no image (empty or failed).
+    match atlas.build(&mut builder)? {
+        Some((texture, remapped)) => {
+            let material = glb::MaterialDesc {
+                base_color_factor: [1.0, 1.0, 1.0, 1.0],
+                metallic_factor: 0.0,
+                roughness_factor: 1.0,
+                base_color_texture: Some(texture),
+            };
+            let uv = atlas
+                .textured
+                .iter()
+                .flat_map(|&(_, path, poly)| {
+                    remapped[path][poly]
+                        .iter()
+                        .map(|&[u, v]| [u as f32, v as f32])
+                })
+                .collect();
+            let tris: Vec<usize> = atlas.textured.iter().map(|&(t, _, _)| t).collect();
+            primitives.push(push_group(
+                &mut builder,
+                &cell,
+                &tris,
+                material,
+                Some(uv),
+                compute_flat_normal,
+            ));
+        }
+        None => {
+            for &(triangle, _, _) in &atlas.textured {
+                let factors = MaterialFactors::of(cell.triangle_material[triangle].as_ref());
+                color_groups
+                    .entry(factors.key())
+                    .or_insert_with(|| (factors, Vec::new()))
+                    .1
+                    .push(triangle);
+            }
+        }
+    }
+
+    for (factors, tris) in color_groups.into_values() {
+        let material = glb::MaterialDesc {
+            base_color_factor: factors.base_color_factor,
+            metallic_factor: factors.metallic_factor,
+            roughness_factor: factors.roughness_factor,
+            base_color_texture: None,
+        };
+        primitives.push(push_group(
+            &mut builder,
+            &cell,
+            &tris,
+            material,
+            None,
+            compute_flat_normal,
+        ));
+    }
+
+    metadata::encode(&table, &mut builder, &primitives, &cell.feature_ids);
+    let gltf_origin = [cell.origin[0], cell.origin[2], -cell.origin[1]];
     let glb = builder.build(gltf_origin);
 
     if draco {
@@ -287,6 +451,113 @@ fn build_cell_glb(
     } else {
         Ok(glb)
     }
+}
+
+/// Whether triangle `t`'s corner UVs fall outside `[0,1]` (with the same 0.1
+/// tolerance the old writer used): such a texture can't be atlased, so the face
+/// falls back to colour-only.
+fn uv_wraps(cell: &CellMesh, triangle: usize) -> bool {
+    const TOLERANCE: f32 = 0.1;
+    cell.corner_uv[triangle * 3..triangle * 3 + 3]
+        .iter()
+        .any(|&[u, v]| {
+            u < -TOLERANCE || u > 1.0 + TOLERANCE || v < -TOLERANCE || v > 1.0 + TOLERANCE
+        })
+}
+
+/// Textured triangles grouped by texture path for one atlas pass.
+#[derive(Default)]
+struct AtlasBatch {
+    /// One [`TextureInput`] per distinct path; `uvs[i]` is a triangle's 3 UVs.
+    inputs: Vec<TextureInput>,
+    path_index: HashMap<PathBuf, usize>,
+    /// `(triangle, path index, polygon within that path)`, in insertion order.
+    textured: Vec<(usize, usize, usize)>,
+}
+
+impl AtlasBatch {
+    fn push(&mut self, triangle: usize, source: &appearance::TextureSource, uvs: Vec<[f64; 2]>) {
+        let path = *self
+            .path_index
+            .entry(source.path.clone())
+            .or_insert_with(|| {
+                self.inputs.push(TextureInput {
+                    path: source.path.clone(),
+                    uvs: Vec::new(),
+                });
+                self.inputs.len() - 1
+            });
+        let poly = self.inputs[path].uvs.len();
+        self.textured.push((triangle, path, poly));
+        self.inputs[path].uvs.push(uvs);
+    }
+
+    /// Pack the batch, embed the resulting image, and return its texture handle
+    /// with the remapped UVs (per path, per polygon). `Ok(None)` if there was
+    /// nothing to pack; UVs are filled in [`AtlasBatch::fill_uvs`] first.
+    fn build(
+        &mut self,
+        builder: &mut glb::Builder,
+    ) -> crate::errors::Result<Option<(glb::TextureRef, Vec<reearth_flow_atlas::TextureUVs>)>> {
+        if self.textured.is_empty() {
+            return Ok(None);
+        }
+        let built = match build_atlas(&self.inputs, MAX_ATLAS_SIZE) {
+            Ok(Some(built)) => built,
+            Ok(None) => return Ok(None),
+            Err(e) => {
+                tracing::error!("Cesium3DTilesWriter: atlas packing failed: {e}; textures dropped");
+                return Ok(None);
+            }
+        };
+
+        let mut png = Vec::new();
+        image::DynamicImage::ImageRgba8(built.image)
+            .write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)
+            .map_err(|e| SinkError::Cesium3DTilesWriter(format!("atlas PNG encode failed: {e}")))?;
+        let texture = builder.push_image_texture(&png, "image/png", ATLAS_SAMPLER);
+        Ok(Some((texture, built.remapped_uvs)))
+    }
+}
+
+/// Push one primitive for the triangles in `tris`, keyed by a single material.
+/// Positions are shared with the whole cell (dedup drops the unreferenced ones);
+/// `uv`, when present, is a `TEXCOORD_0` value per corner in `tris` order.
+fn push_group(
+    builder: &mut glb::Builder,
+    cell: &CellMesh,
+    tris: &[usize],
+    material: glb::MaterialDesc,
+    uv: Option<Vec<[f32; 2]>>,
+    compute_flat_normal: bool,
+) -> glb::PrimitiveHandle {
+    let indices: Vec<[u32; 3]> = tris.iter().map(|&t| cell.indices[t]).collect();
+    // One "polygon" per triangle, so the per-triangle normal is looked up
+    // directly; coplanar triangles share a normal and still weld at shared edges.
+    let polygon_tris = vec![1u32; indices.len()];
+
+    let mut dedup_attrs = Vec::new();
+    if compute_flat_normal {
+        let normals: Vec<[f32; 3]> = tris.iter().map(|&t| cell.triangle_normals[t]).collect();
+        dedup_attrs.push(glb::normal(Granularity::PerPolygon, normals));
+    }
+    let corner_src: Vec<u32> = if uv.is_some() {
+        (0..indices.len() as u32 * 3).collect()
+    } else {
+        Vec::new()
+    };
+    if let Some(uv) = uv {
+        dedup_attrs.push(glb::texcoord(uv));
+    }
+
+    builder.push_primitive(
+        cell.positions.clone(),
+        indices,
+        material,
+        &polygon_tris,
+        &corner_src,
+        dedup_attrs,
+    )
 }
 
 fn centroid(points: &[[f64; 3]]) -> [f64; 3] {

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
@@ -255,19 +255,34 @@ fn build_cell_glb(
             // in the neutral fallback colour rather than dropping it.
             None => (color_material(DEFAULT_MATERIAL), None),
         };
-        let handle = push_geom(&mut builder, &textured.geom, origin, material, uv, compute_flat_normal);
+        let handle = push_geom(
+            &mut builder,
+            &textured.geom,
+            origin,
+            material,
+            uv,
+            compute_flat_normal,
+        );
         primitives.push((handle, textured.geom.feature_ids));
     }
 
     for color in cells.color {
         let material = color_material(color.factors);
-        let handle =
-            push_geom(&mut builder, &color.geom, origin, material, None, compute_flat_normal);
+        let handle = push_geom(
+            &mut builder,
+            &color.geom,
+            origin,
+            material,
+            None,
+            compute_flat_normal,
+        );
         primitives.push((handle, color.geom.feature_ids));
     }
 
-    let refs: Vec<(glb::PrimitiveHandle, &[u32])> =
-        primitives.iter().map(|(h, ids)| (*h, ids.as_slice())).collect();
+    let refs: Vec<(glb::PrimitiveHandle, &[u32])> = primitives
+        .iter()
+        .map(|(h, ids)| (*h, ids.as_slice()))
+        .collect();
     metadata::encode(&table, &mut builder, &refs);
 
     let gltf_origin = [origin[0], origin[2], -origin[1]];
@@ -315,7 +330,9 @@ fn build_atlas_texture(
             inputs.len() - 1
         });
         let poly = inputs[pi].uvs.len();
-        inputs[pi].uvs.push(textured.geom.corner_uv[offset..offset + corners].to_vec());
+        inputs[pi]
+            .uvs
+            .push(textured.geom.corner_uv[offset..offset + corners].to_vec());
         slots.push((pi, poly, offset));
         offset += corners;
     }
@@ -432,6 +449,10 @@ fn cell_origin(cells: &primitive::CellPrimitives) -> [f64; 3] {
     if count == 0 {
         [0.0, 0.0, 0.0]
     } else {
-        [sum[0] / count as f64, sum[1] / count as f64, sum[2] / count as f64]
+        [
+            sum[0] / count as f64,
+            sum[1] / count as f64,
+            sum[2] / count as f64,
+        ]
     }
 }

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
@@ -6,6 +6,7 @@
 
 mod appearance;
 mod mesh;
+mod primitive;
 mod quadtree;
 mod subtree;
 mod tileset;
@@ -19,7 +20,7 @@ use reearth_flow_atlas::{build_atlas, TextureInput};
 use reearth_flow_gltf::next::glb::{self, Granularity};
 use reearth_flow_gltf::next::metadata;
 
-use appearance::ResolvedMaterial;
+use primitive::{Geom, TexturedPrimitive, DEFAULT_MATERIAL};
 use reearth_flow_runtime::executor_operation::{ExecutorContext, NodeContext};
 use reearth_flow_runtime::node::FEATURES_PORT;
 use reearth_flow_types::Feature;
@@ -206,15 +207,6 @@ fn subtree_path(cell: Cell) -> String {
 /// exceeding this are globally downsampled (see [`reearth_flow_atlas`]).
 const MAX_ATLAS_SIZE: u32 = 8192;
 
-/// Fallback for a face bound to no material: flat gray (the old writer's
-/// X3DMaterial default), which keeps adjacent buildings from merging into the
-/// glTF-default white.
-const DEFAULT_MATERIAL: MaterialFactors = MaterialFactors {
-    base_color_factor: [0.7, 0.7, 0.7, 1.0],
-    metallic_factor: 0.0,
-    roughness_factor: 0.9,
-};
-
 /// The atlas holds many textures side by side, so a repeating wrap would bleed
 /// across sub-images; clamp instead.
 const ATLAS_SAMPLER: glb::SamplerDesc = glb::SamplerDesc {
@@ -224,225 +216,61 @@ const ATLAS_SAMPLER: glb::SamplerDesc = glb::SamplerDesc {
     min: glb::MinFilter::LinearMipmap,
 };
 
-/// The PBR factors that key a colour-only primitive; textures multiply these.
-#[derive(Clone, Copy, PartialEq)]
-struct MaterialFactors {
-    base_color_factor: [f32; 4],
-    metallic_factor: f32,
-    roughness_factor: f32,
-}
-
-impl MaterialFactors {
-    fn of(material: Option<&ResolvedMaterial>) -> Self {
-        match material {
-            Some(m) => Self {
-                base_color_factor: m.base_color_factor,
-                metallic_factor: m.metallic_factor,
-                roughness_factor: m.roughness_factor,
-            },
-            None => DEFAULT_MATERIAL,
-        }
-    }
-
-    /// A hashable identity for grouping (f32 has no `Eq`/`Hash`).
-    fn key(&self) -> [u32; 6] {
-        let [r, g, b, a] = self.base_color_factor;
-        [
-            r.to_bits(),
-            g.to_bits(),
-            b.to_bits(),
-            a.to_bits(),
-            self.metallic_factor.to_bits(),
-            self.roughness_factor.to_bits(),
-        ]
-    }
-}
-
-/// Merged, tile-local geometry plus its resolved appearance, all in glTF
-/// convention (Z-up pre-rotated, positions localized to the tile origin).
-struct CellMesh {
-    positions: Vec<[f32; 3]>,
-    origin: [f64; 3],
-    indices: Vec<[u32; 3]>,
-    /// Per-vertex feature row in the tile's property table.
-    feature_ids: Vec<u32>,
-    /// Per-triangle flat normal.
-    triangle_normals: Vec<[f32; 3]>,
-    /// Per-triangle resolved material (`None` = unbound → [`DEFAULT_MATERIAL`]).
-    triangle_material: Vec<Option<ResolvedMaterial>>,
-    /// Per-corner base-map UV, length `3 * indices.len()`.
-    corner_uv: Vec<[f32; 2]>,
-}
-
-/// Concatenate one occupied cell's features (index-offset) and flatten their
-/// per-triangle appearance, converting to glTF convention.
-fn merge_cell(cell_members: &[&(&Feature, mesh::ExtractedMesh)]) -> CellMesh {
-    let mut ecef_vertices: Vec<[f64; 3]> = Vec::new();
-    let mut indices: Vec<[u32; 3]> = Vec::new();
-    let mut feature_ids: Vec<u32> = Vec::new();
-    let mut triangle_normals: Vec<[f32; 3]> = Vec::new();
-    let mut triangle_material: Vec<Option<ResolvedMaterial>> = Vec::new();
-    let mut corner_uv: Vec<[f32; 2]> = Vec::new();
-
-    for (row, (_, m)) in cell_members.iter().enumerate() {
-        let base = ecef_vertices.len() as u32;
-        indices.extend(
-            m.indices
-                .iter()
-                .map(|&[a, b, c]| [a + base, b + base, c + base]),
-        );
-        ecef_vertices.extend(&m.ecef_vertices);
-        feature_ids.extend(std::iter::repeat_n(row as u32, m.ecef_vertices.len()));
-        // A source polygon's flat normal is shared by all the triangles it
-        // split into; expand it to one per triangle.
-        for (polygon, &count) in m.polygon_tris.iter().enumerate() {
-            let [x, y, z] = m.polygon_normals[polygon];
-            triangle_normals.extend(std::iter::repeat_n(
-                [x as f32, z as f32, -y as f32],
-                count as usize,
-            ));
-        }
-        triangle_material.extend(
-            m.triangle_material
-                .iter()
-                .map(|&bound| bound.and_then(|mi| m.materials.get(mi as usize).cloned())),
-        );
-        corner_uv.extend(m.corner_uv.iter().map(|&[u, v]| [u as f32, v as f32]));
-    }
-
-    // Per-tile local origin keeps the f32 positions small next to ECEF's
-    // ~6.378e6 m magnitude. 3D Tiles renderers rotate bare-glTF content
-    // Y-up -> Z-up on load; our input is already Z-up (ECEF-relative), so
-    // pre-apply the inverse and the renderer's rotation cancels out.
-    let origin = centroid(&ecef_vertices);
-    let positions: Vec<[f32; 3]> = ecef_vertices
-        .iter()
-        .map(|p| {
-            [
-                (p[0] - origin[0]) as f32,
-                (p[2] - origin[2]) as f32,
-                -((p[1] - origin[1]) as f32),
-            ]
-        })
-        .collect();
-
-    CellMesh {
-        positions,
-        origin,
-        indices,
-        feature_ids,
-        triangle_normals,
-        triangle_material,
-        corner_uv,
-    }
-}
-
-/// Render one occupied cell's merged mesh to a glb: one primitive per resolved
-/// colour-only material, plus one shared atlas primitive for all textured
-/// faces. `compute_flat_normal` attaches per-triangle flat normals; `draco`
-/// Draco-compresses the output.
+/// Render one occupied cell to a glb: one primitive per resolved colour-only
+/// material, plus one shared atlas primitive for all textured faces (see
+/// [`primitive::collect`]). `compute_flat_normal` attaches per-polygon flat
+/// normals; `draco` Draco-compresses the output.
 fn build_cell_glb(
     cell_members: &[&(&Feature, mesh::ExtractedMesh)],
     options: MetadataOptions,
     draco: bool,
     compute_flat_normal: bool,
 ) -> crate::errors::Result<Vec<u8>> {
-    let cell = merge_cell(cell_members);
+    let cells = primitive::collect(cell_members);
 
     let cell_features: Vec<&Feature> = cell_members.iter().map(|(f, _)| *f).collect();
     let table = metadata::build_table(&cell_features, options);
 
+    // Per-tile local origin keeps the f32 positions small next to ECEF's
+    // ~6.378e6 m magnitude (see [`push_geom`]).
+    let origin = cell_origin(&cells);
+
     let mut builder = glb::Builder::new();
-    let mut primitives = Vec::new();
+    // Each primitive keeps its own per-vertex feature IDs (its vertex buffer is
+    // compacted independently), attached together in `metadata::encode`.
+    let mut primitives: Vec<(glb::PrimitiveHandle, Vec<u32>)> = Vec::new();
 
-    // Partition triangles into the shared atlas (textured, non-wrapping) and
-    // colour-only groups keyed by PBR factors.
-    let mut atlas = AtlasBatch::default();
-    let mut color_groups: HashMap<[u32; 6], (MaterialFactors, Vec<usize>)> = HashMap::new();
-    for triangle in 0..cell.indices.len() {
-        let material = cell.triangle_material[triangle].as_ref();
-        let texture = material
-            .and_then(|m| m.base_texture.as_ref())
-            .filter(|_| !uv_wraps(&cell, triangle));
-        match texture {
-            Some(source) => {
-                let uvs: Vec<[f64; 2]> = cell.corner_uv[triangle * 3..triangle * 3 + 3]
-                    .iter()
-                    .map(|&[u, v]| [u as f64, v as f64])
-                    .collect();
-                atlas.push(triangle, source, uvs);
-            }
-            None => {
-                let factors = MaterialFactors::of(material);
-                color_groups
-                    .entry(factors.key())
-                    .or_insert_with(|| (factors, Vec::new()))
-                    .1
-                    .push(triangle);
-            }
-        }
-    }
-
-    // Build the atlas primitive, or fold its triangles back into colour-only
-    // groups if packing yields no image (empty or failed).
-    match atlas.build(&mut builder)? {
-        Some((texture, remapped)) => {
-            let material = glb::MaterialDesc {
-                base_color_factor: [1.0, 1.0, 1.0, 1.0],
-                metallic_factor: 0.0,
-                roughness_factor: 1.0,
-                base_color_texture: Some(texture),
-            };
-            let uv = atlas
-                .textured
-                .iter()
-                .flat_map(|&(_, path, poly)| {
-                    remapped[path][poly]
-                        .iter()
-                        .map(|&[u, v]| [u as f32, v as f32])
-                })
-                .collect();
-            let tris: Vec<usize> = atlas.textured.iter().map(|&(t, _, _)| t).collect();
-            primitives.push(push_group(
-                &mut builder,
-                &cell,
-                &tris,
-                material,
+    if let Some(textured) = cells.textured {
+        let (material, uv) = match build_atlas_texture(&mut builder, &textured)? {
+            Some((texture, uv)) => (
+                glb::MaterialDesc {
+                    base_color_factor: [1.0, 1.0, 1.0, 1.0],
+                    metallic_factor: 0.0,
+                    roughness_factor: 1.0,
+                    base_color_texture: Some(texture),
+                },
                 Some(uv),
-                compute_flat_normal,
-            ));
-        }
-        None => {
-            for &(triangle, _, _) in &atlas.textured {
-                let factors = MaterialFactors::of(cell.triangle_material[triangle].as_ref());
-                color_groups
-                    .entry(factors.key())
-                    .or_insert_with(|| (factors, Vec::new()))
-                    .1
-                    .push(triangle);
-            }
-        }
-    }
-
-    for (factors, tris) in color_groups.into_values() {
-        let material = glb::MaterialDesc {
-            base_color_factor: factors.base_color_factor,
-            metallic_factor: factors.metallic_factor,
-            roughness_factor: factors.roughness_factor,
-            base_color_texture: None,
+            ),
+            // Packing failed or produced no image: render the textured geometry
+            // in the neutral fallback colour rather than dropping it.
+            None => (color_material(DEFAULT_MATERIAL), None),
         };
-        primitives.push(push_group(
-            &mut builder,
-            &cell,
-            &tris,
-            material,
-            None,
-            compute_flat_normal,
-        ));
+        let handle = push_geom(&mut builder, &textured.geom, origin, material, uv, compute_flat_normal);
+        primitives.push((handle, textured.geom.feature_ids));
     }
 
-    metadata::encode(&table, &mut builder, &primitives, &cell.feature_ids);
-    let gltf_origin = [cell.origin[0], cell.origin[2], -cell.origin[1]];
+    for color in cells.color {
+        let material = color_material(color.factors);
+        let handle =
+            push_geom(&mut builder, &color.geom, origin, material, None, compute_flat_normal);
+        primitives.push((handle, color.geom.feature_ids));
+    }
+
+    let refs: Vec<(glb::PrimitiveHandle, &[u32])> =
+        primitives.iter().map(|(h, ids)| (*h, ids.as_slice())).collect();
+    metadata::encode(&table, &mut builder, &refs);
+
+    let gltf_origin = [origin[0], origin[2], -origin[1]];
     let glb = builder.build(gltf_origin);
 
     if draco {
@@ -453,109 +281,117 @@ fn build_cell_glb(
     }
 }
 
-/// Whether triangle `t`'s corner UVs fall outside `[0,1]` (with the same 0.1
-/// tolerance the old writer used): such a texture can't be atlased, so the face
-/// falls back to colour-only.
-fn uv_wraps(cell: &CellMesh, triangle: usize) -> bool {
-    const TOLERANCE: f32 = 0.1;
-    cell.corner_uv[triangle * 3..triangle * 3 + 3]
-        .iter()
-        .any(|&[u, v]| {
-            let unit = -TOLERANCE..=1.0 + TOLERANCE;
-            !unit.contains(&u) || !unit.contains(&v)
-        })
+fn color_material(factors: primitive::MaterialFactors) -> glb::MaterialDesc {
+    glb::MaterialDesc {
+        base_color_factor: factors.base_color_factor,
+        metallic_factor: factors.metallic_factor,
+        roughness_factor: factors.roughness_factor,
+        base_color_texture: None,
+    }
 }
 
-/// Textured triangles grouped by texture path for one atlas pass.
-#[derive(Default)]
-struct AtlasBatch {
-    /// One [`TextureInput`] per distinct path; `uvs[i]` is a triangle's 3 UVs.
-    inputs: Vec<TextureInput>,
-    path_index: HashMap<PathBuf, usize>,
-    /// `(triangle, path index, polygon within that path)`, in insertion order.
-    textured: Vec<(usize, usize, usize)>,
-}
-
-impl AtlasBatch {
-    fn push(&mut self, triangle: usize, source: &appearance::TextureSource, uvs: Vec<[f64; 2]>) {
-        let path = *self
-            .path_index
-            .entry(source.path.clone())
-            .or_insert_with(|| {
-                self.inputs.push(TextureInput {
-                    path: source.path.clone(),
-                    uvs: Vec::new(),
-                });
-                self.inputs.len() - 1
+/// Pack the textured primitive's per-polygon UVs into one atlas, embed it as a
+/// WebP texture, and return the handle with the atlas-remapped per-corner UVs
+/// (parallel to `textured.geom.corner_uv`). `Ok(None)` if packing produced no
+/// image.
+fn build_atlas_texture(
+    builder: &mut glb::Builder,
+    textured: &TexturedPrimitive,
+) -> crate::errors::Result<Option<(glb::TextureRef, Vec<[f32; 2]>)>> {
+    // Group polygons by texture path, feeding one atlas polygon per source
+    // polygon; `slots[p]` locates polygon `p`'s remapped UVs afterward.
+    let mut inputs: Vec<TextureInput> = Vec::new();
+    let mut path_index: HashMap<PathBuf, usize> = HashMap::new();
+    let mut slots: Vec<(usize, usize, usize)> = Vec::new(); // (path, poly, corner offset)
+    let mut offset = 0usize;
+    for (polygon, &tris) in textured.geom.polygon_tris.iter().enumerate() {
+        let corners = tris as usize * 3;
+        let path = &textured.polygon_texture[polygon];
+        let pi = *path_index.entry(path.clone()).or_insert_with(|| {
+            inputs.push(TextureInput {
+                path: path.clone(),
+                uvs: Vec::new(),
             });
-        let poly = self.inputs[path].uvs.len();
-        self.textured.push((triangle, path, poly));
-        self.inputs[path].uvs.push(uvs);
+            inputs.len() - 1
+        });
+        let poly = inputs[pi].uvs.len();
+        inputs[pi].uvs.push(textured.geom.corner_uv[offset..offset + corners].to_vec());
+        slots.push((pi, poly, offset));
+        offset += corners;
     }
 
-    /// Pack the batch, embed the resulting image, and return its texture handle
-    /// with the remapped UVs (per path, per polygon). `Ok(None)` if there was
-    /// nothing to pack; UVs are filled in [`AtlasBatch::fill_uvs`] first.
-    fn build(
-        &mut self,
-        builder: &mut glb::Builder,
-    ) -> crate::errors::Result<Option<(glb::TextureRef, Vec<reearth_flow_atlas::TextureUVs>)>> {
-        if self.textured.is_empty() {
+    let built = match build_atlas(&inputs, MAX_ATLAS_SIZE) {
+        Ok(Some(built)) => built,
+        Ok(None) => return Ok(None),
+        Err(e) => {
+            tracing::error!("Cesium3DTilesWriter: atlas packing failed: {e}; textures dropped");
             return Ok(None);
         }
-        let built = match build_atlas(&self.inputs, MAX_ATLAS_SIZE) {
-            Ok(Some(built)) => built,
-            Ok(None) => return Ok(None),
-            Err(e) => {
-                tracing::error!("Cesium3DTilesWriter: atlas packing failed: {e}; textures dropped");
-                return Ok(None);
-            }
-        };
+    };
 
-        let mut webp = Vec::new();
-        image::DynamicImage::ImageRgba8(built.image)
-            .write_to(&mut Cursor::new(&mut webp), image::ImageFormat::WebP)
-            .map_err(|e| {
-                SinkError::Cesium3DTilesWriter(format!("atlas WebP encode failed: {e}"))
-            })?;
-        let image = builder.push_image(&webp, "image/webp");
-        // WebP has no core-glTF fallback image, so the extension is required.
-        builder.require_extension("EXT_texture_webp");
-        let texture = builder.push_texture(
-            None,
-            ATLAS_SAMPLER,
-            vec![(
-                "EXT_texture_webp",
-                serde_json::json!({ "source": image.index() }),
-            )],
-        );
-        Ok(Some((texture, built.remapped_uvs)))
+    let mut corner_uv = vec![[0.0f32, 0.0]; textured.geom.corner_uv.len()];
+    for &(pi, poly, offset) in &slots {
+        for (k, &[u, v]) in built.remapped_uvs[pi][poly].iter().enumerate() {
+            corner_uv[offset + k] = [u as f32, v as f32];
+        }
     }
+
+    let mut webp = Vec::new();
+    image::DynamicImage::ImageRgba8(built.image)
+        .write_to(&mut Cursor::new(&mut webp), image::ImageFormat::WebP)
+        .map_err(|e| SinkError::Cesium3DTilesWriter(format!("atlas WebP encode failed: {e}")))?;
+    let image = builder.push_image(&webp, "image/webp");
+    // WebP has no core-glTF fallback image, so the extension is required.
+    builder.require_extension("EXT_texture_webp");
+    let texture = builder.push_texture(
+        None,
+        ATLAS_SAMPLER,
+        vec![(
+            "EXT_texture_webp",
+            serde_json::json!({ "source": image.index() }),
+        )],
+    );
+    Ok(Some((texture, corner_uv)))
 }
 
-/// Push one primitive for the triangles in `tris`, keyed by a single material.
-/// Positions are shared with the whole cell (dedup drops the unreferenced ones);
-/// `uv`, when present, is a `TEXCOORD_0` value per corner in `tris` order.
-fn push_group(
+/// Push one primitive from a [`Geom`], localizing positions to `origin` and
+/// converting to glTF (Y-up -> Z-up) convention. `uv`, when present, is a
+/// per-corner `TEXCOORD_0` parallel to the geometry's corners.
+fn push_geom(
     builder: &mut glb::Builder,
-    cell: &CellMesh,
-    tris: &[usize],
+    geom: &Geom,
+    origin: [f64; 3],
     material: glb::MaterialDesc,
     uv: Option<Vec<[f32; 2]>>,
     compute_flat_normal: bool,
 ) -> glb::PrimitiveHandle {
-    let indices: Vec<[u32; 3]> = tris.iter().map(|&t| cell.indices[t]).collect();
-    // One "polygon" per triangle, so the per-triangle normal is looked up
-    // directly; coplanar triangles share a normal and still weld at shared edges.
-    let polygon_tris = vec![1u32; indices.len()];
+    // 3D Tiles renderers rotate bare-glTF content Y-up -> Z-up on load; our
+    // input is already Z-up (ECEF-relative), so pre-apply the inverse and the
+    // renderer's rotation cancels out.
+    let positions: Vec<[f32; 3]> = geom
+        .positions
+        .iter()
+        .map(|p| {
+            [
+                (p[0] - origin[0]) as f32,
+                (p[2] - origin[2]) as f32,
+                -((p[1] - origin[1]) as f32),
+            ]
+        })
+        .collect();
 
     let mut dedup_attrs = Vec::new();
     if compute_flat_normal {
-        let normals: Vec<[f32; 3]> = tris.iter().map(|&t| cell.triangle_normals[t]).collect();
+        // Same axis swap as position, no translation (a normal is a direction).
+        let normals: Vec<[f32; 3]> = geom
+            .polygon_normals
+            .iter()
+            .map(|&[x, y, z]| [x as f32, z as f32, -y as f32])
+            .collect();
         dedup_attrs.push(glb::normal(Granularity::PerPolygon, normals));
     }
     let corner_src: Vec<u32> = if uv.is_some() {
-        (0..indices.len() as u32 * 3).collect()
+        (0..geom.indices.len() as u32 * 3).collect()
     } else {
         Vec::new()
     };
@@ -564,25 +400,38 @@ fn push_group(
     }
 
     builder.push_primitive(
-        cell.positions.clone(),
-        indices,
+        positions,
+        geom.indices.clone(),
         material,
-        &polygon_tris,
+        &geom.polygon_tris,
         &corner_src,
         dedup_attrs,
     )
 }
 
-fn centroid(points: &[[f64; 3]]) -> [f64; 3] {
-    if points.is_empty() {
-        return [0.0, 0.0, 0.0];
+/// Centroid of every primitive's vertices — a tile-local origin near the
+/// geometry. Shared vertices count once per primitive, which is immaterial to a
+/// centroid used only to keep f32 positions small.
+fn cell_origin(cells: &primitive::CellPrimitives) -> [f64; 3] {
+    let mut sum = [0.0f64; 3];
+    let mut count = 0usize;
+    let mut add = |positions: &[[f64; 3]]| {
+        for p in positions {
+            sum[0] += p[0];
+            sum[1] += p[1];
+            sum[2] += p[2];
+        }
+        count += positions.len();
+    };
+    for color in &cells.color {
+        add(&color.geom.positions);
     }
-    let n = points.len() as f64;
-    let mut sum = [0.0; 3];
-    for p in points {
-        sum[0] += p[0];
-        sum[1] += p[1];
-        sum[2] += p[2];
+    if let Some(textured) = &cells.textured {
+        add(&textured.geom.positions);
     }
-    [sum[0] / n, sum[1] / n, sum[2] / n]
+    if count == 0 {
+        [0.0, 0.0, 0.0]
+    } else {
+        [sum[0] / count as f64, sum[1] / count as f64, sum[2] / count as f64]
+    }
 }

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/mod.rs
@@ -511,11 +511,23 @@ impl AtlasBatch {
             }
         };
 
-        let mut png = Vec::new();
+        let mut webp = Vec::new();
         image::DynamicImage::ImageRgba8(built.image)
-            .write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)
-            .map_err(|e| SinkError::Cesium3DTilesWriter(format!("atlas PNG encode failed: {e}")))?;
-        let texture = builder.push_image_texture(&png, "image/png", ATLAS_SAMPLER);
+            .write_to(&mut Cursor::new(&mut webp), image::ImageFormat::WebP)
+            .map_err(|e| {
+                SinkError::Cesium3DTilesWriter(format!("atlas WebP encode failed: {e}"))
+            })?;
+        let image = builder.push_image(&webp, "image/webp");
+        // WebP has no core-glTF fallback image, so the extension is required.
+        builder.require_extension("EXT_texture_webp");
+        let texture = builder.push_texture(
+            None,
+            ATLAS_SAMPLER,
+            vec![(
+                "EXT_texture_webp",
+                serde_json::json!({ "source": image.index() }),
+            )],
+        );
         Ok(Some((texture, built.remapped_uvs)))
     }
 }

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/primitive.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/primitive.rs
@@ -207,3 +207,71 @@ fn polygon_wraps(uvs: &[[f64; 2]]) -> bool {
     uvs.iter()
         .any(|&[u, v]| !unit.contains(&u) || !unit.contains(&v))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file::cesium3dtiles::next::appearance::TextureSource;
+    use reearth_flow_types::{Attributes, Feature};
+
+    #[test]
+    fn collect_keeps_textured_and_color_faces_separate() {
+        let feature = Feature::new_with_attributes(Attributes::new());
+        let mesh = ExtractedMesh {
+            ecef_vertices: vec![
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 1.0, 0.0],
+            ],
+            geographic_vertices: Vec::new(),
+            indices: vec![[0, 1, 2], [1, 3, 2]],
+            polygon_normals: vec![[0.0, 0.0, 1.0]; 2],
+            polygon_tris: vec![1, 1],
+            materials: vec![
+                ResolvedMaterial {
+                    base_color_factor: [1.0, 1.0, 1.0, 1.0],
+                    metallic_factor: 0.0,
+                    roughness_factor: 1.0,
+                    base_texture: Some(TextureSource {
+                        path: PathBuf::from("texture.png"),
+                    }),
+                },
+                ResolvedMaterial {
+                    base_color_factor: [1.0, 0.0, 0.0, 1.0],
+                    metallic_factor: 0.0,
+                    roughness_factor: 0.9,
+                    base_texture: None,
+                },
+            ],
+            triangle_material: vec![Some(0), Some(1)],
+            corner_uv: vec![
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 0.0],
+                [1.0, 1.0],
+                [0.0, 1.0],
+            ],
+        };
+        let member = (&feature, mesh);
+
+        let primitives = collect(&[&member]);
+
+        let textured = primitives.textured.expect("textured face");
+        assert_eq!(textured.geom.indices, vec![[0, 1, 2]]);
+        assert_eq!(
+            textured.geom.corner_uv,
+            vec![[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]]
+        );
+        assert_eq!(textured.polygon_texture, vec![PathBuf::from("texture.png")]);
+
+        let color = primitives
+            .color
+            .iter()
+            .find(|primitive| primitive.factors.base_color_factor == [1.0, 0.0, 0.0, 1.0])
+            .expect("color face");
+        assert_eq!(color.geom.indices, vec![[0, 1, 2]]);
+        assert!(color.geom.corner_uv.is_empty());
+    }
+}

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/primitive.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/primitive.rs
@@ -1,0 +1,209 @@
+//! Partition a cell's polygons by resolved material into glTF primitives.
+//!
+//! Material is a primitive-level selector (one material per glTF primitive), so
+//! this is the coarse partition that *produces* primitives; the per-polygon
+//! normals and per-corner UVs each primitive carries are vertex attributes the
+//! glb builder's dedup resolves to per-vertex later. Geometry is kept in source
+//! granularity and ECEF coordinates here — no per-triangle flattening — so the
+//! builder deduplicates once instead of the caller expanding then re-collapsing.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use super::appearance::ResolvedMaterial;
+use super::mesh::ExtractedMesh;
+use reearth_flow_types::Feature;
+
+/// Fallback for a face bound to no material: flat gray (the old writer's
+/// X3DMaterial default), which keeps adjacent buildings from merging into the
+/// glTF-default white.
+pub(super) const DEFAULT_MATERIAL: MaterialFactors = MaterialFactors {
+    base_color_factor: [0.7, 0.7, 0.7, 1.0],
+    metallic_factor: 0.0,
+    roughness_factor: 0.9,
+};
+
+/// UVs this far outside `[0, 1]` (the old writer's tolerance) mean a wrapping
+/// texture, which can't be atlased; such a face falls back to colour-only.
+const WRAP_TOLERANCE: f64 = 0.1;
+
+/// The PBR factors that key a colour-only primitive; textures multiply these.
+#[derive(Clone, Copy, PartialEq)]
+pub(super) struct MaterialFactors {
+    pub(super) base_color_factor: [f32; 4],
+    pub(super) metallic_factor: f32,
+    pub(super) roughness_factor: f32,
+}
+
+impl MaterialFactors {
+    fn of(material: Option<&ResolvedMaterial>) -> Self {
+        match material {
+            Some(m) => Self {
+                base_color_factor: m.base_color_factor,
+                metallic_factor: m.metallic_factor,
+                roughness_factor: m.roughness_factor,
+            },
+            None => DEFAULT_MATERIAL,
+        }
+    }
+
+    /// A hashable identity for grouping (f32 has no `Eq`/`Hash`).
+    fn key(&self) -> [u32; 6] {
+        let [r, g, b, a] = self.base_color_factor;
+        [
+            r.to_bits(),
+            g.to_bits(),
+            b.to_bits(),
+            a.to_bits(),
+            self.metallic_factor.to_bits(),
+            self.roughness_factor.to_bits(),
+        ]
+    }
+}
+
+/// One primitive's geometry in source granularity and ECEF coordinates.
+#[derive(Default)]
+pub(super) struct Geom {
+    /// Compacted vertex positions (only those this primitive's polygons use).
+    pub(super) positions: Vec<[f64; 3]>,
+    /// Triangle indices into `positions`.
+    pub(super) indices: Vec<[u32; 3]>,
+    /// One flat normal per source polygon.
+    pub(super) polygon_normals: Vec<[f64; 3]>,
+    /// Triangle count per source polygon, parallel to `polygon_normals`.
+    pub(super) polygon_tris: Vec<u32>,
+    /// Per-corner base-map UV (length `3 * indices.len()`); empty for a
+    /// colour-only primitive.
+    pub(super) corner_uv: Vec<[f64; 2]>,
+    /// Per-vertex feature row in the tile's property table, parallel to
+    /// `positions`.
+    pub(super) feature_ids: Vec<u32>,
+}
+
+/// A colour-only primitive: PBR factors plus geometry.
+pub(super) struct ColorPrimitive {
+    pub(super) factors: MaterialFactors,
+    pub(super) geom: Geom,
+}
+
+/// The single primitive aggregating every textured face in the cell; its
+/// `geom.corner_uv` holds source UVs until the atlas remaps them, and
+/// `polygon_texture` names each polygon's source image (parallel to
+/// `geom.polygon_tris`) for the atlas pass.
+pub(super) struct TexturedPrimitive {
+    pub(super) geom: Geom,
+    pub(super) polygon_texture: Vec<PathBuf>,
+}
+
+/// A cell's polygons partitioned into one primitive per colour-only material
+/// plus the shared textured primitive.
+pub(super) struct CellPrimitives {
+    pub(super) color: Vec<ColorPrimitive>,
+    pub(super) textured: Option<TexturedPrimitive>,
+}
+
+/// Accumulates one primitive's geometry, welding vertices by their source index
+/// so the builder's dedup only has to split at genuine attribute seams.
+#[derive(Default)]
+struct GeomBuilder {
+    geom: Geom,
+    /// `(cell member, source vertex) -> local vertex` within this primitive.
+    remap: HashMap<(usize, u32), u32>,
+}
+
+impl GeomBuilder {
+    /// Append source polygon `p` of cell member `member` (`m`), spanning triangles
+    /// `tris`, welding its vertices into this primitive. `with_uv` copies the
+    /// polygon's per-corner UVs (textured primitive only).
+    fn add_polygon(
+        &mut self,
+        member: usize,
+        m: &ExtractedMesh,
+        p: usize,
+        tris: std::ops::Range<usize>,
+        with_uv: bool,
+    ) {
+        for t in tris.clone() {
+            let mut out = [0u32; 3];
+            for (corner, &orig) in m.indices[t].iter().enumerate() {
+                let local = *self.remap.entry((member, orig)).or_insert_with(|| {
+                    let idx = self.geom.positions.len() as u32;
+                    self.geom.positions.push(m.ecef_vertices[orig as usize]);
+                    self.geom.feature_ids.push(member as u32);
+                    idx
+                });
+                out[corner] = local;
+                if with_uv {
+                    self.geom.corner_uv.push(m.corner_uv[t * 3 + corner]);
+                }
+            }
+            self.geom.indices.push(out);
+        }
+        self.geom.polygon_normals.push(m.polygon_normals[p]);
+        self.geom.polygon_tris.push(tris.len() as u32);
+    }
+}
+
+/// Partition every polygon of the cell's members into a textured bucket
+/// (textured material with non-wrapping UVs) and colour-only buckets keyed by
+/// PBR factors. Cross-member vertices never share, so welding is keyed by
+/// `(member, source vertex)`.
+pub(super) fn collect(cell_members: &[&(&Feature, ExtractedMesh)]) -> CellPrimitives {
+    let mut color: HashMap<[u32; 6], (MaterialFactors, GeomBuilder)> = HashMap::new();
+    let mut textured = GeomBuilder::default();
+    let mut polygon_texture: Vec<PathBuf> = Vec::new();
+
+    for (member, (_, m)) in cell_members.iter().enumerate() {
+        let mut tri_off = 0usize;
+        for (p, &count) in m.polygon_tris.iter().enumerate() {
+            let count = count as usize;
+            if count == 0 {
+                continue;
+            }
+            let tris = tri_off..tri_off + count;
+            tri_off += count;
+
+            let material = m.triangle_material[tris.start]
+                .and_then(|mi| m.materials.get(mi as usize));
+            let texture = material
+                .and_then(|mm| mm.base_texture.as_ref())
+                .filter(|_| !polygon_wraps(&m.corner_uv[tris.start * 3..tris.end * 3]));
+
+            match texture {
+                Some(source) => {
+                    textured.add_polygon(member, m, p, tris, true);
+                    polygon_texture.push(source.path.clone());
+                }
+                None => {
+                    let factors = MaterialFactors::of(material);
+                    color
+                        .entry(factors.key())
+                        .or_insert_with(|| (factors, GeomBuilder::default()))
+                        .1
+                        .add_polygon(member, m, p, tris, false);
+                }
+            }
+        }
+    }
+
+    let textured = (!textured.geom.indices.is_empty()).then_some(TexturedPrimitive {
+        geom: textured.geom,
+        polygon_texture,
+    });
+    let color = color
+        .into_values()
+        .map(|(factors, builder)| ColorPrimitive {
+            factors,
+            geom: builder.geom,
+        })
+        .collect();
+
+    CellPrimitives { color, textured }
+}
+
+/// Whether any of a polygon's corner UVs falls outside `[0, 1]` (with tolerance).
+fn polygon_wraps(uvs: &[[f64; 2]]) -> bool {
+    let unit = -WRAP_TOLERANCE..=1.0 + WRAP_TOLERANCE;
+    uvs.iter()
+        .any(|&[u, v]| !unit.contains(&u) || !unit.contains(&v))
+}

--- a/engine/runtime/action-sink/src/file/cesium3dtiles/next/primitive.rs
+++ b/engine/runtime/action-sink/src/file/cesium3dtiles/next/primitive.rs
@@ -163,8 +163,8 @@ pub(super) fn collect(cell_members: &[&(&Feature, ExtractedMesh)]) -> CellPrimit
             let tris = tri_off..tri_off + count;
             tri_off += count;
 
-            let material = m.triangle_material[tris.start]
-                .and_then(|mi| m.materials.get(mi as usize));
+            let material =
+                m.triangle_material[tris.start].and_then(|mi| m.materials.get(mi as usize));
             let texture = material
                 .and_then(|mm| mm.base_texture.as_ref())
                 .filter(|_| !polygon_wraps(&m.corner_uv[tris.start * 3..tris.end * 3]));

--- a/engine/runtime/atlas/Cargo.toml
+++ b/engine/runtime/atlas/Cargo.toml
@@ -10,6 +10,12 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[features]
+# Under the new-geometry migration, flow's canonical UV origin is top-left
+# (v down). Off (legacy geometry), the packer keeps the bottom-left (v up)
+# convention its old-writer caller feeds it.
+new-geometry = []
+
 [dependencies]
 image.workspace = true
 rstar.workspace = true

--- a/engine/runtime/atlas/src/damage.rs
+++ b/engine/runtime/atlas/src/damage.rs
@@ -126,10 +126,20 @@ pub fn collect_damage(materials: &[TextureInput]) -> crate::Result<Vec<(PathBuf,
             let min_v = min_v.clamp(0.0, 1.0);
             let max_v = max_v.clamp(0.0, 1.0);
 
+            // Pixel-row span of the UV box, per the v origin: top-left
+            // (new-geometry) runs top row = min_v; bottom-left (legacy) inverts.
             let x = ((min_u * tw as f64).floor() as u32).min(tw);
-            let y = (((1.0 - max_v) * th as f64).floor() as u32).min(th);
             let right = ((max_u * tw as f64).ceil() as u32).min(tw);
-            let bottom = (((1.0 - min_v) * th as f64).ceil() as u32).min(th);
+            #[cfg(feature = "new-geometry")]
+            let (y, bottom) = (
+                ((min_v * th as f64).floor() as u32).min(th),
+                ((max_v * th as f64).ceil() as u32).min(th),
+            );
+            #[cfg(not(feature = "new-geometry"))]
+            let (y, bottom) = (
+                (((1.0 - max_v) * th as f64).floor() as u32).min(th),
+                (((1.0 - min_v) * th as f64).ceil() as u32).min(th),
+            );
 
             // Every polygon must be represented — guarantee a minimum 1×1 damage rect
             // so that polygon_regions is dense and no index is ever left unmapped.

--- a/engine/runtime/atlas/src/lib.rs
+++ b/engine/runtime/atlas/src/lib.rs
@@ -79,11 +79,20 @@ struct RemapContext {
 fn remap_uv(u: f64, v: f64, ctx: &RemapContext) -> [f64; 2] {
     let scale = ctx.downsample as f64;
     let px = u * ctx.texture_size.0 as f64 - ctx.damage.x as f64;
+    // Pixel row this UV samples, and the row back to a UV — both depend on the
+    // v origin. Top-left (new-geometry): v runs with the row index. Bottom-left
+    // (legacy): v runs against it, hence the `1.0 - …` on both ends.
+    #[cfg(feature = "new-geometry")]
+    let py = v * ctx.texture_size.1 as f64 - ctx.damage.y as f64;
+    #[cfg(not(feature = "new-geometry"))]
     let py = (1.0 - v) * ctx.texture_size.1 as f64 - ctx.damage.y as f64;
-    [
-        (px / scale + ctx.frame.x as f64) / ctx.atlas_size.0,
-        1.0 - (py / scale + ctx.frame.y as f64) / ctx.atlas_size.1,
-    ]
+    let out_u = (px / scale + ctx.frame.x as f64) / ctx.atlas_size.0;
+    let row = (py / scale + ctx.frame.y as f64) / ctx.atlas_size.1;
+    #[cfg(feature = "new-geometry")]
+    let out_v = row;
+    #[cfg(not(feature = "new-geometry"))]
+    let out_v = 1.0 - row;
+    [out_u, out_v]
 }
 
 fn remap_polygon_uvs(

--- a/engine/runtime/geometry/src/appearance/uv.rs
+++ b/engine/runtime/geometry/src/appearance/uv.rs
@@ -10,6 +10,17 @@
 //! channel from the material map's selector. So `channel` carries no global
 //! meaning: it is a material-local index into the UV sets of whatever theme/side
 //! the face resolves to.
+//!
+//! # Coordinate convention
+//!
+//! Flow's canonical UV origin is **top-left, `v` increasing downward** — the
+//! glTF / image-storage convention, where `(0, 0)` is the first texel. Every
+//! producer and consumer inside the engine assumes it: a reader converts from
+//! its source convention at ingest (the CityGML reader flips its bottom-left
+//! `v`), and the texture atlas packer follows it under `new-geometry`. A sink
+//! whose format matches (glTF, 3D Tiles) writes coordinates through unchanged;
+//! one that differs converts at its own boundary rather than mutating this
+//! shared convention.
 
 use serde::{Deserialize, Serialize};
 

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -136,6 +136,12 @@ impl GeometryCollection {
     pub fn members(&self) -> &[Geometry] {
         &self.members
     }
+
+    /// Per-member attributes, parallel to [`members`](Self::members), or empty
+    /// if no member carries any.
+    pub fn member_attributes(&self) -> &[Attributes] {
+        &self.attrs
+    }
 }
 
 /// 2D-embedded geometry. All coordinates are 2D `(x, y)`; some leaves carry an

--- a/engine/runtime/gltf/src/next/glb/mod.rs
+++ b/engine/runtime/gltf/src/next/glb/mod.rs
@@ -11,6 +11,7 @@
 //! layer that builds Cesium's metadata extensions on top of this.
 
 mod primitive;
+mod texture;
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashSet};
@@ -19,6 +20,7 @@ use gltf::json;
 use gltf::json::validation::{Checked, USize64};
 
 pub use primitive::{normal, texcoord, DedupAttribute, Granularity};
+pub use texture::{ImageRef, MagFilter, MinFilter, SamplerDesc, TextureRef, Wrap};
 
 /// A material's PBR metallic-roughness description: the base factors, plus an
 /// optional base-color texture. A textured material's primitive must also carry
@@ -29,48 +31,6 @@ pub struct MaterialDesc {
     pub roughness_factor: f32,
     /// `baseColorTexture`; `None` for a colour-only material.
     pub base_color_texture: Option<TextureRef>,
-}
-
-/// Handle to a texture pushed via [`Builder::push_image_texture`], for
-/// referencing from a [`MaterialDesc`].
-#[derive(Clone, Copy)]
-pub struct TextureRef(json::Index<json::Texture>);
-
-impl TextureRef {
-    pub(super) fn index(self) -> json::Index<json::Texture> {
-        self.0
-    }
-}
-
-/// How a texture's coordinates are wrapped and filtered — the glTF-agnostic
-/// subset this writer needs. Maps to a glTF `sampler`.
-#[derive(Clone, Copy)]
-pub struct SamplerDesc {
-    pub wrap_s: Wrap,
-    pub wrap_t: Wrap,
-    pub mag: MagFilter,
-    pub min: MinFilter,
-}
-
-#[derive(Clone, Copy)]
-pub enum Wrap {
-    Repeat,
-    MirroredRepeat,
-    ClampToEdge,
-}
-
-#[derive(Clone, Copy)]
-pub enum MagFilter {
-    Nearest,
-    Linear,
-}
-
-#[derive(Clone, Copy)]
-pub enum MinFilter {
-    Nearest,
-    Linear,
-    NearestMipmap,
-    LinearMipmap,
 }
 
 /// Opaque handle to a primitive pushed via [`Builder::push_primitive`], for
@@ -151,50 +111,12 @@ impl Builder {
         })
     }
 
-    /// Embed an image as a bufferView-backed glTF texture (self-contained: no
-    /// external URI), with its sampler, and return a handle for a
-    /// [`MaterialDesc::base_color_texture`]. `mime_type` is the image's MIME
-    /// (e.g. `"image/png"`).
-    pub fn push_image_texture(
-        &mut self,
-        image_bytes: &[u8],
-        mime_type: &str,
-        sampler: SamplerDesc,
-    ) -> TextureRef {
-        let buffer_view = self.push_buffer_view_targeted(image_bytes, None);
-        let image = self.root.push(json::Image {
-            name: None,
-            buffer_view: Some(buffer_view),
-            mime_type: Some(json::image::MimeType(mime_type.to_string())),
-            uri: None,
-            extensions: Default::default(),
-            extras: Default::default(),
-        });
-        let sampler_index = self.root.push(json::texture::Sampler {
-            name: None,
-            mag_filter: Some(Checked::Valid(match sampler.mag {
-                MagFilter::Nearest => json::texture::MagFilter::Nearest,
-                MagFilter::Linear => json::texture::MagFilter::Linear,
-            })),
-            min_filter: Some(Checked::Valid(match sampler.min {
-                MinFilter::Nearest => json::texture::MinFilter::Nearest,
-                MinFilter::Linear => json::texture::MinFilter::Linear,
-                MinFilter::NearestMipmap => json::texture::MinFilter::NearestMipmapNearest,
-                MinFilter::LinearMipmap => json::texture::MinFilter::LinearMipmapLinear,
-            })),
-            wrap_s: Checked::Valid(wrap(sampler.wrap_s)),
-            wrap_t: Checked::Valid(wrap(sampler.wrap_t)),
-            extensions: None,
-            extras: Default::default(),
-        });
-        let texture = self.root.push(json::Texture {
-            name: None,
-            sampler: Some(sampler_index),
-            source: image,
-            extensions: Default::default(),
-            extras: Default::default(),
-        });
-        TextureRef(texture)
+    /// Mark `name` in both `extensionsUsed` and `extensionsRequired`.
+    pub fn require_extension(&mut self, name: &'static str) {
+        self.mark_extension_used(name);
+        if !self.root.extensions_required.iter().any(|n| n == name) {
+            self.root.extensions_required.push(name.to_string());
+        }
     }
 
     /// Append a `VEC3` f32 accessor (positions or normals); `with_bounds`
@@ -420,14 +342,6 @@ impl Builder {
             bin: Some(Cow::Owned(self.bin)),
         };
         glb.to_vec().expect("GLB binary output is always writable")
-    }
-}
-
-fn wrap(w: Wrap) -> json::texture::WrappingMode {
-    match w {
-        Wrap::Repeat => json::texture::WrappingMode::Repeat,
-        Wrap::MirroredRepeat => json::texture::WrappingMode::MirroredRepeat,
-        Wrap::ClampToEdge => json::texture::WrappingMode::ClampToEdge,
     }
 }
 

--- a/engine/runtime/gltf/src/next/glb/mod.rs
+++ b/engine/runtime/gltf/src/next/glb/mod.rs
@@ -18,14 +18,59 @@ use std::collections::{BTreeMap, HashSet};
 use gltf::json;
 use gltf::json::validation::{Checked, USize64};
 
-pub use primitive::{normal, DedupAttribute, Granularity};
+pub use primitive::{normal, texcoord, DedupAttribute, Granularity};
 
-/// A material's PBR metallic-roughness factors; each primitive is untextured
-/// and single-material.
+/// A material's PBR metallic-roughness description: the base factors, plus an
+/// optional base-color texture. A textured material's primitive must also carry
+/// a `TEXCOORD_0` attribute (see [`texcoord`]) for the texture to sample.
 pub struct MaterialDesc {
     pub base_color_factor: [f32; 4],
     pub metallic_factor: f32,
     pub roughness_factor: f32,
+    /// `baseColorTexture`; `None` for a colour-only material.
+    pub base_color_texture: Option<TextureRef>,
+}
+
+/// Handle to a texture pushed via [`Builder::push_image_texture`], for
+/// referencing from a [`MaterialDesc`].
+#[derive(Clone, Copy)]
+pub struct TextureRef(json::Index<json::Texture>);
+
+impl TextureRef {
+    pub(super) fn index(self) -> json::Index<json::Texture> {
+        self.0
+    }
+}
+
+/// How a texture's coordinates are wrapped and filtered — the glTF-agnostic
+/// subset this writer needs. Maps to a glTF `sampler`.
+#[derive(Clone, Copy)]
+pub struct SamplerDesc {
+    pub wrap_s: Wrap,
+    pub wrap_t: Wrap,
+    pub mag: MagFilter,
+    pub min: MinFilter,
+}
+
+#[derive(Clone, Copy)]
+pub enum Wrap {
+    Repeat,
+    MirroredRepeat,
+    ClampToEdge,
+}
+
+#[derive(Clone, Copy)]
+pub enum MagFilter {
+    Nearest,
+    Linear,
+}
+
+#[derive(Clone, Copy)]
+pub enum MinFilter {
+    Nearest,
+    Linear,
+    NearestMipmap,
+    LinearMipmap,
 }
 
 /// Opaque handle to a primitive pushed via [`Builder::push_primitive`], for
@@ -104,6 +149,52 @@ impl Builder {
             extensions: Default::default(),
             extras: Default::default(),
         })
+    }
+
+    /// Embed an image as a bufferView-backed glTF texture (self-contained: no
+    /// external URI), with its sampler, and return a handle for a
+    /// [`MaterialDesc::base_color_texture`]. `mime_type` is the image's MIME
+    /// (e.g. `"image/png"`).
+    pub fn push_image_texture(
+        &mut self,
+        image_bytes: &[u8],
+        mime_type: &str,
+        sampler: SamplerDesc,
+    ) -> TextureRef {
+        let buffer_view = self.push_buffer_view_targeted(image_bytes, None);
+        let image = self.root.push(json::Image {
+            name: None,
+            buffer_view: Some(buffer_view),
+            mime_type: Some(json::image::MimeType(mime_type.to_string())),
+            uri: None,
+            extensions: Default::default(),
+            extras: Default::default(),
+        });
+        let sampler_index = self.root.push(json::texture::Sampler {
+            name: None,
+            mag_filter: Some(Checked::Valid(match sampler.mag {
+                MagFilter::Nearest => json::texture::MagFilter::Nearest,
+                MagFilter::Linear => json::texture::MagFilter::Linear,
+            })),
+            min_filter: Some(Checked::Valid(match sampler.min {
+                MinFilter::Nearest => json::texture::MinFilter::Nearest,
+                MinFilter::Linear => json::texture::MinFilter::Linear,
+                MinFilter::NearestMipmap => json::texture::MinFilter::NearestMipmapNearest,
+                MinFilter::LinearMipmap => json::texture::MinFilter::LinearMipmapLinear,
+            })),
+            wrap_s: Checked::Valid(wrap(sampler.wrap_s)),
+            wrap_t: Checked::Valid(wrap(sampler.wrap_t)),
+            extensions: None,
+            extras: Default::default(),
+        });
+        let texture = self.root.push(json::Texture {
+            name: None,
+            sampler: Some(sampler_index),
+            source: image,
+            extensions: Default::default(),
+            extras: Default::default(),
+        });
+        TextureRef(texture)
     }
 
     /// Append a `VEC3` f32 accessor (positions or normals); `with_bounds`
@@ -329,6 +420,14 @@ impl Builder {
             bin: Some(Cow::Owned(self.bin)),
         };
         glb.to_vec().expect("GLB binary output is always writable")
+    }
+}
+
+fn wrap(w: Wrap) -> json::texture::WrappingMode {
+    match w {
+        Wrap::Repeat => json::texture::WrappingMode::Repeat,
+        Wrap::MirroredRepeat => json::texture::WrappingMode::MirroredRepeat,
+        Wrap::ClampToEdge => json::texture::WrappingMode::ClampToEdge,
     }
 }
 

--- a/engine/runtime/gltf/src/next/glb/primitive.rs
+++ b/engine/runtime/gltf/src/next/glb/primitive.rs
@@ -7,6 +7,19 @@ use gltf::json;
 
 use super::{Builder, Extension, MaterialDesc, PrimitiveHandle};
 
+/// A per-corner UV (`TEXCOORD_0`), folded into [`Builder::push_primitive`]'s
+/// vertex dedup so corners sharing a position/normal but differing in UV are
+/// kept distinct. `values` is one entry per polygon-vertex, resolved against
+/// `push_primitive`'s `corner_src`.
+pub fn texcoord(values: Vec<[f32; 2]>) -> Box<dyn DedupAttribute> {
+    Box::new(DedupValue {
+        semantic: json::mesh::Semantic::TexCoords(0),
+        granularity: Granularity::PerPolygonCorner,
+        values,
+        out_values: Vec::new(),
+    })
+}
+
 pub(super) struct PrimitiveBuilder {
     pub(super) positions: Vec<[f32; 3]>,
     pub(super) dedup_attrs: Vec<Box<dyn DedupAttribute>>,
@@ -185,11 +198,18 @@ impl Builder {
             }
         }
 
+        let base_color_texture = material.base_color_texture.map(|tex| json::texture::Info {
+            index: tex.index(),
+            tex_coord: 0,
+            extensions: Default::default(),
+            extras: Default::default(),
+        });
         let material_index = self.root.push(json::Material {
             pbr_metallic_roughness: json::material::PbrMetallicRoughness {
                 base_color_factor: json::material::PbrBaseColorFactor(material.base_color_factor),
                 metallic_factor: json::material::StrengthFactor(material.metallic_factor),
                 roughness_factor: json::material::StrengthFactor(material.roughness_factor),
+                base_color_texture,
                 ..Default::default()
             },
             ..Default::default()
@@ -235,6 +255,7 @@ mod tests {
             base_color_factor: [1.0, 1.0, 1.0, 1.0],
             metallic_factor: 0.0,
             roughness_factor: 1.0,
+            base_color_texture: None,
         }
     }
 

--- a/engine/runtime/gltf/src/next/glb/texture.rs
+++ b/engine/runtime/gltf/src/next/glb/texture.rs
@@ -1,0 +1,128 @@
+//! Image and texture construction: [`Builder::push_image`],
+//! [`Builder::push_texture`], and the sampler description they accept.
+
+use gltf::json;
+use gltf::json::validation::Checked;
+
+use super::Builder;
+
+/// Handle to a texture pushed via [`Builder::push_texture`], for referencing
+/// from a [`MaterialDesc`](super::MaterialDesc).
+#[derive(Clone, Copy)]
+pub struct TextureRef(json::Index<json::Texture>);
+
+impl TextureRef {
+    pub(super) fn index(self) -> json::Index<json::Texture> {
+        self.0
+    }
+}
+
+/// Handle to an image embedded via [`Builder::push_image`]. `index` is what a
+/// texture extension references (e.g. `EXT_texture_webp`'s `source`).
+#[derive(Clone, Copy)]
+pub struct ImageRef(json::Index<json::Image>);
+
+impl ImageRef {
+    pub fn index(self) -> usize {
+        self.0.value()
+    }
+}
+
+/// How a texture's coordinates are wrapped and filtered — the glTF-agnostic
+/// subset this writer needs. Maps to a glTF `sampler`.
+#[derive(Clone, Copy)]
+pub struct SamplerDesc {
+    pub wrap_s: Wrap,
+    pub wrap_t: Wrap,
+    pub mag: MagFilter,
+    pub min: MinFilter,
+}
+
+#[derive(Clone, Copy)]
+pub enum Wrap {
+    Repeat,
+    MirroredRepeat,
+    ClampToEdge,
+}
+
+#[derive(Clone, Copy)]
+pub enum MagFilter {
+    Nearest,
+    Linear,
+}
+
+#[derive(Clone, Copy)]
+pub enum MinFilter {
+    Nearest,
+    Linear,
+    NearestMipmap,
+    LinearMipmap,
+}
+
+impl Builder {
+    /// Embed `image_bytes` as a bufferView-backed image. A `mime_type` glTF
+    /// admits only via an extension (e.g. `"image/webp"`) embeds fine; the
+    /// caller references it through [`push_texture`](Self::push_texture).
+    pub fn push_image(&mut self, image_bytes: &[u8], mime_type: &str) -> ImageRef {
+        let buffer_view = self.push_buffer_view_targeted(image_bytes, None);
+        ImageRef(self.root.push(json::Image {
+            name: None,
+            buffer_view: Some(buffer_view),
+            mime_type: Some(json::image::MimeType(mime_type.to_string())),
+            uri: None,
+            extensions: Default::default(),
+            extras: Default::default(),
+        }))
+    }
+
+    /// Build a texture, attaching the given texture-level extension payloads and
+    /// marking each `extensionsUsed`. `source` is `None` when an extension
+    /// supplies the image (e.g. `EXT_texture_webp`), which the caller must then
+    /// also [`require_extension`](Self::require_extension).
+    pub fn push_texture(
+        &mut self,
+        source: Option<ImageRef>,
+        sampler: SamplerDesc,
+        extensions: Vec<(&'static str, serde_json::Value)>,
+    ) -> TextureRef {
+        let sampler_index = self.root.push(json::texture::Sampler {
+            name: None,
+            mag_filter: Some(Checked::Valid(match sampler.mag {
+                MagFilter::Nearest => json::texture::MagFilter::Nearest,
+                MagFilter::Linear => json::texture::MagFilter::Linear,
+            })),
+            min_filter: Some(Checked::Valid(match sampler.min {
+                MinFilter::Nearest => json::texture::MinFilter::Nearest,
+                MinFilter::Linear => json::texture::MinFilter::Linear,
+                MinFilter::NearestMipmap => json::texture::MinFilter::NearestMipmapNearest,
+                MinFilter::LinearMipmap => json::texture::MinFilter::LinearMipmapLinear,
+            })),
+            wrap_s: Checked::Valid(wrap(sampler.wrap_s)),
+            wrap_t: Checked::Valid(wrap(sampler.wrap_t)),
+            extensions: None,
+            extras: Default::default(),
+        });
+        let mut ext = json::extensions::texture::Texture::default();
+        for (name, value) in extensions {
+            ext.others.insert(name.to_string(), value);
+            self.mark_extension_used(name);
+        }
+        // Absent source serializes as the schema's skipped `u32::MAX` sentinel.
+        let source = source.map_or_else(|| json::Index::new(u32::MAX), |image| image.0);
+        TextureRef(self.root.push(json::Texture {
+            name: None,
+            sampler: Some(sampler_index),
+            source,
+            extensions: (!ext.others.is_empty()).then_some(ext),
+            extras: Default::default(),
+        }))
+    }
+}
+
+fn wrap(w: Wrap) -> json::texture::WrappingMode {
+    match w {
+        Wrap::Repeat => json::texture::WrappingMode::Repeat,
+        Wrap::MirroredRepeat => json::texture::WrappingMode::MirroredRepeat,
+        Wrap::ClampToEdge => json::texture::WrappingMode::ClampToEdge,
+    }
+}

--- a/engine/runtime/gltf/src/next/metadata.rs
+++ b/engine/runtime/gltf/src/next/metadata.rs
@@ -66,14 +66,16 @@ pub fn build_table(features: &[&Feature], options: MetadataOptions) -> PropertyT
     PropertyTable { properties, rows }
 }
 
-/// Attach `table` to `builder` as an `EXT_structural_metadata` property table
-/// plus an `EXT_mesh_features` feature-ID attribute on `primitive`, tagging
-/// each of its vertices with `feature_ids[original_vertex]`. No-op if `table`
-/// has no properties.
+/// Attach `table` to `builder` as one `EXT_structural_metadata` property table
+/// (built once) plus, on every primitive in `primitives`, an `EXT_mesh_features`
+/// feature-ID attribute tagging each of its vertices with
+/// `feature_ids[original_vertex]`. Every primitive shares the one property
+/// table, so all reference `propertyTable` 0 and the same original-vertex
+/// `feature_ids`. No-op if `table` has no properties.
 pub fn encode(
     table: &PropertyTable,
     builder: &mut Builder,
-    primitive: PrimitiveHandle,
+    primitives: &[PrimitiveHandle],
     feature_ids: &[u32],
 ) {
     if table.properties.is_empty() {
@@ -139,26 +141,28 @@ pub fn encode(
             .expect("EXT_structural_metadata is always serializable"),
     );
 
-    builder.extend(
-        primitive,
-        "EXT_mesh_features",
-        serde_json::to_value(&ExtMeshFeatures {
-            feature_ids: vec![FeatureId {
-                feature_count: table.rows.len(),
-                attribute: 0,
-                property_table: 0,
-            }],
-        })
-        .expect("EXT_mesh_features is always serializable"),
-    );
+    for &primitive in primitives {
+        builder.extend(
+            primitive,
+            "EXT_mesh_features",
+            serde_json::to_value(&ExtMeshFeatures {
+                feature_ids: vec![FeatureId {
+                    feature_count: table.rows.len(),
+                    attribute: 0,
+                    property_table: 0,
+                }],
+            })
+            .expect("EXT_mesh_features is always serializable"),
+        );
 
-    // `Semantic::Extras`'s inner name excludes the glTF-spec-mandated
-    // leading underscore; the crate adds it on (de)serialization.
-    builder.set_attribute(
-        primitive,
-        json::mesh::Semantic::Extras("FEATURE_ID_0".to_string()),
-        feature_ids,
-    );
+        // `Semantic::Extras`'s inner name excludes the glTF-spec-mandated
+        // leading underscore; the crate adds it on (de)serialization.
+        builder.set_attribute(
+            primitive,
+            json::mesh::Semantic::Extras("FEATURE_ID_0".to_string()),
+            feature_ids,
+        );
+    }
 }
 
 #[derive(Serialize)]

--- a/engine/runtime/gltf/src/next/metadata.rs
+++ b/engine/runtime/gltf/src/next/metadata.rs
@@ -67,16 +67,16 @@ pub fn build_table(features: &[&Feature], options: MetadataOptions) -> PropertyT
 }
 
 /// Attach `table` to `builder` as one `EXT_structural_metadata` property table
-/// (built once) plus, on every primitive in `primitives`, an `EXT_mesh_features`
-/// feature-ID attribute tagging each of its vertices with
-/// `feature_ids[original_vertex]`. Every primitive shares the one property
-/// table, so all reference `propertyTable` 0 and the same original-vertex
-/// `feature_ids`. No-op if `table` has no properties.
+/// (built once) plus, on each `(primitive, feature_ids)` in `primitives`, an
+/// `EXT_mesh_features` feature-ID attribute tagging each of that primitive's
+/// vertices with `feature_ids[original_vertex]`. All primitives share the one
+/// property table (reference `propertyTable` 0), but each carries its own
+/// per-vertex `feature_ids` (their vertex buffers are independent). No-op if
+/// `table` has no properties.
 pub fn encode(
     table: &PropertyTable,
     builder: &mut Builder,
-    primitives: &[PrimitiveHandle],
-    feature_ids: &[u32],
+    primitives: &[(PrimitiveHandle, &[u32])],
 ) {
     if table.properties.is_empty() {
         return;
@@ -141,7 +141,7 @@ pub fn encode(
             .expect("EXT_structural_metadata is always serializable"),
     );
 
-    for &primitive in primitives {
+    for &(primitive, feature_ids) in primitives {
         builder.extend(
             primitive,
             "EXT_mesh_features",


### PR DESCRIPTION
# Overview

This PR implemented basic appearance writing for the new cesium writer. It also handled lod parsing in the new CityGML as per-geometry attributes for split/filtering. Also, this PR flips the UV direction convention (new geometry only) to be top-left based.

## Why top-left?

- UV related implementations are simpler and more efficient. Atlas packer had to flip UV back and forth in the old convention.
- modern choice (Vulkan, WebGPU, DirectX, Metal vs OpenGL, WebGL)
- Natural choice to have (0,0) maps to `u=0`, `v=0`

drawback: during migration all texture/uv related reader/writer need to flip the order. But since we are migrating everything to new geometry this is probably the best chance to move to a better convention.

## Screenshot

<img width="964" height="548" alt="2026-07-17_10-09-59" src="https://github.com/user-attachments/assets/8596d13d-bb51-4d3f-bb08-67b8b1c3a5c6" />

## Todo

- KTX2
- max atlas size + multipage export
- resolution knob (geometric error aware)
- PBR/Phong actual material parameter conversion (currently fixed parameter)
- theme selection in parameter
- double-sided material and multiple TEX_COORD attributes