### PR TITLE
chore(websocket-go): bump ygo to v1.34.0

### DIFF
--- a/server/websocket-go/go.mod
+++ b/server/websocket-go/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fsouza/fake-gcs-server v1.54.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/redis/go-redis/v9 v9.20.0
-	github.com/reearth/ygo v1.30.1
+	github.com/reearth/ygo v1.34.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.42.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.44.0

--- a/server/websocket-go/go.sum
+++ b/server/websocket-go/go.sum
@@ -149,8 +149,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/redis/go-redis/v9 v9.20.0 h1:WnQYxLkgO2xiXTCJY0ldIiI8dNqCDlQAG+AtaH7a2a0=
 github.com/redis/go-redis/v9 v9.20.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
-github.com/reearth/ygo v1.30.1 h1:M8NAaLKs6xX3Lntw/OziZTvFRCGRs5WR0CyvJJ6SUvU=
-github.com/reearth/ygo v1.30.1/go.mod h1:QN5MsM+QBk9cP6Sr/iaKlkJtnJ9Fo0fT+MJqSw2xPUA=
+github.com/reearth/ygo v1.34.0 h1:lsreoPJX7XQY3mmtlW+J7XDZVyO4+Zf8DYMr7hj6/J0=
+github.com/reearth/ygo v1.34.0/go.mod h1:QN5MsM+QBk9cP6Sr/iaKlkJtnJ9Fo0fT+MJqSw2xPUA=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=


### PR DESCRIPTION
## What
Bumps the Go Y-WebSocket server's `ygo` dependency from **v1.30.1 → v1.34.0** (latest) so the `websocket-go` Docker image builds against the current ygo.

## Change
- `server/websocket-go/go.mod` + `go.sum` only. No source changes were needed, the ygo API used by the server is unchanged across 1.30 → 1.34.

## Verification (`GOWORK=off`, in `server/websocket-go`)
- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./...` ✅ (all packages)
- `go test -race ./...` ✅ (all packages)

## Note for reviewers / before deploy
This is a version bump only; it does not itself change traffic routing (traffic is on the Rust server). One thing worth keeping in mind before any Go cutover: ygo minor bumps can touch the update/persistence encoding, and we previously hit a **ygo-V2-snapshot vs yrs** interop issue (Rust reading Go-written GCS docs). This PR doesn't attempt to validate cross-implementation persistence/interop, so if a Go deploy is planned, that should be checked separately with the interop harness.