### PR TITLE
chore(websocket-go): bump ygo to v1.35.0

### DIFF
--- a/server/websocket-go/go.mod
+++ b/server/websocket-go/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fsouza/fake-gcs-server v1.54.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/redis/go-redis/v9 v9.20.0
-	github.com/reearth/ygo v1.34.0
+	github.com/reearth/ygo v1.35.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.42.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.44.0

--- a/server/websocket-go/go.sum
+++ b/server/websocket-go/go.sum
@@ -149,8 +149,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/redis/go-redis/v9 v9.20.0 h1:WnQYxLkgO2xiXTCJY0ldIiI8dNqCDlQAG+AtaH7a2a0=
 github.com/redis/go-redis/v9 v9.20.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
-github.com/reearth/ygo v1.34.0 h1:lsreoPJX7XQY3mmtlW+J7XDZVyO4+Zf8DYMr7hj6/J0=
-github.com/reearth/ygo v1.34.0/go.mod h1:QN5MsM+QBk9cP6Sr/iaKlkJtnJ9Fo0fT+MJqSw2xPUA=
+github.com/reearth/ygo v1.35.0 h1:mawG6scRYOwiE8XRz86dWJ+aDFRtzvRWubZ/5x0DncI=
+github.com/reearth/ygo v1.35.0/go.mod h1:QN5MsM+QBk9cP6Sr/iaKlkJtnJ9Fo0fT+MJqSw2xPUA=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=


### PR DESCRIPTION
## What

Bumps `server/websocket-go` from `github.com/reearth/ygo` v1.34.0 → **v1.35.0**.

## Why

v1.35.0 is the release that carries the slow-peer work we landed upstream (reearth/ygo#173, issue #172), addressing the "peer write queue full" churn seen in production. Upgrading brings:

- **Broadcast head-of-line-blocking fix (automatic).** The per-peer write mutex is no longer held across the blocking socket write, so one slow peer no longer stalls the broadcaster for other peers in the room.
- **Default `PeerWriteQueueSize` bumped 256 → 512 (automatic).** More slack before a transiently-slow peer's queue overflows.
- **Opt-in `SlowPeerResync` policy (not wired here).** On overflow, keep the connection open and re-sync the peer in place with a full-state SyncStep2 instead of disconnecting. This is opt-in via `Server.SlowPeerPolicy` and is left as a follow-up (see note below); the default behaviour is unchanged.

## Scope

Version bump only (`go.mod` / `go.sum`), same shape as the v1.34.0 bump (#2267). No flow-side code changes.

## Verification

- `GOWORK=off go build ./...` — ok
- `GOWORK=off go test -race ./...` — all packages pass

## Follow-up (optional)

To actually enable graceful in-place recovery, we would set `s.ws.SlowPeerPolicy = ygws.SlowPeerResync` in `internal/server` (both `New` and `NewWithPersistence`). Happy to do that in this PR or a separate one, whichever you prefer.
