### PR TITLE
chore(websocket-go): bump ygo to v1.37.0

### DIFF
--- a/server/websocket-go/go.mod
+++ b/server/websocket-go/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/fsouza/fake-gcs-server v1.54.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/redis/go-redis/v9 v9.20.0
-	github.com/reearth/ygo v1.36.0
+	github.com/reearth/ygo v1.37.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.42.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.44.0

--- a/server/websocket-go/go.sum
+++ b/server/websocket-go/go.sum
@@ -149,8 +149,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/redis/go-redis/v9 v9.20.0 h1:WnQYxLkgO2xiXTCJY0ldIiI8dNqCDlQAG+AtaH7a2a0=
 github.com/redis/go-redis/v9 v9.20.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
-github.com/reearth/ygo v1.36.0 h1:K8lIykQDits4YzIXQsF3/L3Vh91FBgE48aUuu0di9Bc=
-github.com/reearth/ygo v1.36.0/go.mod h1:QN5MsM+QBk9cP6Sr/iaKlkJtnJ9Fo0fT+MJqSw2xPUA=
+github.com/reearth/ygo v1.37.0 h1:8swSu3hLrOSY7b2w9t0DcAw1P40QW4fNEzM5UVodicI=
+github.com/reearth/ygo v1.37.0/go.mod h1:QN5MsM+QBk9cP6Sr/iaKlkJtnJ9Fo0fT+MJqSw2xPUA=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=


### PR DESCRIPTION
## What

Bumps `github.com/reearth/ygo` **v1.36.0 → v1.37.0** in `server/websocket-go`.

## Why

v1.37.0 is a minor, non-breaking release hardening the coalesced-persistence path:

- **Fixes [ygo#175](https://github.com/reearth/ygo/issues/175) — lost edits on quick refresh with coalesced persistence.** Room-teardown paths (`handleDisconnect`, `CloseRoom`) now durably flush (and await) the pending coalesced batch while the room is still discoverable, then re-check and evict; a peer reconnecting during the flush reuses the live in-memory doc instead of reloading stale state. This is the exact durability gap we filed, and the fix is default behavior, so we pick it up automatically with the bump.
- **Adds optional `CompactableAdapter` / `Server.CompactEvery` / `LegacyAdapter.KeepVersions`** to bound stored-version growth. Opt-in; behavior is unchanged for servers that don't wire it up. We can adopt this in a follow-up if we want to cap version growth in GCS.

No breaking changes; no code changes needed in websocket-go beyond the version bump.

## Verification

All run with `GOWORK=off` in `server/websocket-go`:

- `go build ./...` ✅
- `go vet ./...` ✅
- `go mod verify` ✅
- `go test -race ./...` ✅ (all packages)