### PR TITLE
feat: reprojection bug fix and action migration for new geometry

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4094,7 +4094,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plateau-tiles-test"
-version = "0.2.83"
+version = "0.2.84"
 dependencies = [
  "bytes",
  "gltf 1.4.1 (git+https://github.com/gltf-rs/gltf?rev=3def30c9caf96f2dbc85238179ea5a6152c5cf22)",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-log"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "futures",
  "once_cell",
@@ -4652,7 +4652,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-plateau-processor"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "approx",
  "async-trait",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-processor"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "Inflector",
  "approx",
@@ -4752,7 +4752,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-python-processor"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "indexmap 2.13.0",
  "once_cell",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-sink"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-action-source"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "async-trait",
  "async_zip",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-atlas"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "image",
  "rstar 0.12.2",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-cli"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "bytes",
  "clap",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-common"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "approx",
  "async-recursion",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-examples"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5010,7 +5010,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-expr"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "indexmap 2.13.0",
  "lalrpop",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-geometry"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "approx",
  "bvh",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-gltf"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "ahash",
  "base64 0.22.1",
@@ -5092,7 +5092,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-macros"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runner"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-runtime"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sevenz"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "bit-set",
  "byteorder",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-sql"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "futures-util",
  "once_cell",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-state"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "bytes",
  "futures",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-storage"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "bytes",
  "futures",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-telemetry"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5247,7 +5247,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-tests"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-types"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "ahash",
  "bytes",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "reearth-flow-worker"
-version = "0.0.449"
+version = "0.0.450"
 dependencies = [
  "async-trait",
  "axum",
@@ -8050,7 +8050,7 @@ dependencies = [
 
 [[package]]
 name = "workflow-tests"
-version = "0.1.273"
+version = "0.1.274"
 dependencies = [
  "anyhow",
  "csv",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,7 +20,7 @@ homepage = "https://github.com/reearth/reearth-flow"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/reearth/reearth-flow"
 rust-version = "1.93.1" # Remember to update clippy.toml as well
-version = "0.0.449"
+version = "0.0.450"
 
 [profile.dev]
 opt-level = 0

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -181,7 +181,7 @@ parking_lot = "0.12.5"
 petgraph = "0.8.3"
 pretty_assertions = "1.4.1"
 proj = { version = "0.31.0" }
-proj-sys = "0.27.0"
+proj-sys = { version = "0.27.0", features = ["tiff"] }
 prost = "0.13.5"
 quick-xml = { version = "0.37.5", features = ["serialize"] }
 rand = "0.10.0"

--- a/engine/runtime/action-processor/src/geometry.rs
+++ b/engine/runtime/action-processor/src/geometry.rs
@@ -10,6 +10,8 @@ pub(crate) mod closed_curve_filter;
 pub(crate) mod coercer;
 pub(crate) mod convex_hull_accumulator;
 pub(crate) mod coordinate_extractor;
+#[cfg(feature = "new-geometry")]
+pub(crate) mod coordinate_frame_reprojector;
 pub(crate) mod csg;
 pub(crate) mod dimension_filter;
 pub(crate) mod dissolver;

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -21,7 +21,8 @@ use super::errors::GeometryProcessorError;
 
 /// Input port carrying base-point features in the `fromPort` base-point mode.
 static BASE_POINT_PORT: Lazy<Port> = Lazy::new(|| Port::new("base-point"));
-/// Output port for features that could not be reprojected.
+/// Output port for features that could not be converted, or that arrived on an
+/// input port unused in the active base-point mode.
 static REJECTED_PORT: Lazy<Port> = Lazy::new(|| Port::new("rejected"));
 
 thread_local! {
@@ -303,19 +304,21 @@ impl Processor for CoordinateFrameReprojector {
     ) -> Result<(), BoxedError> {
         match &self.base_point {
             BasePointSource::AsIs => {
+                let feature = ctx.feature.clone();
                 if ctx.port != *BASE_POINT_PORT {
-                    let feature = ctx.feature.clone();
                     self.convert_and_forward(&ctx, fw, &feature, None);
+                } else {
+                    fw.send(ctx.new_with_feature_and_port(feature, REJECTED_PORT.clone()));
                 }
             }
             BasePointSource::Value(code) => {
+                let feature = ctx.feature.clone();
                 if ctx.port != *BASE_POINT_PORT {
                     let base_point = code
                         .eval(&ctx.feature, ctx.env_vars.clone())
                         .ok()
                         .as_ref()
                         .and_then(attribute_value_to_xyz);
-                    let feature = ctx.feature.clone();
                     match base_point {
                         Some(bp) => self.convert_and_forward(&ctx, fw, &feature, Some(bp)),
                         None => {
@@ -326,6 +329,8 @@ impl Processor for CoordinateFrameReprojector {
                             fw.send(ctx.new_with_feature_and_port(feature, REJECTED_PORT.clone()));
                         }
                     }
+                } else {
+                    fw.send(ctx.new_with_feature_and_port(feature, REJECTED_PORT.clone()));
                 }
             }
             BasePointSource::FromPort { key } => {

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -1,0 +1,413 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use once_cell::sync::Lazy;
+use reearth_flow_geometry::coordinate::{CoordinateFrame, EpsgCode};
+use reearth_flow_geometry::ops::{ConvertFrame, ReprojectionCache};
+use reearth_flow_geometry::{Euclidean2DGeometry, Euclidean3DGeometry, Geometry};
+use reearth_flow_runtime::{
+    errors::BoxedError,
+    event::EventHub,
+    executor_operation::{ExecutorContext, NodeContext},
+    forwarder::ProcessorChannelForwarder,
+    node::{Port, Processor, ProcessorFactory, FEATURES_PORT},
+};
+use reearth_flow_types::{Code, CodeType, CompiledCode, Feature};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::errors::GeometryProcessorError;
+
+/// Input port carrying base-point features in the `fromPort` base-point mode.
+static BASE_POINT_PORT: Lazy<Port> = Lazy::new(|| Port::new("base-point"));
+/// Output port for features that could not be reprojected.
+static REJECTED_PORT: Lazy<Port> = Lazy::new(|| Port::new("rejected"));
+
+thread_local! {
+    /// The live PROJ transform holder. Kept off the `Processor` (which must be
+    /// `Send + Sync + Clone`) because it wraps a non-shareable PROJ pointer; one
+    /// per worker thread, reused across features so a stable CRS pair stays warm.
+    static REPROJECTION_CACHE: RefCell<ReprojectionCache> = RefCell::new(ReprojectionCache::new());
+}
+
+/// The destination coordinate frame kind.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+enum DestinationFrame {
+    /// # CRS
+    /// Reproject to a coordinate reference system identified by an EPSG code.
+    Crs,
+    /// # Euclidean
+    /// Convert to a non-georeferenced Euclidean frame.
+    Euclidean,
+}
+
+/// How coordinates bridge the Euclidean/CRS boundary. Ignored for a pure
+/// CRS-to-CRS reprojection.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+enum BasePointMode {
+    /// # As Is
+    /// Reinterpret coordinate values unchanged across the boundary.
+    #[default]
+    AsIs,
+    /// # Value
+    /// Offset by a base point given as an expression evaluating to `[x, y, z]`.
+    Value,
+    /// # From Port
+    /// Offset by a base point taken from the base-point input port, matched to
+    /// each feature by a key.
+    FromPort,
+}
+
+/// # Coordinate Frame Reprojector Parameters
+/// Reproject geometry across coordinate reference systems and convert between a
+/// CRS and a Euclidean frame.
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CoordinateFrameReprojectorParam {
+    /// # Destination Frame
+    /// Coordinate frame to convert geometry into.
+    destination_frame: DestinationFrame,
+    /// # EPSG Code
+    /// EPSG code of the destination CRS. Required when the destination frame is
+    /// a CRS.
+    #[serde(default)]
+    epsg_code: Option<u16>,
+    /// # Base Point Mode
+    /// How coordinates bridge the Euclidean/CRS boundary.
+    #[serde(default)]
+    base_point_mode: BasePointMode,
+    /// # Base Point
+    /// Expression evaluating to an `[x, y, z]` origin in CRS space. Used when
+    /// the base point mode is `value`.
+    #[serde(default)]
+    base_point: Option<Code<{ CodeType::FlowExpr as u32 }>>,
+    /// # Match Key
+    /// Expression identifying which base-point feature applies to a given
+    /// feature. Evaluated against both streams. Used when the base point mode is
+    /// `fromPort`.
+    #[serde(default)]
+    match_key: Option<Code<{ CodeType::FlowExpr as u32 }>>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CoordinateFrameReprojectorFactory;
+
+impl ProcessorFactory for CoordinateFrameReprojectorFactory {
+    fn name(&self) -> &str {
+        "Coordinate Frame Reprojector"
+    }
+
+    fn description(&self) -> &str {
+        "Reprojects geometry between coordinate reference systems and converts between a CRS and a Euclidean frame."
+    }
+
+    fn parameter_schema(&self) -> Option<schemars::schema::RootSchema> {
+        Some(schemars::schema_for!(CoordinateFrameReprojectorParam))
+    }
+
+    fn categories(&self) -> &[&'static str] {
+        &["Geometry"]
+    }
+
+    fn tags(&self) -> &[&'static str] {
+        &["coordinate-system", "3d"]
+    }
+
+    fn get_input_ports(&self) -> Vec<Port> {
+        vec![FEATURES_PORT.clone(), BASE_POINT_PORT.clone()]
+    }
+
+    fn get_output_ports(&self) -> Vec<Port> {
+        vec![FEATURES_PORT.clone(), REJECTED_PORT.clone()]
+    }
+
+    fn build(
+        &self,
+        _ctx: NodeContext,
+        _event_hub: EventHub,
+        _action: String,
+        with: Option<HashMap<String, Value>>,
+    ) -> Result<Box<dyn Processor>, BoxedError> {
+        let params: CoordinateFrameReprojectorParam = {
+            let with = with.ok_or_else(|| {
+                GeometryProcessorError::CoordinateFrameReprojectorFactory(
+                    "Missing required parameter `with`".to_string(),
+                )
+            })?;
+            let value = serde_json::to_value(with).map_err(|e| {
+                GeometryProcessorError::CoordinateFrameReprojectorFactory(format!(
+                    "Failed to serialize `with` parameter: {e}"
+                ))
+            })?;
+            serde_json::from_value(value).map_err(|e| {
+                GeometryProcessorError::CoordinateFrameReprojectorFactory(format!(
+                    "Failed to deserialize `with` parameter: {e}"
+                ))
+            })?
+        };
+
+        let target = match params.destination_frame {
+            DestinationFrame::Crs => {
+                let epsg = params.epsg_code.ok_or_else(|| {
+                    GeometryProcessorError::CoordinateFrameReprojectorFactory(
+                        "`epsgCode` is required when the destination frame is a CRS".to_string(),
+                    )
+                })?;
+                CoordinateFrame::Crs(EpsgCode::new(epsg))
+            }
+            DestinationFrame::Euclidean => CoordinateFrame::Euclidean,
+        };
+
+        let base_point = match params.base_point_mode {
+            BasePointMode::AsIs => BasePointSource::AsIs,
+            BasePointMode::Value => {
+                let code = params.base_point.ok_or_else(|| {
+                    GeometryProcessorError::CoordinateFrameReprojectorFactory(
+                        "`basePoint` is required when the base point mode is `value`".to_string(),
+                    )
+                })?;
+                let compiled = code.compile().map_err(|e| {
+                    GeometryProcessorError::CoordinateFrameReprojectorFactory(format!(
+                        "Failed to compile `basePoint` expression: {e:?}"
+                    ))
+                })?;
+                BasePointSource::Value(compiled)
+            }
+            BasePointMode::FromPort => {
+                let key = params.match_key.ok_or_else(|| {
+                    GeometryProcessorError::CoordinateFrameReprojectorFactory(
+                        "`matchKey` is required when the base point mode is `fromPort`".to_string(),
+                    )
+                })?;
+                let compiled = key.compile().map_err(|e| {
+                    GeometryProcessorError::CoordinateFrameReprojectorFactory(format!(
+                        "Failed to compile `matchKey` expression: {e:?}"
+                    ))
+                })?;
+                BasePointSource::FromPort { key: compiled }
+            }
+        };
+
+        Ok(Box::new(CoordinateFrameReprojector {
+            target,
+            base_point,
+            pending: Vec::new(),
+            base_points: HashMap::new(),
+        }))
+    }
+}
+
+/// Resolved base-point sourcing for a built processor.
+#[derive(Debug, Clone)]
+enum BasePointSource {
+    /// No offset: coordinate values reinterpreted unchanged.
+    AsIs,
+    /// Offset by an expression evaluated per feature.
+    Value(CompiledCode),
+    /// Offset by a base point from the base-point port, matched by key.
+    FromPort { key: CompiledCode },
+}
+
+/// Reprojects a feature's geometry to a target coordinate frame, bridging the
+/// Euclidean/CRS boundary by a base point when configured.
+#[derive(Debug, Clone)]
+pub struct CoordinateFrameReprojector {
+    target: CoordinateFrame,
+    base_point: BasePointSource,
+    /// Buffered `(key, feature)` pairs from the features port, in `fromPort` mode.
+    pending: Vec<(String, Feature)>,
+    /// Base points keyed by match key, collected from the base-point port.
+    base_points: HashMap<String, [f64; 3]>,
+}
+
+impl CoordinateFrameReprojector {
+    /// Convert a feature's geometry to `self.target`, offsetting by `base_point`
+    /// across the Euclidean/CRS boundary.
+    fn convert(
+        &self,
+        feature: &Feature,
+        base_point: Option<[f64; 3]>,
+    ) -> Result<Feature, BoxedError> {
+        let mut feature = feature.clone();
+        REPROJECTION_CACHE
+            .with(|cache| {
+                feature.geometry_mut().convert_frame(
+                    &self.target,
+                    base_point,
+                    &mut cache.borrow_mut(),
+                )
+            })
+            .map_err(|e| {
+                Box::new(GeometryProcessorError::CoordinateFrameReprojector(
+                    e.to_string(),
+                )) as BoxedError
+            })?;
+        Ok(feature)
+    }
+
+    /// Convert `feature` and forward it to the features port, or forward the
+    /// original to the rejected port on failure.
+    fn convert_and_forward(
+        &self,
+        ctx: &ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+        feature: &Feature,
+        base_point: Option<[f64; 3]>,
+    ) {
+        match self.convert(feature, base_point) {
+            Ok(converted) => {
+                fw.send(ctx.new_with_feature_and_port(converted, FEATURES_PORT.clone()))
+            }
+            Err(e) => {
+                ctx.event_hub
+                    .warn_log(Some(ctx.error_span()), format!("reproject failed: {e}"));
+                fw.send(ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()))
+            }
+        }
+    }
+}
+
+impl Processor for CoordinateFrameReprojector {
+    fn num_threads(&self) -> usize {
+        // The `fromPort` mode correlates two streams in a single buffer, so it
+        // must run on one thread; the other modes are stateless per feature.
+        match self.base_point {
+            BasePointSource::FromPort { .. } => 1,
+            _ => 2,
+        }
+    }
+
+    fn process(
+        &mut self,
+        ctx: ExecutorContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        match &self.base_point {
+            BasePointSource::AsIs => {
+                if ctx.port != *BASE_POINT_PORT {
+                    let feature = ctx.feature.clone();
+                    self.convert_and_forward(&ctx, fw, &feature, None);
+                }
+            }
+            BasePointSource::Value(code) => {
+                if ctx.port != *BASE_POINT_PORT {
+                    let base_point = code
+                        .eval(&ctx.feature, ctx.env_vars.clone())
+                        .ok()
+                        .as_ref()
+                        .and_then(attribute_value_to_xyz);
+                    let feature = ctx.feature.clone();
+                    match base_point {
+                        Some(bp) => self.convert_and_forward(&ctx, fw, &feature, Some(bp)),
+                        None => {
+                            ctx.event_hub.warn_log(
+                                Some(ctx.error_span()),
+                                "base point expression did not evaluate to [x, y, z]".to_string(),
+                            );
+                            fw.send(ctx.new_with_feature_and_port(feature, REJECTED_PORT.clone()));
+                        }
+                    }
+                }
+            }
+            BasePointSource::FromPort { key } => {
+                let feature = &ctx.feature;
+                let matched_key = key
+                    .eval(feature, ctx.env_vars.clone())
+                    .ok()
+                    .map(|v| v.to_string());
+                if ctx.port == *BASE_POINT_PORT {
+                    if let (Some(matched_key), Some(point)) =
+                        (matched_key, representative_point(&feature.geometry))
+                    {
+                        self.base_points.insert(matched_key, point);
+                    } else {
+                        ctx.event_hub.warn_log(
+                            Some(ctx.error_span()),
+                            "base-point feature lacks a key or a point geometry; skipping"
+                                .to_string(),
+                        );
+                    }
+                } else {
+                    match matched_key {
+                        Some(matched_key) => self.pending.push((matched_key, feature.clone())),
+                        None => fw.send(
+                            ctx.new_with_feature_and_port(feature.clone(), REJECTED_PORT.clone()),
+                        ),
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(
+        &mut self,
+        ctx: NodeContext,
+        fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        if !matches!(self.base_point, BasePointSource::FromPort { .. }) {
+            return Ok(());
+        }
+        let pending = std::mem::take(&mut self.pending);
+        for (matched_key, feature) in pending {
+            let base_point = self.base_points.get(&matched_key).copied();
+            let (port, out) = match base_point {
+                Some(bp) => match self.convert(&feature, Some(bp)) {
+                    Ok(converted) => (FEATURES_PORT.clone(), converted),
+                    Err(e) => {
+                        ctx.event_hub
+                            .warn_log(None, format!("reproject failed: {e}"));
+                        (REJECTED_PORT.clone(), feature)
+                    }
+                },
+                None => (REJECTED_PORT.clone(), feature),
+            };
+            fw.send(ExecutorContext::new_with_node_context_feature_and_port(
+                &ctx, out, port,
+            ));
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "Coordinate Frame Reprojector"
+    }
+}
+
+/// A representative `[x, y, z]` from a point geometry, or `None` when the
+/// geometry is not a single point.
+fn representative_point(geometry: &Geometry) -> Option<[f64; 3]> {
+    match geometry {
+        Geometry::Euclidean3D(Euclidean3DGeometry::Point(p)) => Some(p.position()),
+        Geometry::Euclidean2D(Euclidean2DGeometry::Point(p)) => {
+            let [x, y] = p.position();
+            Some([x, y, 0.0])
+        }
+        _ => None,
+    }
+}
+
+/// Parse an attribute value into an `[x, y, z]` triple. Accepts a two- or
+/// three-element numeric array; a two-element array is placed at `z = 0`.
+fn attribute_value_to_xyz(
+    value: &reearth_flow_common::attribute::AttributeValue,
+) -> Option<[f64; 3]> {
+    use reearth_flow_common::attribute::AttributeValue;
+    let AttributeValue::Array(items) = value else {
+        return None;
+    };
+    if items.len() != 2 && items.len() != 3 {
+        return None;
+    }
+    let mut out = [0.0f64; 3];
+    for (slot, item) in out.iter_mut().zip(items) {
+        match item {
+            AttributeValue::Number(n) => *slot = n.as_f64()?,
+            _ => return None,
+        }
+    }
+    Some(out)
+}

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -44,22 +44,32 @@ enum DestinationFrame {
     Euclidean,
 }
 
-/// How coordinates bridge the Euclidean/CRS boundary. Ignored for a pure
-/// CRS-to-CRS reprojection.
+/// How coordinates bridge the Euclidean/CRS boundary, carrying the input each
+/// mode needs. Ignored for a pure CRS-to-CRS reprojection.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-enum BasePointMode {
+#[serde(tag = "basePointMode", rename_all = "camelCase")]
+enum BasePoint {
     /// # As Is
     /// Reinterpret coordinate values unchanged across the boundary.
     #[default]
     AsIs,
     /// # Value
     /// Offset by a base point given as an expression evaluating to `[x, y, z]`.
-    Value,
+    Value {
+        /// # Base Point
+        /// Expression evaluating to an `[x, y, z]` origin in CRS space, in the
+        /// CRS's declared axis order.
+        base_point: Code<{ CodeType::FlowExpr as u32 }>,
+    },
     /// # From Port
     /// Offset by a base point taken from the base-point input port, matched to
     /// each feature by a key.
-    FromPort,
+    FromPort {
+        /// # Match Key
+        /// Expression identifying which base-point feature applies to a given
+        /// feature. Evaluated against both streams.
+        match_key: Code<{ CodeType::FlowExpr as u32 }>,
+    },
 }
 
 /// # Coordinate Frame Reprojector Parameters
@@ -78,21 +88,10 @@ pub struct CoordinateFrameReprojectorParam {
     /// a CRS.
     #[serde(default)]
     epsg_code: Option<u16>,
-    /// # Base Point Mode
-    /// How coordinates bridge the Euclidean/CRS boundary.
-    #[serde(default)]
-    base_point_mode: BasePointMode,
     /// # Base Point
-    /// Expression evaluating to an `[x, y, z]` origin in CRS space, in the CRS's
-    /// declared axis order. Used when the base point mode is `value`.
-    #[serde(default)]
-    base_point: Option<Code<{ CodeType::FlowExpr as u32 }>>,
-    /// # Match Key
-    /// Expression identifying which base-point feature applies to a given
-    /// feature. Evaluated against both streams. Used when the base point mode is
-    /// `fromPort`.
-    #[serde(default)]
-    match_key: Option<Code<{ CodeType::FlowExpr as u32 }>>,
+    /// How coordinates bridge the Euclidean/CRS boundary.
+    #[serde(flatten, default)]
+    base_point: BasePoint,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -164,28 +163,18 @@ impl ProcessorFactory for CoordinateFrameReprojectorFactory {
             DestinationFrame::Euclidean => CoordinateFrame::Euclidean,
         };
 
-        let base_point = match params.base_point_mode {
-            BasePointMode::AsIs => BasePointSource::AsIs,
-            BasePointMode::Value => {
-                let code = params.base_point.ok_or_else(|| {
-                    GeometryProcessorError::CoordinateFrameReprojectorFactory(
-                        "`basePoint` is required when the base point mode is `value`".to_string(),
-                    )
-                })?;
-                let compiled = code.compile().map_err(|e| {
+        let base_point = match params.base_point {
+            BasePoint::AsIs => BasePointSource::AsIs,
+            BasePoint::Value { base_point } => {
+                let compiled = base_point.compile().map_err(|e| {
                     GeometryProcessorError::CoordinateFrameReprojectorFactory(format!(
                         "Failed to compile `basePoint` expression: {e:?}"
                     ))
                 })?;
                 BasePointSource::Value(compiled)
             }
-            BasePointMode::FromPort => {
-                let key = params.match_key.ok_or_else(|| {
-                    GeometryProcessorError::CoordinateFrameReprojectorFactory(
-                        "`matchKey` is required when the base point mode is `fromPort`".to_string(),
-                    )
-                })?;
-                let compiled = key.compile().map_err(|e| {
+            BasePoint::FromPort { match_key } => {
+                let compiled = match_key.compile().map_err(|e| {
                     GeometryProcessorError::CoordinateFrameReprojectorFactory(format!(
                         "Failed to compile `matchKey` expression: {e:?}"
                     ))
@@ -428,4 +417,60 @@ fn attribute_value_to_xyz(
         }
     }
     Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn parse(value: Value) -> CoordinateFrameReprojectorParam {
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn value_mode_carries_its_base_point() {
+        let params = parse(json!({
+            "destinationFrame": "crs",
+            "epsgCode": 6677,
+            "basePointMode": "value",
+            "basePoint": { "type": "flowExpr", "value": "[1, 2, 3]" },
+        }));
+        assert!(matches!(params.base_point, BasePoint::Value { .. }));
+    }
+
+    #[test]
+    fn from_port_mode_carries_its_match_key() {
+        let params = parse(json!({
+            "destinationFrame": "euclidean",
+            "basePointMode": "fromPort",
+            "matchKey": { "type": "flowExpr", "value": "id" },
+        }));
+        assert!(matches!(params.base_point, BasePoint::FromPort { .. }));
+    }
+
+    #[test]
+    fn explicit_as_is_mode() {
+        let params = parse(json!({
+            "destinationFrame": "euclidean",
+            "basePointMode": "asIs",
+        }));
+        assert!(matches!(params.base_point, BasePoint::AsIs));
+    }
+
+    #[test]
+    fn absent_base_point_mode_defaults_to_as_is() {
+        let params = parse(json!({ "destinationFrame": "euclidean" }));
+        assert!(matches!(params.base_point, BasePoint::AsIs));
+    }
+
+    #[test]
+    fn value_mode_without_its_base_point_is_rejected() {
+        let result: Result<CoordinateFrameReprojectorParam, _> = serde_json::from_value(json!({
+            "destinationFrame": "crs",
+            "epsgCode": 6677,
+            "basePointMode": "value",
+        }));
+        assert!(result.is_err());
+    }
 }

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -57,13 +57,16 @@ enum BasePointMode {
     Value,
     /// # From Port
     /// Offset by a base point taken from the base-point input port, matched to
-    /// each feature by a key.
+    /// each feature by a key. The base-point geometry is reprojected into the
+    /// destination frame before it is applied.
     FromPort,
 }
 
 /// # Coordinate Frame Reprojector Parameters
 /// Reproject geometry across coordinate reference systems and convert between a
-/// CRS and a Euclidean frame.
+/// CRS and a Euclidean frame. Converting across the Euclidean/CRS boundary
+/// reinterprets coordinates as-is: values and ring winding are left unchanged,
+/// so orientation follows the destination frame's axis order.
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CoordinateFrameReprojectorParam {
@@ -80,8 +83,8 @@ pub struct CoordinateFrameReprojectorParam {
     #[serde(default)]
     base_point_mode: BasePointMode,
     /// # Base Point
-    /// Expression evaluating to an `[x, y, z]` origin in CRS space. Used when
-    /// the base point mode is `value`.
+    /// Expression evaluating to an `[x, y, z]` origin in CRS space, in the CRS's
+    /// declared axis order. Used when the base point mode is `value`.
     #[serde(default)]
     base_point: Option<Code<{ CodeType::FlowExpr as u32 }>>,
     /// # Match Key
@@ -248,6 +251,19 @@ impl CoordinateFrameReprojector {
         Ok(feature)
     }
 
+    /// Reproject a base-point feature's geometry into the destination frame and
+    /// return its representative `[x, y, z]`, or `None` when it is not a single
+    /// point or cannot be converted. Reprojecting first removes the ambiguity of
+    /// which frame the base point was authored in, so the offset is always
+    /// applied in the destination frame's coordinate space.
+    fn base_point_in_target(&self, geometry: &Geometry) -> Option<[f64; 3]> {
+        let mut geometry = geometry.clone();
+        REPROJECTION_CACHE
+            .with(|cache| geometry.convert_frame(&self.target, None, &mut cache.borrow_mut()))
+            .ok()?;
+        representative_point(&geometry)
+    }
+
     /// Convert `feature` and forward it to the features port, or forward the
     /// original to the rejected port on failure.
     fn convert_and_forward(
@@ -320,7 +336,7 @@ impl Processor for CoordinateFrameReprojector {
                     .map(|v| v.to_string());
                 if ctx.port == *BASE_POINT_PORT {
                     if let (Some(matched_key), Some(point)) =
-                        (matched_key, representative_point(&feature.geometry))
+                        (matched_key, self.base_point_in_target(&feature.geometry))
                     {
                         self.base_points.insert(matched_key, point);
                     } else {

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -47,7 +47,7 @@ enum DestinationFrame {
 /// How coordinates bridge the Euclidean/CRS boundary, carrying the input each
 /// mode needs. Ignored for a pure CRS-to-CRS reprojection.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, JsonSchema)]
-#[serde(tag = "basePointMode", rename_all = "camelCase")]
+#[serde(tag = "type", rename_all = "camelCase")]
 enum BasePoint {
     /// # As Is
     /// Reinterpret coordinate values unchanged across the boundary.
@@ -55,6 +55,7 @@ enum BasePoint {
     AsIs,
     /// # Value
     /// Offset by a base point given as an expression evaluating to `[x, y, z]`.
+    #[serde(rename_all = "camelCase")]
     Value {
         /// # Base Point
         /// Expression evaluating to an `[x, y, z]` origin in CRS space, in the
@@ -64,6 +65,7 @@ enum BasePoint {
     /// # From Port
     /// Offset by a base point taken from the base-point input port, matched to
     /// each feature by a key.
+    #[serde(rename_all = "camelCase")]
     FromPort {
         /// # Match Key
         /// Expression identifying which base-point feature applies to a given
@@ -90,8 +92,8 @@ pub struct CoordinateFrameReprojectorParam {
     epsg_code: Option<u16>,
     /// # Base Point
     /// How coordinates bridge the Euclidean/CRS boundary.
-    #[serde(flatten, default)]
-    base_point: BasePoint,
+    #[serde(default)]
+    base_point_source: BasePoint,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -163,7 +165,7 @@ impl ProcessorFactory for CoordinateFrameReprojectorFactory {
             DestinationFrame::Euclidean => CoordinateFrame::Euclidean,
         };
 
-        let base_point = match params.base_point {
+        let base_point = match params.base_point_source {
             BasePoint::AsIs => BasePointSource::AsIs,
             BasePoint::Value { base_point } => {
                 let compiled = base_point.compile().map_err(|e| {
@@ -433,35 +435,42 @@ mod tests {
         let params = parse(json!({
             "destinationFrame": "crs",
             "epsgCode": 6677,
-            "basePointMode": "value",
-            "basePoint": { "type": "flowExpr", "value": "[1, 2, 3]" },
+            "basePointSource": {
+                "type": "value",
+                "basePoint": { "type": "flowExpr", "value": "[1, 2, 3]" },
+            },
         }));
-        assert!(matches!(params.base_point, BasePoint::Value { .. }));
+        assert!(matches!(params.base_point_source, BasePoint::Value { .. }));
     }
 
     #[test]
     fn from_port_mode_carries_its_match_key() {
         let params = parse(json!({
             "destinationFrame": "euclidean",
-            "basePointMode": "fromPort",
-            "matchKey": { "type": "flowExpr", "value": "id" },
+            "basePointSource": {
+                "type": "fromPort",
+                "matchKey": { "type": "flowExpr", "value": "id" },
+            },
         }));
-        assert!(matches!(params.base_point, BasePoint::FromPort { .. }));
+        assert!(matches!(
+            params.base_point_source,
+            BasePoint::FromPort { .. }
+        ));
     }
 
     #[test]
     fn explicit_as_is_mode() {
         let params = parse(json!({
             "destinationFrame": "euclidean",
-            "basePointMode": "asIs",
+            "basePointSource": { "type": "asIs" },
         }));
-        assert!(matches!(params.base_point, BasePoint::AsIs));
+        assert!(matches!(params.base_point_source, BasePoint::AsIs));
     }
 
     #[test]
-    fn absent_base_point_mode_defaults_to_as_is() {
+    fn absent_base_point_source_defaults_to_as_is() {
         let params = parse(json!({ "destinationFrame": "euclidean" }));
-        assert!(matches!(params.base_point, BasePoint::AsIs));
+        assert!(matches!(params.base_point_source, BasePoint::AsIs));
     }
 
     #[test]
@@ -469,7 +478,7 @@ mod tests {
         let result: Result<CoordinateFrameReprojectorParam, _> = serde_json::from_value(json!({
             "destinationFrame": "crs",
             "epsgCode": 6677,
-            "basePointMode": "value",
+            "basePointSource": { "type": "value" },
         }));
         assert!(result.is_err());
     }

--- a/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/coordinate_frame_reprojector.rs
@@ -58,8 +58,7 @@ enum BasePointMode {
     Value,
     /// # From Port
     /// Offset by a base point taken from the base-point input port, matched to
-    /// each feature by a key. The base-point geometry is reprojected into the
-    /// destination frame before it is applied.
+    /// each feature by a key.
     FromPort,
 }
 
@@ -254,9 +253,7 @@ impl CoordinateFrameReprojector {
 
     /// Reproject a base-point feature's geometry into the destination frame and
     /// return its representative `[x, y, z]`, or `None` when it is not a single
-    /// point or cannot be converted. Reprojecting first removes the ambiguity of
-    /// which frame the base point was authored in, so the offset is always
-    /// applied in the destination frame's coordinate space.
+    /// point or cannot be converted.
     fn base_point_in_target(&self, geometry: &Geometry) -> Option<[f64; 3]> {
         let mut geometry = geometry.clone();
         REPROJECTION_CACHE

--- a/engine/runtime/action-processor/src/geometry/errors.rs
+++ b/engine/runtime/action-processor/src/geometry/errors.rs
@@ -35,6 +35,10 @@ pub(super) enum GeometryProcessorError {
     VerticalReprojectorFactory(String),
     #[error("VerticalReprojector error: {0}")]
     VerticalReprojector(String),
+    #[error("CoordinateFrameReprojector Factory error: {0}")]
+    CoordinateFrameReprojectorFactory(String),
+    #[error("CoordinateFrameReprojector error: {0}")]
+    CoordinateFrameReprojector(String),
     #[error("TwoDimensionForcer Factory error: {0}")]
     TwoDimensionForcerFactory(String),
     #[error("TwoDimensionForcer error: {0}")]

--- a/engine/runtime/action-processor/src/geometry/horizontal_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/horizontal_reprojector.rs
@@ -414,6 +414,22 @@ where
 }
 
 impl Processor for HorizontalReprojector {
+    // TODO(new-geometry): remove this action once the legacy geometry model is
+    // gone. Superseded by the Coordinate Frame Reprojector.
+    #[cfg(feature = "new-geometry")]
+    fn process(
+        &mut self,
+        _ctx: ExecutorContext,
+        _fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Err(GeometryProcessorError::HorizontalReprojector(
+            "Horizontal Reprojector is not available under the new geometry model; use \
+             Coordinate Frame Reprojector instead."
+                .to_string(),
+        )
+        .into())
+    }
+
     #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,

--- a/engine/runtime/action-processor/src/geometry/mapping.rs
+++ b/engine/runtime/action-processor/src/geometry/mapping.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use once_cell::sync::Lazy;
 use reearth_flow_runtime::node::{NodeKind, ProcessorFactory};
 
+#[cfg(feature = "new-geometry")]
+use super::coordinate_frame_reprojector::CoordinateFrameReprojectorFactory;
 use super::{
     appearance_remover::AppearanceRemoverFactory,
     area_calculator::AreaCalculatorFactory,
@@ -58,7 +60,8 @@ use super::{
 };
 
 pub static ACTION_FACTORY_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
-    let factories: Vec<Box<dyn ProcessorFactory>> = vec![
+    #[cfg_attr(not(feature = "new-geometry"), allow(unused_mut))]
+    let mut factories: Vec<Box<dyn ProcessorFactory>> = vec![
         Box::<AppearanceRemoverFactory>::default(),
         Box::<ExtruderFactory>::default(),
         Box::<BoundaryExtractorFactory>::default(),
@@ -113,6 +116,8 @@ pub static ACTION_FACTORY_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(
         Box::<CoordinateExtractorFactory>::default(),
         Box::<NeighborFinderFactory>::default(),
     ];
+    #[cfg(feature = "new-geometry")]
+    factories.push(Box::<CoordinateFrameReprojectorFactory>::default());
     factories
         .into_iter()
         .map(|f| (f.name().to_string(), NodeKind::Processor(f)))

--- a/engine/runtime/action-processor/src/geometry/mapping.rs
+++ b/engine/runtime/action-processor/src/geometry/mapping.rs
@@ -60,8 +60,7 @@ use super::{
 };
 
 pub static ACTION_FACTORY_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(|| {
-    #[cfg_attr(not(feature = "new-geometry"), allow(unused_mut))]
-    let mut factories: Vec<Box<dyn ProcessorFactory>> = vec![
+    let factories: Vec<Box<dyn ProcessorFactory>> = vec![
         Box::<AppearanceRemoverFactory>::default(),
         Box::<ExtruderFactory>::default(),
         Box::<BoundaryExtractorFactory>::default(),

--- a/engine/runtime/action-processor/src/geometry/mapping.rs
+++ b/engine/runtime/action-processor/src/geometry/mapping.rs
@@ -115,9 +115,9 @@ pub static ACTION_FACTORY_MAPPINGS: Lazy<HashMap<String, NodeKind>> = Lazy::new(
         Box::<Rotator3DFactory>::default(),
         Box::<CoordinateExtractorFactory>::default(),
         Box::<NeighborFinderFactory>::default(),
+        #[cfg(feature = "new-geometry")]
+        Box::<CoordinateFrameReprojectorFactory>::default(),
     ];
-    #[cfg(feature = "new-geometry")]
-    factories.push(Box::<CoordinateFrameReprojectorFactory>::default());
     factories
         .into_iter()
         .map(|f| (f.name().to_string(), NodeKind::Processor(f)))

--- a/engine/runtime/action-processor/src/geometry/vertical_reprojector.rs
+++ b/engine/runtime/action-processor/src/geometry/vertical_reprojector.rs
@@ -105,6 +105,22 @@ impl Processor for VerticalReprojector {
         2
     }
 
+    // TODO(new-geometry): remove this action once the legacy geometry model is
+    // gone. Superseded by the Coordinate Frame Reprojector.
+    #[cfg(feature = "new-geometry")]
+    fn process(
+        &mut self,
+        _ctx: ExecutorContext,
+        _fw: &ProcessorChannelForwarder,
+    ) -> Result<(), BoxedError> {
+        Err(GeometryProcessorError::VerticalReprojector(
+            "Vertical Reprojector is not available under the new geometry model; use \
+             Coordinate Frame Reprojector instead."
+                .to_string(),
+        )
+        .into())
+    }
+
     #[cfg(not(feature = "new-geometry"))]
     fn process(
         &mut self,

--- a/engine/runtime/geometry/src/collection.rs
+++ b/engine/runtime/geometry/src/collection.rs
@@ -166,6 +166,52 @@ impl Reproject for Collection3D {
 crate::unsupported!(Collection2D: Triangulate);
 crate::unsupported!(Collection3D: Triangulate);
 
+impl crate::ops::ConvertFrame for Collection2D {
+    fn convert_frame(
+        &mut self,
+        target: &crate::coordinate::CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut crate::ops::ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        for member in self.members_mut() {
+            member.convert_frame(target, base_point, cache)?;
+        }
+        Ok(())
+    }
+}
+
+impl crate::ops::ConvertFrame for Collection3D {
+    fn convert_frame(
+        &mut self,
+        target: &crate::coordinate::CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut crate::ops::ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        for member in self.members_mut() {
+            member.convert_frame(target, base_point, cache)?;
+        }
+        Ok(())
+    }
+}
+
+impl crate::ops::Translate for Collection2D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        for member in self.members_mut() {
+            member.translate(delta)?;
+        }
+        Ok(())
+    }
+}
+
+impl crate::ops::Translate for Collection3D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        for member in self.members_mut() {
+            member.translate(delta)?;
+        }
+        Ok(())
+    }
+}
+
 // A collection validates by recursing into its members (see
 // `validation_next::validate`), so it declares no direct checks and inherits
 // every `Validate` default.

--- a/engine/runtime/geometry/src/csg/mod.rs
+++ b/engine/runtime/geometry/src/csg/mod.rs
@@ -33,5 +33,4 @@ pub enum Csg {
 }
 
 // Tessellation is defined only for `Polygon` / `PolygonMesh`.
-crate::unsupported!(Csg: Triangulate);
-crate::unsupported!(Csg: Reproject);
+crate::unsupported!(Csg: Triangulate, Reproject, ConvertFrame, Translate);

--- a/engine/runtime/geometry/src/lib.rs
+++ b/engine/runtime/geometry/src/lib.rs
@@ -52,7 +52,10 @@ use reearth_flow_common::attribute::Attributes;
 use serde::{Deserialize, Serialize};
 
 use ops::triangulation::Cache;
-use ops::{Aabb, BoundingBox, Reproject, ReprojectionCache, Triangulate, UnsupportedOperation};
+use ops::{
+    Aabb, BoundingBox, ConvertFrame, Reproject, ReprojectionCache, Translate, Triangulate,
+    UnsupportedOperation,
+};
 // `ValidationParams` / `ValidationType` / `ValidationReport` are named by the
 // `enum_dispatch`-generated `Validate` impls on the geometry enums, so they must
 // be in scope here.
@@ -155,11 +158,11 @@ impl GeometryCollection {
 /// `Collection`) stays inline.
 #[cfg_attr(
     not(feature = "new-geometry"),
-    enum_dispatch(BoundingBox, Triangulate, Reproject)
+    enum_dispatch(BoundingBox, Triangulate, Reproject, ConvertFrame, Translate)
 )]
 #[cfg_attr(
     feature = "new-geometry",
-    enum_dispatch(BoundingBox, Triangulate, Reproject, Validate)
+    enum_dispatch(BoundingBox, Triangulate, Reproject, Validate, ConvertFrame, Translate)
 )]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum Euclidean2DGeometry {
@@ -184,11 +187,11 @@ pub enum Euclidean2DGeometry {
 /// operands.
 #[cfg_attr(
     not(feature = "new-geometry"),
-    enum_dispatch(BoundingBox, Triangulate, Reproject)
+    enum_dispatch(BoundingBox, Triangulate, Reproject, ConvertFrame, Translate)
 )]
 #[cfg_attr(
     feature = "new-geometry",
-    enum_dispatch(BoundingBox, Triangulate, Reproject, Validate)
+    enum_dispatch(BoundingBox, Triangulate, Reproject, Validate, ConvertFrame, Translate)
 )]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub enum Euclidean3DGeometry {
@@ -281,6 +284,56 @@ impl Reproject for GeometryCollection {
     ) -> crate::error::Result<()> {
         for member in self.members_mut() {
             member.reproject(target, cache)?;
+        }
+        Ok(())
+    }
+}
+
+impl ConvertFrame for Geometry {
+    fn convert_frame(
+        &mut self,
+        target: &coordinate::CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match self {
+            Geometry::None => Ok(()),
+            Geometry::Euclidean2D(g) => g.convert_frame(target, base_point, cache),
+            Geometry::Euclidean3D(g) => g.convert_frame(target, base_point, cache),
+            Geometry::GeometryCollection(c) => c.convert_frame(target, base_point, cache),
+        }
+    }
+}
+
+impl ConvertFrame for GeometryCollection {
+    fn convert_frame(
+        &mut self,
+        target: &coordinate::CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        for member in self.members_mut() {
+            member.convert_frame(target, base_point, cache)?;
+        }
+        Ok(())
+    }
+}
+
+impl Translate for Geometry {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        match self {
+            Geometry::None => Ok(()),
+            Geometry::Euclidean2D(g) => g.translate(delta),
+            Geometry::Euclidean3D(g) => g.translate(delta),
+            Geometry::GeometryCollection(c) => c.translate(delta),
+        }
+    }
+}
+
+impl Translate for GeometryCollection {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        for member in self.members_mut() {
+            member.translate(delta)?;
         }
         Ok(())
     }

--- a/engine/runtime/geometry/src/line_string/ops.rs
+++ b/engine/runtime/geometry/src/line_string/ops.rs
@@ -52,6 +52,60 @@ impl Reproject for LineString3D {
     }
 }
 
+use crate::ops::{plan_frame_step, translate_2d, translate_3d, ConvertFrame, FrameStep, Translate};
+
+impl Translate for LineString2D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        translate_2d(&mut self.coords, self.z.as_deref_mut(), delta);
+        Ok(())
+    }
+}
+
+impl Translate for LineString3D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        translate_3d(&mut self.coords, delta);
+        Ok(())
+    }
+}
+
+impl ConvertFrame for LineString2D {
+    fn convert_frame(
+        &mut self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match plan_frame_step(&self.frame, target, base_point)? {
+            FrameStep::Noop => Ok(()),
+            FrameStep::Reproject(to) => self.reproject(to, cache),
+            FrameStep::Translate(offset, frame) => {
+                self.translate(offset)?;
+                self.frame = frame;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl ConvertFrame for LineString3D {
+    fn convert_frame(
+        &mut self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match plan_frame_step(&self.frame, target, base_point)? {
+            FrameStep::Noop => Ok(()),
+            FrameStep::Reproject(to) => self.reproject(to, cache),
+            FrameStep::Translate(offset, frame) => {
+                self.translate(offset)?;
+                self.frame = frame;
+                Ok(())
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -14,6 +14,9 @@ pub mod triangulation;
 pub(crate) use reproject::{axis_order_sign, crs_is_linear};
 pub use reproject::{Reproject, ReprojectionCache};
 
+use crate::coordinate::{CoordinateFrame, EpsgCode};
+use crate::error::Error;
+
 /// Returned by an operation a given geometry type does not support. Carries the
 /// concrete type name (via [`type_name`](core::any::type_name)) and the
 /// operation name for diagnostics.
@@ -244,6 +247,258 @@ impl<T: Triangulate + ?Sized> Triangulate for Box<T> {
         cache: &mut crate::ops::triangulation::Cache,
     ) -> Result<crate::Geometry, UnsupportedOperation> {
         (**self).triangulate(cache)
+    }
+}
+
+/// Shift every coordinate by a vector.
+///
+/// A general primitive carrying no frame semantics: translating a CRS geometry
+/// keeps it in the same CRS and a Euclidean one Euclidean. Frame changes are the
+/// job of [`Reproject`] and [`ConvertFrame`].
+#[enum_dispatch::enum_dispatch]
+pub trait Translate {
+    /// Add `delta` to every coordinate. For a 2D-embedded geometry, `delta`'s
+    /// `z` applies to the optional per-vertex elevation. The default body reports
+    /// the type as unsupported; a leaf opts in by overriding it.
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        let _ = delta;
+        Err(Error::projection(format!(
+            "translate is not supported by `{}`",
+            core::any::type_name::<Self>()
+        )))
+    }
+}
+
+// The boxed enum variants (`Box<Polygon2D>`, `Box<Solid>`, …) need the trait on
+// the `Box` itself: `enum_dispatch` forwards by UFCS, not auto-deref.
+impl<T: Translate + ?Sized> Translate for Box<T> {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        (**self).translate(delta)
+    }
+}
+
+/// Add `delta`'s `(x, y)` to a 2D coordinate buffer, and its `z` to a parallel
+/// elevation buffer when present.
+pub(crate) fn translate_2d(coords: &mut [[f64; 2]], z: Option<&mut [f64]>, delta: [f64; 3]) {
+    for c in coords.iter_mut() {
+        c[0] += delta[0];
+        c[1] += delta[1];
+    }
+    if let Some(z) = z {
+        for elevation in z.iter_mut() {
+            *elevation += delta[2];
+        }
+    }
+}
+
+/// Add `delta` to a 3D coordinate buffer.
+pub(crate) fn translate_3d(coords: &mut [[f64; 3]], delta: [f64; 3]) {
+    for c in coords.iter_mut() {
+        c[0] += delta[0];
+        c[1] += delta[1];
+        c[2] += delta[2];
+    }
+}
+
+/// Convert a geometry's coordinate frame to `target`.
+///
+/// A CRS-to-CRS conversion reprojects (delegating to [`Reproject`]) and ignores
+/// `base_point`. A conversion that crosses the Euclidean/CRS boundary translates
+/// by `base_point` (an offset in CRS space, defaulting to the origin) and
+/// retags: a Euclidean coordinate maps to `base_point + coordinate` in the CRS,
+/// a CRS coordinate to `coordinate - base_point` in Euclidean space. A `Tangent`
+/// frame on either side is rejected.
+#[enum_dispatch::enum_dispatch]
+pub trait ConvertFrame {
+    /// Convert every coordinate to `target`. The default body reports the type
+    /// as unsupported; a leaf opts in by overriding it.
+    fn convert_frame(
+        &mut self,
+        target: &crate::coordinate::CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        let _ = (target, base_point, cache);
+        Err(Error::projection(format!(
+            "convert_frame is not supported by `{}`",
+            core::any::type_name::<Self>()
+        )))
+    }
+}
+
+impl<T: ConvertFrame + ?Sized> ConvertFrame for Box<T> {
+    fn convert_frame(
+        &mut self,
+        target: &crate::coordinate::CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        (**self).convert_frame(target, base_point, cache)
+    }
+}
+
+/// The concrete step a leaf takes to reach a target frame from its current one.
+pub(crate) enum FrameStep {
+    /// Coordinates are already in the target frame.
+    Noop,
+    /// Reproject across CRSs to this EPSG code.
+    Reproject(EpsgCode),
+    /// Translate every coordinate by this offset, then adopt this frame.
+    Translate([f64; 3], CoordinateFrame),
+}
+
+/// Decide how a leaf currently in `src` reaches `target`, given the base point.
+/// Errors when either frame is a `Tangent` plane.
+pub(crate) fn plan_frame_step(
+    src: &CoordinateFrame,
+    target: &CoordinateFrame,
+    base_point: Option<[f64; 3]>,
+) -> crate::error::Result<FrameStep> {
+    let base = base_point.unwrap_or([0.0; 3]);
+    match (src, target) {
+        (CoordinateFrame::Crs(from), CoordinateFrame::Crs(to)) => Ok(if from == to {
+            FrameStep::Noop
+        } else {
+            FrameStep::Reproject(*to)
+        }),
+        (CoordinateFrame::Euclidean, CoordinateFrame::Crs(_)) => {
+            Ok(FrameStep::Translate(base, target.clone()))
+        }
+        (CoordinateFrame::Crs(_), CoordinateFrame::Euclidean) => Ok(FrameStep::Translate(
+            [-base[0], -base[1], -base[2]],
+            target.clone(),
+        )),
+        (CoordinateFrame::Euclidean, CoordinateFrame::Euclidean) => Ok(if base == [0.0; 3] {
+            FrameStep::Noop
+        } else {
+            FrameStep::Translate(base, target.clone())
+        }),
+        (CoordinateFrame::Tangent(_), _) | (_, CoordinateFrame::Tangent(_)) => Err(
+            Error::projection("cannot convert to or from a Tangent-plane frame"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod translate_tests {
+    use super::Translate;
+    use crate::coordinate::{CoordinateFrame, EpsgCode};
+    use crate::line_string::LineString3D;
+    use crate::point::Point3D;
+
+    #[test]
+    fn translate_preserves_frame() {
+        let mut p = Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), [1.0, 2.0, 3.0]);
+        p.translate([10.0, 20.0, 30.0]).unwrap();
+        assert_eq!(p.position(), [11.0, 22.0, 33.0]);
+        // A translation is frame-preserving: still the same CRS.
+        assert_eq!(p.frame(), &CoordinateFrame::Crs(EpsgCode::new(4979)));
+    }
+
+    #[test]
+    fn translate_shifts_every_coordinate() {
+        let mut ls = LineString3D::from_coords(
+            CoordinateFrame::Euclidean,
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+        );
+        ls.translate([2.0, 3.0, 100.0]).unwrap();
+        assert_eq!(ls.coords(), &[[2.0, 3.0, 100.0], [3.0, 4.0, 101.0]]);
+    }
+}
+
+#[cfg(test)]
+mod convert_frame_tests {
+    use super::{ConvertFrame, ReprojectionCache};
+    use crate::coordinate::{BaseFrame, CoordinateFrame, EpsgCode, TangentPlane};
+    use crate::point::Point3D;
+
+    #[test]
+    fn euclidean_to_crs_adds_base_point() {
+        let mut cache = ReprojectionCache::new();
+        let mut p = Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0]);
+        p.convert_frame(
+            &CoordinateFrame::Crs(EpsgCode::new(6697)),
+            Some([10.0, 20.0, 30.0]),
+            &mut cache,
+        )
+        .unwrap();
+        assert_eq!(p.position(), [11.0, 22.0, 33.0]);
+        assert_eq!(p.frame(), &CoordinateFrame::Crs(EpsgCode::new(6697)));
+    }
+
+    #[test]
+    fn crs_to_euclidean_subtracts_base_point() {
+        let mut cache = ReprojectionCache::new();
+        let mut p = Point3D::new(
+            CoordinateFrame::Crs(EpsgCode::new(6697)),
+            [11.0, 22.0, 33.0],
+        );
+        p.convert_frame(
+            &CoordinateFrame::Euclidean,
+            Some([10.0, 20.0, 30.0]),
+            &mut cache,
+        )
+        .unwrap();
+        assert_eq!(p.position(), [1.0, 2.0, 3.0]);
+        assert_eq!(p.frame(), &CoordinateFrame::Euclidean);
+    }
+
+    #[test]
+    fn as_is_bridge_only_retags() {
+        let mut cache = ReprojectionCache::new();
+        let mut p = Point3D::new(CoordinateFrame::Euclidean, [1.0, 2.0, 3.0]);
+        p.convert_frame(&CoordinateFrame::Crs(EpsgCode::new(4979)), None, &mut cache)
+            .unwrap();
+        assert_eq!(p.position(), [1.0, 2.0, 3.0]);
+        assert_eq!(p.frame(), &CoordinateFrame::Crs(EpsgCode::new(4979)));
+    }
+
+    #[test]
+    fn same_crs_is_noop() {
+        let mut cache = ReprojectionCache::new();
+        let mut p = Point3D::new(CoordinateFrame::Crs(EpsgCode::new(4979)), [1.0, 2.0, 3.0]);
+        p.convert_frame(&CoordinateFrame::Crs(EpsgCode::new(4979)), None, &mut cache)
+            .unwrap();
+        assert_eq!(p.position(), [1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn crs_to_crs_reprojects_ignoring_base_point() {
+        let mut cache = ReprojectionCache::new();
+        // 4979 (geographic 3D) -> 4978 (ECEF) is a grid-free datum-identity transform.
+        let mut p = Point3D::new(
+            CoordinateFrame::Crs(EpsgCode::new(4979)),
+            [35.0, 139.0, 0.0],
+        );
+        p.convert_frame(
+            &CoordinateFrame::Crs(EpsgCode::new(4978)),
+            Some([999.0, 999.0, 999.0]),
+            &mut cache,
+        )
+        .unwrap();
+        assert_eq!(p.frame(), &CoordinateFrame::Crs(EpsgCode::new(4978)));
+        // ECEF magnitude is ~ Earth radius, so the base point was not added.
+        let [x, y, z] = p.position();
+        let r = (x * x + y * y + z * z).sqrt();
+        assert!(
+            r > 6_000_000.0 && r < 6_500_000.0,
+            "unexpected ECEF radius {r}"
+        );
+    }
+
+    #[test]
+    fn tangent_frame_is_rejected() {
+        let mut cache = ReprojectionCache::new();
+        let tangent = CoordinateFrame::Tangent(Box::new(TangentPlane {
+            base: BaseFrame::Euclidean,
+            origin: [0.0, 0.0, 0.0],
+            u: [1.0, 0.0, 0.0],
+            v: [0.0, 1.0, 0.0],
+        }));
+        let mut p = Point3D::new(tangent, [1.0, 2.0, 3.0]);
+        assert!(p
+            .convert_frame(&CoordinateFrame::Crs(EpsgCode::new(4979)), None, &mut cache)
+            .is_err());
     }
 }
 

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -304,10 +304,12 @@ pub(crate) fn translate_3d(coords: &mut [[f64; 3]], delta: [f64; 3]) {
 ///
 /// A CRS-to-CRS conversion reprojects (delegating to [`Reproject`]) and ignores
 /// `base_point`. A conversion that crosses the Euclidean/CRS boundary translates
-/// by `base_point` (an offset in CRS space, defaulting to the origin) and
-/// retags: a Euclidean coordinate maps to `base_point + coordinate` in the CRS,
-/// a CRS coordinate to `coordinate - base_point` in Euclidean space. A `Tangent`
-/// frame on either side is rejected.
+/// by `base_point` (an offset in the CRS-side frame, defaulting to the origin)
+/// and retags: a Euclidean coordinate maps to `base_point + coordinate` in the
+/// CRS, a CRS coordinate to `coordinate - base_point` in Euclidean space. The
+/// bridge is a positional reinterpretation: coordinate values and ring winding
+/// are left unchanged, so a ring's orientation follows the axis order of the
+/// frame it is retagged into. A `Tangent` frame on either side is rejected.
 #[enum_dispatch::enum_dispatch]
 pub trait ConvertFrame {
     /// Convert every coordinate to `target`. The default body reports the type

--- a/engine/runtime/geometry/src/ops/mod.rs
+++ b/engine/runtime/geometry/src/ops/mod.rs
@@ -302,8 +302,9 @@ pub(crate) fn translate_3d(coords: &mut [[f64; 3]], delta: [f64; 3]) {
 
 /// Convert a geometry's coordinate frame to `target`.
 ///
-/// A CRS-to-CRS conversion reprojects (delegating to [`Reproject`]) and ignores
-/// `base_point`. A conversion that crosses the Euclidean/CRS boundary translates
+/// A CRS-to-CRS conversion reprojects (delegating to [`Reproject`]); supplying a
+/// `base_point` for it is an error, since the offset cannot apply. A conversion
+/// that crosses the Euclidean/CRS boundary translates
 /// by `base_point` (an offset in the CRS-side frame, defaulting to the origin)
 /// and retags: a Euclidean coordinate maps to `base_point + coordinate` in the
 /// CRS, a CRS coordinate to `coordinate - base_point` in Euclidean space. The
@@ -350,7 +351,8 @@ pub(crate) enum FrameStep {
 }
 
 /// Decide how a leaf currently in `src` reaches `target`, given the base point.
-/// Errors when either frame is a `Tangent` plane.
+/// Errors when either frame is a `Tangent` plane, or when a base point is
+/// supplied for a CRS-to-CRS step.
 pub(crate) fn plan_frame_step(
     src: &CoordinateFrame,
     target: &CoordinateFrame,
@@ -358,11 +360,18 @@ pub(crate) fn plan_frame_step(
 ) -> crate::error::Result<FrameStep> {
     let base = base_point.unwrap_or([0.0; 3]);
     match (src, target) {
-        (CoordinateFrame::Crs(from), CoordinateFrame::Crs(to)) => Ok(if from == to {
-            FrameStep::Noop
-        } else {
-            FrameStep::Reproject(*to)
-        }),
+        (CoordinateFrame::Crs(from), CoordinateFrame::Crs(to)) => {
+            if base_point.is_some() {
+                return Err(Error::projection(
+                    "a base point does not apply to a CRS-to-CRS reprojection",
+                ));
+            }
+            Ok(if from == to {
+                FrameStep::Noop
+            } else {
+                FrameStep::Reproject(*to)
+            })
+        }
         (CoordinateFrame::Euclidean, CoordinateFrame::Crs(_)) => {
             Ok(FrameStep::Translate(base, target.clone()))
         }
@@ -465,27 +474,39 @@ mod convert_frame_tests {
     }
 
     #[test]
-    fn crs_to_crs_reprojects_ignoring_base_point() {
+    fn crs_to_crs_reprojects_without_a_base_point() {
         let mut cache = ReprojectionCache::new();
         // 4979 (geographic 3D) -> 4978 (ECEF) is a grid-free datum-identity transform.
         let mut p = Point3D::new(
             CoordinateFrame::Crs(EpsgCode::new(4979)),
             [35.0, 139.0, 0.0],
         );
-        p.convert_frame(
-            &CoordinateFrame::Crs(EpsgCode::new(4978)),
-            Some([999.0, 999.0, 999.0]),
-            &mut cache,
-        )
-        .unwrap();
+        p.convert_frame(&CoordinateFrame::Crs(EpsgCode::new(4978)), None, &mut cache)
+            .unwrap();
         assert_eq!(p.frame(), &CoordinateFrame::Crs(EpsgCode::new(4978)));
-        // ECEF magnitude is ~ Earth radius, so the base point was not added.
+        // ECEF magnitude is ~ Earth radius.
         let [x, y, z] = p.position();
         let r = (x * x + y * y + z * z).sqrt();
         assert!(
             r > 6_000_000.0 && r < 6_500_000.0,
             "unexpected ECEF radius {r}"
         );
+    }
+
+    #[test]
+    fn crs_to_crs_with_a_base_point_is_rejected() {
+        let mut cache = ReprojectionCache::new();
+        let mut p = Point3D::new(
+            CoordinateFrame::Crs(EpsgCode::new(4979)),
+            [35.0, 139.0, 0.0],
+        );
+        assert!(p
+            .convert_frame(
+                &CoordinateFrame::Crs(EpsgCode::new(4978)),
+                Some([999.0, 999.0, 999.0]),
+                &mut cache,
+            )
+            .is_err());
     }
 
     #[test]

--- a/engine/runtime/geometry/src/ops/reproject/ffi.rs
+++ b/engine/runtime/geometry/src/ops/reproject/ffi.rs
@@ -1,5 +1,6 @@
 //! PROJ-backed coordinate transformation for the reprojection ops.
 
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int};
@@ -17,6 +18,8 @@ use proj_sys::{
     PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_CARTESIAN,
     PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_ELLIPSOIDAL,
     PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_SPHERICAL, PJ_DIRECTION_PJ_FWD, PJ_XYZT,
+    proj_coordoperation_has_ballpark_transformation,
+    proj_trans_get_last_used_operation
 };
 
 use crate::error::{Error, Result};
@@ -38,6 +41,10 @@ struct Entry {
     ctx: *mut PJ_CONTEXT,
     /// The PROJ transformation.
     pj: *mut PJ,
+    /// Whether the ballpark guard has already run for this transform. The guard
+    /// can only inspect the actually-used operation after a first `proj_trans`,
+    /// so it runs lazily on the first transform and is memoized here.
+    ballpark_checked: Cell<bool>,
 }
 
 impl Drop for Entry {
@@ -100,12 +107,49 @@ impl ReprojectionCache {
                     "proj_trans EPSG:{from}->EPSG:{to} produced non-finite output"
                 )));
             }
+            entry.guard_against_ballpark()?;
             Ok([o.x, o.y, o.z])
         }
     }
 }
 
 impl Entry {
+    /// Fail if the operation PROJ actually used for the last transform is a
+    /// ballpark one. A ballpark transformation silently omits the datum and
+    /// geoid shift (leaving, for example, an orthometric height untouched
+    /// instead of converting it to an ellipsoidal one), so accepting it would
+    /// place geometry tens of metres off. PROJ selects it only when no accurate
+    /// operation is instantiable, which in practice means a required grid is
+    /// absent or the PROJ build cannot read it. Memoized: the check runs once,
+    /// on the first transform.
+    ///
+    /// Must be called immediately after a successful `proj_trans` on `self.pj`.
+    // SAFETY: `self.pj` must have just completed a `proj_trans`; `self.ctx` and
+    // `self.pj` must be valid, non-null PROJ objects.
+    unsafe fn guard_against_ballpark(&self) -> Result<()> {
+        if self.ballpark_checked.get() {
+            return Ok(());
+        }
+        self.ballpark_checked.set(true);
+
+        let used = proj_trans_get_last_used_operation(self.pj);
+        if used.is_null() {
+            return Ok(());
+        }
+        let is_ballpark = proj_coordoperation_has_ballpark_transformation(self.ctx, used);
+        proj_destroy(used);
+
+        if is_ballpark == 1 {
+            let (from, to) = (self.from, self.to);
+            return Err(Error::projection(format!(
+                "EPSG:{from}->EPSG:{to}: PROJ has no accurate transform and fell back to a \
+                 ballpark that omits the datum/geoid shift; a required transformation grid is \
+                 missing or the PROJ build lacks TIFF grid support"
+            )));
+        }
+        Ok(())
+    }
+
     /// Build the PROJ transformation for the `(from, to)` EPSG pair.
     fn build(from: EpsgCode, to: EpsgCode) -> Result<Self> {
         // SAFETY: each PROJ object is null-checked before use; errno is read
@@ -129,7 +173,13 @@ impl Entry {
                 )));
             }
 
-            Ok(Self { from, to, ctx, pj })
+            Ok(Self {
+                from,
+                to,
+                ctx,
+                pj,
+                ballpark_checked: Cell::new(false),
+            })
         }
     }
 }
@@ -467,6 +517,26 @@ mod tests {
         assert!(linear(3857)); // Web Mercator (metres)
         assert!(linear(4978)); // WGS84 geocentric (Cartesian, metres)
         assert!(crs_is_linear(EpsgCode::new(1)).is_err());
+    }
+
+    fn dutch_vertical_is_corrected_or_rejected_never_silently_wrong() {
+        // EPSG:7415 (Amersfoort / RD New + NAP height) carries an orthometric
+        // height; converting to WGS84 3D must add the ~46 m NL geoid separation.
+        // With the grid present the height is corrected; without it PROJ can only
+        // ballpark, which the guard rejects. The one outcome that must never
+        // happen is silently returning the input height as if it were ellipsoidal.
+        let mut cache = ReprojectionCache::new();
+        match cache.transform(
+            EpsgCode::new(7415),
+            EpsgCode::new(4979),
+            [204000.0, 325300.0, 95.0],
+        ) {
+            Ok([_, _, z]) => assert!(
+                z > 130.0,
+                "expected a geoid-corrected ellipsoidal height (~140 m), got {z}"
+            ),
+            Err(e) => assert!(e.to_string().contains("ballpark"), "unexpected error: {e}"),
+        }
     }
 
     #[test]

--- a/engine/runtime/geometry/src/ops/reproject/ffi.rs
+++ b/engine/runtime/geometry/src/ops/reproject/ffi.rs
@@ -12,14 +12,13 @@ use parking_lot::RwLock;
 use crate::coordinate::EpsgCode;
 use proj_sys::{
     proj_context_create, proj_context_destroy, proj_context_errno, proj_context_errno_string,
-    proj_create, proj_create_crs_to_crs, proj_crs_get_coordinate_system, proj_crs_get_sub_crs,
-    proj_cs_get_axis_count, proj_cs_get_axis_info, proj_cs_get_type, proj_destroy, proj_errno,
-    proj_errno_reset, proj_trans, PJ, PJ_CONTEXT, PJ_COORD,
+    proj_coordoperation_has_ballpark_transformation, proj_create, proj_create_crs_to_crs,
+    proj_crs_get_coordinate_system, proj_crs_get_sub_crs, proj_cs_get_axis_count,
+    proj_cs_get_axis_info, proj_cs_get_type, proj_destroy, proj_errno, proj_errno_reset,
+    proj_trans, proj_trans_get_last_used_operation, PJ, PJ_CONTEXT, PJ_COORD,
     PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_CARTESIAN,
     PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_ELLIPSOIDAL,
     PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_SPHERICAL, PJ_DIRECTION_PJ_FWD, PJ_XYZT,
-    proj_coordoperation_has_ballpark_transformation,
-    proj_trans_get_last_used_operation
 };
 
 use crate::error::{Error, Result};
@@ -519,6 +518,7 @@ mod tests {
         assert!(crs_is_linear(EpsgCode::new(1)).is_err());
     }
 
+    #[test]
     fn dutch_vertical_is_corrected_or_rejected_never_silently_wrong() {
         // EPSG:7415 (Amersfoort / RD New + NAP height) carries an orthometric
         // height; converting to WGS84 3D must add the ~46 m NL geoid separation.

--- a/engine/runtime/geometry/src/ops/reproject/ffi.rs
+++ b/engine/runtime/geometry/src/ops/reproject/ffi.rs
@@ -1,6 +1,5 @@
 //! PROJ-backed coordinate transformation for the reprojection ops.
 
-use std::cell::Cell;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int};
@@ -12,10 +11,9 @@ use parking_lot::RwLock;
 use crate::coordinate::EpsgCode;
 use proj_sys::{
     proj_context_create, proj_context_destroy, proj_context_errno, proj_context_errno_string,
-    proj_coordoperation_has_ballpark_transformation, proj_create, proj_create_crs_to_crs,
-    proj_crs_get_coordinate_system, proj_crs_get_sub_crs, proj_cs_get_axis_count,
-    proj_cs_get_axis_info, proj_cs_get_type, proj_destroy, proj_errno, proj_errno_reset,
-    proj_trans, proj_trans_get_last_used_operation, PJ, PJ_CONTEXT, PJ_COORD,
+    proj_create, proj_create_crs_to_crs_from_pj, proj_crs_get_coordinate_system,
+    proj_crs_get_sub_crs, proj_cs_get_axis_count, proj_cs_get_axis_info, proj_cs_get_type,
+    proj_destroy, proj_errno, proj_errno_reset, proj_trans, PJ, PJ_CONTEXT, PJ_COORD,
     PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_CARTESIAN,
     PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_ELLIPSOIDAL,
     PJ_COORDINATE_SYSTEM_TYPE_PJ_CS_TYPE_SPHERICAL, PJ_DIRECTION_PJ_FWD, PJ_XYZT,
@@ -40,10 +38,6 @@ struct Entry {
     ctx: *mut PJ_CONTEXT,
     /// The PROJ transformation.
     pj: *mut PJ,
-    /// Whether the ballpark guard has already run for this transform. The guard
-    /// can only inspect the actually-used operation after a first `proj_trans`,
-    /// so it runs lazily on the first transform and is memoized here.
-    ballpark_checked: Cell<bool>,
 }
 
 impl Drop for Entry {
@@ -106,54 +100,27 @@ impl ReprojectionCache {
                     "proj_trans EPSG:{from}->EPSG:{to} produced non-finite output"
                 )));
             }
-            entry.guard_against_ballpark()?;
             Ok([o.x, o.y, o.z])
         }
     }
 }
 
 impl Entry {
-    /// Fail if the operation PROJ actually used for the last transform is a
-    /// ballpark one. A ballpark transformation silently omits the datum and
-    /// geoid shift (leaving, for example, an orthometric height untouched
-    /// instead of converting it to an ellipsoidal one), so accepting it would
-    /// place geometry tens of metres off. PROJ selects it only when no accurate
-    /// operation is instantiable, which in practice means a required grid is
-    /// absent or the PROJ build cannot read it. Memoized: the check runs once,
-    /// on the first transform.
-    ///
-    /// Must be called immediately after a successful `proj_trans` on `self.pj`.
-    // SAFETY: `self.pj` must have just completed a `proj_trans`; `self.ctx` and
-    // `self.pj` must be valid, non-null PROJ objects.
-    unsafe fn guard_against_ballpark(&self) -> Result<()> {
-        if self.ballpark_checked.get() {
-            return Ok(());
-        }
-        self.ballpark_checked.set(true);
-
-        let used = proj_trans_get_last_used_operation(self.pj);
-        if used.is_null() {
-            return Ok(());
-        }
-        let is_ballpark = proj_coordoperation_has_ballpark_transformation(self.ctx, used);
-        proj_destroy(used);
-
-        if is_ballpark == 1 {
-            let (from, to) = (self.from, self.to);
-            return Err(Error::projection(format!(
-                "EPSG:{from}->EPSG:{to}: PROJ has no accurate transform and fell back to a \
-                 ballpark that omits the datum/geoid shift; a required transformation grid is \
-                 missing or the PROJ build lacks TIFF grid support"
-            )));
-        }
-        Ok(())
-    }
-
     /// Build the PROJ transformation for the `(from, to)` EPSG pair.
+    ///
+    /// The transformation forbids ballpark fallback (`ALLOW_BALLPARK=NO`): a
+    /// ballpark silently omits the datum and geoid shift (leaving, for example,
+    /// an orthometric height untouched instead of converting it to an
+    /// ellipsoidal one), placing geometry tens of metres off. With ballpark
+    /// disallowed, any coordinate that has no accurate operation errors at
+    /// transform time instead. PROJ can only ballpark when a required grid is
+    /// absent or the build cannot read it.
     fn build(from: EpsgCode, to: EpsgCode) -> Result<Self> {
         // SAFETY: each PROJ object is null-checked before use; errno is read
         // while the context is still alive; on any failure all objects created
-        // so far are freed before returning.
+        // so far are freed before returning. The source and target CRS objects
+        // are only needed to build the transformation and are freed once it is
+        // created.
         unsafe {
             let ctx = proj_context_create();
             if ctx.is_null() {
@@ -163,7 +130,30 @@ impl Entry {
             let c_from = CString::new(format!("EPSG:{from}")).map_err(Error::projection)?;
             let c_to = CString::new(format!("EPSG:{to}")).map_err(Error::projection)?;
 
-            let pj = proj_create_crs_to_crs(ctx, c_from.as_ptr(), c_to.as_ptr(), ptr::null_mut());
+            let src = proj_create(ctx, c_from.as_ptr());
+            if src.is_null() {
+                let msg = ctx_errno_string(ctx);
+                proj_context_destroy(ctx);
+                return Err(Error::projection(format!(
+                    "failed to create CRS EPSG:{from}: {msg}"
+                )));
+            }
+            let dst = proj_create(ctx, c_to.as_ptr());
+            if dst.is_null() {
+                let msg = ctx_errno_string(ctx);
+                proj_destroy(src);
+                proj_context_destroy(ctx);
+                return Err(Error::projection(format!(
+                    "failed to create CRS EPSG:{to}: {msg}"
+                )));
+            }
+
+            let allow_ballpark = CString::new("ALLOW_BALLPARK=NO").map_err(Error::projection)?;
+            let options = [allow_ballpark.as_ptr(), ptr::null()];
+            let pj =
+                proj_create_crs_to_crs_from_pj(ctx, src, dst, ptr::null_mut(), options.as_ptr());
+            proj_destroy(src);
+            proj_destroy(dst);
             if pj.is_null() {
                 let msg = ctx_errno_string(ctx);
                 proj_context_destroy(ctx);
@@ -172,13 +162,7 @@ impl Entry {
                 )));
             }
 
-            Ok(Self {
-                from,
-                to,
-                ctx,
-                pj,
-                ballpark_checked: Cell::new(false),
-            })
+            Ok(Self { from, to, ctx, pj })
         }
     }
 }
@@ -523,8 +507,9 @@ mod tests {
         // EPSG:7415 (Amersfoort / RD New + NAP height) carries an orthometric
         // height; converting to WGS84 3D must add the ~46 m NL geoid separation.
         // With the grid present the height is corrected; without it PROJ can only
-        // ballpark, which the guard rejects. The one outcome that must never
-        // happen is silently returning the input height as if it were ellipsoidal.
+        // ballpark, which is disallowed so the transform errors. The one outcome
+        // that must never happen is silently returning the input height as if it
+        // were ellipsoidal.
         let mut cache = ReprojectionCache::new();
         match cache.transform(
             EpsgCode::new(7415),
@@ -535,7 +520,7 @@ mod tests {
                 z > 130.0,
                 "expected a geoid-corrected ellipsoidal height (~140 m), got {z}"
             ),
-            Err(e) => assert!(e.to_string().contains("ballpark"), "unexpected error: {e}"),
+            Err(e) => assert!(e.to_string().contains("7415"), "unexpected error: {e}"),
         }
     }
 

--- a/engine/runtime/geometry/src/point/ops.rs
+++ b/engine/runtime/geometry/src/point/ops.rs
@@ -46,6 +46,63 @@ impl Reproject for Point3D {
     }
 }
 
+use crate::ops::{plan_frame_step, ConvertFrame, FrameStep, Translate};
+
+impl Translate for Point2D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        self.position[0] += delta[0];
+        self.position[1] += delta[1];
+        Ok(())
+    }
+}
+
+impl Translate for Point3D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        self.position[0] += delta[0];
+        self.position[1] += delta[1];
+        self.position[2] += delta[2];
+        Ok(())
+    }
+}
+
+impl ConvertFrame for Point2D {
+    fn convert_frame(
+        &mut self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match plan_frame_step(&self.frame, target, base_point)? {
+            FrameStep::Noop => Ok(()),
+            FrameStep::Reproject(to) => self.reproject(to, cache),
+            FrameStep::Translate(offset, frame) => {
+                self.translate(offset)?;
+                self.frame = frame;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl ConvertFrame for Point3D {
+    fn convert_frame(
+        &mut self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match plan_frame_step(&self.frame, target, base_point)? {
+            FrameStep::Noop => Ok(()),
+            FrameStep::Reproject(to) => self.reproject(to, cache),
+            FrameStep::Translate(offset, frame) => {
+                self.translate(offset)?;
+                self.frame = frame;
+                Ok(())
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/point_cloud/mod.rs
+++ b/engine/runtime/geometry/src/point_cloud/mod.rs
@@ -150,4 +150,4 @@ impl fmt::Debug for PointCloud {
     }
 }
 
-crate::unsupported!(PointCloud: Triangulate, Reproject);
+crate::unsupported!(PointCloud: Triangulate, Reproject, ConvertFrame, Translate);

--- a/engine/runtime/geometry/src/polygon/ops.rs
+++ b/engine/runtime/geometry/src/polygon/ops.rs
@@ -59,6 +59,60 @@ impl Reproject for Polygon3D {
     }
 }
 
+use crate::ops::{plan_frame_step, translate_2d, translate_3d, ConvertFrame, FrameStep, Translate};
+
+impl Translate for Polygon2D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        translate_2d(&mut self.coords, self.z.as_deref_mut(), delta);
+        Ok(())
+    }
+}
+
+impl Translate for Polygon3D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        translate_3d(&mut self.coords, delta);
+        Ok(())
+    }
+}
+
+impl ConvertFrame for Polygon2D {
+    fn convert_frame(
+        &mut self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match plan_frame_step(&self.frame, target, base_point)? {
+            FrameStep::Noop => Ok(()),
+            FrameStep::Reproject(to) => self.reproject(to, cache),
+            FrameStep::Translate(offset, frame) => {
+                self.translate(offset)?;
+                self.frame = frame;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl ConvertFrame for Polygon3D {
+    fn convert_frame(
+        &mut self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match plan_frame_step(&self.frame, target, base_point)? {
+            FrameStep::Noop => Ok(()),
+            FrameStep::Reproject(to) => self.reproject(to, cache),
+            FrameStep::Translate(offset, frame) => {
+                self.translate(offset)?;
+                self.frame = frame;
+                Ok(())
+            }
+        }
+    }
+}
+
 impl Triangulate for Polygon2D {
     fn triangulate(&mut self, cache: &mut Cache) -> Result<Geometry, UnsupportedOperation> {
         let Cache { earcut, buffers } = cache;

--- a/engine/runtime/geometry/src/polygon_mesh/ops.rs
+++ b/engine/runtime/geometry/src/polygon_mesh/ops.rs
@@ -65,6 +65,60 @@ impl Reproject for PolygonMesh3D {
     }
 }
 
+use crate::ops::{plan_frame_step, translate_2d, translate_3d, ConvertFrame, FrameStep, Translate};
+
+impl Translate for PolygonMesh2D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        translate_2d(&mut self.vertices, self.z.as_deref_mut(), delta);
+        Ok(())
+    }
+}
+
+impl Translate for PolygonMesh3D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        translate_3d(self.data.vertices_mut(), delta);
+        Ok(())
+    }
+}
+
+impl ConvertFrame for PolygonMesh2D {
+    fn convert_frame(
+        &mut self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match plan_frame_step(&self.frame, target, base_point)? {
+            FrameStep::Noop => Ok(()),
+            FrameStep::Reproject(to) => self.reproject(to, cache),
+            FrameStep::Translate(offset, frame) => {
+                self.translate(offset)?;
+                self.frame = frame;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl ConvertFrame for PolygonMesh3D {
+    fn convert_frame(
+        &mut self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match plan_frame_step(&self.frame, target, base_point)? {
+            FrameStep::Noop => Ok(()),
+            FrameStep::Reproject(to) => self.reproject(to, cache),
+            FrameStep::Translate(offset, frame) => {
+                self.translate(offset)?;
+                self.frame = frame;
+                Ok(())
+            }
+        }
+    }
+}
+
 impl Triangulate for PolygonMesh2D {
     fn triangulate(&mut self, cache: &mut Cache) -> Result<Geometry, UnsupportedOperation> {
         let Cache { earcut, buffers } = cache;

--- a/engine/runtime/geometry/src/solid/ops.rs
+++ b/engine/runtime/geometry/src/solid/ops.rs
@@ -82,6 +82,40 @@ fn reproject_shell(
     transform_coords_3d(cache, from, target, vertices)
 }
 
+use crate::ops::{plan_frame_step, translate_3d, ConvertFrame, FrameStep, Translate};
+
+impl Translate for Solid {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        for shell in std::iter::once(&mut self.exterior).chain(self.interiors.iter_mut()) {
+            let vertices = match shell {
+                Shell::PolygonMesh(data) => data.vertices_mut(),
+                Shell::TriangularMesh(data) => data.vertices_mut(),
+            };
+            translate_3d(vertices, delta);
+        }
+        Ok(())
+    }
+}
+
+impl ConvertFrame for Solid {
+    fn convert_frame(
+        &mut self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match plan_frame_step(&self.frame, target, base_point)? {
+            FrameStep::Noop => Ok(()),
+            FrameStep::Reproject(to) => self.reproject(to, cache),
+            FrameStep::Translate(offset, frame) => {
+                self.translate(offset)?;
+                self.frame = frame;
+                Ok(())
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/runtime/geometry/src/triangular_mesh/ops.rs
+++ b/engine/runtime/geometry/src/triangular_mesh/ops.rs
@@ -57,6 +57,60 @@ impl Reproject for TriangularMesh3D {
     }
 }
 
+use crate::ops::{plan_frame_step, translate_2d, translate_3d, ConvertFrame, FrameStep, Translate};
+
+impl Translate for TriangularMesh2D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        translate_2d(&mut self.vertices, self.z.as_deref_mut(), delta);
+        Ok(())
+    }
+}
+
+impl Translate for TriangularMesh3D {
+    fn translate(&mut self, delta: [f64; 3]) -> crate::error::Result<()> {
+        translate_3d(self.data.vertices_mut(), delta);
+        Ok(())
+    }
+}
+
+impl ConvertFrame for TriangularMesh2D {
+    fn convert_frame(
+        &mut self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match plan_frame_step(&self.frame, target, base_point)? {
+            FrameStep::Noop => Ok(()),
+            FrameStep::Reproject(to) => self.reproject(to, cache),
+            FrameStep::Translate(offset, frame) => {
+                self.translate(offset)?;
+                self.frame = frame;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl ConvertFrame for TriangularMesh3D {
+    fn convert_frame(
+        &mut self,
+        target: &CoordinateFrame,
+        base_point: Option<[f64; 3]>,
+        cache: &mut ReprojectionCache,
+    ) -> crate::error::Result<()> {
+        match plan_frame_step(&self.frame, target, base_point)? {
+            FrameStep::Noop => Ok(()),
+            FrameStep::Reproject(to) => self.reproject(to, cache),
+            FrameStep::Translate(offset, frame) => {
+                self.translate(offset)?;
+                self.frame = frame;
+                Ok(())
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/testing/plateau-tiles-test/Cargo.toml
+++ b/engine/testing/plateau-tiles-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plateau-tiles-test"
-version = "0.2.83"
+version = "0.2.84"
 edition = "2021"
 
 [dependencies]

--- a/engine/testing/workflow-tests/Cargo.toml
+++ b/engine/testing/workflow-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workflow-tests"
-version = "0.1.273"
+version = "0.1.274"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
# Overview
This PR does two things:
1. Fixes a bug in the reprojection core where it wasn't able to read `.tif` grid file. Also, reprojection now loud-fails on ballpark case to help future debugging.
2. Adds `CoordinateFrameReprojector` action that converts geometry between different `CoordinateFrame`s. It does not only serve as the consolidation of legacy `HorizontalReprojector` and `VerticalReprojector`, but also supports reprojection between CRS coordinate and non-CRS coordinate (i.e., general Euclidean coordinate), with optional base-point, either given as an expression or a point geometry through `base-point` port. This is useful, for example, in a workflow that embeds plain geometries from obj or gltf into GIS formats like CityGML or 3DTiles.

## Minor details
- Added `Translate` trait and `ConvertFrame` trait under `ops` module in `geometry` crate. `Translate` is hoisted here because it would be useful for other places. `ConvertFrame` is deliberately not a simple frame access; otherwise, the collections, whose children have different frames, can have problems converting frames.
- `HorizontalReprojector` and `VerticalReprojector` will not be implemented in the new-geometry world. This fact is flagged in the code base to prevent future mistakes.

## Limitation / Out of scope
Reprojection from/to tangent frames are not supported, though we might need to support the "from" direction in the future. The "to" direction is deliberately out of scope and will not be implemented; it should be implemented as part of the projection actions (e.g. footprint replacer)