### PR TITLE
ci(ui): fix invalid e2e workflow YAML and migrate Allure history to v3

### DIFF
--- a/.github/workflows/e2e_ui.yml
+++ b/.github/workflows/e2e_ui.yml
@@ -16,7 +16,10 @@ on:
           - smoke # @smoke-tagged sanity check only
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Workflow-global (not per-ref): serializes every run so there is a single
+  # writer to the shared GCS history.jsonl/index.json objects, and so no two
+  # suites hit the shared e2e environment (FLOW_DASHBOARD_E2E_BASEURL) at once.
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 permissions:
@@ -152,8 +155,8 @@ jobs:
 
       - name: Persist Allure history to GCS
         # `allure generate` appended this run to history.jsonl; store it so the
-        # next run restores it. The workflow concurrency group serializes runs,
-        # so there is a single writer and no lost-update race here.
+        # next run restores it. The workflow-global concurrency group serializes
+        # every run, so there is a single writer and no lost-update race here.
         if: ${{ !cancelled() && steps.check-results.outputs.has_results == 'true' }}
         run: |
           if [ -f ./history.jsonl ]; then

--- a/.github/workflows/e2e_ui.yml
+++ b/.github/workflows/e2e_ui.yml
@@ -86,7 +86,7 @@ jobs:
         if: ${{ !cancelled() && steps.check-results.outputs.has_results == 'true' }}
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2.2.1
 
-      - name: Load dashboard index and history from GCS
+      - name: Load dashboard index and Allure history from GCS
         if: ${{ !cancelled() && steps.check-results.outputs.has_results == 'true' }}
         run: |
           # Download index or create empty one if it does not exist
@@ -105,32 +105,21 @@ jobs:
           fi
           rm -f /tmp/gsutil_index_err.log || true
 
-          # Get most recent run for history
-          MOST_RECENT_RUN=$(python3 -c "
-          import json, sys
-          try:
-              with open('/tmp/index.json') as f:
-                  data = json.load(f)
-              print(data[0]['id'] if data else '')
-          except Exception:
-              print('')
-          ")
-
-          if [ -n "$MOST_RECENT_RUN" ]; then
-            echo "Found previous run: $MOST_RECENT_RUN"
-            mkdir -p ./allure-results/history
-            if ! gsutil -m rsync -r "gs://$BUCKET/runs/$MOST_RECENT_RUN/history/" ./allure-results/history/ 2>/tmp/gsutil_history_err.log; then
-              if grep -qE "Matched 0 objects|No URLs matched" /tmp/gsutil_history_err.log; then
-                echo "No history objects found for run $MOST_RECENT_RUN; continuing without history."
-              else
-                echo "Error syncing history from GCS:" >&2
-                cat /tmp/gsutil_history_err.log >&2
-              fi
-            fi
-            rm -f /tmp/gsutil_history_err.log || true
+          # Allure 3 keeps cross-run trends in a single history file rather than a
+          # per-run history/ folder (see historyPath in allurerc.mjs). Restore it so
+          # the generated report shows trend/retry charts; the generate step below
+          # reads it and appends this run, and a later step re-uploads it.
+          if gsutil cp "gs://$BUCKET/history.jsonl" ./history.jsonl 2>/tmp/gsutil_history_err.log; then
+            echo "Restored Allure history from GCS ($(wc -l < ./history.jsonl) entries)."
+          elif grep -qiE "No URLs matched|Matched no objects|404" /tmp/gsutil_history_err.log; then
+            echo "No existing history.jsonl in bucket; starting fresh."
           else
-            echo "No previous runs, starting fresh"
+            echo "Failed to download history.jsonl from GCS. Error output:" >&2
+            cat /tmp/gsutil_history_err.log >&2
+            rm -f /tmp/gsutil_history_err.log
+            exit 1
           fi
+          rm -f /tmp/gsutil_history_err.log || true
 
       - name: Generate Allure report
         if: ${{ !cancelled() && steps.check-results.outputs.has_results == 'true' }}
@@ -157,8 +146,21 @@ jobs:
           RUN_ID: ${{ steps.run-id.outputs.run_id }}
         run: |
           gsutil -m rsync -r -d ./allure-report "gs://$BUCKET/runs/$RUN_ID/"
-          if [ -f "./allure-report/widgets/summary.json" ]; then
-            gsutil cp ./allure-report/widgets/summary.json "gs://$BUCKET/runs/$RUN_ID/summary.json"
+          if [ -f "./allure-report/summary.json" ]; then
+            gsutil cp ./allure-report/summary.json "gs://$BUCKET/runs/$RUN_ID/summary.json"
+          fi
+
+      - name: Persist Allure history to GCS
+        # `allure generate` appended this run to history.jsonl; store it so the
+        # next run restores it. The workflow concurrency group serializes runs,
+        # so there is a single writer and no lost-update race here.
+        if: ${{ !cancelled() && steps.check-results.outputs.has_results == 'true' }}
+        run: |
+          if [ -f ./history.jsonl ]; then
+            gsutil -h "Cache-Control:no-cache" cp ./history.jsonl "gs://$BUCKET/history.jsonl"
+            echo "Persisted Allure history to GCS ($(wc -l < ./history.jsonl) entries)."
+          else
+            echo "No history.jsonl produced; skipping history upload."
           fi
 
       - name: Point bucket root at latest report
@@ -177,9 +179,9 @@ jobs:
           cat > /tmp/root-index.html <<EOF
           <!doctype html>
           <meta charset="utf-8">
-<meta http-equiv="refresh" content="0; url=runs/${RUN_ID}/index.html">
-<title>Re:Earth Flow E2E</title>
-<a href="runs/${RUN_ID}/index.html">Latest report</a>
+          <meta http-equiv="refresh" content="0; url=runs/${RUN_ID}/index.html">
+          <title>Re:Earth Flow E2E</title>
+          <a href="runs/${RUN_ID}/index.html">Latest report</a>
           EOF
           gsutil -h "Content-Type:text/html" -h "Cache-Control:no-cache" \
             cp /tmp/root-index.html "gs://$BUCKET/index.html"

--- a/ui/e2e/.gitignore
+++ b/ui/e2e/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 /blob-report/
 /allure-results/
 /allure-report/
+/history.jsonl
 /playwright/.cache/
 /.auth/
 .env

--- a/ui/e2e/allurerc.mjs
+++ b/ui/e2e/allurerc.mjs
@@ -3,6 +3,13 @@ import { defineConfig } from "allure";
 export default defineConfig({
   name: "Re:Earth Flow E2E",
   output: "allure-report",
+  // Cross-run trends live in this single JSONL file (Allure 3 replaced the
+  // Allure 2 `history/` folder). The CI workflow restores it from GCS before
+  // generating and re-uploads it afterwards; `allure generate` reads it for
+  // trend/retry charts and appends the current run. Kept in sync with the
+  // 50-run cap on the dashboard index.json.
+  historyPath: "history.jsonl",
+  historyLimit: 50,
   plugins: {
     awesome: {
       options: {


### PR DESCRIPTION
## What
- Fix a YAML parse error in `e2e_ui.yml` that made the whole workflow invalid (GitHub Actions rejected the file): the root-index.html heredoc had body lines at column 0, breaking out of the `run: |` block scalar (`could not find expected ':'`), plus an indented `EOF` under a plain `<<EOF`.
- Migrate cross-run Allure history/trends to Allure 3. The old per-run `history/` rsync was a no-op under Allure 3, so trend charts were always empty. Now uses the top-level `historyPath` JSONL: restore `history.jsonl` from GCS before generating, re-upload it after. `allure generate` reads it for trend/retry charts and appends the current run.
- Fix the per-run summary upload guard — Allure 3 writes `summary.json` to the report root, not `widgets/`, so the old path was always missing and the summary was never uploaded.

## Notes
- First scheduled run after merge starts trends from a single point and builds up daily (no prior `history.jsonl` in the bucket yet).
- History is global (one `history.jsonl` at the bucket root), matching the existing single-root-report / single-`index.json` design.

## Verification
- `e2e_ui.yml` now parses; every `run` step passes `bash -n`.
- Full cold→warm cycle with the committed `allurerc.mjs`: run 1 creates `history.jsonl` (1 entry), run 2 restores + appends (2 entries), trend widget data grows accordingly; report stays multi-file with `summary.json` at root.
