### PR TITLE
feat(websocket-go): make peer write queue size configurable, default 512

### DIFF
--- a/server/websocket-go/internal/config/config.go
+++ b/server/websocket-go/internal/config/config.go
@@ -42,6 +42,12 @@ type Config struct {
 	MaxPeersPerRoom int
 	// MaxRooms caps distinct rooms server-wide (doc_id is client-supplied).
 	MaxRooms int
+	// PeerWriteQueueSize is the per-peer outbound broadcast queue depth; when a
+	// peer's queue fills (slow/lagged connection) ygo disconnects it, forcing a
+	// reconnect-and-resync. Larger values tolerate bigger update bursts before
+	// evicting. ygo's own default is 256; we default higher to match the Rust
+	// server's 512 broadcast buffer.
+	PeerWriteQueueSize int
 
 	// WSAuthEnabled gates protected-mode WS token verification. Default OFF;
 	// when ON the AuthFunc fails closed. Sourced from REEARTH_FLOW_WS_PROTECTED.
@@ -68,9 +74,10 @@ const (
 	defaultLogLevel      = "info"
 	defaultWSPort        = 8000
 
-	defaultMaxConnections  = 10000
-	defaultMaxPeersPerRoom = 256
-	defaultMaxRooms        = 50000
+	defaultMaxConnections     = 10000
+	defaultMaxPeersPerRoom    = 256
+	defaultMaxRooms           = 50000
+	defaultPeerWriteQueueSize = 512
 
 	defaultOTLPExporterType       = "otlp"
 	defaultOTLPServiceName        = "reearth-flow-websocket"
@@ -108,9 +115,10 @@ func Load() *Config {
 		WSPort:        envPort("REEARTH_FLOW_WS_PORT", defaultWSPort),
 		APISecret:     os.Getenv("REEARTH_FLOW_API_SECRET"),
 
-		MaxConnections:  envPositive("REEARTH_FLOW_MAX_CONNECTIONS", defaultMaxConnections),
-		MaxPeersPerRoom: envPositive("REEARTH_FLOW_MAX_PEERS_PER_ROOM", defaultMaxPeersPerRoom),
-		MaxRooms:        envPositive("REEARTH_FLOW_MAX_ROOMS", defaultMaxRooms),
+		MaxConnections:     envPositive("REEARTH_FLOW_MAX_CONNECTIONS", defaultMaxConnections),
+		MaxPeersPerRoom:    envPositive("REEARTH_FLOW_MAX_PEERS_PER_ROOM", defaultMaxPeersPerRoom),
+		MaxRooms:           envPositive("REEARTH_FLOW_MAX_ROOMS", defaultMaxRooms),
+		PeerWriteQueueSize: envPositive("REEARTH_FLOW_PEER_WRITE_QUEUE_SIZE", defaultPeerWriteQueueSize),
 
 		WSAuthEnabled: envBool("REEARTH_FLOW_WS_PROTECTED", false),
 

--- a/server/websocket-go/internal/config/config_test.go
+++ b/server/websocket-go/internal/config/config_test.go
@@ -339,6 +339,7 @@ func clearEnv(t *testing.T) {
 		"REEARTH_FLOW_MAX_CONNECTIONS",
 		"REEARTH_FLOW_MAX_PEERS_PER_ROOM",
 		"REEARTH_FLOW_MAX_ROOMS",
+		"REEARTH_FLOW_PEER_WRITE_QUEUE_SIZE",
 		"REEARTH_FLOW_ENABLE_OTLP",
 		"REEARTH_FLOW_OTLP_ENDPOINT",
 		"REEARTH_FLOW_GCP_PROJECT_ID",
@@ -352,4 +353,27 @@ func clearEnv(t *testing.T) {
 	} {
 		t.Setenv(k, "")
 	}
+}
+
+func TestLoad_PeerWriteQueueSize(t *testing.T) {
+	t.Run("default is 512", func(t *testing.T) {
+		clearEnv(t)
+		if c := Load(); c.PeerWriteQueueSize != 512 {
+			t.Errorf("PeerWriteQueueSize = %d, want 512", c.PeerWriteQueueSize)
+		}
+	})
+	t.Run("env override", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("REEARTH_FLOW_PEER_WRITE_QUEUE_SIZE", "1024")
+		if c := Load(); c.PeerWriteQueueSize != 1024 {
+			t.Errorf("PeerWriteQueueSize = %d, want 1024", c.PeerWriteQueueSize)
+		}
+	})
+	t.Run("non-positive falls back to default", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("REEARTH_FLOW_PEER_WRITE_QUEUE_SIZE", "-5")
+		if c := Load(); c.PeerWriteQueueSize != 512 {
+			t.Errorf("PeerWriteQueueSize = %d, want 512", c.PeerWriteQueueSize)
+		}
+	})
 }

--- a/server/websocket-go/internal/server/persistence.go
+++ b/server/websocket-go/internal/server/persistence.go
@@ -26,5 +26,6 @@ func NewWithPersistence(ctx context.Context, cfg *config.Config, p persistence.V
 	s.ws.MaxConnections = cfg.MaxConnections
 	s.ws.MaxPeersPerRoom = cfg.MaxPeersPerRoom
 	s.ws.MaxRooms = cfg.MaxRooms
+	s.ws.PeerWriteQueueSize = cfg.PeerWriteQueueSize
 	return s
 }

--- a/server/websocket-go/internal/server/ws.go
+++ b/server/websocket-go/internal/server/ws.go
@@ -44,6 +44,7 @@ func New(cfg *config.Config) *Server {
 	s.ws.MaxConnections = cfg.MaxConnections
 	s.ws.MaxPeersPerRoom = cfg.MaxPeersPerRoom
 	s.ws.MaxRooms = cfg.MaxRooms
+	s.ws.PeerWriteQueueSize = cfg.PeerWriteQueueSize
 	return s
 }
 


### PR DESCRIPTION
## What
Makes the ygo per-peer outbound broadcast queue depth (`PeerWriteQueueSize`) configurable and raises the default **256 → 512**.

- New env var **`REEARTH_FLOW_PEER_WRITE_QUEUE_SIZE`** (default 512), wired into both server setups (`ws.go`, `persistence.go`), following the existing `MaxPeersPerRoom` pattern.

## Why
When a peer's outbound queue fills, ygo **disconnects** it (forcing reconnect + full resync). We were on ygo's default of **256** and never overrode it, so under bursty updates we saw frequent `peer write queue full; closing slow peer` warnings and reconnect churn, even with just two peers in a room.

The Rust (yrs) server tolerates more before reacting and, notably, handles a lagging peer by **skipping** missed updates rather than disconnecting (shared `tokio::broadcast` buffer of **512**, `RecvError::Lagged` → continue). ygo only offers "disconnect on full," so the practical lever is a larger queue. Bumping the default to **512** matches the Rust buffer and gives legitimate clients more burst headroom; deployments can tune it further via the env var.

Not a data-loss issue (reconnect resyncs cleanly); this reduces churn and the associated log noise.

## Verification (`GOWORK=off`, in `server/websocket-go`)
- `go build ./...`, `go vet ./...` ✅
- `go test ./...` and `go test -race ./...` ✅ (all packages)
- Added config tests: default 512, env override, non-positive → default.