### PR TITLE
fix(ui): stop Y.Doc churn and [yjs#509] undo-scope flood

### DIFF
--- a/ui/src/lib/auth/auth0Auth.ts
+++ b/ui/src/lib/auth/auth0Auth.ts
@@ -1,4 +1,5 @@
 import { useAuth0 } from "@auth0/auth0-react";
+import { useCallback, useMemo } from "react";
 
 import { e2eAccessToken, logOutFromTenant } from "@flow/config";
 
@@ -15,25 +16,41 @@ export const useAuth0Auth = (): AuthHook => {
     user,
   } = useAuth0();
 
-  return {
-    isAuthenticated: !!e2eAccessToken() || (isAuthenticated && !error),
-    isLoading,
-    error: error?.message ?? null,
-    getAccessToken: () => getAccessTokenSilently(),
-    login: () => {
-      logOutFromTenant();
-      return loginWithRedirect();
-    },
-    logout: () => {
-      logOutFromTenant();
-      return logout({
-        logoutParams: {
-          returnTo: error
-            ? `${window.location.origin}?${errorKey}=${encodeURIComponent(error?.message)}`
-            : window.location.origin,
-        },
-      });
-    },
-    user: user,
-  };
+  // Memoize the returned methods and object. Without this, every render produced
+  // a new `getAccessToken` reference, which is a dependency of the yjs setup
+  // effect (useYjsSetup) and forced the Y.Doc to be recreated on every auth
+  // re-render / token refresh — the churn behind the [yjs#509] flood.
+  const getAccessToken = useCallback(
+    () => getAccessTokenSilently(),
+    [getAccessTokenSilently],
+  );
+
+  const login = useCallback(() => {
+    logOutFromTenant();
+    return loginWithRedirect();
+  }, [loginWithRedirect]);
+
+  const logoutCb = useCallback(() => {
+    logOutFromTenant();
+    return logout({
+      logoutParams: {
+        returnTo: error
+          ? `${window.location.origin}?${errorKey}=${encodeURIComponent(error?.message)}`
+          : window.location.origin,
+      },
+    });
+  }, [logout, error]);
+
+  return useMemo(
+    () => ({
+      isAuthenticated: !!e2eAccessToken() || (isAuthenticated && !error),
+      isLoading,
+      error: error?.message ?? null,
+      getAccessToken,
+      login,
+      logout: logoutCb,
+      user,
+    }),
+    [isAuthenticated, error, isLoading, getAccessToken, login, logoutCb, user],
+  );
 };

--- a/ui/src/lib/yjs/useYjsSetup.ts
+++ b/ui/src/lib/yjs/useYjsSetup.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Awareness } from "y-protocols/awareness";
 import { WebsocketProvider } from "y-websocket";
 import * as Y from "yjs";
@@ -171,17 +171,30 @@ export default ({
 
   const observedMapsRef = useRef(new WeakSet());
 
-  function recursivelyTrackSharedType(sharedType?: Y.Map<any>): void {
+  // Read the current UndoManager through a ref so the long-lived observers
+  // registered below never capture a stale manager from an earlier render. After
+  // a Y.Doc swap, a captured-stale manager belongs to the old (destroyed) doc, so
+  // every subsequent remote update flooded [yjs#509] "Not same Y.Doc" via these
+  // observers. The doc-equality check is yjs's own precondition for addToScope,
+  // so a type from a different doc is skipped rather than warned on.
+  const undoManagerRef = useRef<Y.UndoManager | null>(null);
+  useEffect(() => {
+    undoManagerRef.current = undoManager;
+  }, [undoManager]);
+
+  const trackSharedType = useCallback((sharedType?: Y.Map<any>): void => {
     if (!sharedType) return;
+    const manager = undoManagerRef.current;
+    if (!manager || sharedType.doc !== manager.doc) return;
     if (observedMapsRef.current.has(sharedType)) return;
     observedMapsRef.current.add(sharedType);
 
-    undoManager?.addToScope([sharedType]);
+    manager.addToScope([sharedType]);
 
     if (sharedType instanceof Y.Map) {
       sharedType.forEach((value: any) => {
         if (value instanceof Y.Map) {
-          recursivelyTrackSharedType(value);
+          trackSharedType(value);
         }
       });
 
@@ -190,16 +203,19 @@ export default ({
           if (change.action === "add" || change.action === "update") {
             const newValue: any = sharedType.get(key);
             if (newValue instanceof Y.Map) {
-              recursivelyTrackSharedType(newValue);
+              trackSharedType(newValue);
             }
           }
         });
       });
     }
-  }
+  }, []);
 
-  // Start the recursive tracking
-  recursivelyTrackSharedType(yWorkflows);
+  // Track from an effect (not the render body) once the workflows map and its
+  // matching UndoManager are in place.
+  useEffect(() => {
+    trackSharedType(yWorkflows);
+  }, [yWorkflows, undoManager, trackSharedType]);
 
   return {
     yWorkflows,


### PR DESCRIPTION
## What

Fixes the `[yjs#509] Not same Y.Doc` warning flood seen in the browser console against the collaborative editor, plus the underlying `Y.Doc` churn that causes it.

## Root cause (from the console stack trace)

The warning is emitted by `UndoManager.addToScope` (it's a `console.warn`, and yjs then skips the type; no crash, no data loss). The stack trace pointed at `useYjsSetup`'s `recursivelyTrackSharedType`, firing both from React commits and, in a flood, from remote-update observers (`... _callObserver -> onmessage`). Two problems combine:

1. **Unstable `getAccessToken`.** `useAuth0Auth` returned a fresh object (and a fresh `getAccessToken`) every render, and the context value wasn't memoized. `getAccessToken` is a dependency of `useYjsSetup`'s effect, so the `Y.Doc` (and its WebSocket) was recreated on every auth re-render / token refresh.

2. **Stale-closure undo tracking.** `recursivelyTrackSharedType` ran in the render body and registered per-type `observe` callbacks that captured the render-scoped `UndoManager`. After a `Y.Doc` swap (from #1), those long-lived observers still held the old, destroyed doc's manager, so every subsequent remote update called `addToScope` with a type from a different doc than the manager, flooding `[yjs#509]`.

## Fix

- **`auth0Auth.ts`**: wrap `getAccessToken`/`login`/`logout` in `useCallback` and the returned object in `useMemo`, so the auth value is stable and the `Y.Doc` stops being recreated needlessly.
- **`useYjsSetup.ts`**: read the `UndoManager` through a ref (so observers never capture a stale manager), guard `addToScope` with yjs's own `sharedType.doc === manager.doc` precondition, and run tracking from an effect instead of the render body.

## Not a server/ygo bug

I verified separately that yjs<->ygo sync converges correctly (two-then-three client convergence test, including nested `Y.Map`/`Y.Text`), so this is purely a client-side undo-tracking issue. ygo's higher inbound-update volume (periodic resync, reconnects) simply surfaced this latent bug far more often than the old Rust/yrs server did.

## Verification

- `tsc --noEmit`: 0 errors
- `eslint` on both files: clean
- `vitest run src/lib/yjs src/lib/auth`: 84 passed
