### PR TITLE
chore(websocket-go): bump ygo to v1.36.0

### DIFF
--- a/server/websocket-go/go.mod
+++ b/server/websocket-go/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fsouza/fake-gcs-server v1.54.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/redis/go-redis/v9 v9.20.0
-	github.com/reearth/ygo v1.35.0
+	github.com/reearth/ygo v1.36.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.42.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.44.0

--- a/server/websocket-go/go.sum
+++ b/server/websocket-go/go.sum
@@ -149,8 +149,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/redis/go-redis/v9 v9.20.0 h1:WnQYxLkgO2xiXTCJY0ldIiI8dNqCDlQAG+AtaH7a2a0=
 github.com/redis/go-redis/v9 v9.20.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
-github.com/reearth/ygo v1.35.0 h1:mawG6scRYOwiE8XRz86dWJ+aDFRtzvRWubZ/5x0DncI=
-github.com/reearth/ygo v1.35.0/go.mod h1:QN5MsM+QBk9cP6Sr/iaKlkJtnJ9Fo0fT+MJqSw2xPUA=
+github.com/reearth/ygo v1.36.0 h1:K8lIykQDits4YzIXQsF3/L3Vh91FBgE48aUuu0di9Bc=
+github.com/reearth/ygo v1.36.0/go.mod h1:QN5MsM+QBk9cP6Sr/iaKlkJtnJ9Fo0fT+MJqSw2xPUA=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=


### PR DESCRIPTION
## What

Bumps `github.com/reearth/ygo` from `v1.35.0` to `v1.36.0` (latest) in `server/websocket-go`.

Dependency bump only, no source changes. The ygo API used by the server is unchanged across this range.

## Verification

All run with `GOWORK=off` in `server/websocket-go`:

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test -race ./...` — all packages pass
- `go mod verify` — all modules verified
- `govulncheck ./...` — no CALLED vulnerabilities

## Notes

Based on current `main` (post-#2281), so `x/text v0.40.0` / `x/sync v0.22.0` are already present; this PR's only delta is the ygo version.