### PR TITLE
feat(ui): allow for deployments and sharing when project is locked [FLOW-DEV-229]

### DIFF
--- a/ui/src/features/Editor/components/OverlayUI/components/ActionBar/index.tsx
+++ b/ui/src/features/Editor/components/OverlayUI/components/ActionBar/index.tsx
@@ -78,7 +78,6 @@ const ActionBar: React.FC<Props> = ({
               tooltipOffset={tooltipOffset}
               icon={<RocketIcon weight="thin" size={18} />}
               onClick={() => onDialogOpen("deploy")}
-              disabled={isLocked}
             />
           }
         />
@@ -105,7 +104,6 @@ const ActionBar: React.FC<Props> = ({
             <IconButton
               tooltipText={t("Share Project")}
               tooltipOffset={tooltipOffset}
-              disabled={isLocked}
               icon={<PaperPlaneTiltIcon weight="thin" size={18} />}
               onClick={() => onDialogOpen("share")}
             />


### PR DESCRIPTION
# Overview
This PR updates the Editor overlay ActionBar behavior so that **Deploy** and **Share Project** actions remain available even when the current project is in a locked state, aligning UI affordances with the intent to allow deployments/sharing during lock.
## What I've done
- Removed the `disabled={isLocked}` restriction from the Deploy action trigger.
- Removed the `disabled={isLocked}` restriction from the Share Project action trigger.
## What I haven't done

## How I tested

## Screenshot

## Which point I want you to review particularly

## Memo
